### PR TITLE
Add complex-registry as vcpkg registry

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,17 @@
+{
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://github.com/BlueQuartzSoftware/complex-registry",
+      "packages": [
+        "catch2",
+        "eigen3",
+        "expected-lite",
+        "fmt",
+        "nlohmann-json",
+        "pybind11"
+      ],
+      "baseline": "324d79cfb52980f1cc5e78866af8c16fbe736905"
+    }
+  ]
+}


### PR DESCRIPTION
* [complex-registry](https://github.com/BlueQuartzSoftware/complex-registry) gives us control over how our dependencies are
built
* At the moment the packages are largely the same as the vcpkg
versions except for the removal of pkg-config support. This removes
the implicit pkg-config dependency for ports that used the function
`vcpkg_fixup_pkgconfig`