### PR TITLE
Added `StringLiteral` type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ set(COMPLEX_HDRS
   ${COMPLEX_SOURCE_DIR}/Common/Ray.hpp
   ${COMPLEX_SOURCE_DIR}/Common/Result.hpp
   ${COMPLEX_SOURCE_DIR}/Common/RgbColor.hpp
+  ${COMPLEX_SOURCE_DIR}/Common/StringLiteral.hpp
   ${COMPLEX_SOURCE_DIR}/Common/Types.hpp
   ${COMPLEX_SOURCE_DIR}/Common/Uuid.hpp
 

--- a/scripts/filter.cpp.in
+++ b/scripts/filter.cpp.in
@@ -1,5 +1,6 @@
 #include "@FILTER_NAME@.hpp"
 
+//#include "complex/Common/StringLiteral.hpp"
 // INSERT YOUR PARAMETER HEADERS
 //#include "complex/Core/Parameters/BoolParameter.hpp"
 //#include "complex/Core/Parameters/NumberParameter.hpp"
@@ -9,8 +10,8 @@ using namespace complex;
 namespace
 {
 // Use this section to set the "keys" for each parameter that your filter needs
-// constexpr const char k_Param1Key[] = "param1";
-// constexpr const char k_Param2Key[] = "param2";
+// constexpr StringLiteral k_Param1Key = "param1";
+// constexpr StringLiteral k_Param2Key = "param2";
 } // namespace
 
 namespace complex
@@ -34,8 +35,8 @@ Parameters @FILTER_NAME@::parameters() const
 {
   Parameters params;
   // Create the parameter descriptors that are needed for this filter
-  // params.insert(std::make_unique<Float32Parameter>(k_Param1Key, "Parameter 1", "The 1st parameter", 0.1234f));
-  // params.insert(std::make_unique<BoolParameter>(k_Param2Key, "Parameter 2", "The 2nd parameter", false));
+  // params.insert(std::make_unique<Float32Parameter>(k_Param1Key.str(), "Parameter 1", "The 1st parameter", 0.1234f));
+  // params.insert(std::make_unique<BoolParameter>(k_Param2Key.str(), "Parameter 2", "The 2nd parameter", false));
   return params;
 }
 
@@ -61,8 +62,8 @@ Result<> @FILTER_NAME@::executeImpl(DataStructure& data, const Arguments& args) 
   /****************************************************************************
    * You will probably need to extract your parameters from the 'args' object
    ***************************************************************************/
-  // auto inputFloatValue = args.value<float>(k_Param1Key);
-  // auto inputBoolValue = args.value<bool>(k_Param2Key);
+  // auto inputFloatValue = args.value<float>(k_Param1Key.view());
+  // auto inputBoolValue = args.value<bool>(k_Param2Key.view());
 
   return {};
 }

--- a/src/complex/Common/StringLiteral.hpp
+++ b/src/complex/Common/StringLiteral.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "complex/Common/Types.hpp"
+
+#include <string>
+#include <string_view>
+
+namespace complex
+{
+/**
+ * @brief BasicStringLiteral is meant to be a safe container for a string literal allowing for easy access to its size/length.
+ * This class should always contain a pointer to a static compile time null-terminated string literal.
+ * Typical usage will be for static string constants. At this time the constructors allow non string literals to be passed in.
+ * This is undesired behavior, but there is no way to overcome this in C++17 without using character parameter packs which come with their own issues.
+ * @tparam T Character type
+ */
+template <class T>
+class BasicStringLiteral
+{
+public:
+  BasicStringLiteral() = delete;
+
+  /**
+   * @brief Constructor that accepts a string literal of fixed size.
+   * @param string
+   * @return
+   */
+  template <usize Size>
+  constexpr BasicStringLiteral(const T (&string)[Size]) noexcept
+  : m_Size(Size)
+  , m_String(string)
+  {
+  }
+
+  ~BasicStringLiteral() noexcept = default;
+
+  BasicStringLiteral(const BasicStringLiteral&) noexcept = default;
+  BasicStringLiteral(BasicStringLiteral&&) noexcept = default;
+
+  BasicStringLiteral& operator=(const BasicStringLiteral&) noexcept = default;
+  BasicStringLiteral& operator=(BasicStringLiteral&&) noexcept = default;
+
+  /**
+   * @brief Returns the c-string pointer
+   * @return const T*
+   */
+  constexpr const T* c_str() const noexcept
+  {
+    return m_String;
+  }
+
+  /**
+   * @brief Returns the size of the string literal including the null terminator
+   * @return usize
+   */
+  constexpr usize size() const noexcept
+  {
+    return m_Size;
+  }
+
+  /**
+   * @brief Returns the size of the string literal not including the null terminator
+   * @return usize
+   */
+  constexpr usize length() const noexcept
+  {
+    return m_Size - 1;
+  }
+
+  /**
+   * @brief Returns a view of string literal not including the null terminator
+   * @return std::basic_string_view<T>
+   */
+  constexpr std::basic_string_view<T> view() const
+  {
+    return std::basic_string_view<T>(m_String, length());
+  }
+
+  /**
+   * @brief Returns a view of string literal including the null terminator
+   * @return std::basic_string_view<T>
+   */
+  constexpr std::basic_string_view<T> c_view() const
+  {
+    return std::basic_string_view<T>(m_String, size());
+  }
+
+  /**
+   * @brief Returns a null-terminated heap allocated string
+   * @return std::basic_string<T>
+   */
+  std::basic_string<T> str() const
+  {
+    return std::basic_string<T>(m_String, length());
+  }
+
+private:
+  const T* m_String;
+  usize m_Size;
+};
+
+using StringLiteral = BasicStringLiteral<char>;
+using WStringLiteral = BasicStringLiteral<wchar_t>;
+using String16Literal = BasicStringLiteral<char16_t>;
+using String32Literal = BasicStringLiteral<char32_t>;
+} // namespace complex

--- a/src/complex/Common/StringLiteral.hpp
+++ b/src/complex/Common/StringLiteral.hpp
@@ -2,16 +2,36 @@
 
 #include "complex/Common/Types.hpp"
 
