### PR TITLE
moved to referenced list return values

### DIFF
--- a/src/complex/Core/FilterList.cpp
+++ b/src/complex/Core/FilterList.cpp
@@ -87,7 +87,7 @@ bool FilterList::addPlugin(const std::string& path)
   return addPlugin(std::make_shared<PluginLoader>(path));
 }
 
-std::unordered_set<FilterHandle> FilterList::getFilterHandles() const
+std::unordered_set<FilterHandle> const& FilterList::getFilterHandles() const
 {
   return m_FilterHandles;
 }

--- a/src/complex/Core/FilterList.hpp
+++ b/src/complex/Core/FilterList.hpp
@@ -37,7 +37,7 @@ public:
    * @brief Returns a set of FilterHandles for each of the filters.
    * @return std::set<FilterHandle>
    */
-  std::unordered_set<FilterHandle> getFilterHandles() const;
+  std::unordered_set<FilterHandle> const& getFilterHandles() const;
 
   /**
    * @brief Searches the FilterHandles for the text in the filter and plugin

--- a/src/complex/Core/Filters/ImportTextFilter.cpp
+++ b/src/complex/Core/Filters/ImportTextFilter.cpp
@@ -69,6 +69,17 @@ Result<> ReadFile(const fs::path& inputPath, DataArray<T>& data, u64 skipLines, 
 
 namespace complex
 {
+ImportTextFilter::ImportTextFilter()
+{
+    m_params.insert(std::make_unique<InputFileParameter>(k_InputFileKey, "Input File", "File to read from", ""));
+    m_params.insert(std::make_unique<NumericTypeParameter>(k_ScalarTypeKey, "Scalar Type", "Type to interpret data as", NumericType::i8));
+    m_params.insert(std::make_unique<UInt64Parameter>(k_NCompKey, "Number of Components", "Number of columns", 0));
+    m_params.insert(std::make_unique<UInt64Parameter>(k_NSkipLinesKey, "Skip Header Lines", "Number of lines to skip in the file", 0));
+    m_params.insert(std::make_unique<ChoicesParameter>(k_DelimiterChoiceKey, "Delimiter", "Delimiter for values on a line", 0,
+                                                     ChoicesParameter::Choices{", (comma)", "; (semicolon)", "  (space)", ": (colon)", "\\t (Tab)"}));
+    m_params.insert(std::make_unique<ArrayCreationParameter>(k_DataArrayKey, "Created Array", "Array storing the file data", DataPath{}));
+}
+
 std::string ImportTextFilter::name() const
 {
   return "ImportTextFilter";
@@ -85,17 +96,9 @@ std::string ImportTextFilter::humanName() const
   return "Import Text Data";
 }
 
-Parameters ImportTextFilter::parameters() const
+Parameters const& ImportTextFilter::parameters() const
 {
-  Parameters params;
-  params.insert(std::make_unique<InputFileParameter>(k_InputFileKey, "Input File", "File to read from", ""));
-  params.insert(std::make_unique<NumericTypeParameter>(k_ScalarTypeKey, "Scalar Type", "Type to interpret data as", NumericType::i8));
-  params.insert(std::make_unique<UInt64Parameter>(k_NCompKey, "Number of Components", "Number of columns", 0));
-  params.insert(std::make_unique<UInt64Parameter>(k_NSkipLinesKey, "Skip Header Lines", "Number of lines to skip in the file", 0));
-  params.insert(std::make_unique<ChoicesParameter>(k_DelimiterChoiceKey, "Delimiter", "Delimiter for values on a line", 0,
-                                                   ChoicesParameter::Choices{", (comma)", "; (semicolon)", "  (space)", ": (colon)", "\\t (Tab)"}));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_DataArrayKey, "Created Array", "Array storing the file data", DataPath{}));
-  return params;
+    return m_params;
 }
 
 IFilter::UniquePointer ImportTextFilter::clone() const

--- a/src/complex/Core/Filters/ImportTextFilter.hpp
+++ b/src/complex/Core/Filters/ImportTextFilter.hpp
@@ -8,7 +8,7 @@ namespace complex
 class COMPLEX_EXPORT ImportTextFilter : public IFilter
 {
 public:
-  ImportTextFilter() = default;
+  ImportTextFilter();
   ~ImportTextFilter() noexcept override = default;
 
   ImportTextFilter(const ImportTextFilter&) = delete;
@@ -39,7 +39,7 @@ public:
    * @brief
    * @return
    */
