### PR TITLE
Add support for multiple valid file extensions in FileSystemPathParameter

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExampleFilter1.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExampleFilter1.cpp
@@ -53,10 +53,13 @@ Parameters ExampleFilter1::parameters() const
 {
   Parameters params;
   params.insertSeparator({"FileSystem Selections"});
-  params.insert(std::make_unique<FileSystemPathParameter>(k_InputDir_Key, "Input Directory", "", "Data", FileSystemPathParameter::PathType::InputDir));
-  params.insert(std::make_unique<FileSystemPathParameter>(k_InputFile_Key, "Input File", "", "/opt/local/bin/ninja", FileSystemPathParameter::PathType::InputFile));
-  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputDir_Key, "Ouptut Directory", "", "Output Data", FileSystemPathParameter::PathType::OutputDir));
-  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputFile_Key, "Output File", "", "Output Data/Some Really Cool File.txt", FileSystemPathParameter::PathType::OutputFile));
+  params.insert(std::make_unique<FileSystemPathParameter>(k_InputDir_Key, "Input Directory", "", "Data", FileSystemPathParameter::ExtensionsType{}, FileSystemPathParameter::PathType::InputDir));
+  params.insert(
+      std::make_unique<FileSystemPathParameter>(k_InputFile_Key, "Input File", "", "/opt/local/bin/ninja", FileSystemPathParameter::ExtensionsType{}, FileSystemPathParameter::PathType::InputFile));
+  params.insert(
+      std::make_unique<FileSystemPathParameter>(k_OutputDir_Key, "Ouptut Directory", "", "Output Data", FileSystemPathParameter::ExtensionsType{}, FileSystemPathParameter::PathType::OutputDir));
+  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputFile_Key, "Output File", "", "Output Data/Some Really Cool File.txt", FileSystemPathParameter::ExtensionsType{},
+                                                          FileSystemPathParameter::PathType::OutputFile));
 
   params.insertSeparator({"Linked Parameter"});
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_Param2, "BoolParameter", "The 2nd parameter", true));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExportDREAM3DFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExportDREAM3DFilter.cpp
@@ -42,7 +42,7 @@ Parameters ExportDREAM3DFilter::parameters() const
 {
   Parameters params;
   params.insert(std::make_unique<FileSystemPathParameter>(k_ExportFilePath, "Export File Path", "The file path the DataStructure should be written to as an HDF5 file.", "",
-                                                          FileSystemPathParameter::PathType::OutputFile));
+                                                          FileSystemPathParameter::PathType::OutputFile, FileSystemPathParameter::ExtensionsType{".dream3d"}));
   return params;
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExportDREAM3DFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExportDREAM3DFilter.cpp
@@ -42,7 +42,7 @@ Parameters ExportDREAM3DFilter::parameters() const
 {
   Parameters params;
   params.insert(std::make_unique<FileSystemPathParameter>(k_ExportFilePath, "Export File Path", "The file path the DataStructure should be written to as an HDF5 file.", "",
-                                                          FileSystemPathParameter::PathType::OutputFile, FileSystemPathParameter::ExtensionsType{".dream3d"}));
+                                                          FileSystemPathParameter::ExtensionsType{".dream3d"}, FileSystemPathParameter::PathType::OutputFile));
   return params;
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
@@ -54,8 +54,8 @@ std::string ImportTextFilter::humanName() const
 Parameters ImportTextFilter::parameters() const
 {
   Parameters params;
-  params.insert(
-      std::make_unique<FileSystemPathParameter>(k_InputFileKey, "Input File", "File to read from", fs::path("<default file to read goes here>"), FileSystemPathParameter::PathType::InputFile));
+  params.insert(std::make_unique<FileSystemPathParameter>(k_InputFileKey, "Input File", "File to read from", fs::path("<default file to read goes here>"), FileSystemPathParameter::ExtensionsType{},
+                                                          FileSystemPathParameter::PathType::InputFile));
   params.insert(std::make_unique<NumericTypeParameter>(k_ScalarTypeKey, "Scalar Type", "Type to interpret data as", NumericType::int8));
   params.insert(std::make_unique<UInt64Parameter>(k_NTuplesKey, "Number of Tuples", "Number of tuples in resulting array (i.e. number of lines to read)", 3));
   params.insert(std::make_unique<UInt64Parameter>(k_NCompKey, "Number of Components", "Number of columns", 3));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
@@ -61,7 +61,7 @@ Parameters RawBinaryReaderFilter::parameters() const
 {
   Parameters params;
 
-  params.insert(std::make_unique<FileSystemPathParameter>(k_InputFile_Key, "Input File", "", fs::path(), FileSystemPathParameter::PathType::InputFile));
+  params.insert(std::make_unique<FileSystemPathParameter>(k_InputFile_Key, "Input File", "", fs::path(), FileSystemPathParameter::ExtensionsType{}, FileSystemPathParameter::PathType::InputFile));
   params.insert(std::make_unique<NumericTypeParameter>(k_ScalarType_Key, "Scalar Type", "", NumericType::int8));
   params.insert(std::make_unique<UInt64Parameter>(k_NumberOfComponents_Key, "Number of Components", "", 0));
   params.insert(std::make_unique<ChoicesParameter>(k_Endian_Key, "Endian", "", 0, ChoicesParameter::Choices{"Little", "Big"}));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
@@ -57,7 +57,7 @@ Parameters StlFileReaderFilter::parameters() const
 {
   Parameters params;
   // Create the parameter descriptors that are needed for this filter
-  params.insert(std::make_unique<FileSystemPathParameter>(k_StlFilePath_Key, "STL File", "Input STL File", fs::path("*.stl"), FileSystemPathParameter::PathType::InputFile));
+  params.insert(std::make_unique<FileSystemPathParameter>(k_StlFilePath_Key, "STL File", "Input STL File", fs::path("*.stl"), FileSystemPathParameter::PathType::InputFile, FileSystemPathParameter::ExtensionsType{".stl"}));
   // params.insert(std::make_unique<DataGroupSelectionParameter>(k_ParentDataGroupPath_Key, "Parent DataGroup", "", DataPath{}));
 
   params.insertSeparator(Parameters::Separator{"Created Objects"});

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
@@ -57,7 +57,8 @@ Parameters StlFileReaderFilter::parameters() const
 {
   Parameters params;
   // Create the parameter descriptors that are needed for this filter
-  params.insert(std::make_unique<FileSystemPathParameter>(k_StlFilePath_Key, "STL File", "Input STL File", fs::path("*.stl"), FileSystemPathParameter::PathType::InputFile, FileSystemPathParameter::ExtensionsType{".stl"}));
+  params.insert(std::make_unique<FileSystemPathParameter>(k_StlFilePath_Key, "STL File", "Input STL File", fs::path("*.stl"), FileSystemPathParameter::PathType::InputFile,
+                                                          FileSystemPathParameter::ExtensionsType{".stl"}));
   // params.insert(std::make_unique<DataGroupSelectionParameter>(k_ParentDataGroupPath_Key, "Parent DataGroup", "", DataPath{}));
 
   params.insertSeparator(Parameters::Separator{"Created Objects"});

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
@@ -57,8 +57,8 @@ Parameters StlFileReaderFilter::parameters() const
 {
   Parameters params;
   // Create the parameter descriptors that are needed for this filter
-  params.insert(std::make_unique<FileSystemPathParameter>(k_StlFilePath_Key, "STL File", "Input STL File", fs::path("*.stl"), FileSystemPathParameter::PathType::InputFile,
-                                                          FileSystemPathParameter::ExtensionsType{".stl"}));
+  params.insert(std::make_unique<FileSystemPathParameter>(k_StlFilePath_Key, "STL File", "Input STL File", fs::path("*.stl"), FileSystemPathParameter::ExtensionsType{".stl"},
+                                                          FileSystemPathParameter::PathType::InputFile));
   // params.insert(std::make_unique<DataGroupSelectionParameter>(k_ParentDataGroupPath_Key, "Parent DataGroup", "", DataPath{}));
 
   params.insertSeparator(Parameters::Separator{"Created Objects"});

--- a/src/complex/Parameters/FileSystemPathParameter.cpp
+++ b/src/complex/Parameters/FileSystemPathParameter.cpp
@@ -70,7 +70,7 @@ Result<> ValidateOutputDir(const FileSystemPathParameter::ValueType& path)
 namespace complex
 {
 //-----------------------------------------------------------------------------
-FileSystemPathParameter::FileSystemPathParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, PathType pathType, ExtensionsType extensionsType)
+FileSystemPathParameter::FileSystemPathParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, PathType pathType, const ExtensionsType extensionsType)
 : ValueParameter(name, humanName, helpText)
 , m_DefaultValue(defaultValue)
 , m_PathType(pathType)

--- a/src/complex/Parameters/FileSystemPathParameter.cpp
+++ b/src/complex/Parameters/FileSystemPathParameter.cpp
@@ -70,8 +70,8 @@ Result<> ValidateOutputDir(const FileSystemPathParameter::ValueType& path)
 namespace complex
 {
 //-----------------------------------------------------------------------------
-FileSystemPathParameter::FileSystemPathParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, PathType pathType,
-                                                 const ExtensionsType extensionsType)
+FileSystemPathParameter::FileSystemPathParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, const ExtensionsType extensionsType,
+                                                 PathType pathType)
 : ValueParameter(name, humanName, helpText)
 , m_DefaultValue(defaultValue)
 , m_PathType(pathType)
@@ -116,7 +116,7 @@ Result<std::any> FileSystemPathParameter::fromJson(const nlohmann::json& json) c
 //-----------------------------------------------------------------------------
 IParameter::UniquePointer FileSystemPathParameter::clone() const
 {
-  return std::make_unique<FileSystemPathParameter>(name(), humanName(), helpText(), m_DefaultValue, m_PathType, m_AvailableExtensions);
+  return std::make_unique<FileSystemPathParameter>(name(), humanName(), helpText(), m_DefaultValue, m_AvailableExtensions, m_PathType);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/complex/Parameters/FileSystemPathParameter.cpp
+++ b/src/complex/Parameters/FileSystemPathParameter.cpp
@@ -162,7 +162,7 @@ Result<> FileSystemPathParameter::validatePath(const ValueType& path) const
     return {nonstd::make_unexpected(std::vector<Error>{{-2, "Path must include a file extension"}})};
   }
 
-  if (path.has_extension() && m_AvailableExtensions.find(path.extension().string()) == m_AvailableExtensions.end())
+  if (path.has_extension() && !m_AvailableExtensions.empty() && m_AvailableExtensions.find(path.extension().string()) == m_AvailableExtensions.end())
   {
     return {nonstd::make_unexpected(std::vector<Error>{{-3, fmt::format("File extension '{}' is not a valid file extension", path.extension().string())}})};
   }

--- a/src/complex/Parameters/FileSystemPathParameter.cpp
+++ b/src/complex/Parameters/FileSystemPathParameter.cpp
@@ -70,7 +70,8 @@ Result<> ValidateOutputDir(const FileSystemPathParameter::ValueType& path)
 namespace complex
 {
 //-----------------------------------------------------------------------------
-FileSystemPathParameter::FileSystemPathParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, PathType pathType, const ExtensionsType extensionsType)
+FileSystemPathParameter::FileSystemPathParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, PathType pathType,
+                                                 const ExtensionsType extensionsType)
 : ValueParameter(name, humanName, helpText)
 , m_DefaultValue(defaultValue)
 , m_PathType(pathType)
@@ -157,12 +158,12 @@ Result<> FileSystemPathParameter::validatePath(const ValueType& path) const
     return {nonstd::make_unexpected(std::vector<Error>{{-1, "Path must not be empty"}})};
   }
 
-  if (!m_AvailableExtensions.empty() && !path.has_extension())
+  if(!m_AvailableExtensions.empty() && !path.has_extension())
   {
     return {nonstd::make_unexpected(std::vector<Error>{{-2, "Path must include a file extension"}})};
   }
 
-  if (path.has_extension() && !m_AvailableExtensions.empty() && m_AvailableExtensions.find(path.extension().string()) == m_AvailableExtensions.end())
+  if(path.has_extension() && !m_AvailableExtensions.empty() && m_AvailableExtensions.find(path.extension().string()) == m_AvailableExtensions.end())
   {
     return {nonstd::make_unexpected(std::vector<Error>{{-3, fmt::format("File extension '{}' is not a valid file extension", path.extension().string())}})};
   }

--- a/src/complex/Parameters/FileSystemPathParameter.hpp
+++ b/src/complex/Parameters/FileSystemPathParameter.hpp
@@ -5,6 +5,7 @@
 #include "complex/complex_export.hpp"
 
 #include <filesystem>
+#include <unordered_set>
 
 namespace complex
 {
@@ -25,10 +26,12 @@ public:
     OutputDir = 3
   };
 
+  using ExtensionsType = std::unordered_set<std::string>;
+
   using ValueType = std::filesystem::path;
 
   FileSystemPathParameter() = delete;
-  FileSystemPathParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, PathType pathType);
+  FileSystemPathParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, PathType pathType, ExtensionsType extensionsType={});
   ~FileSystemPathParameter() override = default;
 
   FileSystemPathParameter(const FileSystemPathParameter&) = delete;