+#include <stdexcept>
 #include <string>
 #include <string_view>
 
 namespace complex
 {
+namespace detail
+{
+/**
+ * @brief Returns true if the given character array is null-terminated.
+ * @tparam T
+ * @param string
+ * @return
+ */
+template <class T, usize Size>
+constexpr bool HasNullTerminator(const T (&string)[Size]) noexcept
+{
+  return string[Size - 1] == static_cast<T>('\0');
+}
+} // namespace detail
+
 /**
  * @brief BasicStringLiteral is meant to be a safe container for a string literal allowing for easy access to its size/length.
  * This class should always contain a pointer to a static compile time null-terminated string literal.
  * Typical usage will be for static string constants. At this time the constructors allow non string literals to be passed in.
  * This is undesired behavior, but there is no way to overcome this in C++17 without using character parameter packs which come with their own issues.
+ * Example:
+ * @code
+ * static constexpr StringLiteral k_Foo = "foo";
+ * @endcode
  * @tparam T Character type
  */
 template <class T>
@@ -21,15 +41,20 @@ public:
   BasicStringLiteral() = delete;
 
   /**
-   * @brief Constructor that accepts a string literal of fixed size.
+   * @brief Constructor that accepts a string literal of fixed size. Should be made consteval in C++20.
+   * Requires string to be null-terminated.
    * @param string
    * @return
    */
   template <usize Size>
-  constexpr BasicStringLiteral(const T (&string)[Size]) noexcept
-  : m_Size(Size)
-  , m_String(string)
+  constexpr BasicStringLiteral(const T (&string)[Size])
+  : m_String(string)
+  , m_Size(Size)
   {
+    if(!detail::HasNullTerminator(string))
+    {
+      throw std::runtime_error("BasicStringLiteral must be null-terminated");
+    }
   }
 
   ~BasicStringLiteral() noexcept = default;
@@ -41,7 +66,7 @@ public:
   BasicStringLiteral& operator=(BasicStringLiteral&&) noexcept = default;
 
   /**
-   * @brief Returns the c-string pointer
+   * @brief Returns the c-string pointer.
    * @return const T*
    */
   constexpr const T* c_str() const noexcept
@@ -50,48 +75,39 @@ public:
   }
 
   /**
-   * @brief Returns the size of the string literal including the null terminator
+   * @brief Returns the size of the string literal not including the null terminator.
    * @return usize
    */
   constexpr usize size() const noexcept
-  {
-    return m_Size;
-  }
-
-  /**
-   * @brief Returns the size of the string literal not including the null terminator
-   * @return usize
-   */
-  constexpr usize length() const noexcept
   {
     return m_Size - 1;
   }
 
   /**
-   * @brief Returns a view of string literal not including the null terminator
+   * @brief Returns a view of string literal not including the null terminator.
    * @return std::basic_string_view<T>
    */
   constexpr std::basic_string_view<T> view() const
-  {
-    return std::basic_string_view<T>(m_String, length());
-  }
-
-  /**
-   * @brief Returns a view of string literal including the null terminator
-   * @return std::basic_string_view<T>
-   */
-  constexpr std::basic_string_view<T> c_view() const
   {
     return std::basic_string_view<T>(m_String, size());
   }
 
   /**
-   * @brief Returns a null-terminated heap allocated string
+   * @brief Returns a view of string literal including the null terminator.
+   * @return std::basic_string_view<T>
+   */
+  constexpr std::basic_string_view<T> c_view() const
+  {
+    return std::basic_string_view<T>(m_String, m_Size);
+  }
+
+  /**
+   * @brief Returns a null-terminated heap allocated string.
    * @return std::basic_string<T>
    */
   std::basic_string<T> str() const
   {
-    return std::basic_string<T>(m_String, length());
+    return std::basic_string<T>(m_String, size());
   }
 
 private:

--- a/src/complex/Core/Filters/CreateDataArray.cpp
+++ b/src/complex/Core/Filters/CreateDataArray.cpp
@@ -26,7 +26,7 @@ DataArray<T>& ArrayFromPath(DataStructure& data, const DataPath& path)
 
 std::string CreateDataArray::name() const
 {
-  return FilterTraits<CreateDataArray>::name;
+  return FilterTraits<CreateDataArray>::name.str();
 }
 
 Uuid CreateDataArray::uuid() const
@@ -42,10 +42,10 @@ std::string CreateDataArray::humanName() const
 Parameters CreateDataArray::parameters() const
 {
   Parameters params;
-  params.insert(std::make_unique<NumericTypeParameter>(k_NumericType_Key, "Numeric Type", "Numeric Type of data to create", NumericType::i32));
-  params.insert(std::make_unique<UInt64Parameter>(k_NumComps_Key, "Number of Components", "Number of components", 1));
-  params.insert(std::make_unique<UInt64Parameter>(k_NumTuples_Key, "Number of Tuples", "Number of tuples", 0));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_DataPath_Key, "Created Array", "Array storing the file data", DataPath{}));
+  params.insert(std::make_unique<NumericTypeParameter>(k_NumericType_Key.str(), "Numeric Type", "Numeric Type of data to create", NumericType::i32));
+  params.insert(std::make_unique<UInt64Parameter>(k_NumComps_Key.str(), "Number of Components", "Number of components", 1));
+  params.insert(std::make_unique<UInt64Parameter>(k_NumTuples_Key.str(), "Number of Tuples", "Number of tuples", 0));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_DataPath_Key.str(), "Created Array", "Array storing the file data", DataPath{}));
   return params;
 }
 