-  [[nodiscard]] Parameters parameters() const override;
+  [[nodiscard]] Parameters const& parameters() const override;
 
   /**
    * @brief
@@ -65,5 +65,10 @@ private:
    * @return
    */
   Result<> executeImpl(DataStructure& data, const Arguments& args, const MessageHandler& messageHandler) const override;
+
+  /**
+   * @brief
+   */
+  Parameters m_params;
 };
 } // namespace complex

--- a/src/complex/Core/Filters/TestFilter1.cpp
+++ b/src/complex/Core/Filters/TestFilter1.cpp
@@ -13,6 +13,12 @@ constexpr const char k_Param2[] = "param2";
 
 namespace complex
 {
+TestFilter1::TestFilter1()
+{
+    m_params.insert(std::make_unique<Float32Parameter>(k_Param1, "Parameter 1", "The 1st parameter", 0.0f));
+    m_params.insert(std::make_unique<BoolParameter>(k_Param2, "Parameter 2", "The 2nd parameter", false));
+}
+
 std::string TestFilter1::name() const
 {
   return "TestFilter1";
@@ -29,12 +35,9 @@ std::string TestFilter1::humanName() const
   return "Test Filter 1";
 }
 
-Parameters TestFilter1::parameters() const
+Parameters const& TestFilter1::parameters() const
 {
-  Parameters params;
-  params.insert(std::make_unique<Float32Parameter>(k_Param1, "Parameter 1", "The 1st parameter", 0.0f));
-  params.insert(std::make_unique<BoolParameter>(k_Param2, "Parameter 2", "The 2nd parameter", false));
-  return params;
+    return m_params;
 }
 
 IFilter::UniquePointer TestFilter1::clone() const

--- a/src/complex/Core/Filters/TestFilter1.hpp
+++ b/src/complex/Core/Filters/TestFilter1.hpp
@@ -8,7 +8,7 @@ namespace complex
 class COMPLEX_EXPORT TestFilter1 : public IFilter
 {
 public:
-  TestFilter1() = default;
+  TestFilter1();
   ~TestFilter1() noexcept override = default;
 
   TestFilter1(const TestFilter1&) = delete;
@@ -39,7 +39,7 @@ public:
    * @brief
    * @return
    */
-  [[nodiscard]] Parameters parameters() const override;
+  [[nodiscard]] Parameters const& parameters() const override;
 
   /**
    * @brief
@@ -65,5 +65,10 @@ private:
    * @return
    */
   Result<> executeImpl(DataStructure& data, const Arguments& args, const MessageHandler& messageHandler) const override;
+
+  /**
+   * @brief
+   */
+  Parameters m_params;
 };
 } // namespace complex

