### PR TITLE
Adding Raw Binary Reader Filter

### DIFF
--- a/src/Plugins/ComplexCore/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/CMakeLists.txt
@@ -29,6 +29,7 @@ set(FilterList
   MultiThresholdObjects
   PointSampleTriangleGeometryFilter
   QuickSurfaceMeshFilter
+  RawBinaryReaderFilter
   RemoveMinimumSizeFeaturesFilter
   RobustAutomaticThreshold
   ScalarSegmentFeatures
@@ -45,6 +46,7 @@ set(AlgorithmList
   QuickSurfaceMesh
   PointSampleTriangleGeometry
   TupleTransfer
+  RawBinaryReader
   )
 
 create_complex_plugin(NAME ${PLUGIN_NAME}

--- a/src/Plugins/ComplexCore/docs/RawBinaryReader.md
+++ b/src/Plugins/ComplexCore/docs/RawBinaryReader.md
@@ -1,0 +1,93 @@
+# Raw Binary Reader  #
+
+
+## Group (Subgroup) ##
+
+IO (Input)
+
+## Description ##
+
+This **Filter** is designed to read data stored in files on the users system in _binary_ form. The data file should **not** have any type of header before the data in the file. The user should know exactly how the data is stored in the file and properly define this in the user interface. Not correctly identifying the type of data can cause serious issues since this **Filter**  is simply reading the data into a pre-allocated array interpreted as the user defines.
+
+This **Filter**  will error out and block the **Pipeline** from running if the total number of bytes that would need to be read from the file is larger than the actual file itself. The user can use an input file that is actually **larger** than the number of bytes required by the **Filter**; in this case, the **Filter**  will only read the first part of the file unless an amount of bytes to skip is set.
+
+### Scalar Type ###
+
+Computer data comes in 10 basic types on modern 32 bit and 64 bit operating systems. Data can be categorized as either _integer_ or _floating point_. With each of these types, the number of bits that represent the data determine their maximum and minimum values. For integer values, the standard types are 8, 16, 32 and 64 bit (1, 2, 4, and 8 bytes). For floating point values, there are either 32 bit or 64 bit (4 or 8 bytes). Integer types can be either _signed_ or _unsigned_. A signed integer can take negative values. An unsigned integer can only take positive values, but will have twice the positive value range as a signed integer.
+
+The types of data that can be read with this **Filter** include:
+
+    signed Int8
+    unsigned UInt8
+    signed Int16
+    unsigned UInt16
+    signed Int32
+    unsigned UInt32
+    signed Int64
+    unsigned UInt64
+    Float 32 bit
+    Double 64 bit
+
+---
+
+
+### Number of Components ###
+
+This parameter tells the program how many values are present for each _tuple_. For example, a grayscale image would typically have just a single value of type unsigned 8 bit integer at every pixel/voxel. A color image will have at least 3 components for red (R), breen (G) and blue (B), and sometimes 4 values if the alpha (A) channel is also stored. Euler angles are typically stored as a 3 component vector of 32 bit floating point values.
+
+### Endian ###
+
+This parameter tells the program which byte is _most significant_ for multibyte values. Intel architecture computers are little endian while Power PC, Sun Sparc and DEC Alpha CPUs are big endian. Consider the following example:
+
+**Byte Ordering Example for 32 Bit Signed Integer**
+
+| Byte 0 | Byte 1 | Byte 2 | Byte 3 | Interpretation |
+|---|---|---|---|----------------|
+| FF | AA | 00 | 00 | -5636096 (Big Endian) |
+| 00 | 00 | AA | FF | 43775 (Little Endian) |
+
+This setting is _crucial_ to the correct interpretation of the binary data, so the user must be aware of how their binary data was encoded.
+
+
+### Skip Header Bytes ###
+
+If the raw binary file you are reading has a _header_ before the actual data begins, the user can instruct the **Filter** to skip this header portion of the file. The user needs to know how lond the header is in bytes. Another way to use this value is if the user wants to read data out of the interior of a file by skipping a defined number of bytes.
+
+
+## Parameters ##
+
+| Name | Type | Description |
+|------|------| ----------- |
+| Input File | File Path | The input binary file path |
+| Scalar Type | Enumeration | Data type of the binary data |
+| Number of Components | int32_t | The number of values at each tuple |
+| Endian | Enumeration | The endianness of the data |
+| Skip Header Bytes | int32_t | Number of bytes to skip before reading data |
+
+## Required Geometry ##
+
+Not Applicable
+
+## Required Objects ##
+
+None
+
+## Created Objects ##
+
+| Kind | Default Name | Type | Component Dimensions | Description |
+|------|--------------|------|----------------------|-------------|
+| Any  | None     | Any  | Any                  |  Created **Attribute Array** name |
+
+
+
+## Example Pipelines ##
+
+
+
+## License & Copyright ##
+
+Please see the description file distributed with this **Plugin**
+
+## DREAM.3D Mailing Lists ##
+
+If you need more help with a **Filter**, please consider asking your question on the [DREAM.3D Users Google group!](https://groups.google.com/forum/?hl=en#!forum/dream3d-users)

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/RawBinaryReader.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/RawBinaryReader.cpp
@@ -1,0 +1,246 @@
+/* ============================================================================
+ * Copyright (c) 2009-2019 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the following contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *    United States Air Force Prime Contract FA8650-15-D-5231
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "RawBinaryReader.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "complex/Common/ComplexConstants.hpp"
+#include "complex/Common/Types.hpp"
+#include "complex/DataStructure/DataArray.hpp"
+#include "complex/DataStructure/DataStore.hpp"
+
+#if defined(_MSC_VER)
+#define FSEEK _fseeki64
+#else
+#define FSEEK std::fseek
+#endif
+
+namespace complex
+{
+
+namespace
+{
+#ifdef CMP_WORDS_BIGENDIAN
+constexpr int32_t k_EndianCheck = 0;
+#else
+constexpr int32_t k_EndianCheck = 1;
+#endif
+
+constexpr int32_t k_RbrNoError = 0;
+constexpr int32_t k_RbrFileNotOpen = -1000;
+constexpr int32_t k_RbrFileTooSmall = -1010;
+constexpr int32_t k_RbrFileTooBig = -1020;
+constexpr int32_t k_RbrReadEOF = -1030;
+constexpr int32_t k_RbrDAError = -1040;
+constexpr int32_t k_RbrComponentError = -1050;
+constexpr int32_t k_RbrDANull = -1060;
+
+// -----------------------------------------------------------------------------
+int32_t SanityCheckFileSizeVersusAllocatedSize(size_t allocatedBytes, size_t fileSize, size_t skipHeaderBytes)
+{
+  if(fileSize - skipHeaderBytes < allocatedBytes)
+  {
+    return -1;
+  }
+  if(fileSize - skipHeaderBytes > allocatedBytes)
+  {
+    return 1;
+  }
+  // File Size and Allocated Size are equal so we are good to go
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+int32_t readBinaryFile(IDataArray* dataArrayPtr, const std::string& filename, uint64_t skipHeaderBytes, ChoicesParameter::ValueType endian)
+{
+  constexpr size_t k_DefaultBlocksize = 1048576;
+
+  DataArray<T>* dataArray = dynamic_cast<DataArray<T>*>(dataArrayPtr);
+
+  if(dataArray == nullptr)
+  {
+    return k_RbrDANull;
+  }
+
+  const size_t fileSize = std::filesystem::file_size(filename);
+  const size_t numBytesToRead = dataArray->getSize() * sizeof(T);
+  int32_t err = SanityCheckFileSizeVersusAllocatedSize(numBytesToRead, fileSize, skipHeaderBytes);
+
+  if(err < 0)
+  {
+    return k_RbrFileTooSmall;
+  }
+  if(err > 0)
+  {
+    return k_RbrFileTooBig;
+  }
+
+  FILE* f = std::fopen(filename.c_str(), "rb");
+  if(f == nullptr)
+  {
+    return k_RbrFileNotOpen;
+  }
+
+  // Skip some header bytes if the user asked for it.
+  if(skipHeaderBytes > 0)
+  {
+    FSEEK(f, skipHeaderBytes, SEEK_SET);
+  }
+
+  //  std::byte* chunkptr = reinterpret_cast<std::byte*>(dataArray->data());
+  std::byte* chunkptr = reinterpret_cast<std::byte*>(dataArray->template getIDataStoreAs<DataStore<T>>()->data());
+
+  // Now start reading the data in chunks if needed.
+  size_t chunkSize = std::min(numBytesToRead, k_DefaultBlocksize);
+
+  size_t master_counter = 0;
+  while(master_counter < numBytesToRead)
+  {
+    size_t bytes_read = std::fread(chunkptr, sizeof(std::byte), chunkSize, f);
+    chunkptr += bytes_read;
+    master_counter += bytes_read;
+
+    size_t bytesLeft = numBytesToRead - master_counter;
+
+    if(bytesLeft < chunkSize)
+    {
+      chunkSize = bytesLeft;
+    }
+  }
+
+  if(endian == k_EndianCheck)
+  {
+    dataArray->byteSwapElements();
+  }
+
+  std::fclose(f);
+
+  return k_RbrNoError;
+}
+} // namespace
+
+using namespace complex;
+
+RawBinaryReader::RawBinaryReader(DataStructure& dataStructure, RawBinaryReaderInputValues* inputValues, const IFilter* filter, const IFilter::MessageHandler& mesgHandler)
+: m_DataStructure(dataStructure)
+, m_InputValues(inputValues)
+, m_Filter(filter)
+, m_MessageHandler(mesgHandler)
+{
+}
+
+RawBinaryReader::~RawBinaryReader() noexcept = default;
+
+Result<> RawBinaryReader::operator()()
+{
+  return execute();
+}
+
+// -----------------------------------------------------------------------------
+Result<> RawBinaryReader::execute()
+{
+  IDataArray* binaryIDataArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->createdAttributeArrayPathValue);
+  if(binaryIDataArray == nullptr)
+  {
+    return MakeErrorResult(k_RbrDAError, "Can't obtain DataArray from path '" + m_InputValues->createdAttributeArrayPathValue.toString() + "'.");
+  }
+
+  if(binaryIDataArray->getNumberOfComponents() != static_cast<size_t>(m_InputValues->numberOfComponentsValue))
+  {
+    return MakeErrorResult(k_RbrComponentError, "Failed to acquire DataArray from path '" + m_InputValues->createdAttributeArrayPathValue.toString() + "' with the correct number of components.");
+  }
+
+  const std::string inputFile = m_InputValues->inputFileValue;
+
+  int32_t err = 0;
+  switch(m_InputValues->scalarTypeValue)
+  {
+  case NumericType::int8:
+    err = readBinaryFile<int8_t>(binaryIDataArray, inputFile, m_InputValues->skipHeaderBytesValue, m_InputValues->endianValue);
+    break;
+  case NumericType::uint8:
+    err = readBinaryFile<uint8_t>(binaryIDataArray, inputFile, m_InputValues->skipHeaderBytesValue, m_InputValues->endianValue);
+    break;
+  case NumericType::int16:
+    err = readBinaryFile<int16_t>(binaryIDataArray, inputFile, m_InputValues->skipHeaderBytesValue, m_InputValues->endianValue);
+    break;
+  case NumericType::uint16:
+    err = readBinaryFile<uint16_t>(binaryIDataArray, inputFile, m_InputValues->skipHeaderBytesValue, m_InputValues->endianValue);
+    break;
+  case NumericType::int32:
+    err = readBinaryFile<int32_t>(binaryIDataArray, inputFile, m_InputValues->skipHeaderBytesValue, m_InputValues->endianValue);
+    break;
+  case NumericType::uint32:
+    err = readBinaryFile<uint32_t>(binaryIDataArray, inputFile, m_InputValues->skipHeaderBytesValue, m_InputValues->endianValue);
+    break;
+  case NumericType::int64:
+    err = readBinaryFile<int64_t>(binaryIDataArray, inputFile, m_InputValues->skipHeaderBytesValue, m_InputValues->endianValue);
+    break;
+  case NumericType::uint64:
+    err = readBinaryFile<uint64_t>(binaryIDataArray, inputFile, m_InputValues->skipHeaderBytesValue, m_InputValues->endianValue);
+    break;
+  case NumericType::float32:
+    err = readBinaryFile<float>(binaryIDataArray, inputFile, m_InputValues->skipHeaderBytesValue, m_InputValues->endianValue);
+    break;
+  case NumericType::float64:
+    err = readBinaryFile<double>(binaryIDataArray, inputFile, m_InputValues->skipHeaderBytesValue, m_InputValues->endianValue);
+    break;
+    //  case NumericType::boolean:
+    //    err = readBinaryFile<uint8_t>(binaryIDataArray, inputFile, m_InputValues->skipHeaderBytesValue, m_InputValues->endianValue);
+    //    break;
+  default:
+    throw std::runtime_error("The chosen scalar type is not supported.");
+  }
+
+  switch(err)
+  {
+  case k_RbrFileNotOpen:
+    return MakeErrorResult(k_RbrFileNotOpen, "Unable to open the specified file");
+  case k_RbrFileTooSmall:
+    return MakeErrorResult(k_RbrFileTooSmall, "The file size is smaller than the allocated size");
+  case k_RbrFileTooBig:
+    return MakeWarningVoidResult(k_RbrFileTooBig, "The file size is larger than the allocated size");
+  case k_RbrDANull:
+    return MakeErrorResult(k_RbrDANull, "Failed DataArray cast");
+  default:
+    return {};
+  }
+}
+
+} // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/RawBinaryReader.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/RawBinaryReader.cpp
@@ -185,7 +185,7 @@ Result<> RawBinaryReader::execute()
     return MakeErrorResult(k_RbrComponentError, "Failed to acquire DataArray from path '" + m_InputValues->createdAttributeArrayPathValue.toString() + "' with the correct number of components.");
   }
 
-  const std::string inputFile = m_InputValues->inputFileValue;
+  const std::string inputFile = m_InputValues->inputFileValue.string();
 
   int32_t err = 0;
   switch(m_InputValues->scalarTypeValue)

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/RawBinaryReader.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/RawBinaryReader.cpp
@@ -45,9 +45,9 @@
 #include "complex/DataStructure/DataStore.hpp"
 
 #if defined(_MSC_VER)
-#define FSEEK _fseeki64
+const auto FSEEK = _fseeki64;
 #else
-#define FSEEK std::fseek
+const auto FSEEK = std::fseek;
 #endif
 
 namespace complex
@@ -65,7 +65,6 @@ constexpr int32_t k_RbrNoError = 0;
 constexpr int32_t k_RbrFileNotOpen = -1000;
 constexpr int32_t k_RbrFileTooSmall = -1010;
 constexpr int32_t k_RbrFileTooBig = -1020;
-constexpr int32_t k_RbrReadEOF = -1030;
 constexpr int32_t k_RbrDAError = -1040;
 constexpr int32_t k_RbrComponentError = -1050;
 constexpr int32_t k_RbrDANull = -1060;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/RawBinaryReader.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/RawBinaryReader.hpp
@@ -8,11 +8,13 @@
 namespace complex
 {
 
+constexpr int32 k_UnsupportedScalarType = -1070;
+
 struct COMPLEXCORE_EXPORT RawBinaryReaderInputValues
 {
   FileSystemPathParameter::ValueType inputFileValue;
   NumericType scalarTypeValue;
-  int32 numberOfComponentsValue;
+  uint64 numberOfComponentsValue;
   ChoicesParameter::ValueType endianValue;
   uint64 skipHeaderBytesValue;
   DataPath createdAttributeArrayPathValue;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/RawBinaryReader.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/RawBinaryReader.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "ComplexCore/ComplexCore_export.hpp"
+#include "complex/Filter/IFilter.hpp"
+#include "complex/Parameters/ChoicesParameter.hpp"
+#include "complex/Parameters/FileSystemPathParameter.hpp"
+
+namespace complex
+{
+
+struct COMPLEXCORE_EXPORT RawBinaryReaderInputValues
+{
+  FileSystemPathParameter::ValueType inputFileValue;
+  NumericType scalarTypeValue;
+  int32 numberOfComponentsValue;
+  ChoicesParameter::ValueType endianValue;
+  uint64 skipHeaderBytesValue;
+  DataPath createdAttributeArrayPathValue;
+};
+
+class COMPLEXCORE_EXPORT RawBinaryReader
+{
+public:
+  RawBinaryReader(DataStructure& data, RawBinaryReaderInputValues* inputValues, const IFilter* filter, const IFilter::MessageHandler& mesgHandler);
+  ~RawBinaryReader() noexcept;
+
+  RawBinaryReader(const RawBinaryReader&) = delete;
+  RawBinaryReader(RawBinaryReader&&) noexcept = delete;
+  RawBinaryReader& operator=(const RawBinaryReader&) = delete;
+  RawBinaryReader& operator=(RawBinaryReader&&) noexcept = delete;
+
+  Result<> operator()();
+
+private:
+  DataStructure& m_DataStructure;
+  const RawBinaryReaderInputValues* m_InputValues = nullptr;
+  const IFilter* m_Filter = nullptr;
+  const IFilter::MessageHandler& m_MessageHandler;
+
+  Result<> execute();
+};
+
+} // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
@@ -19,8 +19,6 @@ using namespace complex;
 namespace complex
 {
 
-constexpr int32_t k_RbrFileNameEmpty = -387;
-constexpr int32_t k_RbrFileNotExist = -388;
 constexpr int32_t k_RbrZeroComponentsError = -391;
 constexpr int32_t k_RbrNumComponentsError = -392;
 constexpr int32_t k_RbrWrongType = -393;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
@@ -93,7 +93,7 @@ IFilter::PreflightResult RawBinaryReaderFilter::preflightImpl(const DataStructur
 
   complex::Result<OutputActions> resultOutputActions;
 
-  uint32 inputFileSize = std::filesystem::file_size(std::filesystem::path{pInputFileValue});
+  uint32 inputFileSize = std::filesystem::file_size(pInputFileValue);
   if(inputFileSize == 0)
   {
     auto error = MakeErrorResult<OutputActions>(k_RbrEmptyFile, "File '" + pInputFileValue.string() + "' is empty.");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
@@ -20,11 +20,11 @@ using namespace complex;
 namespace complex
 {
 
-constexpr int32_t k_RbrZeroComponentsError = -391;
-constexpr int32_t k_RbrNumComponentsError = -392;
-constexpr int32_t k_RbrWrongType = -393;
-constexpr int32_t k_RbrEmptyFile = -394;
-constexpr int32_t k_RbrSkippedTooMuch = -395;
+int32 k_RbrZeroComponentsError = -391;
+int32 k_RbrNumComponentsError = -392;
+int32 k_RbrWrongType = -393;
+int32 k_RbrEmptyFile = -394;
+int32 k_RbrSkippedTooMuch = -395;
 
 //------------------------------------------------------------------------------
 std::string RawBinaryReaderFilter::name() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
@@ -1,0 +1,205 @@
+#include "RawBinaryReaderFilter.hpp"
+
+#include "complex/DataStructure/DataPath.hpp"
+#include "complex/Filter/Actions/CreateArrayAction.hpp"
+#include "complex/Filter/Actions/EmptyAction.hpp"
+#include "complex/Parameters/ArrayCreationParameter.hpp"
+#include "complex/Parameters/ChoicesParameter.hpp"
+#include "complex/Parameters/FileSystemPathParameter.hpp"
+#include "complex/Parameters/NumberParameter.hpp"
+#include "complex/Parameters/NumericTypeParameter.hpp"
+
+#include "ComplexCore/Filters/Algorithms/RawBinaryReader.hpp"
+
+#include <filesystem>
+namespace fs = std::filesystem;
+
+using namespace complex;
+
+namespace complex
+{
+
+constexpr int32_t k_RbrFileNameEmpty = -387;
+constexpr int32_t k_RbrFileNotExist = -388;
+constexpr int32_t k_RbrZeroComponentsError = -391;
+constexpr int32_t k_RbrNumComponentsError = -392;
+constexpr int32_t k_RbrWrongType = -393;
+constexpr int32_t k_RbrEmptyFile = -394;
+constexpr int32_t k_RbrSkippedTooMuch = -395;
+
+//------------------------------------------------------------------------------
+std::string RawBinaryReaderFilter::name() const
+{
+  return FilterTraits<RawBinaryReaderFilter>::name.str();
+}
+
+//------------------------------------------------------------------------------
+std::string RawBinaryReaderFilter::className() const
+{
+  return FilterTraits<RawBinaryReaderFilter>::className;
+}
+
+//------------------------------------------------------------------------------
+Uuid RawBinaryReaderFilter::uuid() const
+{
+  return FilterTraits<RawBinaryReaderFilter>::uuid;
+}
+
+//------------------------------------------------------------------------------
+std::string RawBinaryReaderFilter::humanName() const
+{
+  return "Raw Binary Importer";
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> RawBinaryReaderFilter::defaultTags() const
+{
+  return {"#IO", "#Input", "#Read", "#Import"};
+}
+
+//------------------------------------------------------------------------------
+Parameters RawBinaryReaderFilter::parameters() const
+{
+  Parameters params;
+  // Create the parameter descriptors that are needed for this filter
+  params.insert(std::make_unique<FileSystemPathParameter>(k_InputFile_Key, "Input File", "", fs::path(), FileSystemPathParameter::PathType::InputFile));
+  params.insert(std::make_unique<NumericTypeParameter>(k_ScalarType_Key, "Scalar Type", "", NumericType::int8));
+  params.insert(std::make_unique<Int32Parameter>(k_NumberOfComponents_Key, "Number of Components", "", 0));
+  params.insert(std::make_unique<ChoicesParameter>(k_Endian_Key, "Endian", "", 0, ChoicesParameter::Choices{"Little", "Big"}));
+  params.insert(std::make_unique<UInt64Parameter>(k_SkipHeaderBytes_Key, "Skip Header Bytes", "", 0));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_CreatedAttributeArrayPath_Key, "Output Attribute Array", "", DataPath(std::vector<std::string>{"Imported Array"})));
+
+  return params;
+}
+
+//------------------------------------------------------------------------------
+IFilter::UniquePointer RawBinaryReaderFilter::clone() const
+{
+  return std::make_unique<RawBinaryReaderFilter>();
+}
+
+//------------------------------------------------------------------------------
+IFilter::PreflightResult RawBinaryReaderFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler) const
+{
+  auto pInputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFile_Key);
+  auto pScalarTypeValue = filterArgs.value<NumericType>(k_ScalarType_Key);
+  auto pNumberOfComponentsValue = filterArgs.value<int32>(k_NumberOfComponents_Key);
+  auto pSkipHeaderBytesValue = filterArgs.value<uint64>(k_SkipHeaderBytes_Key);
+  auto pCreatedAttributeArrayPathValue = filterArgs.value<DataPath>(k_CreatedAttributeArrayPath_Key);
+
+  if(pNumberOfComponentsValue < 1)
+  {
+    auto error = MakeErrorResult<OutputActions>(k_RbrZeroComponentsError, "The number of components must be positive.");
+    return {std::move(error), {}};
+  }
+
+  complex::Result<OutputActions> resultOutputActions;
+
+  uint32 inputFileSize = std::filesystem::file_size(std::filesystem::path{pInputFileValue});
+  if(inputFileSize == 0)
+  {
+    auto error = MakeErrorResult<OutputActions>(k_RbrEmptyFile, "File '" + pInputFileValue.string() + "' is empty.");
+    return {std::move(error), {}};
+  }
+
+  uint32 intendedFileSize = inputFileSize - pSkipHeaderBytesValue;
+  if(intendedFileSize <= 0)
+  {
+    auto error = MakeErrorResult<OutputActions>(k_RbrSkippedTooMuch, "More bytes have been skipped than exist in file '" + pInputFileValue.string() + "'.");
+    return {std::move(error), {}};
+  }
+
+  uint32 typeSize = 0;
+  switch(pScalarTypeValue)
+  {
+  case NumericType::int8:
+    typeSize = sizeof(int8);
+    break;
+  case NumericType::uint8:
+    typeSize = sizeof(uint8);
+    break;
+  case NumericType::int16:
+    typeSize = sizeof(int16);
+    break;
+  case NumericType::uint16:
+    typeSize = sizeof(uint16);
+    break;
+  case NumericType::int32:
+    typeSize = sizeof(int32);
+    break;
+  case NumericType::uint32:
+    typeSize = sizeof(uint32);
+    break;
+  case NumericType::int64:
+    typeSize = sizeof(int64);
+    break;
+  case NumericType::uint64:
+    typeSize = sizeof(uint64);
+    break;
+  case NumericType::float32:
+    typeSize = sizeof(float32);
+    break;
+  case NumericType::float64:
+    typeSize = sizeof(float64);
+    break;
+    //  case NumericType::boolean:
+    //    break;
+  default:
+    throw std::runtime_error("The chosen scalar type is not supported by this filter.");
+  }
+
+  // Sanity check the chosen scalar type and the total bytes in the data file
+  if(intendedFileSize % typeSize != 0)
+  {
+    auto error = MakeErrorResult<OutputActions>(k_RbrWrongType, "After skipping " + std::to_string(pSkipHeaderBytesValue) + " bytes, the data to be read in file '" + pInputFileValue.string() +
+                                                                    "' does not convert into an exact number of elements using the chosen scalar type.  Are you sure this is the correct scalar type?");
+    return {std::move(error), {}};
+  }
+
+  uint32 totalElements = intendedFileSize / typeSize;
+
+  // Sanity check the chosen number of components and the number of elements in the data file
+  if(totalElements % pNumberOfComponentsValue != 0)
+  {
+    auto error = MakeErrorResult<OutputActions>(k_RbrNumComponentsError,
+                                                "After skipping " + std::to_string(pSkipHeaderBytesValue) + " bytes, the data in file '" + pInputFileValue.string() +
+                                                    "' does not convert into an exact number of tuples using the chosen components.  Are you sure this is the correct component number?");
+    return {std::move(error), {}};
+  }
+
+  int32 numTuples = totalElements / pNumberOfComponentsValue;
+
+  // Create the CreateArray action and add it to the resultOutputActions object
+  {
+    auto action = std::make_unique<CreateArrayAction>(pScalarTypeValue, std::vector<usize>{static_cast<usize>(numTuples)}, std::vector<usize>{static_cast<usize>(pNumberOfComponentsValue)},
+                                                      pCreatedAttributeArrayPathValue);
+
+    resultOutputActions.value().actions.push_back(std::move(action));
+  }
+
+  // If your filter is going to pass back some `preflight updated values` then this is where you
+  // would create the code to store those values in the appropriate object. Note that we
+  // in line creating the pair (NOT a std::pair<>) of Key:Value that will get stored in
+  // the std::vector<PreflightValue> object.
+  std::vector<PreflightValue> preflightUpdatedValues;
+
+  // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
+  return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
+}
+
+//------------------------------------------------------------------------------
+Result<> RawBinaryReaderFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler) const
+{
+  complex::RawBinaryReaderInputValues inputValues;
+
+  inputValues.inputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFile_Key);
+  inputValues.scalarTypeValue = filterArgs.value<NumericType>(k_ScalarType_Key);
+  inputValues.numberOfComponentsValue = filterArgs.value<int32>(k_NumberOfComponents_Key);
+  inputValues.endianValue = filterArgs.value<ChoicesParameter::ValueType>(k_Endian_Key);
+  inputValues.skipHeaderBytesValue = filterArgs.value<uint64>(k_SkipHeaderBytes_Key);
+  inputValues.createdAttributeArrayPathValue = filterArgs.value<DataPath>(k_CreatedAttributeArrayPath_Key);
+
+  // Let the Algorithm instance do the work
+  return RawBinaryReader(dataStructure, &inputValues, this, messageHandler)();
+}
+} // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
@@ -1,5 +1,6 @@
 #include "RawBinaryReaderFilter.hpp"
 
+#include "complex/Common/TypesUtility.hpp"
 #include "complex/DataStructure/DataPath.hpp"
 #include "complex/Filter/Actions/CreateArrayAction.hpp"
 #include "complex/Filter/Actions/EmptyAction.hpp"
@@ -62,7 +63,7 @@ Parameters RawBinaryReaderFilter::parameters() const
   // Create the parameter descriptors that are needed for this filter
   params.insert(std::make_unique<FileSystemPathParameter>(k_InputFile_Key, "Input File", "", fs::path(), FileSystemPathParameter::PathType::InputFile));
   params.insert(std::make_unique<NumericTypeParameter>(k_ScalarType_Key, "Scalar Type", "", NumericType::int8));
-  params.insert(std::make_unique<Int32Parameter>(k_NumberOfComponents_Key, "Number of Components", "", 0));
+  params.insert(std::make_unique<UInt64Parameter>(k_NumberOfComponents_Key, "Number of Components", "", 0));
   params.insert(std::make_unique<ChoicesParameter>(k_Endian_Key, "Endian", "", 0, ChoicesParameter::Choices{"Little", "Big"}));
   params.insert(std::make_unique<UInt64Parameter>(k_SkipHeaderBytes_Key, "Skip Header Bytes", "", 0));
   params.insert(std::make_unique<ArrayCreationParameter>(k_CreatedAttributeArrayPath_Key, "Output Attribute Array", "", DataPath(std::vector<std::string>{"Imported Array"})));
@@ -81,96 +82,57 @@ IFilter::PreflightResult RawBinaryReaderFilter::preflightImpl(const DataStructur
 {
   auto pInputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFile_Key);
   auto pScalarTypeValue = filterArgs.value<NumericType>(k_ScalarType_Key);
-  auto pNumberOfComponentsValue = filterArgs.value<int32>(k_NumberOfComponents_Key);
+  auto pNumberOfComponentsValue = filterArgs.value<uint64>(k_NumberOfComponents_Key);
   auto pSkipHeaderBytesValue = filterArgs.value<uint64>(k_SkipHeaderBytes_Key);
   auto pCreatedAttributeArrayPathValue = filterArgs.value<DataPath>(k_CreatedAttributeArrayPath_Key);
 
   if(pNumberOfComponentsValue < 1)
   {
-    auto error = MakeErrorResult<OutputActions>(k_RbrZeroComponentsError, "The number of components must be positive.");
-    return {std::move(error), {}};
+    return {MakeErrorResult<OutputActions>(k_RbrZeroComponentsError, "The number of components must be positive.")};
   }
 
   complex::Result<OutputActions> resultOutputActions;
 
-  uint32 inputFileSize = std::filesystem::file_size(pInputFileValue);
+  usize inputFileSize = fs::file_size(pInputFileValue);
   if(inputFileSize == 0)
   {
-    auto error = MakeErrorResult<OutputActions>(k_RbrEmptyFile, "File '" + pInputFileValue.string() + "' is empty.");
-    return {std::move(error), {}};
+    return {MakeErrorResult<OutputActions>(k_RbrEmptyFile, fmt::format("File '{}' is empty.", pInputFileValue.string()))};
   }
 
-  uint32 intendedFileSize = inputFileSize - pSkipHeaderBytesValue;
-  if(intendedFileSize <= 0)
+  usize totalBytesToRead = inputFileSize - pSkipHeaderBytesValue;
+  if(totalBytesToRead <= 0)
   {
-    auto error = MakeErrorResult<OutputActions>(k_RbrSkippedTooMuch, "More bytes have been skipped than exist in file '" + pInputFileValue.string() + "'.");
-    return {std::move(error), {}};
+    return {MakeErrorResult<OutputActions>(k_RbrSkippedTooMuch, fmt::format("More bytes have been skipped than exist in file '{}'.", pInputFileValue.string()))};
   }
 
-  uint32 typeSize = 0;
-  switch(pScalarTypeValue)
-  {
-  case NumericType::int8:
-    typeSize = sizeof(int8);
-    break;
-  case NumericType::uint8:
-    typeSize = sizeof(uint8);
-    break;
-  case NumericType::int16:
-    typeSize = sizeof(int16);
-    break;
-  case NumericType::uint16:
-    typeSize = sizeof(uint16);
-    break;
-  case NumericType::int32:
-    typeSize = sizeof(int32);
-    break;
-  case NumericType::uint32:
-    typeSize = sizeof(uint32);
-    break;
-  case NumericType::int64:
-    typeSize = sizeof(int64);
-    break;
-  case NumericType::uint64:
-    typeSize = sizeof(uint64);
-    break;
-  case NumericType::float32:
-    typeSize = sizeof(float32);
-    break;
-  case NumericType::float64:
-    typeSize = sizeof(float64);
-    break;
-    //  case NumericType::boolean:
-    //    break;
-  default:
-    throw std::runtime_error("The chosen scalar type is not supported by this filter.");
-  }
+  usize typeSize = GetNumericTypeSize(pScalarTypeValue);
 
   // Sanity check the chosen scalar type and the total bytes in the data file
-  if(intendedFileSize % typeSize != 0)
+  if(totalBytesToRead % typeSize != 0)
   {
-    auto error = MakeErrorResult<OutputActions>(k_RbrWrongType, "After skipping " + std::to_string(pSkipHeaderBytesValue) + " bytes, the data to be read in file '" + pInputFileValue.string() +
-                                                                    "' does not convert into an exact number of elements using the chosen scalar type.  Are you sure this is the correct scalar type?");
-    return {std::move(error), {}};
+    return {MakeErrorResult<OutputActions>(
+        k_RbrWrongType,
+        fmt::format(
+            "After skipping {} bytes, the data to be read in file '{}' does not convert into an exact number of elements using the chosen scalar type. Are you sure this is the correct scalar type?",
+            pSkipHeaderBytesValue, pInputFileValue.string()))};
   }
 
-  uint32 totalElements = intendedFileSize / typeSize;
+  usize totalElements = totalBytesToRead / typeSize;
 
   // Sanity check the chosen number of components and the number of elements in the data file
   if(totalElements % pNumberOfComponentsValue != 0)
   {
-    auto error = MakeErrorResult<OutputActions>(k_RbrNumComponentsError,
-                                                "After skipping " + std::to_string(pSkipHeaderBytesValue) + " bytes, the data in file '" + pInputFileValue.string() +
-                                                    "' does not convert into an exact number of tuples using the chosen components.  Are you sure this is the correct component number?");
-    return {std::move(error), {}};
+    return {MakeErrorResult<OutputActions>(
+        k_RbrNumComponentsError,
+        fmt::format("After skipping {} bytes, the data in file '{}' does not convert into an exact number of tuples using the chosen components.  Are you sure this is the correct component number?",
+                    std::to_string(pSkipHeaderBytesValue), pInputFileValue.string()))};
   }
 
-  int32 numTuples = totalElements / pNumberOfComponentsValue;
+  usize numTuples = totalElements / pNumberOfComponentsValue;
 
   // Create the CreateArray action and add it to the resultOutputActions object
   {
-    auto action = std::make_unique<CreateArrayAction>(pScalarTypeValue, std::vector<usize>{static_cast<usize>(numTuples)}, std::vector<usize>{static_cast<usize>(pNumberOfComponentsValue)},
-                                                      pCreatedAttributeArrayPathValue);
+    auto action = std::make_unique<CreateArrayAction>(pScalarTypeValue, std::vector<usize>{numTuples}, std::vector<usize>{pNumberOfComponentsValue}, pCreatedAttributeArrayPathValue);
 
     resultOutputActions.value().actions.push_back(std::move(action));
   }
@@ -192,7 +154,7 @@ Result<> RawBinaryReaderFilter::executeImpl(DataStructure& dataStructure, const 
 
   inputValues.inputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFile_Key);
   inputValues.scalarTypeValue = filterArgs.value<NumericType>(k_ScalarType_Key);
-  inputValues.numberOfComponentsValue = filterArgs.value<int32>(k_NumberOfComponents_Key);
+  inputValues.numberOfComponentsValue = filterArgs.value<uint64>(k_NumberOfComponents_Key);
   inputValues.endianValue = filterArgs.value<ChoicesParameter::ValueType>(k_Endian_Key);
   inputValues.skipHeaderBytesValue = filterArgs.value<uint64>(k_SkipHeaderBytes_Key);
   inputValues.createdAttributeArrayPathValue = filterArgs.value<DataPath>(k_CreatedAttributeArrayPath_Key);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "ComplexCore/ComplexCore_export.hpp"
+
+#include "complex/Filter/FilterTraits.hpp"
+#include "complex/Filter/IFilter.hpp"
+
+namespace complex
+{
+/**
+ * @class RawBinaryReaderFilter
+ * @brief This filter will ....
+ */
+class COMPLEXCORE_EXPORT RawBinaryReaderFilter : public IFilter
+{
+public:
+  RawBinaryReaderFilter() = default;
+  ~RawBinaryReaderFilter() noexcept override = default;
+
+  RawBinaryReaderFilter(const RawBinaryReaderFilter&) = delete;
+  RawBinaryReaderFilter(RawBinaryReaderFilter&&) noexcept = delete;
+
+  RawBinaryReaderFilter& operator=(const RawBinaryReaderFilter&) = delete;
+  RawBinaryReaderFilter& operator=(RawBinaryReaderFilter&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_InputFile_Key = "InputFile";
+  static inline constexpr StringLiteral k_ScalarType_Key = "ScalarType";
+  static inline constexpr StringLiteral k_NumberOfComponents_Key = "NumberOfComponents";
+  static inline constexpr StringLiteral k_Endian_Key = "Endian";
+  static inline constexpr StringLiteral k_SkipHeaderBytes_Key = "SkipHeaderBytes";
+  static inline constexpr StringLiteral k_CreatedAttributeArrayPath_Key = "CreatedAttributeArrayPath";
+
+  /**
+   * @brief Returns the name of the filter.
+   * @return
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the C++ classname of this filter.
+   * @return
+   */
+  std::string className() const override;
+
+  /**
+   * @brief Returns the uuid of the filter.
+   * @return
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief Returns the human readable name of the filter.
+   * @return
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
+   * @brief Returns the parameters of the filter (i.e. its inputs)
+   * @return
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief Returns a copy of the filter.
+   * @return
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param ds The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  PreflightResult preflightImpl(const DataStructure& ds, const Arguments& filterArgs, const MessageHandler& messageHandler) const override;
+
+  /**
+   * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
+   * On failure, there is no guarantee that the DataStructure is in a correct state.
+   * @param ds The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  Result<> executeImpl(DataStructure& data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler) const override;
+};
+} // namespace complex
+
+COMPLEX_DEF_FILTER_TRAITS(complex, RawBinaryReaderFilter, "0791f556-3d73-5b1e-b275-db3f7bb6850d");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.hpp
@@ -9,7 +9,12 @@ namespace complex
 {
 /**
  * @class RawBinaryReaderFilter
- * @brief This filter will ....
+ * @brief This filter reads data stored in files on the user's system
+ * in binary form. The user should know exactly how the data is stored
+ * in the file and properly define this in the user interface. Not
+ * correctly identifying the type of data can cause serious issues since
+ * this filter is simply reading the data into a pre-allocated array
+ * interpreted as the user defines.
  */
 class COMPLEXCORE_EXPORT RawBinaryReaderFilter : public IFilter
 {

--- a/src/Plugins/ComplexCore/test/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/test/CMakeLists.txt
@@ -14,6 +14,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   InterpolatePointCloudToRegularGridTest.cpp
   MapPointCloudToRegularGridTest.cpp
   RobustAutomaticThresholdTest.cpp
+  RawBinaryReaderTest.cpp
   CreateImageGeometryTest.cpp
   StlFileReaderTest.cpp
   CalculateTriangleAreasFilterTest.cpp

--- a/src/Plugins/ComplexCore/test/RawBinaryReaderTest.cpp
+++ b/src/Plugins/ComplexCore/test/RawBinaryReaderTest.cpp
@@ -36,7 +36,7 @@ namespace fs = std::filesystem;
 
 using namespace complex;
 
-const std::string k_TestOutput = (fs::path(complex::unit_test::k_BinaryDir).append("RawBinaryReaderTest").append("Output.bin")).string();
+const std::string k_TestOutput = (fs::path(complex::unit_test::k_BinaryDir.str()).append("RawBinaryReaderTest").append("Output.bin")).string();
 const DataPath k_CreatedArrayPath = DataPath(std::vector<std::string>{"Test_Array"});
 
 constexpr int32_t k_RbrNumComponentsError = -392;

--- a/src/Plugins/ComplexCore/test/RawBinaryReaderTest.cpp
+++ b/src/Plugins/ComplexCore/test/RawBinaryReaderTest.cpp
@@ -1,0 +1,148 @@
+/**
+ * This file is auto generated from the original Core/RawBinaryReaderFilter
+ * runtime information. These are the steps that need to be taken to utilize this
+ * unit test in the proper way.
+ *
+ * 1: Validate each of the default parameters that gets created.
+ * 2: Inspect the actual filter to determine if the filter in its default state
+ * would pass or fail BOTH the preflight() and execute() methods
+ * 3: UPDATE the ```REQUIRE(result.result.valid());``` code to have the proper
+ *
+ * 4: Add additional unit tests to actually test each code path within the filter
+ *
+ * There are some example Catch2 ```TEST_CASE``` sections for your inspiration.
+ *
+ * NOTE the format of the ```TEST_CASE``` macro. Please stick to this format to
+ * allow easier parsing of the unit tests.
+ *
+ * When you start working on this unit test remove "[RawBinaryReaderFilter][.][UNIMPLEMENTED]"
+ * from the TEST_CASE macro. This will enable this unit test to be run by default
+ * and report errors.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <fstream>
+
+#include "complex/DataStructure/DataArray.hpp"
+#include "complex/Parameters/ArrayCreationParameter.hpp"
+#include "complex/Parameters/ChoicesParameter.hpp"
+#include "complex/Parameters/FileSystemPathParameter.hpp"
+#include "complex/Parameters/NumberParameter.hpp"
+#include "complex/Parameters/NumericTypeParameter.hpp"
+
+#include <filesystem>
+#include <fstream>
+namespace fs = std::filesystem;
+
+#include "ComplexCore/Filters/RawBinaryReaderFilter.hpp"
+#include "complex/unit_test/complex_test_dirs.hpp"
+
+using namespace complex;
+
+TEST_CASE("Core::RawBinaryReaderFilter: Valid filter execution")
+{
+  std::string inputFile = (fs::temp_directory_path() /= "raw_binary_reader_data.bin").string();
+  std::string arrayName = "Imported Array";
+  DataPath createdAttributeArrayPathValue = DataPath(std::vector<std::string>{arrayName});
+
+  // Write binary file
+  std::array<char, 10> buffer = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::fstream myFile(inputFile, std::ios::out | std::ios::binary);
+  myFile.write(buffer.data(), buffer.size());
+  myFile.close();
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  RawBinaryReaderFilter filter;
+  DataStructure ds;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(RawBinaryReaderFilter::k_InputFile_Key, std::make_any<FileSystemPathParameter::ValueType>(fs::path(inputFile)));
+  args.insertOrAssign(RawBinaryReaderFilter::k_ScalarType_Key, std::make_any<NumericType>(NumericType::uint8));
+  args.insertOrAssign(RawBinaryReaderFilter::k_NumberOfComponents_Key, std::make_any<int32>(1));
+  args.insertOrAssign(RawBinaryReaderFilter::k_Endian_Key, std::make_any<ChoicesParameter::ValueType>(0));
+  args.insertOrAssign(RawBinaryReaderFilter::k_SkipHeaderBytes_Key, std::make_any<uint64>(0));
+  args.insertOrAssign(RawBinaryReaderFilter::k_CreatedAttributeArrayPath_Key, std::make_any<DataPath>(createdAttributeArrayPathValue));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(ds, args);
+  REQUIRE(executeResult.result.valid());
+
+  // Check the results
+  auto* resultArray = ds.getDataAs<DataArray<uint8>>(createdAttributeArrayPathValue);
+  for(int i = 0; i < 10; i++)
+  {
+    uint8 resultVal = resultArray->at(i);
+    REQUIRE(resultVal == i);
+  }
+}
+
+TEST_CASE("Core::RawBinaryReaderFilter: Invalid filter execution")
+{
+  std::string arrayName = "Imported Array";
+  DataPath createdAttributeArrayPathValue = DataPath(std::vector<std::string>{arrayName});
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  RawBinaryReaderFilter filter;
+  DataStructure ds;
+  Arguments args;
+
+  // Test empty input file
+  std::string inputFile;
+
+  args.insertOrAssign(RawBinaryReaderFilter::k_InputFile_Key, std::make_any<FileSystemPathParameter::ValueType>(fs::path(inputFile)));
+  args.insertOrAssign(RawBinaryReaderFilter::k_ScalarType_Key, std::make_any<NumericType>(NumericType::uint8));
+  args.insertOrAssign(RawBinaryReaderFilter::k_NumberOfComponents_Key, std::make_any<int32>(1));
+  args.insertOrAssign(RawBinaryReaderFilter::k_Endian_Key, std::make_any<ChoicesParameter::ValueType>(0));
+  args.insertOrAssign(RawBinaryReaderFilter::k_SkipHeaderBytes_Key, std::make_any<uint64>(0));
+  args.insertOrAssign(RawBinaryReaderFilter::k_CreatedAttributeArrayPath_Key, std::make_any<DataPath>(createdAttributeArrayPathValue));
+
+  auto preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.invalid());
+
+  // Test non-existent input file
+  inputFile = "/tmp/this_does_not_exist.bin";
+  args.insertOrAssign(RawBinaryReaderFilter::k_InputFile_Key, std::make_any<FileSystemPathParameter::ValueType>(fs::path(inputFile)));
+  preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.invalid());
+
+  // Update InputFile to the correct path and write the file so it exists
+  inputFile = (fs::temp_directory_path() /= "raw_binary_reader_data.bin").string();
+  args.insertOrAssign(RawBinaryReaderFilter::k_InputFile_Key, std::make_any<FileSystemPathParameter::ValueType>(fs::path(inputFile)));
+
+  std::array<char, 10> buffer = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::fstream myFile(inputFile, std::ios::out | std::ios::binary);
+  myFile.write(buffer.data(), 10);
+
+  // Test empty input file
+  preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.invalid());
+  myFile.close();
+
+  // Test zero components
+  args.insertOrAssign(RawBinaryReaderFilter::k_NumberOfComponents_Key, std::make_any<int32>(0));
+  preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.invalid());
+  args.insertOrAssign(RawBinaryReaderFilter::k_NumberOfComponents_Key, std::make_any<int32>(1));
+
+  // Test incorrect scalar type
+  args.insertOrAssign(RawBinaryReaderFilter::k_ScalarType_Key, std::make_any<NumericType>(NumericType::uint32));
+  preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.invalid());
+  args.insertOrAssign(RawBinaryReaderFilter::k_ScalarType_Key, std::make_any<NumericType>(NumericType::uint8));
+
+  // Test incorrect components
+  args.insertOrAssign(RawBinaryReaderFilter::k_NumberOfComponents_Key, std::make_any<int32>(3));
+  preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.invalid());
+  args.insertOrAssign(RawBinaryReaderFilter::k_NumberOfComponents_Key, std::make_any<int32>(1));
+
+  //  // Execute the filter and check the result
+  //  auto executeResult = filter.execute(ds, args);
+  //  REQUIRE(executeResult.result.valid());
+}

--- a/src/Plugins/ComplexCore/test/RawBinaryReaderTest.cpp
+++ b/src/Plugins/ComplexCore/test/RawBinaryReaderTest.cpp
@@ -28,7 +28,6 @@
 #include "complex/Parameters/NumericTypeParameter.hpp"
 
 #include <filesystem>
-#include <fstream>
 namespace fs = std::filesystem;
 
 #include "ComplexCore/Filters/RawBinaryReaderFilter.hpp"
@@ -61,7 +60,7 @@ Arguments createFilterArguments(complex::NumericType scalarType, usize N, usize 
 
   args.insertOrAssign(RawBinaryReaderFilter::k_InputFile_Key, std::make_any<FileSystemPathParameter::ValueType>(fs::path(k_TestOutput)));
   args.insertOrAssign(RawBinaryReaderFilter::k_ScalarType_Key, std::make_any<NumericType>(scalarType));
-  args.insertOrAssign(RawBinaryReaderFilter::k_NumberOfComponents_Key, std::make_any<int32>(N));
+  args.insertOrAssign(RawBinaryReaderFilter::k_NumberOfComponents_Key, std::make_any<uint64>(N));
   args.insertOrAssign(RawBinaryReaderFilter::k_Endian_Key, std::make_any<ChoicesParameter::ValueType>(Detail::Little));
   args.insertOrAssign(RawBinaryReaderFilter::k_SkipHeaderBytes_Key, std::make_any<uint64>(skipBytes));
   args.insertOrAssign(RawBinaryReaderFilter::k_CreatedAttributeArrayPath_Key, k_CreatedArrayPath);
@@ -375,7 +374,7 @@ void testCase4_TestPrimitives(complex::NumericType scalarType)
 }
 
 // Case1: This tests when skipHeaderBytes equals 0, and checks to see if the data read is the same as the data written.
-TEST_CASE("Core::RawBinaryReaderFilter: Case1")
+TEST_CASE("RawBinaryReaderFilter(Case1)", "[ComplexCore][RawBinaryReaderFilter][Case1]")
 {
   // Create the parent directory path
   fs::create_directories(fs::path(k_TestOutput).parent_path());
@@ -393,7 +392,7 @@ TEST_CASE("Core::RawBinaryReaderFilter: Case1")
 }
 
 // Case2: This tests when the wrong scalar type is selected. (The total number of bytes in the file does not evenly divide by the scalar type size).
-TEST_CASE("Core::RawBinaryReaderFilter: Case2")
+TEST_CASE("RawBinaryReaderFilter(Case2)", "[ComplexCore][RawBinaryReaderFilter][Case2]")
 {
   // Create the parent directory path
   fs::create_directories(fs::path(k_TestOutput).parent_path());
@@ -402,7 +401,7 @@ TEST_CASE("Core::RawBinaryReaderFilter: Case2")
 }
 
 // Case3: This tests when the wrong component size is chosen. (The total number of scalar elements in the file does not evenly divide by the chosen component size).
-TEST_CASE("Core::RawBinaryReaderFilter: Case3")
+TEST_CASE("RawBinaryReaderFilter(Case3)", "[ComplexCore][RawBinaryReaderFilter][Case3]")
 {
   // Create the parent directory path
   fs::create_directories(fs::path(k_TestOutput).parent_path());
@@ -411,7 +410,7 @@ TEST_CASE("Core::RawBinaryReaderFilter: Case3")
 }
 
 // Case4: This tests when skipHeaderBytes is non-zero, and checks to see if the data read is the same as the data written.
-TEST_CASE("Core::RawBinaryReaderFilter: Case4")
+TEST_CASE("RawBinaryReaderFilter(Case4)", "[ComplexCore][RawBinaryReaderFilter][Case4]")
 {
   // Create the parent directory path
   fs::create_directories(fs::path(k_TestOutput).parent_path());
@@ -429,7 +428,7 @@ TEST_CASE("Core::RawBinaryReaderFilter: Case4")
 }
 
 // Case5: This tests when skipHeaderBytes equals the file size
-TEST_CASE("Core::RawBinaryReaderFilter: Case5")
+TEST_CASE("RawBinaryReaderFilter(Case5)", "[ComplexCore][RawBinaryReaderFilter][Case5]")
 {
   // Create the parent directory path
   fs::create_directories(fs::path(k_TestOutput).parent_path());

--- a/src/Plugins/ComplexCore/test/RawBinaryReaderTest.cpp
+++ b/src/Plugins/ComplexCore/test/RawBinaryReaderTest.cpp
@@ -125,7 +125,7 @@ void testCase1_Execute(complex::NumericType scalarType)
   bool result = createAndWriteToFile(k_TestOutput, dataArray, dataArraySize);
 
   // Test to make sure that the file was created and written to successfully
-  REQUIRE(result == true);
+  REQUIRE(result);
 
   // Create the filter, passing in the skipHeaderBytes
   RawBinaryReaderFilter filt;

--- a/src/Plugins/ComplexCore/test/RawBinaryReaderTest.cpp
+++ b/src/Plugins/ComplexCore/test/RawBinaryReaderTest.cpp
@@ -137,7 +137,7 @@ void testCase1_Execute(complex::NumericType scalarType)
 
   // Execute the filter, check that there are no errors, and compare the data
   auto executeResult = filt.execute(ds, args);
-  REQUIRE(executeResult.result.valid());
+  COMPLEX_RESULT_REQUIRE_VALID(executeResult.result);
 
   DataArray<T>* createdData = ds.getDataAs<DataArray<T>>(k_CreatedArrayPath);
   for(usize i = 0; i < dataArraySize; ++i)

--- a/src/complex/Common/Bit.hpp
+++ b/src/complex/Common/Bit.hpp
@@ -112,7 +112,7 @@ inline constexpr T byteswap(T value) noexcept
   {
     if constexpr(std::is_floating_point_v<T>)
     {
-      return bit_cast<T>(byteswap64(bit_cast<uint64_t>(value)));
+      return bit_cast<T>(byteswap64(bit_cast<uint64>(value)));
     }
     else
     {

--- a/src/complex/Common/Bit.hpp
+++ b/src/complex/Common/Bit.hpp
@@ -24,6 +24,11 @@ enum class endian : uint8
   native = COMPLEX_BYTE_ORDER
 };
 
+inline constexpr uint16 byteswap16(uint16 value) noexcept
+{
+  return ((value >> 8) & 0xFFu) | ((value & 0xFFu) << 8);
+}
+
 inline constexpr uint32 byteswap32(uint32 value) noexcept
 {
   return ((value & 0x000000FFu) << 24) | ((value & 0x00FF0000u) >> 8) | ((value & 0x0000FF00u) << 8) | ((value & 0xFF000000u) >> 24);
@@ -83,14 +88,14 @@ To bit_cast(const From& src) noexcept
 template <class T>
 inline constexpr T byteswap(T value) noexcept
 {
-  static_assert(std::is_arithmetic_v<T>, "byteSwap only works on arithmetic types");
+  static_assert(std::is_arithmetic_v<T>, "byteswap only works on arithmetic types");
   if constexpr(sizeof(T) == sizeof(uint8))
   {
     return value;
   }
   else if constexpr(sizeof(T) == sizeof(uint16))
   {
-    return ((value >> 8) & 0xFFu) | ((value & 0xFFu) << 8);
+    return byteswap16(value);
   }
   else if constexpr(sizeof(T) == sizeof(uint32))
   {

--- a/src/complex/Common/Bit.hpp
+++ b/src/complex/Common/Bit.hpp
@@ -24,27 +24,15 @@ enum class endian : uint8
   native = COMPLEX_BYTE_ORDER
 };
 
-template <class T>
-inline constexpr T byteswap(T value) noexcept
+inline constexpr uint32 byteswap32(uint32 value) noexcept
 {
-  static_assert(std::is_integral_v<T>);
-  if constexpr(sizeof(T) == sizeof(uint8))
-  {
-    return value;
-  }
-  else if constexpr(sizeof(T) == sizeof(uint16))
-  {
-    return ((value >> 8) & 0xFFu) | ((value & 0xFFu) << 8);
-  }
-  else if constexpr(sizeof(T) == sizeof(uint32))
-  {
-    return ((value & 0x000000FFu) << 24) | ((value & 0x00FF0000u) >> 8) | ((value & 0x0000FF00u) << 8) | ((value & 0xFF000000u) >> 24);
-  }
-  else if constexpr(sizeof(T) == sizeof(uint64))
-  {
-    return (((value & 0xFF00000000000000ull) >> 56) | ((value & 0x00FF000000000000ull) >> 40) | ((value & 0x0000FF0000000000ull) >> 24) | ((value & 0x000000FF00000000ull) >> 8) |
-            ((value & 0x00000000FF000000ull) << 8) | ((value & 0x0000000000FF0000ull) << 24) | ((value & 0x000000000000FF00ull) << 40) | ((value & 0x00000000000000FFull) << 56));
-  }
+  return ((value & 0x000000FFu) << 24) | ((value & 0x00FF0000u) >> 8) | ((value & 0x0000FF00u) << 8) | ((value & 0xFF000000u) >> 24);
+}
+
+inline constexpr uint64 byteswap64(uint64 value) noexcept
+{
+  return (((value & 0xFF00000000000000ull) >> 56) | ((value & 0x00FF000000000000ull) >> 40) | ((value & 0x0000FF0000000000ull) >> 24) | ((value & 0x000000FF00000000ull) >> 8) |
+          ((value & 0x00000000FF000000ull) << 8) | ((value & 0x0000000000FF0000ull) << 24) | ((value & 0x000000000000FF00ull) << 40) | ((value & 0x00000000000000FFull) << 56));
 }
 
 template <class T, endian Endianness = endian::native, usize Size = sizeof(T)>
@@ -90,5 +78,41 @@ To bit_cast(const From& src) noexcept
   To dst;
   std::memcpy(&dst, &src, sizeof(To));
   return dst;
+}
+
+template <class T>
+inline constexpr T byteswap(T value) noexcept
+{
+  static_assert(std::is_arithmetic_v<T>, "byteSwap only works on arithmetic types");
+  if constexpr(sizeof(T) == sizeof(uint8))
+  {
+    return value;
+  }
+  else if constexpr(sizeof(T) == sizeof(uint16))
+  {
+    return ((value >> 8) & 0xFFu) | ((value & 0xFFu) << 8);
+  }
+  else if constexpr(sizeof(T) == sizeof(uint32))
+  {
+    if constexpr(std::is_floating_point_v<T>)
+    {
+      return bit_cast<T>(byteswap32(bit_cast<uint32>(value)));
+    }
+    else
+    {
+      return byteswap32(value);
+    }
+  }
+  else if constexpr(sizeof(T) == sizeof(uint64))
+  {
+    if constexpr(std::is_floating_point_v<T>)
+    {
+      return bit_cast<T>(byteswap64(bit_cast<uint64_t>(value)));
+    }
+    else
+    {
+      return byteswap64(value);
+    }
+  }
 }
 } // namespace complex

--- a/src/complex/Common/TypesUtility.hpp
+++ b/src/complex/Common/TypesUtility.hpp
@@ -2,6 +2,8 @@
 
 #include "complex/Common/Types.hpp"
 
+#include <stdexcept>
+
 #include <type_traits>
 
 namespace complex
@@ -56,5 +58,47 @@ constexpr NumericType GetNumericType() noexcept
   {
     static_assert(AlwaysFalse_v<T>, "complex::GetNumericType: Unsupported type");
   }
+}
+
+inline constexpr usize GetNumericTypeSize(const NumericType& numericType)
+{
+  usize typeSize = 0;
+  switch(numericType)
+  {
+  case NumericType::int8:
+    typeSize = sizeof(int8);
+    break;
+  case NumericType::uint8:
+    typeSize = sizeof(uint8);
+    break;
+  case NumericType::int16:
+    typeSize = sizeof(int16);
+    break;
+  case NumericType::uint16:
+    typeSize = sizeof(uint16);
+    break;
+  case NumericType::int32:
+    typeSize = sizeof(int32);
+    break;
+  case NumericType::uint32:
+    typeSize = sizeof(uint32);
+    break;
+  case NumericType::int64:
+    typeSize = sizeof(int64);
+    break;
+  case NumericType::uint64:
+    typeSize = sizeof(uint64);
+    break;
+  case NumericType::float32:
+    typeSize = sizeof(float32);
+    break;
+  case NumericType::float64:
+    typeSize = sizeof(float64);
+    break;
+  default:
+    throw std::runtime_error("complex::GetNumericTypeSize: Unsupported type");
+  }
+
+  return typeSize;
 }
 } // namespace complex

--- a/src/complex/Common/TypesUtility.hpp
+++ b/src/complex/Common/TypesUtility.hpp
@@ -60,45 +60,32 @@ constexpr NumericType GetNumericType() noexcept
   }
 }
 
-inline constexpr usize GetNumericTypeSize(const NumericType& numericType)
+inline constexpr usize GetNumericTypeSize(NumericType numericType)
 {
-  usize typeSize = 0;
   switch(numericType)
   {
   case NumericType::int8:
-    typeSize = sizeof(int8);
-    break;
+    return sizeof(int8);
   case NumericType::uint8:
-    typeSize = sizeof(uint8);
-    break;
+    return sizeof(uint8);
   case NumericType::int16:
-    typeSize = sizeof(int16);
-    break;
+    return sizeof(int16);
   case NumericType::uint16:
-    typeSize = sizeof(uint16);
-    break;
+    return sizeof(uint16);
   case NumericType::int32:
-    typeSize = sizeof(int32);
-    break;
+    return sizeof(int32);
   case NumericType::uint32:
-    typeSize = sizeof(uint32);
-    break;
+    return sizeof(uint32);
   case NumericType::int64:
-    typeSize = sizeof(int64);
-    break;
+    return sizeof(int64);
   case NumericType::uint64:
-    typeSize = sizeof(uint64);
-    break;
+    return sizeof(uint64);
   case NumericType::float32:
-    typeSize = sizeof(float32);
-    break;
+    return sizeof(float32);
   case NumericType::float64:
-    typeSize = sizeof(float64);
-    break;
+    return sizeof(float64);
   default:
     throw std::runtime_error("complex::GetNumericTypeSize: Unsupported type");
   }
-
-  return typeSize;
 }
 } // namespace complex

--- a/src/complex/DataStructure/DataArray.hpp
+++ b/src/complex/DataStructure/DataArray.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "complex/Common/Bit.hpp"
 #include "complex/DataStructure/EmptyDataStore.hpp"
 #include "complex/DataStructure/IDataArray.hpp"
 #include "complex/Utilities/Parsing/HDF5/H5GroupWriter.hpp"
@@ -256,6 +257,17 @@ public:
       auto value = m_DataStore->getValue(fromCompIndex);
       usize toCompIndex = to * numComponents;
       m_DataStore->setValue(toCompIndex, value);
+    }
+  }
+
+  /**
+   * @brief Byte swaps all elements in the data array
+   */
+  void byteSwapElements()
+  {
+    for(auto& value : *this)
+    {
+      value = complex::byteswap(value);
     }
   }
 


### PR DESCRIPTION
* Ported RawBinaryReader filter from DREAM.3D to DREAM.3D-NX.  Added a helper class for the actual RawBinaryReader algorithm.
* Included a unit test and documentation.
* Updated Bit.hpp to include bit swapping for 32-bit and 64-bit floating point values.
* Updated DataArray.hpp to bitswap all elements in a DataArray.
* These bit-swapping API changes are needed for the RawBinaryReader filter.