### PR TITLE
Updated ImportDREAM3DFilter with std::optional paths

### DIFF
--- a/src/complex/Parameters/Dream3dImportParameter.cpp
+++ b/src/complex/Parameters/Dream3dImportParameter.cpp
@@ -47,12 +47,19 @@ nlohmann::json Dream3dImportParameter::toJson(const std::any& value) const
   json[k_FilePathKey] = importData.FilePath.string();
 
   // DataPaths
-  nlohmann::json dataPathsJson = nlohmann::json::array();
-  for(const auto& dataPath : importData.DataPaths)
+  if(importData.DataPaths.has_value())
   {
-    dataPathsJson.push_back(dataPath.toString());
+    nlohmann::json dataPathsJson = nlohmann::json::array();
+    for(const auto& dataPath : importData.DataPaths.value())
+    {
+      dataPathsJson.push_back(dataPath.toString());
+    }
+    json[k_DataPathsKey] = std::move(dataPathsJson);
   }
-  json[k_DataPathsKey] = std::move(dataPathsJson);
+  else
+  {
+    json[k_DataPathsKey] = nullptr;
+  }
 
   return json;
 }

--- a/src/complex/Parameters/Dream3dImportParameter.hpp
+++ b/src/complex/Parameters/Dream3dImportParameter.hpp
@@ -6,6 +6,7 @@
 #include "complex/complex_export.hpp"
 
 #include <filesystem>
+#include <optional>
 
 #include "nonstd/span.hpp"
 
@@ -20,8 +21,17 @@ class COMPLEX_EXPORT Dream3dImportParameter : public ValueParameter
 public:
   struct ImportData
   {
+    /**
+     * @brief The path to the .dream3d file to import.
+     */
     std::filesystem::path FilePath;
-    std::vector<complex::DataPath> DataPaths = {};
+
+    /**
+     * @brief Holds an optional vector of the DataPaths to import. If this
+     * value is missing, all available DataPaths will be imported. Otherwise,
+     * only the paths provided will be imported.
+     */
+    std::optional<std::vector<complex::DataPath>> DataPaths = std::nullopt;
   };
 
   using ValueType = ImportData;
@@ -37,32 +47,32 @@ public:
   Dream3dImportParameter& operator=(Dream3dImportParameter&&) noexcept = delete;
 
   /**
-   * @brief
-   * @return
+   * @brief Returns the parameter class's Uuid.
+   * @return Uuid
    */
   Uuid uuid() const override;
 
   /**
-   * @brief
-   * @return
+   * @brief Returns a vector of accepted value types.
+   * @return AcceptedTypes
    */
   AcceptedTypes acceptedTypes() const override;
 
   /**
-   * @brief
+   * @brief Writes the provided value to JSON.
    * @param value
    */
   nlohmann::json toJson(const std::any& value) const override;
 
   /**
-   * @brief
-   * @return
+   * @brief Reads and returns the parameter's values from JSON.
+   * @return Result<std::any>
    */
   Result<std::any> fromJson(const nlohmann::json& json) const override;
 
   /**
-   * @brief
-   * @return
+   * @brief Creates and returns a copy of the parameter.
+   * @return UniquePointer
    */
   UniquePointer clone() const override;
 


### PR DESCRIPTION
* Changed ImportData.DataPaths to std::optional. std::nullopt signifies that all data should be imported. An empty vector is not an expected value and requires feedback for the user.
* Updated ImportDREAM3DFilter accordingly.