--- a/src/complex/Core/Filters/TestFilter2.cpp
+++ b/src/complex/Core/Filters/TestFilter2.cpp
@@ -15,6 +15,14 @@ constexpr const char k_Param3[] = "param3";
 
 namespace complex
 {
+
+TestFilter2::TestFilter2()
+{
+    m_params.insert(std::make_unique<Int32Parameter>(k_Param1, "Parameter 1", "The 1st parameter", 0));
+    m_params.insert(std::make_unique<StringParameter>(k_Param2, "Parameter 2", "The 2nd parameter", "test string"));
+    m_params.insert(std::make_unique<ChoicesParameter>(k_Param3, "Parameter 3", "The 3rd parameter", 0, ChoicesParameter::Choices{"foo", "bar", "baz"}));
+}
+
 std::string TestFilter2::name() const
 {
   return "TestFilter2";
@@ -31,13 +39,9 @@ std::string TestFilter2::humanName() const
   return "Test Filter 2";
 }
 
-Parameters TestFilter2::parameters() const
+Parameters const& TestFilter2::parameters() const
 {
-  Parameters params;
-  params.insert(std::make_unique<Int32Parameter>(k_Param1, "Parameter 1", "The 1st parameter", 0));
-  params.insert(std::make_unique<StringParameter>(k_Param2, "Parameter 2", "The 2nd parameter", "test string"));
-  params.insert(std::make_unique<ChoicesParameter>(k_Param3, "Parameter 3", "The 3rd parameter", 0, ChoicesParameter::Choices{"foo", "bar", "baz"}));
-  return params;
+  return m_params;
 }
 
 IFilter::UniquePointer TestFilter2::clone() const

--- a/src/complex/Core/Filters/TestFilter2.hpp
+++ b/src/complex/Core/Filters/TestFilter2.hpp
@@ -8,7 +8,7 @@ namespace complex
 class COMPLEX_EXPORT TestFilter2 : public IFilter
 {
 public:
-  TestFilter2() = default;
+  TestFilter2();
   ~TestFilter2() noexcept override = default;
 
   TestFilter2(const TestFilter2&) = delete;
@@ -39,7 +39,7 @@ public:
    * @brief
    * @return
    */
-  [[nodiscard]] Parameters parameters() const override;
+  [[nodiscard]] Parameters const& parameters() const override;
 
   /**
    * @brief
@@ -65,5 +65,10 @@ private:
    * @return
    */
   Result<> executeImpl(DataStructure& data, const Arguments& args, const MessageHandler& messageHandler) const override;
+
+  /**
+   * @brief
+   */
+  Parameters m_params;
 };
 } // namespace complex

--- a/src/complex/Filter/IFilter.cpp
+++ b/src/complex/Filter/IFilter.cpp
@@ -32,7 +32,7 @@ namespace complex
 {
 Result<OutputActions> IFilter::preflight(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler) const
 {
-  Parameters params = parameters();
+  Parameters const& params = parameters();
 
   std::vector<Error> errors;
   std::vector<Warning> warnings;
@@ -131,7 +131,7 @@ Result<> IFilter::execute(DataStructure& data, const Arguments& args, const Mess
 nlohmann::json IFilter::toJson(const Arguments& args) const
 {
   nlohmann::json json;
-  Parameters params = parameters();
+  Parameters const& params = parameters();
   for(auto&& [name, param] : params)
   {
     nlohmann::json parameterJson = param->toJson(args.at(name));
@@ -142,7 +142,7 @@ nlohmann::json IFilter::toJson(const Arguments& args) const
 
 Result<Arguments> IFilter::fromJson(const nlohmann::json& json) const
 {
-  Parameters params = parameters();
+  Parameters const& params = parameters();
   Arguments args;
   std::vector<Error> errors;
   std::vector<Warning> warnings;

--- a/src/complex/Filter/IFilter.hpp
+++ b/src/complex/Filter/IFilter.hpp
@@ -90,7 +90,7 @@ public:
    * @brief
    * @return
    */
-  [[nodiscard]] virtual Parameters parameters() const = 0;
+  [[nodiscard]] virtual Parameters const& parameters() const = 0;
 
   /**
    * @brief

--- a/test/CoreFilterTest.cpp
+++ b/test/CoreFilterTest.cpp
@@ -12,10 +12,10 @@ TEST_CASE("Create Core Filter")
   REQUIRE(filterList != nullptr);
 
   // Only core filters should exists since plugins were not loaded
-  auto handles = filterList->getFilterHandles();
+  auto const& handles = filterList->getFilterHandles();
   REQUIRE(handles.size() > 0);
 
-  for(auto handle : handles)
+  for(auto const& handle : handles)
   {
     auto coreFilter = filterList->createFilter(handle);
     REQUIRE(coreFilter != nullptr);


### PR DESCRIPTION
The Core directory in complex contains the interface definitions for working with the library.   In those interfaces container/lists can be queried but are being returned using by-value semantics.  These by-value containers typically hold std::unique_ptrs() so ownership of the contained items are being exported.   This means each time a request is make another distinct copy of the items are created and returned.

Instead, and what this pull-request does, is change the interface definitions to return the list by const reference.   This way ownership of the items is maintained by the complex library and changes make by making api call on the items are visible within the complex library.