### PR TITLE
Updated AbstractPipelineNode::Status values

### DIFF
--- a/src/complex/Pipeline/AbstractPipelineNode.cpp
+++ b/src/complex/Pipeline/AbstractPipelineNode.cpp
@@ -1,6 +1,7 @@
 #include "AbstractPipelineNode.hpp"
 
 #include <algorithm>
+#include <bitset>
 #include <cstdlib>
 
 #include "complex/Pipeline/Messaging/NodeStatusMessage.hpp"
@@ -26,14 +27,53 @@ void AbstractPipelineNode::setParentPipeline(Pipeline* parent)
   m_Parent = parent;
 }
 
-void AbstractPipelineNode::markDirty()
+bool AbstractPipelineNode::isExecuting() const
 {
-  m_Status = Status::Dirty;
+  return (m_Status & Status::Executing);
 }
 
-bool AbstractPipelineNode::isDirty() const
+bool AbstractPipelineNode::hasErrors() const
 {
-  return m_Status == Status::Dirty;
+  return (m_Status & Status::Error);
+}
+
+bool AbstractPipelineNode::hasWarnings() const
+{
+  return (m_Status & Status::Warning);
+}
+
+bool AbstractPipelineNode::isDisabled() const
+{
+  return (m_Status & Status::Disabled);
+}
+
+bool AbstractPipelineNode::isEnabled() const
+{
+  return !isDisabled();
+}
+
+void AbstractPipelineNode::setDisabled(bool disabled)
+{
+  std::bitset<8> statusBits(m_Status);
+  
+  if(disabled)
+  {
+    statusBits |= Status::Disabled;
+  }
+  else
+  {
+    std::bitset<8> mask(Status::Disabled);
+    mask.flip();
+    statusBits &= mask;
+  }
+
+  m_Status = static_cast<Status>(statusBits.to_ulong());
+  notify(std::make_shared<NodeStatusMessage>(this, m_Status));
+}
+
+void AbstractPipelineNode::setEnabled(bool enabled)
+{
+  return setDisabled(!enabled);
 }
 
 AbstractPipelineNode::Status AbstractPipelineNode::getStatus() const
@@ -47,23 +87,71 @@ void AbstractPipelineNode::setStatus(Status status)
   notify(std::make_shared<NodeStatusMessage>(this, status));
 }
 
+void AbstractPipelineNode::setHasWarnings(bool value)
+{
+  std::bitset<8> statusBits(m_Status);
+
+  if(value)
+  {
+    statusBits |= Status::Warning;
+  }
+  else
+  {
+    std::bitset<8> mask(Status::Warning);
+    mask.flip();
+    statusBits &= mask;
+  }
+
+  m_Status = static_cast<Status>(statusBits.to_ulong());
+  notify(std::make_shared<NodeStatusMessage>(this, m_Status));
+}
+
+void AbstractPipelineNode::setHasErrors(bool value)
+{
+  std::bitset<8> statusBits(m_Status);
+
+  if(value)
+  {
+    statusBits |= Status::Error;
+  }
+  else
+  {
+    std::bitset<8> mask(Status::Error);
+    mask.flip();
+    statusBits &= mask;
+  }
+
+  m_Status = static_cast<Status>(statusBits.to_ulong());
+  notify(std::make_shared<NodeStatusMessage>(this, m_Status));
+}
+
+void AbstractPipelineNode::setIsExecuting(bool value)
+{
+  std::bitset<8> statusBits(m_Status);
+
+  if(value)
+  {
+    statusBits |= Status::Executing;
+  }
+  else
+  {
+    std::bitset<8> mask(Status::Executing);
+    mask.flip();
+    statusBits &= mask;
+  }
+
+  m_Status = static_cast<Status>(statusBits.to_ulong());
+  notify(std::make_shared<NodeStatusMessage>(this, m_Status));
+}
+
 const DataStructure& AbstractPipelineNode::getDataStructure() const
 {
   return m_DataStructure;
 }
 