@@ -86,6 +89,12 @@ public:
   PathType getPathType() const;
 
   /**
+   * @brief Returns all of the valid extension types that can be used.
+   * @return
+   */
+  ExtensionsType getAvailableExtensions() const;
+
+  /**
    * @brief
    * @param value
    * @return
@@ -102,6 +111,7 @@ public:
 private:
   ValueType m_DefaultValue;
   PathType m_PathType;
+  ExtensionsType m_AvailableExtensions;
 };
 } // namespace complex
 

--- a/src/complex/Parameters/FileSystemPathParameter.hpp
+++ b/src/complex/Parameters/FileSystemPathParameter.hpp
@@ -31,7 +31,7 @@ public:
   using ValueType = std::filesystem::path;
 
   FileSystemPathParameter() = delete;
-  FileSystemPathParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, PathType pathType, ExtensionsType extensionsType={});
+  FileSystemPathParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, PathType pathType, const ExtensionsType extensionsType={});
   ~FileSystemPathParameter() override = default;
 
   FileSystemPathParameter(const FileSystemPathParameter&) = delete;

--- a/src/complex/Parameters/FileSystemPathParameter.hpp
+++ b/src/complex/Parameters/FileSystemPathParameter.hpp
@@ -31,8 +31,7 @@ public:
   using ValueType = std::filesystem::path;
 
   FileSystemPathParameter() = delete;
-  FileSystemPathParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, PathType pathType,
-                          const ExtensionsType extensionsType = {});
+  FileSystemPathParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, const ExtensionsType extensionsType, PathType pathType);
   ~FileSystemPathParameter() override = default;
 
   FileSystemPathParameter(const FileSystemPathParameter&) = delete;

--- a/src/complex/Parameters/FileSystemPathParameter.hpp
+++ b/src/complex/Parameters/FileSystemPathParameter.hpp
@@ -31,7 +31,8 @@ public:
   using ValueType = std::filesystem::path;
 
   FileSystemPathParameter() = delete;
-  FileSystemPathParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, PathType pathType, const ExtensionsType extensionsType={});
+  FileSystemPathParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, PathType pathType,
+                          const ExtensionsType extensionsType = {});
   ~FileSystemPathParameter() override = default;
 
   FileSystemPathParameter(const FileSystemPathParameter&) = delete;


### PR DESCRIPTION
Can now explicitly specify a list of all valid file extension types for Input/Output file path types or leave blank to allow any extensions. 