@@ -56,10 +56,10 @@ IFilter::UniquePointer CreateDataArray::clone() const
 
 Result<OutputActions> CreateDataArray::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler) const
 {
-  auto numericType = args.value<NumericType>(k_NumericType_Key);
-  auto components = args.value<u64>(k_NumComps_Key);
-  auto numTuples = args.value<u64>(k_NumTuples_Key);
-  auto dataArrayPath = args.value<DataPath>(k_DataPath_Key);
+  auto numericType = args.value<NumericType>(k_NumericType_Key.view());
+  auto components = args.value<u64>(k_NumComps_Key.view());
+  auto numTuples = args.value<u64>(k_NumTuples_Key.view());
+  auto dataArrayPath = args.value<DataPath>(k_DataPath_Key.view());
 
   auto action = std::make_unique<CreateArrayAction>(numericType, std::vector<size_t>{numTuples}, components, dataArrayPath);
 
@@ -71,10 +71,10 @@ Result<OutputActions> CreateDataArray::preflightImpl(const DataStructure& data, 
 
 Result<> CreateDataArray::executeImpl(DataStructure& data, const Arguments& args, const MessageHandler& messageHandler) const
 {
-  auto numericType = args.value<NumericType>(k_NumericType_Key);
-  auto components = args.value<u64>(k_NumComps_Key);
-  auto numTuples = args.value<u64>(k_NumTuples_Key);
-  auto path = args.value<DataPath>(k_DataPath_Key);
+  auto numericType = args.value<NumericType>(k_NumericType_Key.view());
+  auto components = args.value<u64>(k_NumComps_Key.view());
+  auto numTuples = args.value<u64>(k_NumTuples_Key.view());
+  auto path = args.value<DataPath>(k_DataPath_Key.view());
 
   switch(numericType)
   {

--- a/src/complex/Core/Filters/CreateDataArray.hpp
+++ b/src/complex/Core/Filters/CreateDataArray.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "complex/Common/StringLiteral.hpp"
 #include "complex/Filter/FilterTraits.hpp"
 #include "complex/Filter/IFilter.hpp"
 #include "complex/complex_export.hpp"
@@ -18,11 +19,11 @@ public:
   CreateDataArray& operator=(const CreateDataArray&) = delete;
   CreateDataArray& operator=(CreateDataArray&&) noexcept = delete;
 
-  // Declare the strings used as keys for the Arguments
-  static inline constexpr const char k_NumericType_Key[] = "numeric_type";
-  static inline constexpr const char k_NumComps_Key[] = "component_count";
-  static inline constexpr const char k_NumTuples_Key[] = "tuple_count";
-  static inline constexpr const char k_DataPath_Key[] = "output_data_array";
+  // Parameter Keys
+  static inline constexpr StringLiteral k_NumericType_Key = "numeric_type";
+  static inline constexpr StringLiteral k_NumComps_Key = "component_count";
+  static inline constexpr StringLiteral k_NumTuples_Key = "tuple_count";
+  static inline constexpr StringLiteral k_DataPath_Key = "output_data_array";
 
   /**
    * @brief

--- a/src/complex/Core/Filters/ImportTextFilter.cpp
+++ b/src/complex/Core/Filters/ImportTextFilter.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <fstream>
 
+#include "complex/Common/StringLiteral.hpp"
 #include "complex/Core/Parameters/ArrayCreationParameter.hpp"
 #include "complex/Core/Parameters/ChoicesParameter.hpp"
 #include "complex/Core/Parameters/FileSystemPathParameter.hpp"
@@ -15,13 +16,13 @@ using namespace complex;
 
 namespace
 {
-constexpr const char k_InputFileKey[] = "input_file";
-constexpr const char k_ScalarTypeKey[] = "scalar_type";
-constexpr const char k_NTuplesKey[] = "n_tuples";
-constexpr const char k_NCompKey[] = "n_comp";
-constexpr const char k_NSkipLinesKey[] = "n_skip_lines";
-constexpr const char k_DelimiterChoiceKey[] = "delimiter_choice";
-constexpr const char k_DataArrayKey[] = "output_data_array";
+constexpr StringLiteral k_InputFileKey = "input_file";
+constexpr StringLiteral k_ScalarTypeKey = "scalar_type";
+constexpr StringLiteral k_NTuplesKey = "n_tuples";
+constexpr StringLiteral k_NCompKey = "n_comp";
+constexpr StringLiteral k_NSkipLinesKey = "n_skip_lines";
+constexpr StringLiteral k_DelimiterChoiceKey = "delimiter_choice";
+constexpr StringLiteral k_DataArrayKey = "output_data_array";
 
 class DelimiterType : public std::ctype<char>
 {
@@ -105,7 +106,7 @@ namespace complex
 {
 std::string ImportTextFilter::name() const
 {
-  return FilterTraits<ImportTextFilter>::name;
+  return FilterTraits<ImportTextFilter>::name.str();
 }
 
 Uuid ImportTextFilter::uuid() const
@@ -122,14 +123,14 @@ Parameters ImportTextFilter::parameters() const
 {
   Parameters params;
   params.insert(
-      std::make_unique<FileSystemPathParameter>(k_InputFileKey, "Input File", "File to read from", fs::path("<default file to read goes here>"), FileSystemPathParameter::PathType::InputFile));
-  params.insert(std::make_unique<NumericTypeParameter>(k_ScalarTypeKey, "Scalar Type", "Type to interpret data as", NumericType::i8));
-  params.insert(std::make_unique<UInt64Parameter>(k_NTuplesKey, "Number of Tuples", "Number of tuples in resulting array (i.e. number of lines to read)", 3));
-  params.insert(std::make_unique<UInt64Parameter>(k_NCompKey, "Number of Components", "Number of columns", 3));
-  params.insert(std::make_unique<UInt64Parameter>(k_NSkipLinesKey, "Skip Header Lines", "Number of lines to skip in the file", 7));
-  params.insert(std::make_unique<ChoicesParameter>(k_DelimiterChoiceKey, "Delimiter", "Delimiter for values on a line", 0,
+      std::make_unique<FileSystemPathParameter>(k_InputFileKey.str(), "Input File", "File to read from", fs::path("<default file to read goes here>"), FileSystemPathParameter::PathType::InputFile));
+  params.insert(std::make_unique<NumericTypeParameter>(k_ScalarTypeKey.str(), "Scalar Type", "Type to interpret data as", NumericType::i8));
+  params.insert(std::make_unique<UInt64Parameter>(k_NTuplesKey.str(), "Number of Tuples", "Number of tuples in resulting array (i.e. number of lines to read)", 3));
+  params.insert(std::make_unique<UInt64Parameter>(k_NCompKey.str(), "Number of Components", "Number of columns", 3));
+  params.insert(std::make_unique<UInt64Parameter>(k_NSkipLinesKey.str(), "Skip Header Lines", "Number of lines to skip in the file", 7));
+  params.insert(std::make_unique<ChoicesParameter>(k_DelimiterChoiceKey.str(), "Delimiter", "Delimiter for values on a line", 0,
                                                    ChoicesParameter::Choices{", (comma)", "; (semicolon)", "  (space)", ": (colon)", "\\t (Tab)"}));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_DataArrayKey, "Created Array", "Array storing the file data", DataPath{}));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_DataArrayKey.str(), "Created Array", "Array storing the file data", DataPath{}));
   return params;
 }
 
@@ -140,10 +141,10 @@ IFilter::UniquePointer ImportTextFilter::clone() const
 
 Result<OutputActions> ImportTextFilter::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler) const
 {
-  auto numericType = args.value<NumericType>(k_ScalarTypeKey);
-  auto arrayPath = args.value<DataPath>(k_DataArrayKey);
-  auto nTuples = args.value<u64>(k_NTuplesKey);
-  auto nComp = args.value<u64>(k_NCompKey);
+  auto numericType = args.value<NumericType>(k_ScalarTypeKey.c_str());
+  auto arrayPath = args.value<DataPath>(k_DataArrayKey.c_str());
+  auto nTuples = args.value<u64>(k_NTuplesKey.c_str());
+  auto nComp = args.value<u64>(k_NCompKey.c_str());
   auto action = std::make_unique<CreateArrayAction>(numericType, std::vector<usize>{nTuples}, nComp, arrayPath);
 
   OutputActions actions;
@@ -154,12 +155,12 @@ Result<OutputActions> ImportTextFilter::preflightImpl(const DataStructure& data,
 
 Result<> ImportTextFilter::executeImpl(DataStructure& data, const Arguments& args, const MessageHandler& messageHandler) const
 {
-  auto inputFilePath = args.value<fs::path>(k_InputFileKey);
-  auto numericType = args.value<NumericType>(k_ScalarTypeKey);
-  auto components = args.value<u64>(k_NCompKey);
-  auto skipLines = args.value<u64>(k_NSkipLinesKey);
-  auto choiceIndex = args.value<u64>(k_DelimiterChoiceKey);
-  auto path = args.value<DataPath>(k_DataArrayKey);
+  auto inputFilePath = args.value<fs::path>(k_InputFileKey.c_str());
+  auto numericType = args.value<NumericType>(k_ScalarTypeKey.c_str());
+  auto components = args.value<u64>(k_NCompKey.c_str());
+  auto skipLines = args.value<u64>(k_NSkipLinesKey.c_str());
+  auto choiceIndex = args.value<u64>(k_DelimiterChoiceKey.c_str());
+  auto path = args.value<DataPath>(k_DataArrayKey.c_str());
 
   char delimiter = IndexToDelimiter(choiceIndex);
 

--- a/src/complex/Core/Filters/ImportTextFilter.cpp
+++ b/src/complex/Core/Filters/ImportTextFilter.cpp
@@ -141,10 +141,10 @@ IFilter::UniquePointer ImportTextFilter::clone() const
 
 Result<OutputActions> ImportTextFilter::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler) const
 {
-  auto numericType = args.value<NumericType>(k_ScalarTypeKey.c_str());
-  auto arrayPath = args.value<DataPath>(k_DataArrayKey.c_str());
-  auto nTuples = args.value<u64>(k_NTuplesKey.c_str());
-  auto nComp = args.value<u64>(k_NCompKey.c_str());
+  auto numericType = args.value<NumericType>(k_ScalarTypeKey.view());
+  auto arrayPath = args.value<DataPath>(k_DataArrayKey.view());
+  auto nTuples = args.value<u64>(k_NTuplesKey.view());
+  auto nComp = args.value<u64>(k_NCompKey.view());
   auto action = std::make_unique<CreateArrayAction>(numericType, std::vector<usize>{nTuples}, nComp, arrayPath);
 
   OutputActions actions;
@@ -155,12 +155,12 @@ Result<OutputActions> ImportTextFilter::preflightImpl(const DataStructure& data,
 
 Result<> ImportTextFilter::executeImpl(DataStructure& data, const Arguments& args, const MessageHandler& messageHandler) const
 {
-  auto inputFilePath = args.value<fs::path>(k_InputFileKey.c_str());
-  auto numericType = args.value<NumericType>(k_ScalarTypeKey.c_str());
-  auto components = args.value<u64>(k_NCompKey.c_str());
-  auto skipLines = args.value<u64>(k_NSkipLinesKey.c_str());
-  auto choiceIndex = args.value<u64>(k_DelimiterChoiceKey.c_str());
-  auto path = args.value<DataPath>(k_DataArrayKey.c_str());
+  auto inputFilePath = args.value<fs::path>(k_InputFileKey.view());
+  auto numericType = args.value<NumericType>(k_ScalarTypeKey.view());
+  auto components = args.value<u64>(k_NCompKey.view());
+  auto skipLines = args.value<u64>(k_NSkipLinesKey.view());
+  auto choiceIndex = args.value<u64>(k_DelimiterChoiceKey.view());
+  auto path = args.value<DataPath>(k_DataArrayKey.view());
 
   char delimiter = IndexToDelimiter(choiceIndex);
 

--- a/src/complex/Core/Filters/TestFilter1.cpp
+++ b/src/complex/Core/Filters/TestFilter1.cpp
@@ -1,5 +1,6 @@
 #include "TestFilter1.hpp"
 
+#include "complex/Common/StringLiteral.hpp"
 #include "complex/Core/Parameters/BoolParameter.hpp"
 #include "complex/Core/Parameters/GeneratedFileListParameter.hpp"
 #include "complex/Core/Parameters/NumberParameter.hpp"
@@ -8,16 +9,16 @@ using namespace complex;
 
 namespace
 {
-constexpr const char k_Param1[] = "param1";
-constexpr const char k_Param2[] = "param2";
-constexpr const char k_Param3[] = "param3";
+constexpr StringLiteral k_Param1 = "param1";
+constexpr StringLiteral k_Param2 = "param2";
+constexpr StringLiteral k_Param3 = "param3";
 } // namespace
 
 namespace complex
 {
 std::string TestFilter1::name() const
 {
-  return FilterTraits<TestFilter1>::name;
+  return FilterTraits<TestFilter1>::name.str();
 }
 
 Uuid TestFilter1::uuid() const
@@ -33,9 +34,9 @@ std::string TestFilter1::humanName() const
 Parameters TestFilter1::parameters() const
 {
   Parameters params;
-  params.insert(std::make_unique<Float32Parameter>(k_Param1, "Parameter 1", "The 1st parameter", 0.1234f));
-  params.insert(std::make_unique<BoolParameter>(k_Param2, "Parameter 2", "The 2nd parameter", false));
-  params.insert(std::make_unique<GeneratedFileListParameter>(k_Param3, "Input File List", "Data needed to generate the input file list", GeneratedFileListParameter::ValueType{}));
+  params.insert(std::make_unique<Float32Parameter>(k_Param1.str(), "Parameter 1", "The 1st parameter", 0.1234f));
+  params.insert(std::make_unique<BoolParameter>(k_Param2.str(), "Parameter 2", "The 2nd parameter", false));
+  params.insert(std::make_unique<GeneratedFileListParameter>(k_Param3.str(), "Input File List", "Data needed to generate the input file list", GeneratedFileListParameter::ValueType{}));
   return params;
 }
 

--- a/src/complex/Core/Filters/TestFilter2.cpp
+++ b/src/complex/Core/Filters/TestFilter2.cpp
@@ -1,5 +1,6 @@
 #include "TestFilter2.hpp"
 
+#include "complex/Common/StringLiteral.hpp"
 #include "complex/Core/Parameters/ChoicesParameter.hpp"
 #include "complex/Core/Parameters/NumberParameter.hpp"
 #include "complex/Core/Parameters/StringParameter.hpp"
@@ -8,16 +9,16 @@ using namespace complex;
 
 namespace
 {
-constexpr const char k_Param1[] = "param1";
-constexpr const char k_Param2[] = "param2";
-constexpr const char k_Param3[] = "param3";
+constexpr StringLiteral k_Param1 = "param1";
+constexpr StringLiteral k_Param2 = "param2";
+constexpr StringLiteral k_Param3 = "param3";
 } // namespace
 
 namespace complex
 {
 std::string TestFilter2::name() const
 {
-  return FilterTraits<TestFilter2>::name;
+  return FilterTraits<TestFilter2>::name.str();
 }
 
 Uuid TestFilter2::uuid() const
@@ -33,9 +34,9 @@ std::string TestFilter2::humanName() const
 Parameters TestFilter2::parameters() const
 {
   Parameters params;
-  params.insert(std::make_unique<Int32Parameter>(k_Param1, "Parameter 1", "The 1st parameter", 0));
-  params.insert(std::make_unique<StringParameter>(k_Param2, "Parameter 2", "The 2nd parameter", "test string"));
-  params.insert(std::make_unique<ChoicesParameter>(k_Param3, "Parameter 3", "The 3rd parameter", 0, ChoicesParameter::Choices{"foo", "bar", "baz"}));
+  params.insert(std::make_unique<Int32Parameter>(k_Param1.str(), "Parameter 1", "The 1st parameter", 0));
+  params.insert(std::make_unique<StringParameter>(k_Param2.str(), "Parameter 2", "The 2nd parameter", "test string"));
+  params.insert(std::make_unique<ChoicesParameter>(k_Param3.str(), "Parameter 3", "The 3rd parameter", 0, ChoicesParameter::Choices{"foo", "bar", "baz"}));
   return params;
 }
 

--- a/src/complex/Core/Parameters/FileSystemPathParameter.cpp
+++ b/src/complex/Core/Parameters/FileSystemPathParameter.cpp
@@ -1,5 +1,7 @@
 #include "FileSystemPathParameter.hpp"
 
+#include "complex/Common/StringLiteral.hpp"
+
 #include <fmt/core.h>
 
 #include <nlohmann/json.hpp>
@@ -10,7 +12,7 @@ using namespace complex;
 
 namespace
 {
-constexpr const char k_PathKey[] = "path";
+constexpr StringLiteral k_PathKey = "path";
 
 //-----------------------------------------------------------------------------
 Result<> ValidateInputFile(const FileSystemPathParameter::ValueType& path)
@@ -90,7 +92,7 @@ nlohmann::json FileSystemPathParameter::toJson(const std::any& value) const
 {
   ValueType path = std::any_cast<ValueType>(value);
   nlohmann::json json;
-  json[k_PathKey] = path.string();
+  json[k_PathKey.c_str()] = path.string();
   return json;
 }
 

--- a/src/complex/Core/Parameters/GeneratedFileListParameter.cpp
+++ b/src/complex/Core/Parameters/GeneratedFileListParameter.cpp
@@ -1,5 +1,6 @@
 #include "GeneratedFileListParameter.hpp"
 
+#include "complex/Common/StringLiteral.hpp"
 #include "complex/Core/Parameters/utils/FilePathGenerator.hpp"
 
 #include <filesystem>
@@ -15,15 +16,15 @@ namespace complex
 {
 namespace
 {
-constexpr const char k_StartIndex[] = "startIndex";
-constexpr const char k_EndIndex[] = "endIndex";
-constexpr const char k_PaddingDigits[] = "paddingDigits";
-constexpr const char k_Ordering[] = "ordering";
-constexpr const char k_IncrementIndex[] = "incrementIndex";
-constexpr const char k_InputPath[] = "inputPath";
-constexpr const char k_FilePrefix[] = "filePrefix";
-constexpr const char k_FileSuffix[] = "fileSuffix";
-constexpr const char k_FileExtension[] = "fileExtension";
+constexpr StringLiteral k_StartIndex = "startIndex";
+constexpr StringLiteral k_EndIndex = "endIndex";
+constexpr StringLiteral k_PaddingDigits = "paddingDigits";
+constexpr StringLiteral k_Ordering = "ordering";
+constexpr StringLiteral k_IncrementIndex = "incrementIndex";
+constexpr StringLiteral k_InputPath = "inputPath";
+constexpr StringLiteral k_FilePrefix = "filePrefix";
+constexpr StringLiteral k_FileSuffix = "fileSuffix";
+constexpr StringLiteral k_FileExtension = "fileExtension";
 } // namespace
 
 //-----------------------------------------------------------------------------
@@ -50,15 +51,15 @@ nlohmann::json GeneratedFileListParameter::toJson(const std::any& value) const
 {
   auto data = std::any_cast<ValueType>(value);
   nlohmann::json json;
-  json[k_StartIndex] = data.startIndex;
-  json[k_EndIndex] = data.endIndex;
-  json[k_PaddingDigits] = data.paddingDigits;
-  json[k_Ordering] = static_cast<std::underlying_type_t<Ordering>>(data.ordering);
-  json[k_IncrementIndex] = data.incrementIndex;
-  json[k_InputPath] = data.inputPath;
-  json[k_FilePrefix] = data.filePrefix;
-  json[k_FileSuffix] = data.fileSuffix;
-  json[k_FileExtension] = data.fileExtension;
+  json[k_StartIndex.c_str()] = data.startIndex;
+  json[k_EndIndex.c_str()] = data.endIndex;
+  json[k_PaddingDigits.c_str()] = data.paddingDigits;
+  json[k_Ordering.c_str()] = static_cast<std::underlying_type_t<Ordering>>(data.ordering);
+  json[k_IncrementIndex.c_str()] = data.incrementIndex;
+  json[k_InputPath.c_str()] = data.inputPath;
+  json[k_FilePrefix.c_str()] = data.filePrefix;
+  json[k_FileSuffix.c_str()] = data.fileSuffix;
+  json[k_FileExtension.c_str()] = data.fileExtension;
   return json;
 }
 
@@ -78,21 +79,21 @@ Result<std::any> GeneratedFileListParameter::fromJson(const nlohmann::json& json
                                               fmt::format("{}}The JSON data entry for key \"{}\" is not in the form of a JSON Object.", prefix, name()));
   }
 
-  uint32_t ordering_check = json[k_Ordering].get<uint32_t>();
+  uint32_t ordering_check = json[k_Ordering.c_str()].get<uint32_t>();
   if(ordering_check != static_cast<uint32_t>(Ordering::LowToHigh) && ordering_check != static_cast<uint32_t>(Ordering::HighToLow))
   {
     return complex::MakeErrorResult<std::any>(
         complex::FilterParameter::Constants::k_Json_Value_Not_Enumeration,
-        fmt::format("{}JSON value for key \"{}\" was not a valid ordering Value. [{}|{}] allowed.", prefix, k_Ordering, Ordering::LowToHigh, Ordering::HighToLow));
+        fmt::format("{}JSON value for key \"{}\" was not a valid ordering Value. [{}|{}] allowed.", prefix, k_Ordering.view(), Ordering::LowToHigh, Ordering::HighToLow));
   }
 
-  if(!json[k_PaddingDigits].is_number_unsigned())
+  if(!json[k_PaddingDigits.c_str()].is_number_unsigned())
   {
     return complex::MakeErrorResult<std::any>(complex::FilterParameter::Constants::k_Json_Value_Not_Unsigned,
-                                              fmt::format("{}JSON value for key \"{}\" is not an unsigned int", prefix, k_PaddingDigits));
+                                              fmt::format("{}JSON value for key \"{}\" is not an unsigned int", prefix, k_PaddingDigits.c_str()));
   }
 
-  std::vector<std::string> keys = {k_StartIndex, k_EndIndex, k_PaddingDigits, k_Ordering, k_IncrementIndex};
+  std::vector<const char*> keys = {k_StartIndex.c_str(), k_EndIndex.c_str(), k_PaddingDigits.c_str(), k_Ordering.c_str(), k_IncrementIndex.c_str()};
   for(const auto& key : keys)
   {
     if(!json[key].is_number_integer())
@@ -101,7 +102,7 @@ Result<std::any> GeneratedFileListParameter::fromJson(const nlohmann::json& json
     }
   }
 
-  keys = {k_InputPath, k_FilePrefix, k_FileSuffix, k_FileExtension};
+  keys = {k_InputPath.c_str(), k_FilePrefix.c_str(), k_FileSuffix.c_str(), k_FileExtension.c_str()};
   for(const auto& key : keys)
   {
     if(!json[key].is_string())
@@ -112,15 +113,15 @@ Result<std::any> GeneratedFileListParameter::fromJson(const nlohmann::json& json
 
   ValueType value;
 
-  value.paddingDigits = json[k_PaddingDigits].get<int32_t>();
-  value.ordering = static_cast<Ordering>(json[k_Ordering].get<uint32_t>());
-  value.incrementIndex = json[k_IncrementIndex].get<int32_t>();
-  value.inputPath = json[k_InputPath].get<std::string>();
-  value.filePrefix = json[k_FilePrefix].get<std::string>();
-  value.fileSuffix = json[k_FileSuffix].get<std::string>();
-  value.fileExtension = json[k_FileExtension].get<std::string>();
-  value.startIndex = json[k_StartIndex].get<int32_t>();
-  value.endIndex = json[k_EndIndex].get<int32_t>();
+  value.paddingDigits = json[k_PaddingDigits.c_str()].get<int32_t>();
+  value.ordering = static_cast<Ordering>(json[k_Ordering.c_str()].get<uint32_t>());
+  value.incrementIndex = json[k_IncrementIndex.c_str()].get<int32_t>();
+  value.inputPath = json[k_InputPath.c_str()].get<std::string>();
+  value.filePrefix = json[k_FilePrefix.c_str()].get<std::string>();
+  value.fileSuffix = json[k_FileSuffix.c_str()].get<std::string>();
+  value.fileExtension = json[k_FileExtension.c_str()].get<std::string>();
+  value.startIndex = json[k_StartIndex.c_str()].get<int32_t>();
+  value.endIndex = json[k_EndIndex.c_str()].get<int32_t>();
 
   return {value};
 }

--- a/src/complex/Core/Parameters/GeneratedFileListParameter.cpp
+++ b/src/complex/Core/Parameters/GeneratedFileListParameter.cpp
@@ -90,7 +90,7 @@ Result<std::any> GeneratedFileListParameter::fromJson(const nlohmann::json& json
   if(!json[k_PaddingDigits.c_str()].is_number_unsigned())
   {
     return complex::MakeErrorResult<std::any>(complex::FilterParameter::Constants::k_Json_Value_Not_Unsigned,
-                                              fmt::format("{}JSON value for key \"{}\" is not an unsigned int", prefix, k_PaddingDigits.c_str()));
+                                              fmt::format("{}JSON value for key \"{}\" is not an unsigned int", prefix, k_PaddingDigits.view()));
   }
 
   std::vector<const char*> keys = {k_StartIndex.c_str(), k_EndIndex.c_str(), k_PaddingDigits.c_str(), k_Ordering.c_str(), k_IncrementIndex.c_str()};

--- a/src/complex/Filter/Arguments.cpp
+++ b/src/complex/Filter/Arguments.cpp
@@ -1,20 +1,29 @@
 #include "Arguments.hpp"
 
+#include <stdexcept>
+
+#include <fmt/core.h>
+
 namespace complex
 {
-void Arguments::insert(const std::string& key, const std::any& value)
+void Arguments::insert(std::string key, const std::any& value)
 {
-  m_Args.insert({key, value});
+  m_Args.insert({std::move(key), value});
 }
 
-void Arguments::insert(const std::string& key, std::any&& value)
+void Arguments::insert(std::string key, std::any&& value)
 {
-  m_Args.insert({key, value});
+  m_Args.insert({std::move(key), value});
 }
 
-const std::any& Arguments::at(const std::string& key) const
+const std::any& Arguments::at(std::string_view key) const
 {
-  return m_Args.at(key);
+  auto iter = m_Args.find(key);
+  if(iter == m_Args.cend())
+  {
+    throw std::out_of_range(fmt::format("Key \"{}\" does not exist in Arguments", key));
+  }
+  return iter->second;
 }
 
 usize Arguments::size() const
@@ -27,7 +36,7 @@ bool Arguments::empty() const
   return m_Args.empty();
 }
 
-bool Arguments::contains(const std::string& key) const
+bool Arguments::contains(std::string_view key) const
 {
   return m_Args.count(key) > 0;
 }

--- a/src/complex/Filter/Arguments.hpp
+++ b/src/complex/Filter/Arguments.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <type_traits>
 
 #include "complex/Common/Types.hpp"
@@ -31,21 +32,21 @@ public:
    * @param key
    * @param value
    */
-  void insert(const std::string& key, const std::any& value);
+  void insert(std::string key, const std::any& value);
 
   /**
    * @brief Insert the given key value pair.
    * @param key
    * @param value
    */
-  void insert(const std::string& key, std::any&& value);
+  void insert(std::string key, std::any&& value);
 
   /**
    * @brief Returns a const reference to the value at the given key.
    * @param key
    * @return
    */
-  [[nodiscard]] const std::any& at(const std::string& key) const;
+  [[nodiscard]] const std::any& at(std::string_view key) const;
 
   /**
    * @brief Returns a const reference to the value at the given key cast to T.
@@ -55,9 +56,9 @@ public:
    * @return
    */
   template <class T>
-  [[nodiscard]] const T& valueRef(const std::string& key) const
+  [[nodiscard]] const T& valueRef(std::string_view key) const
   {
-    const T* value = std::any_cast<T>(&m_Args.at(key));
+    const T* value = std::any_cast<T>(&at(key));
     if(value == nullptr)
     {
       throw std::bad_any_cast();
@@ -73,9 +74,9 @@ public:
    * @return
    */
   template <class T>
-  [[nodiscard]] T value(const std::string& key) const
+  [[nodiscard]] T value(std::string_view key) const
   {
-    return std::any_cast<T>(m_Args.at(key));
+    return std::any_cast<T>(at(key));
   }
 
   /**
@@ -86,9 +87,9 @@ public:
    * @return
    */
   template <class T>
-  [[nodiscard]] T& ref(const std::string& key) const
+  [[nodiscard]] T& ref(std::string_view key) const
   {
-    return std::any_cast<std::reference_wrapper<T>>(m_Args.at(key)).get();
+    return std::any_cast<std::reference_wrapper<T>>(at(key)).get();
   }
 
   /**
@@ -108,7 +109,7 @@ public:
    * @param key
    * @return
    */
-  [[nodiscard]] bool contains(const std::string& key) const;
+  [[nodiscard]] bool contains(std::string_view key) const;
 
   [[nodiscard]] auto begin()
   {
@@ -131,6 +132,6 @@ public:
   }
 
 private:
-  std::map<std::string, std::any> m_Args;
+  std::map<std::string, std::any, std::less<>> m_Args;
 };
 } // namespace complex

--- a/src/complex/Filter/FilterTraits.hpp
+++ b/src/complex/Filter/FilterTraits.hpp
@@ -2,6 +2,7 @@
 
 #include <type_traits>
 
+#include "complex/Common/StringLiteral.hpp"
 #include "complex/Filter/IFilter.hpp"
 
 namespace complex
@@ -20,7 +21,7 @@ struct FilterTraits
   template <>                                                                                                                                                                                          \
   struct complex::FilterTraits<type>                                                                                                                                                                   \
   {                                                                                                                                                                                                    \
-    static inline constexpr const char* name = nameString;                                                                                                                                             \
+    static inline constexpr complex::StringLiteral name = nameString;                                                                                                                                  \
     static inline constexpr complex::Uuid uuid = *complex::Uuid::FromString(uuidString);                                                                                                               \
   }
 

--- a/src/complex/Filter/ParameterTraits.hpp
+++ b/src/complex/Filter/ParameterTraits.hpp
@@ -2,6 +2,7 @@
 
 #include <type_traits>
 
+#include "complex/Common/StringLiteral.hpp"
 #include "complex/Filter/IParameter.hpp"
 
 namespace complex
@@ -20,7 +21,7 @@ struct ParameterTraits
   template <>                                                                                                                                                                                          \
   struct complex::ParameterTraits<type>                                                                                                                                                                \
   {                                                                                                                                                                                                    \
-    static inline constexpr const char* name = nameString;                                                                                                                                             \
+    static inline constexpr complex::StringLiteral name = nameString;                                                                                                                                  \
     static inline constexpr complex::Uuid uuid = *complex::Uuid::FromString(uuidString);                                                                                                               \
   }
 

--- a/src/complex/Filter/Parameters.cpp
+++ b/src/complex/Filter/Parameters.cpp
@@ -2,7 +2,7 @@
 
 namespace
 {
-void cloneParams(const std::map<std::string, std::unique_ptr<complex::IParameter>>& inputParams, std::map<std::string, std::unique_ptr<complex::IParameter>>& outputParams)
+void cloneParams(const std::map<std::string, std::unique_ptr<complex::IParameter>, std::less<>>& inputParams, std::map<std::string, std::unique_ptr<complex::IParameter>, std::less<>>& outputParams)
 {
   for(const auto& [key, value] : inputParams)
   {

--- a/src/complex/Filter/Parameters.hpp
+++ b/src/complex/Filter/Parameters.hpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include "complex/Common/Types.hpp"
 #include "complex/Filter/IParameter.hpp"
@@ -30,7 +31,7 @@ public:
    * @param name
    * @return
    */
-  bool contains(const std::string& name) const
+  bool contains(std::string_view name) const
   {
     return m_Params.count(name) > 0;
   }
@@ -80,6 +81,6 @@ public:
   }
 
 private:
-  std::map<std::string, std::unique_ptr<IParameter>> m_Params;
+  std::map<std::string, std::unique_ptr<IParameter>, std::less<>> m_Params;
 };
 } // namespace complex

--- a/test/ArgumentsTest.cpp
+++ b/test/ArgumentsTest.cpp
@@ -2,22 +2,23 @@
 
 #include <catch2/catch.hpp>
 
+#include <complex/Common/StringLiteral.hpp>
 #include <complex/Filter/Arguments.hpp>
 
-using namespace complex::types;
+using namespace complex;
 
 TEST_CASE("ArgumentsTest")
 {
-  static constexpr char k_FooKey[] = "foo";
-  complex::Arguments args;
+  static constexpr StringLiteral k_FooKey = "foo";
+  Arguments args;
 
   SECTION("insert and retrieve primitive")
   {
     static constexpr i32 k_FooValue = 42;
 
-    args.insert(k_FooKey, k_FooValue);
+    args.insert(k_FooKey.str(), k_FooValue);
 
-    auto value = args.value<i32>(k_FooKey);
+    auto value = args.value<i32>(k_FooKey.view());
 
     REQUIRE(value == k_FooValue);
   }
@@ -25,9 +26,9 @@ TEST_CASE("ArgumentsTest")
   {
     const std::string k_FooValue = "value";
 
-    args.insert(k_FooKey, k_FooValue);
+    args.insert(k_FooKey.str(), k_FooValue);
 
-    auto value = args.value<std::string>(k_FooKey);
+    auto value = args.value<std::string>(k_FooKey.view());
 
     REQUIRE(value == k_FooValue);
   }
@@ -35,9 +36,9 @@ TEST_CASE("ArgumentsTest")
   {
     const std::string k_FooValue = "value";
 
-    args.insert(k_FooKey, k_FooValue);
+    args.insert(k_FooKey.str(), k_FooValue);
 
-    const auto& value = args.valueRef<std::string>(k_FooKey);
+    const auto& value = args.valueRef<std::string>(k_FooKey.view());
 
     REQUIRE(value == k_FooValue);
   }
@@ -45,9 +46,9 @@ TEST_CASE("ArgumentsTest")
   {
     i32 value = 42;
 
-    args.insert(k_FooKey, std::ref(value));
+    args.insert(k_FooKey.str(), std::ref(value));
 
-    auto& valueRefWrapper = args.ref<i32>(k_FooKey);
+    auto& valueRefWrapper = args.ref<i32>(k_FooKey.view());
 
     REQUIRE(&value == &valueRefWrapper);
     REQUIRE(value == valueRefWrapper);
@@ -60,9 +61,9 @@ TEST_CASE("ArgumentsTest")
   {
     i32 value = 42;
 
-    args.insert(k_FooKey, std::cref(value));
+    args.insert(k_FooKey.str(), std::cref(value));
 
-    const auto& valueRefWrapper = args.ref<const i32>(k_FooKey);
+    const auto& valueRefWrapper = args.ref<const i32>(k_FooKey.view());
 
     REQUIRE(&value == &valueRefWrapper);
     REQUIRE(value == valueRefWrapper);
@@ -71,13 +72,13 @@ TEST_CASE("ArgumentsTest")
   {
     static constexpr i32 k_Value = 42;
 
-    args.insert(k_FooKey, k_Value);
+    args.insert(k_FooKey.str(), k_Value);
 
-    REQUIRE(args.contains(k_FooKey));
+    REQUIRE(args.contains(k_FooKey.view()));
   }
   SECTION("not contains test")
   {
-    REQUIRE(!args.contains(k_FooKey));
+    REQUIRE(!args.contains(k_FooKey.view()));
   }
   SECTION("size test")
   {

--- a/test/CoreFilterTest.cpp
+++ b/test/CoreFilterTest.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch.hpp>
 
+#include "complex/Common/StringLiteral.hpp"
 #include "complex/Core/Application.hpp"
 #include "complex/Core/Filters/ImportTextFilter.hpp"
 #include "complex/Core/Parameters/FileSystemPathParameter.hpp"
@@ -58,12 +59,12 @@ TEST_CASE("Create Core Filter")
 
 TEST_CASE("RunCoreFilter")
 {
-  static constexpr const char* k_FileName = "ascii_data.txt";
+  static const fs::path k_FileName = "ascii_data.txt";
   static constexpr u64 k_NLines = 25;
 
   SECTION("Create ASCII File")
   {
-    std::ofstream file(k_FileName);
+    std::ofstream file(k_FileName.c_str());
     for(i32 i = 0; i < k_NLines; i++)
     {
       file << i << "," << i + 1 << "," << i + 2 << "\n";

--- a/test/FilePathGeneratorTest.cpp
+++ b/test/FilePathGeneratorTest.cpp
@@ -19,7 +19,7 @@ TEST_CASE("FilePathGenerator")
   value.filePrefix = "TestFilter";
   value.fileSuffix = "";
   value.fileExtension = ".cpp";
-  value.inputPath = fmt::format("{}/src/complex/Core/Filters/", unit_test::k_ComplexSourceDir);
+  value.inputPath = fmt::format("{}/src/complex/Core/Filters/", unit_test::k_ComplexSourceDir.view());
   value.ordering = GeneratedFileListParameter::Ordering::LowToHigh;
 
   bool missingFiles = false;

--- a/test/Plugin/Test2Filter.cpp
+++ b/test/Plugin/Test2Filter.cpp
@@ -8,7 +8,7 @@ Test2Filter::~Test2Filter() = default;
 
 std::string Test2Filter::name() const
 {
-  return FilterTraits<Test2Filter>::name;
+  return FilterTraits<Test2Filter>::name.str();
 }
 
 complex::Uuid Test2Filter::uuid() const

--- a/test/Plugin/TestFilter.cpp
+++ b/test/Plugin/TestFilter.cpp
@@ -8,7 +8,7 @@ TestFilter::~TestFilter() = default;
 
 std::string TestFilter::name() const
 {
-  return FilterTraits<TestFilter>::name;
+  return FilterTraits<TestFilter>::name.str();
 }
 
 complex::Uuid TestFilter::uuid() const

--- a/test/UuidTest.cpp
+++ b/test/UuidTest.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch.hpp>
 
+#include "complex/Common/StringLiteral.hpp"
 #include "complex/Common/Uuid.hpp"
 
 using namespace complex;
@@ -8,10 +9,10 @@ TEST_CASE("UuidTest")
 {
   SECTION("default")
   {
-    constexpr const char k_UuidString[] = "b6936d18-7476-4855-9e13-e795d717c50f";
+    constexpr StringLiteral k_UuidString = "b6936d18-7476-4855-9e13-e795d717c50f";
     constexpr std::array<std::byte, 16> k_UuidBytes = {std::byte{0xb6u}, std::byte{0x93u}, std::byte{0x6du}, std::byte{0x18u}, std::byte{0x74u}, std::byte{0x76u}, std::byte{0x48u}, std::byte{0x55u},
                                                        std::byte{0x9eu}, std::byte{0x13u}, std::byte{0xe7u}, std::byte{0x95u}, std::byte{0xd7u}, std::byte{0x17u}, std::byte{0xc5u}, std::byte{0x0fu}};
-    std::optional<Uuid> uuid = Uuid::FromString(k_UuidString);
+    std::optional<Uuid> uuid = Uuid::FromString(k_UuidString.view());
 
     REQUIRE(uuid.has_value());
 
@@ -25,14 +26,14 @@ TEST_CASE("UuidTest")
     REQUIRE(uuid->clock_seq_low() == 0x13u);
     REQUIRE(uuid->node() == 0xe795d717c50full);
 
-    REQUIRE(uuid->str() == k_UuidString);
+    REQUIRE(uuid->str() == k_UuidString.view());
   }
   SECTION("leading zeros")
   {
-    constexpr const char k_UuidString[] = "00ab00ff-00ab-0abc-0508-00000ff00000";
+    constexpr StringLiteral k_UuidString = "00ab00ff-00ab-0abc-0508-00000ff00000";
     constexpr std::array<std::byte, 16> k_UuidBytes = {std::byte{0x00u}, std::byte{0xabu}, std::byte{0x00u}, std::byte{0xffu}, std::byte{0x00u}, std::byte{0xabu}, std::byte{0x0au}, std::byte{0xbcu},
                                                        std::byte{0x05u}, std::byte{0x08u}, std::byte{0x00u}, std::byte{0x00u}, std::byte{0x0fu}, std::byte{0xf0u}, std::byte{0x00u}, std::byte{0x00u}};
-    std::optional<Uuid> uuid = Uuid::FromString(k_UuidString);
+    std::optional<Uuid> uuid = Uuid::FromString(k_UuidString.view());
 
     REQUIRE(uuid.has_value());
 
@@ -46,7 +47,7 @@ TEST_CASE("UuidTest")
     REQUIRE(uuid->clock_seq_low() == 0x08u);
     REQUIRE(uuid->node() == 0x00000ff00000ull);
 
-    REQUIRE(uuid->str() == k_UuidString);
+    REQUIRE(uuid->str() == k_UuidString.view());
   }
   SECTION("comparison")
   {

--- a/test/complex_test_dirs.h.in
+++ b/test/complex_test_dirs.h.in
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "complex/Common/StringLiteral.hpp"
+
 namespace complex
 {
 namespace unit_test
 {
-constexpr const char k_ComplexSourceDir[] = "@complex_SOURCE_DIR_NORM@";
+constexpr StringLiteral k_ComplexSourceDir = "@complex_SOURCE_DIR_NORM@";
 }
 } // namespace complex


### PR DESCRIPTION
* Allows easy access to size of a literal
* Replaced uses of `static inline constexpr const char*` with `static inline constexpr StringLiteral`