-void AbstractPipelineNode::setDataStructure(const DataStructure& ds, bool success)
+void AbstractPipelineNode::setDataStructure(const DataStructure& ds)
 {
   m_DataStructure = ds;
-
-  if(success)
-  {
-    setStatus(Status::Completed);
-  }
-  else
-  {
-    markDirty();
-  }
 }
 
 const DataStructure& AbstractPipelineNode::getPreflightStructure() const
@@ -75,24 +163,19 @@ void AbstractPipelineNode::setPreflightStructure(const DataStructure& ds, bool s
 {
   m_PreflightStructure = ds;
   m_IsPreflighted = success;
-
-  if(!success)
-  {
-    m_Status = Status::Dirty;
-  }
 }
 
 void AbstractPipelineNode::clearDataStructure()
 {
   m_DataStructure = DataStructure();
-  m_Status = Status::Dirty;
+  m_Status = Status::None;
 }
 
 void AbstractPipelineNode::clearPreflightStructure()
 {
   m_DataStructure = DataStructure();
   m_PreflightStructure = DataStructure();
-  m_Status = Status::Dirty;
+  m_Status = Status::None;
   m_IsPreflighted = false;
 }
 

--- a/src/complex/Pipeline/AbstractPipelineNode.cpp
+++ b/src/complex/Pipeline/AbstractPipelineNode.cpp
@@ -55,7 +55,7 @@ bool AbstractPipelineNode::isEnabled() const
 void AbstractPipelineNode::setDisabled(bool disabled)
 {
   std::bitset<8> statusBits(m_Status);
-  
+
   if(disabled)
   {
     statusBits |= Status::Disabled;

--- a/src/complex/Pipeline/AbstractPipelineNode.hpp
+++ b/src/complex/Pipeline/AbstractPipelineNode.hpp
@@ -38,11 +38,13 @@ public:
   /**
    * @brief Specific states of pipeline and filter execution.
    */
-  enum class Status
+  enum Status : uint8
   {
-    Dirty = 0,
-    Executing,
-    Completed
+    None = 0,
+    Executing = 1,
+    Error = 2,
+    Warning = 4,
+    Disabled = 8
   };
 
   virtual ~AbstractPipelineNode();
@@ -95,15 +97,51 @@ public:
   virtual std::unique_ptr<AbstractPipelineNode> deepCopy() const = 0;
 
   /**
-   * @brief Marks the node and all of its dependents as dirty.
-   */
-  void markDirty();
-
-  /**
-   * @brief Returns true if node is dirty. Returns false otherwise.
+   * @brief Returns true if the node is currently being executed. Otherwise,
+   * this method returns false.
    * @return bool
    */
-  bool isDirty() const;
+  bool isExecuting() const;
+
+  /**
+   * @brief Returns true if the node has errors. Otherwise, this method returns
+   * false.
+   * @return bool
+   */
+  bool hasErrors() const;
+
+  /**
+   * @brief Returns true if the node has warnings. Otherwise, this method
+   * returns false.
+   * @return bool
+   */
+  bool hasWarnings() const;
+
+  /**
+   * @brief Returns true if the node is disabled. Otherwise, this method
+   * returns false.
+   * @return bool
+   */
+  bool isDisabled() const;
+
+  /**
+   * @brief Returns true if the node is enabled. Otherwise, this method
+   * returns false.
+   * @return bool
+   */
+  bool isEnabled() const;
+
+  /**
+   * @brief Sets whether the node is disabled.
+   * @param disabled = true
+   */
+  void setDisabled(bool disabled = true);
+
+  /**
+   * @brief Sets whether the node is disabled.
+   * @param enabled = true
+   */
+  void setEnabled(bool enabled = true);
 
   /**
    * @brief Returns the pipeline node status.
@@ -169,6 +207,24 @@ protected:
   void setStatus(Status status);
 
   /**
+   * @brief Sets or clears the Warning flag.
+   * @param value = true
+   */
+  void setHasWarnings(bool value = true);
+
+  /**
+   * @brief Sets or clears the Error flag.
+   * @param value = true
+   */
+  void setHasErrors(bool value = true);
+
+  /**
+   * @brief Sets or clears the Executing flag.
+   * @param value = true
+   */
+  void setIsExecuting(bool value = true);
+
+  /**
    * @brief Notifies known observers of the provided message.
    * @param msg
    */
@@ -185,9 +241,8 @@ protected:
    * @brief Updates the stored DataStructure. This should only be called from
    * within the execute(DataStructure&) method.
    * @param ds
-   * @param success = true
    */
-  void setDataStructure(const DataStructure& ds, bool success = true);
+  void setDataStructure(const DataStructure& ds);
 
   /**
    * @brief Updates the stored DataStructure from preflighting the node. This
@@ -205,7 +260,7 @@ protected:
   std::unique_ptr<Pipeline> getPrecedingPipelineSegment() const;
 
 private:
-  Status m_Status = Status::Dirty;
+  Status m_Status = Status::None;
   Pipeline* m_Parent = nullptr;
   DataStructure m_DataStructure;
   DataStructure m_PreflightStructure;

--- a/src/complex/Pipeline/AbstractPipelineNode.hpp
+++ b/src/complex/Pipeline/AbstractPipelineNode.hpp
@@ -24,6 +24,10 @@ class Pipeline;
 class COMPLEX_EXPORT AbstractPipelineNode
 {
 public:
+  // Making Pipeline a friend class allows Pipelines to set flags of the nodes
+  // they contain.
+  friend class Pipeline;
+
   using SignalType = nod::signal<void(AbstractPipelineNode*, const std::shared_ptr<AbstractPipelineMessage>&)>;
 
   /**
@@ -42,9 +46,10 @@ public:
   {
     None = 0,
     Executing = 1,
-    Error = 2,
-    Warning = 4,
-    Disabled = 8
+    Executed = 2,
+    Error = 4,
+    Warning = 8,
+    Disabled = 16
   };
 
   virtual ~AbstractPipelineNode();
@@ -75,6 +80,12 @@ public:
   void setParentPipeline(Pipeline* parent);
 
   /**
+   * @brief Returns true if the node has a parent pipeline. Returns false otherwise.
+   * @return bool
+   */
+  bool hasParentPipeline() const;
+
+  /**
    * @brief Attempts to preflight the node using the provided DataStructure.
    * Returns true if preflighting succeeded. Otherwise, this returns false.
    * @param data
@@ -102,6 +113,13 @@ public:
    * @return bool
    */
   bool isExecuting() const;
+
+  /**
+   * @brief Returns true if the node is has been executed. Otherwise,
+   * this method returns false.
+   * @return bool
+   */
+  bool hasBeenExecuted() const;
 
   /**
    * @brief Returns true if the node has errors. Otherwise, this method returns
@@ -225,6 +243,12 @@ protected:
   void setIsExecuting(bool value = true);
 
   /**
+   * @brief Sets or clears the Executed flag.
+   * @param value = true
+   */
+  virtual void setHasBeenExecuted(bool value = true);
+
+  /**
    * @brief Notifies known observers of the provided message.
    * @param msg
    */
@@ -251,6 +275,13 @@ protected:
    * @param success = true
    */
   void setPreflightStructure(const DataStructure& ds, bool success = true);
+
+  /**
+   * @brief Called when ending pipeline node execution.
+   * Sets the DataStructure and clears the Executing flag.
+   * If there is a parent node, sets the Executed flag.
+   */
+  virtual void endExecution(DataStructure& dataStructure);
 
   /**
    * @brief Returns a Pipeline containing the parent pipeline up to the current

--- a/src/complex/Pipeline/Messaging/NodeStatusMessage.cpp
+++ b/src/complex/Pipeline/Messaging/NodeStatusMessage.cpp
@@ -22,17 +22,23 @@ AbstractPipelineNode::Status NodeStatusMessage::getStatus() const
 std::string NodeStatusMessage::toString() const
 {
   auto output = fmt::format("Node {}: ", getNode()->getName());
-  switch(getStatus())
+
+  if(getNode()->isExecuting())
   {
-  case AbstractPipelineNode::Status::Completed:
-    output += "Completed";
-    break;
-  case AbstractPipelineNode::Status::Dirty:
-    output += "Dirty";
-    break;
-  case AbstractPipelineNode::Status::Executing:
-    output += "Executing";
-    break;
+    output += " is Executing;";
   }
+  if(getNode()->hasErrors())
+  {
+    output += " has Errors;";
+  }
+  if(getNode()->hasWarnings())
+  {
+    output += " has Warnings;";
+  }
+  if(getNode()->isDisabled())
+  {
+    output += " is Disabled;";
+  }
+
   return output;
 }

--- a/src/complex/Pipeline/Pipeline.cpp
+++ b/src/complex/Pipeline/Pipeline.cpp
@@ -127,12 +127,14 @@ void Pipeline::setName(const std::string& name)
 bool Pipeline::preflight()
 {
   DataStructure ds;
+  setStatus(Status::None);
   return preflight(ds);
 }
 
 bool Pipeline::execute()
 {
   DataStructure ds;
+  setStatus(Status::None);
   return execute(ds);
 }
 
@@ -146,7 +148,7 @@ bool Pipeline::execute(DataStructure& ds)
   return executeFrom(0, ds);
 }
 
-bool Pipeline::canPreflightFrom(const index_type& index) const
+bool Pipeline::canPreflightFrom(index_type index) const
 {
   if(index == 0)
   {
@@ -156,30 +158,40 @@ bool Pipeline::canPreflightFrom(const index_type& index) const
   {
     return false;
   }
-  return at(index - 1)->isPreflighted();
+  return at(index - 1)->isPreflighted() && hasErrorsBeforeIndex(index);
 }
 
-bool Pipeline::preflightFrom(const index_type& index, DataStructure& ds)
+bool Pipeline::preflightFrom(index_type index, DataStructure& ds)
 {
-  if(index >= size() && index != 0)
+  if(!canPreflightFrom(index))
   {
     return false;
   }
 
+  setHasWarnings(hasWarningsBeforeIndex(index));
+  setHasErrors(false);
+
   for(auto iter = begin() + index; iter != end(); iter++)
   {
     startObservingNode(iter->get());
-    if(!iter->get()->preflight(ds))
+    bool succeeded = iter->get()->preflight(ds);
+    stopObservingNode();
+
+    if(iter->get()->hasWarnings())
     {
-      stopObservingNode();
+      setHasWarnings(true);
+    }
+
+    if(!succeeded)
+    {
+      setHasErrors(true);
       return false;
     }
-    stopObservingNode();
   }
   return true;
 }
 
-bool Pipeline::preflightFrom(const index_type& index)
+bool Pipeline::preflightFrom(index_type index)
 {
   if(index == 0)
   {
@@ -195,7 +207,7 @@ bool Pipeline::preflightFrom(const index_type& index)
   return preflightFrom(index, ds);
 }
 
-bool Pipeline::canExecuteFrom(const index_type& index) const
+bool Pipeline::canExecuteFrom(index_type index) const
 {
   if(index == 0)
   {
@@ -205,33 +217,43 @@ bool Pipeline::canExecuteFrom(const index_type& index) const
   {
     return false;
   }
-  return at(index - 1)->getStatus() == Status::Completed;
+  return !hasErrorsBeforeIndex(index);
 }
 
-bool Pipeline::executeFrom(const index_type& index, DataStructure& ds)
+bool Pipeline::executeFrom(index_type index, DataStructure& ds)
 {
-  if(index >= size() && index != 0)
+  if(!canExecuteFrom(index))
   {
     return false;
   }
+
+  setHasWarnings(hasWarningsBeforeIndex(index));
+  setHasErrors(false);
+  setIsExecuting();
+
   for(auto iter = begin() + index; iter != end(); iter++)
   {
     startObservingNode(iter->get());
     bool success = iter->get()->execute(ds);
     stopObservingNode();
+
+    if(iter->get()->hasWarnings())
+    {
+      setHasWarnings(true);
+    }
+
     if(!success)
     {
-      setDataStructure(ds);
-      setStatus(Status::Dirty);
+      setHasErrors();
+      endExecution(ds);
       return false;
     }
   }
-  setDataStructure(ds);
-  setStatus(Status::Completed);
+  endExecution(ds);
   return true;
 }
 
-bool Pipeline::executeFrom(const index_type& index)
+bool Pipeline::executeFrom(index_type index)
 {
   if(index == 0)
   {
@@ -245,6 +267,36 @@ bool Pipeline::executeFrom(const index_type& index)
   auto node = at(index - 1);
   DataStructure ds = node->getDataStructure();
   return executeFrom(index, ds);
+}
+
+void Pipeline::endExecution(DataStructure& dataStructure)
+{
+  setDataStructure(dataStructure);
+  setIsExecuting(false);
+}
+
+bool Pipeline::hasWarningsBeforeIndex(index_type index) const
+{
+  for(usize i = 0; i < index; i++)
+  {
+    if(m_Collection[i]->hasWarnings())
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool Pipeline::hasErrorsBeforeIndex(index_type index) const
+{
+  for(usize i = 0; i < index; i++)
+  {
+    if(m_Collection[i]->hasErrors())
+    {
+      return true;
+    }
+  }
+  return false;
 }
 
 usize Pipeline::size() const
@@ -587,7 +639,7 @@ Result<Pipeline> Pipeline::FromJson(const nlohmann::json& json, FilterList* filt
 
   Pipeline pipeline(name, filterList);
 
-  std::vector<Warning> warnings;
+  std::vector<complex::Warning> warnings;
 
   for(const auto& item : json[k_PipelineItemsKey])
   {

--- a/src/complex/Pipeline/Pipeline.cpp
+++ b/src/complex/Pipeline/Pipeline.cpp
@@ -269,10 +269,15 @@ bool Pipeline::executeFrom(index_type index)
   return executeFrom(index, ds);
 }
 
-void Pipeline::endExecution(DataStructure& dataStructure)
+void Pipeline::setHasBeenExecuted(bool value)
 {
-  setDataStructure(dataStructure);
-  setIsExecuting(false);
+  AbstractPipelineNode::setHasBeenExecuted(value);
+  
+  // Set flag for all child nodes
+  for(const auto& node : m_Collection)
+  {
+    node->setHasBeenExecuted(value);
+  }
 }
 
 bool Pipeline::hasWarningsBeforeIndex(index_type index) const

--- a/src/complex/Pipeline/Pipeline.cpp
+++ b/src/complex/Pipeline/Pipeline.cpp
@@ -272,7 +272,7 @@ bool Pipeline::executeFrom(index_type index)
 void Pipeline::setHasBeenExecuted(bool value)
 {
   AbstractPipelineNode::setHasBeenExecuted(value);
-  
+
   // Set flag for all child nodes
   for(const auto& node : m_Collection)
   {

--- a/src/complex/Pipeline/Pipeline.hpp
+++ b/src/complex/Pipeline/Pipeline.hpp
@@ -518,6 +518,12 @@ protected:
    */
   void onNotify(AbstractPipelineNode* node, const std::shared_ptr<AbstractPipelineMessage>& msg) override;
 
+  /**
+   * @brief Sets or clears the Executed flag.
+   * @param value = true
+   */
+  void setHasBeenExecuted(bool value = true) override;
+
 private:
   /**
    * @brief Returns a pointer to the active FilterList that should be used for
@@ -547,12 +553,6 @@ private:
    * @return bool
    */
   bool hasErrorsBeforeIndex(index_type index) const;
-
-  /**
-   * @brief Called when ending pipeline execution.
-   * Sets the DataStructure and clears the Executing flag.
-   */
-  void endExecution(DataStructure& dataStructure);
 
   ////////////
   // Variables

--- a/src/complex/Pipeline/Pipeline.hpp
+++ b/src/complex/Pipeline/Pipeline.hpp
@@ -145,7 +145,7 @@ public:
    * @param ds
    * @return bool
    */
-  bool preflightFrom(const index_type& index, DataStructure& ds);
+  bool preflightFrom(index_type index, DataStructure& ds);
 
   /**
    * @brief Preflights the pipeline segment from a target position using the
@@ -156,7 +156,7 @@ public:
    * @param index
    * @return
    */
-  bool preflightFrom(const index_type& index);
+  bool preflightFrom(index_type index);
 
   /**
    * @brief Checks if the pipeline can be preflighted at the target index.
@@ -166,7 +166,7 @@ public:
    * @param index
    * @return bool
    */
-  bool canPreflightFrom(const index_type& index) const;
+  bool canPreflightFrom(index_type index) const;
 
   /**
    * @brief Checks if the pipeline can be executed at the target index.
@@ -176,7 +176,7 @@ public:
    * @param index
    * @return bool
    */
-  bool canExecuteFrom(const index_type& index) const;
+  bool canExecuteFrom(index_type index) const;
 
   /**
    * @brief Executes the pipeline segment from a target position using the
@@ -188,7 +188,7 @@ public:
    * @param ds
    * @return bool
    */
-  bool executeFrom(const index_type& index, DataStructure& ds);
+  bool executeFrom(index_type index, DataStructure& ds);
 
   /**
    * @brief Executes the pipeline segment from the target position using the
@@ -200,7 +200,7 @@ public:
    * @param index
    * @return
    */
-  bool executeFrom(const index_type& index);
+  bool executeFrom(index_type index);
 
   /**
    * @brief Returns the getSize of the pipeline segment.
@@ -531,6 +531,28 @@ private:
    * @brief Resets all collection nodes' parent pipeline.
    */
   void resetCollectionParent();
+
+  /**
+   * @brief Returns true if the pipeline has encountered warnings before the
+   * specified index. Returns false otherwise.
+   * @param index
+   * @return bool
+   */
+  bool hasWarningsBeforeIndex(index_type index) const;
+
+  /**
+   * @brief Returns true if the pipeline has encountered errors before the
+   * specified index. Returns false otherwise.
+   * @param index
+   * @return bool
+   */
+  bool hasErrorsBeforeIndex(index_type index) const;
+
+  /**
+   * @brief Called when ending pipeline execution.
+   * Sets the DataStructure and clears the Executing flag.
+   */
+  void endExecution(DataStructure& dataStructure);
 
   ////////////
   // Variables

--- a/src/complex/Pipeline/PipelineFilter.cpp
+++ b/src/complex/Pipeline/PipelineFilter.cpp
@@ -119,6 +119,7 @@ bool PipelineFilter::execute(DataStructure& data)
 
   IFilter::MessageHandler messageHandler{[this](const IFilter::Message& message) { this->notifyFilterMessage(message); }};
 
+  setIsExecuting();
   IFilter::ExecuteResult result = m_Filter->execute(data, getArguments(), this, messageHandler);
   m_PreflightValues = std::move(result.outputValues);
 

--- a/src/complex/Pipeline/PipelineFilter.cpp
+++ b/src/complex/Pipeline/PipelineFilter.cpp
@@ -130,11 +130,10 @@ bool PipelineFilter::execute(DataStructure& data)
     m_Errors = result.result.errors();
   }
 
-  setDataStructure(data);
-  setIsExecuting(false);
-
   setHasWarnings(m_Warnings.size() > 0);
   setHasErrors(m_Errors.size() > 0);
+  endExecution(data);
+
   return result.result.valid();
 }
 

--- a/src/complex/Pipeline/PipelineFilter.cpp
+++ b/src/complex/Pipeline/PipelineFilter.cpp
@@ -70,7 +70,6 @@ Arguments PipelineFilter::getArguments() const
 void PipelineFilter::setArguments(const Arguments& args)
 {
   m_Arguments = args;
-  markDirty();
 }
 
 bool PipelineFilter::preflight(DataStructure& data)
@@ -115,27 +114,27 @@ bool PipelineFilter::preflight(DataStructure& data)
 
 bool PipelineFilter::execute(DataStructure& data)
 {
+  m_Warnings.clear();
+  m_Errors.clear();
+
   IFilter::MessageHandler messageHandler{[this](const IFilter::Message& message) { this->notifyFilterMessage(message); }};
 
   IFilter::ExecuteResult result = m_Filter->execute(data, getArguments(), this, messageHandler);
   m_PreflightValues = std::move(result.outputValues);
+
+  m_Warnings = result.result.warnings();
+
   if(result.result.invalid())
   {
-    m_Warnings = result.result.warnings();
-    m_Errors = result.result.errors();
-
-    setDataStructure(data, false);
-    return false;
+    m_Errors = result.result.errors(); 
   }
-  else
-  {
-    m_Warnings = result.result.warnings();
-    m_Errors.clear();
 
-    setDataStructure(data);
-    setStatus(Status::Completed);
-    return true;
-  }
+  setDataStructure(data);
+  setIsExecuting(false);
+
+  setHasWarnings(m_Warnings.size() > 0);
+  setHasErrors(m_Errors.size() > 0);
+  return result.result.valid();
 }
 
 std::vector<complex::Warning> PipelineFilter::getWarnings() const

--- a/src/complex/Pipeline/PipelineFilter.cpp
+++ b/src/complex/Pipeline/PipelineFilter.cpp
@@ -126,7 +126,7 @@ bool PipelineFilter::execute(DataStructure& data)
 
   if(result.result.invalid())
   {
-    m_Errors = result.result.errors(); 
+    m_Errors = result.result.errors();
   }
 
   setDataStructure(data);

--- a/src/complex/Pipeline/PipelineFilter.hpp
+++ b/src/complex/Pipeline/PipelineFilter.hpp
@@ -118,14 +118,14 @@ public:
    * This collection is cleared when the node is preflighted or executed.
    * @return std::vector<complex::Warning>
    */
-  std::vector<Warning> getWarnings() const;
+  std::vector<complex::Warning> getWarnings() const;
 
   /**
    * @brief Returns a collection of errors emitted by the target filter.
    * This collection is cleared when the node is preflighted or executed.
    * @return std::vector<complex::Error>
    */
-  std::vector<Error> getErrors() const;
+  std::vector<complex::Error> getErrors() const;
 
   /**
    * @brief Returns a collection of preflight values emitted by the target filter.
@@ -157,8 +157,8 @@ protected:
 private:
   IFilter::UniquePointer m_Filter;
   Arguments m_Arguments;
-  std::vector<Warning> m_Warnings;
-  std::vector<Error> m_Errors;
+  std::vector<complex::Warning> m_Warnings;
+  std::vector<complex::Error> m_Errors;
   std::vector<IFilter::PreflightValue> m_PreflightValues;
   WarningsChangedSignal m_WarningsSignal;
   ErrorsChangedSignal m_ErrorsSignal;


### PR DESCRIPTION
* Status has been updated to be used as flags instead of single values.
* Convenience methods added to AbstractPipelineNode to check for each of the flags.
* Updated Pipeline and PipelineFilter to take advantage of node Status changes.
* Updated NodeStatusMessage.toString()
* Pipeline no longer accepts index arguments as const references.