### PR TITLE
Feature/export h5 data filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ set(CoreFilters
   CreateDataArray
   CreateDataGroup
   ImportTextFilter
+  ExportH5DataFilter
   TestFilter1
   TestFilter2
 )

--- a/src/complex/Core/Filters/ExportH5DataFilter.cpp
+++ b/src/complex/Core/Filters/ExportH5DataFilter.cpp
@@ -43,7 +43,7 @@ Result<OutputActions> ExportH5DataFilter::preflightImpl(const DataStructure& dat
     return {nonstd::make_unexpected(std::vector<Error>{Error{-1, "Export file path not provided."}})};
   }
   auto exportDirectoryPath = h5FilePath.parent_path();
-  if(std::filesystem::exists(exportDirectoryPath))
+  if(std::filesystem::exists(exportDirectoryPath) == false)
   {
     return {nonstd::make_unexpected(std::vector<Error>{Error{-3, "Export parent directory does not exist."}})};
   }

--- a/src/complex/Core/Filters/ExportH5DataFilter.cpp
+++ b/src/complex/Core/Filters/ExportH5DataFilter.cpp
@@ -1,0 +1,61 @@
+#include "ExportH5DataFilter.hpp"
+
+#include "complex/Core/Parameters/FileSystemPathParameter.hpp"
+#include "complex/Core/Parameters/StringParameter.hpp"
+#include "complex/DataStructure/DataGroup.hpp"
+#include "complex/Utilities/Parsing/HDF5/H5FileWriter.hpp"
+
+namespace complex
+{
+std::string ExportH5DataFilter::name() const
+{
+  return FilterTraits<ExportH5DataFilter>::name;
+}
+
+Uuid ExportH5DataFilter::uuid() const
+{
+  return FilterTraits<ExportH5DataFilter>::uuid;
+}
+
+std::string ExportH5DataFilter::humanName() const
+{
+  return "Export HDF5 Data Filter";
+}
+
+Parameters ExportH5DataFilter::parameters() const
+{
+  Parameters params;
+  params.insert(std::make_unique<FileSystemPathParameter>(k_ExportFilePath, "Export File Path", "The file path the DataStructure should be written to as an HDF5 file.", "",
+                                                          FileSystemPathParameter::PathType::OutputFile));
+  return params;
+}
+
+IFilter::UniquePointer ExportH5DataFilter::clone() const
+{
+  return std::make_unique<ExportH5DataFilter>();
+}
+
+Result<OutputActions> ExportH5DataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler) const
+{
+  auto h5FilePath = args.value<std::filesystem::path>(k_ExportFilePath);
+  if(h5FilePath.empty())
+  {
+    return {nonstd::make_unexpected(std::vector<Error>{Error{-1, "Export file path not provided."}})};
+  }
+  auto exportDirectoryPath = h5FilePath.parent_path();
+  if(std::filesystem::exists(exportDirectoryPath))
+  {
+    return {nonstd::make_unexpected(std::vector<Error>{Error{-3, "Export parent directory does not exist."}})};
+  }
+  return {};
+}
+
+Result<> ExportH5DataFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler) const
+{
+  auto h5FilePath = args.value<std::filesystem::path>(k_ExportFilePath);
+  H5::FileWriter fileWriter(h5FilePath);
+  dataStructure.writeHdf5(fileWriter);
+
+  return {};
+}
+} // namespace complex

--- a/src/complex/Core/Filters/ExportH5DataFilter.cpp
+++ b/src/complex/Core/Filters/ExportH5DataFilter.cpp
@@ -54,7 +54,11 @@ Result<> ExportH5DataFilter::executeImpl(DataStructure& dataStructure, const Arg
 {
   auto h5FilePath = args.value<std::filesystem::path>(k_ExportFilePath);
   H5::FileWriter fileWriter(h5FilePath);
-  dataStructure.writeHdf5(fileWriter);
+  auto errorCode = dataStructure.writeHdf5(fileWriter);
+  if(errorCode < 0)
+  {
+    return {nonstd::make_unexpected(std::vector<Error>{Error{errorCode, "Failed to write DataStructure to HDF5 file."}})};
+  }
 
   return {};
 }

--- a/src/complex/Core/Filters/ExportH5DataFilter.hpp
+++ b/src/complex/Core/Filters/ExportH5DataFilter.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "complex/Filter/Arguments.hpp"
+#include "complex/Filter/FilterTraits.hpp"
+#include "complex/Filter/IFilter.hpp"
+#include "complex/Filter/Parameters.hpp"
+#include "complex/complex_export.hpp"
+
+namespace complex
+{
+/**
+ * @class ExportH5DataFilter
+ * @brief The ExportH5DataFilter is an IFilter class designed to export the
+ * DataStructure to a target HDF5 file.
+ */
+class COMPLEX_EXPORT ExportH5DataFilter : public IFilter
+{
+public:
+  ExportH5DataFilter() = default;
+  ~ExportH5DataFilter() noexcept override = default;
+
+  ExportH5DataFilter(const ExportH5DataFilter&) = delete;
+  ExportH5DataFilter(ExportH5DataFilter&&) noexcept = delete;
+
+  ExportH5DataFilter& operator=(const ExportH5DataFilter&) = delete;
+  ExportH5DataFilter& operator=(ExportH5DataFilter&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_ExportFilePath = "Export_File_Path";
+
+  /**
+   * @brief Returns the name of the filter class.
+   * @return std::string
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the ExportH5DataFilter class's UUID.
+   * @return Uuid
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief Returns the human readable name of the filter.
+   * @return std::string
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief Returns a collection of the filter's parameters (i.e. its inputs)
+   * @return Parameters
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief Returns a copy of the filter as a std::unique_ptr.
+   * @return UniquePointer
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief Classes that implement IFilter must provide this function for preflight.
+   * Runs after the filter runs the checks in its parameters.
+   * @param dataStructure
+   * @param args
+   * @param messageHandler = {}
+   * @return Result<OutputActions>
+   */
+  Result<OutputActions> preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler = {}) const override;
+
+  /**
+   * @brief Classes that implement IFilter must provide this function for execute.
+   * Runs after the filter applies the OutputActions from preflight.
+   * @param dataStructure
+   * @param args
+   * @param messageHandler = {}
+   * @return Result<>
+   */
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler = {}) const override;
+};
+} // namespace complex
+
+COMPLEX_DEF_FILTER_TRAITS(complex::ExportH5DataFilter, "b3a95784-2ced-11ec-8d3d-0242ac130003");


### PR DESCRIPTION
Added ExportH5DataFilter class for exporting the DataStructure to a target HDF5 file.

* The export file path does not have to exist, but a preflight Error will be returned if the parent directory does not.
* A preflight Error will be returned if the target file path is empty.
* If the DataStructure failed to be written to file during execute, an Error will be returned using the HDF5 error code.