### PR TITLE
Added Output DataPath rename checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,7 @@ set(COMPLEX_HDRS
   ${COMPLEX_SOURCE_DIR}/Pipeline/Messaging/NodeMovedMessage.hpp
   ${COMPLEX_SOURCE_DIR}/Pipeline/Messaging/NodeRemovedMessage.hpp
   ${COMPLEX_SOURCE_DIR}/Pipeline/Messaging/NodeStatusMessage.hpp
+  ${COMPLEX_SOURCE_DIR}/Pipeline/Messaging/OutputRenamedMessage.hpp
   ${COMPLEX_SOURCE_DIR}/Pipeline/Messaging/PipelineFilterMessage.hpp
   ${COMPLEX_SOURCE_DIR}/Pipeline/Messaging/PipelineNodeMessage.hpp
   ${COMPLEX_SOURCE_DIR}/Pipeline/Messaging/PipelineNodeObserver.hpp
@@ -425,6 +426,7 @@ set(COMPLEX_SRCS
   ${COMPLEX_SOURCE_DIR}/Pipeline/Messaging/NodeMovedMessage.cpp
   ${COMPLEX_SOURCE_DIR}/Pipeline/Messaging/NodeRemovedMessage.cpp
   ${COMPLEX_SOURCE_DIR}/Pipeline/Messaging/NodeStatusMessage.cpp
+  ${COMPLEX_SOURCE_DIR}/Pipeline/Messaging/OutputRenamedMessage.cpp
   ${COMPLEX_SOURCE_DIR}/Pipeline/Messaging/PipelineFilterMessage.cpp
   ${COMPLEX_SOURCE_DIR}/Pipeline/Messaging/PipelineNodeMessage.cpp
   ${COMPLEX_SOURCE_DIR}/Pipeline/Messaging/PipelineNodeObserver.cpp

--- a/src/complex/DataStructure/DataPath.cpp
+++ b/src/complex/DataStructure/DataPath.cpp
@@ -106,6 +106,28 @@ DataPath DataPath::replace(std::string_view symbol, std::string_view targetName)
   return DataPath(std::move(newPath));
 }
 
+bool DataPath::attemptRename(const DataPath& oldPath, const DataPath& newPath)
+{
+  if(oldPath.getLength() > getLength())
+  {
+    return false;
+  }
+
+  for(usize i = 0; i < oldPath.getLength(); i++)
+  {
+    if(oldPath.m_Path[i] != m_Path[i])
+    {
+      return false;
+    }
+  }
+
+  for(usize i = 0; i < oldPath.getLength(); i++)
+  {
+    m_Path[i] = newPath.m_Path[i];
+  }
+  return true;
+}
+
 bool DataPath::operator==(const DataPath& rhs) const
 {
   return m_Path == rhs.m_Path;

--- a/src/complex/DataStructure/DataPath.hpp
+++ b/src/complex/DataStructure/DataPath.hpp
@@ -119,6 +119,16 @@ public:
   DataPath replace(std::string_view symbol, std::string_view targetName) const;
 
   /**
+   * @brief Attempts to handle renaming the DataPath. If the old path is a
+   * subset or exact match of the current path, the matching section will be
+   * replaced with the new path.
+   * @param oldPath
+   * @param newPath
+   * @return bool
+   */
+  bool attemptRename(const DataPath& oldPath, const DataPath& newPath);
+
+  /**
    * @brief Checks equality between two DataPaths.
    * @param rhs
    * @return bool

--- a/src/complex/Filter/Actions/CopyArrayInstanceAction.cpp
+++ b/src/complex/Filter/Actions/CopyArrayInstanceAction.cpp
@@ -18,8 +18,8 @@ using namespace complex;
 namespace complex
 {
 CopyArrayInstanceAction::CopyArrayInstanceAction(const DataPath& selectedDataPath, const DataPath& createdDataPath)
-: m_SelectedDataPath(selectedDataPath)
-, m_CreatedDataPath(createdDataPath)
+: IDataCreationAction(createdDataPath)
+, m_SelectedDataPath(selectedDataPath)
 {
 }
 
@@ -29,7 +29,7 @@ CopyArrayInstanceAction::~CopyArrayInstanceAction() noexcept = default;
   DataArray<type>* castInputArray = dynamic_cast<DataArray<type>*>(inputDataArray);                                                                                                                    \
   IDataStore::ShapeType tupleShape = castInputArray->getDataStore()->getTupleShape();                                                                                                                  \
   IDataStore::ShapeType componentShape = castInputArray->getDataStore()->getComponentShape();                                                                                                          \
-  return CreateArray<type>(dataStructure, tupleShape, componentShape, m_CreatedDataPath, mode);
+  return CreateArray<type>(dataStructure, tupleShape, componentShape, getCreatedPath(), mode);
 
 Result<> CopyArrayInstanceAction::apply(DataStructure& dataStructure, Mode mode) const
 {
@@ -94,7 +94,7 @@ DataPath CopyArrayInstanceAction::selectedDataPath() const
 
 DataPath CopyArrayInstanceAction::createdDataPath() const
 {
-  return m_CreatedDataPath;
+  return getCreatedPath();
 }
 
 } // namespace complex

--- a/src/complex/Filter/Actions/CopyArrayInstanceAction.hpp
+++ b/src/complex/Filter/Actions/CopyArrayInstanceAction.hpp
@@ -8,7 +8,7 @@ namespace complex
 /**
  * @brief Action that will copy a Source DataArray to a Destination DataPath.
  */
-class COMPLEX_EXPORT CopyArrayInstanceAction : public IDataAction
+class COMPLEX_EXPORT CopyArrayInstanceAction : public IDataCreationAction
 {
 public:
   CopyArrayInstanceAction() = delete;
@@ -26,24 +26,23 @@ public:
    * @brief Applies this action's change to the given DataStructure in the given mode.
    * Returns any warnings/errors. On error, DataStructure is not guaranteed to be consistent.
    * @param dataStructure
-   * @return
+   * @return Result<>
    */
   Result<> apply(DataStructure& dataStructure, Mode mode) const override;
 
   /**
    * @brief The selecte data array path to be copied
-   * @return
+   * @return DataPath
    */
   DataPath selectedDataPath() const;
 
   /**
    * @brief Returns the path of the DataArray to be created.
-   * @return
+   * @return DataPath
    */
   DataPath createdDataPath() const;
 
 private:
   DataPath m_SelectedDataPath;
-  DataPath m_CreatedDataPath;
 };
 } // namespace complex

--- a/src/complex/Filter/Actions/CreateArrayAction.cpp
+++ b/src/complex/Filter/Actions/CreateArrayAction.cpp
@@ -11,10 +11,10 @@ using namespace complex;
 namespace complex
 {
 CreateArrayAction::CreateArrayAction(NumericType type, const std::vector<usize>& tDims, const std::vector<usize>& cDims, const DataPath& path)
-: m_Type(type)
+: IDataCreationAction(path)
+, m_Type(type)
 , m_Dims(tDims)
 , m_CDims(cDims)
-, m_Path(path)
 {
 }
 
@@ -26,34 +26,34 @@ Result<> CreateArrayAction::apply(DataStructure& dataStructure, Mode mode) const
   switch(m_Type)
   {
   case NumericType::int8: {
-    return CreateArray<int8>(dataStructure, m_Dims, m_CDims, m_Path, mode);
+    return CreateArray<int8>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode);
   }
   case NumericType::uint8: {
-    return CreateArray<uint8>(dataStructure, m_Dims, m_CDims, m_Path, mode);
+    return CreateArray<uint8>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode);
   }
   case NumericType::int16: {
-    return CreateArray<int16>(dataStructure, m_Dims, m_CDims, m_Path, mode);
+    return CreateArray<int16>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode);
   }
   case NumericType::uint16: {
-    return CreateArray<uint16>(dataStructure, m_Dims, m_CDims, m_Path, mode);
+    return CreateArray<uint16>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode);
   }
   case NumericType::int32: {
-    return CreateArray<int32>(dataStructure, m_Dims, m_CDims, m_Path, mode);
+    return CreateArray<int32>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode);
   }
   case NumericType::uint32: {
-    return CreateArray<uint32>(dataStructure, m_Dims, m_CDims, m_Path, mode);
+    return CreateArray<uint32>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode);
   }
   case NumericType::int64: {
-    return CreateArray<int64>(dataStructure, m_Dims, m_CDims, m_Path, mode);
+    return CreateArray<int64>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode);
   }
   case NumericType::uint64: {
-    return CreateArray<uint64>(dataStructure, m_Dims, m_CDims, m_Path, mode);
+    return CreateArray<uint64>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode);
   }
   case NumericType::float32: {
-    return CreateArray<float32>(dataStructure, m_Dims, m_CDims, m_Path, mode);
+    return CreateArray<float32>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode);
   }
   case NumericType::float64: {
-    return CreateArray<float64>(dataStructure, m_Dims, m_CDims, m_Path, mode);
+    return CreateArray<float64>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode);
   }
   default:
     throw std::runtime_error(fmt::format("CreateArrayAction: Invalid Numeric Type '{}'", to_underlying(m_Type)));
@@ -77,6 +77,6 @@ const std::vector<usize>& CreateArrayAction::componentDims() const
 
 const DataPath& CreateArrayAction::path() const
 {
-  return m_Path;
+  return getCreatedPath();
 }
 } // namespace complex

--- a/src/complex/Filter/Actions/CreateArrayAction.cpp
+++ b/src/complex/Filter/Actions/CreateArrayAction.cpp
@@ -75,7 +75,7 @@ const std::vector<usize>& CreateArrayAction::componentDims() const
   return m_CDims;
 }
 
-const DataPath& CreateArrayAction::path() const
+DataPath CreateArrayAction::path() const
 {
   return getCreatedPath();
 }

--- a/src/complex/Filter/Actions/CreateArrayAction.hpp
+++ b/src/complex/Filter/Actions/CreateArrayAction.hpp
@@ -50,9 +50,9 @@ public:
 
   /**
    * @brief Returns the path of the DataArray to be created.
-   * @return
+   * @return DataPath
    */
-  const DataPath& path() const;
+  DataPath path() const;
 
 private:
   NumericType m_Type;

--- a/src/complex/Filter/Actions/CreateArrayAction.hpp
+++ b/src/complex/Filter/Actions/CreateArrayAction.hpp
@@ -8,7 +8,7 @@ namespace complex
 /**
  * @brief Action for creating DataArrays in a DataStructure
  */
-class COMPLEX_EXPORT CreateArrayAction : public IDataAction
+class COMPLEX_EXPORT CreateArrayAction : public IDataCreationAction
 {
 public:
   CreateArrayAction() = delete;
@@ -58,6 +58,5 @@ private:
   NumericType m_Type;
   std::vector<usize> m_Dims;
   std::vector<usize> m_CDims;
-  DataPath m_Path;
 };
 } // namespace complex

--- a/src/complex/Filter/Actions/CreateDataGroupAction.cpp
+++ b/src/complex/Filter/Actions/CreateDataGroupAction.cpp
@@ -9,23 +9,18 @@ namespace complex
 {
 //------------------------------------------------------------------------------
 CreateDataGroupAction::CreateDataGroupAction(const DataPath& path)
-: m_Path(path)
+: IDataCreationAction(path)
 {
 }
 
 CreateDataGroupAction::~CreateDataGroupAction() noexcept = default;
 
-DataPath CreateDataGroupAction::parentPath() const
-{
-  return m_Path;
-}
-
 Result<> CreateDataGroupAction::apply(DataStructure& dataStructure, Mode mode) const
 {
-  Result<LinkedPath> linkedPath = dataStructure.makePath(m_Path);
+  Result<LinkedPath> linkedPath = dataStructure.makePath(getCreatedPath());
   if(!linkedPath.valid())
   {
-    return MakeErrorResult(-2, fmt::format("Path '{}' was not created.", m_Path.toString()));
+    return MakeErrorResult(-2, fmt::format("Path '{}' was not created.", getCreatedPath().toString()));
   }
   // Assuming nothing went wrong, return an empty Result<> object
   return {};

--- a/src/complex/Filter/Actions/CreateDataGroupAction.hpp
+++ b/src/complex/Filter/Actions/CreateDataGroupAction.hpp
@@ -9,7 +9,7 @@ namespace complex
 /**
  * @brief Action to create a DataGroup with the DataStructure
  */
-class COMPLEX_EXPORT CreateDataGroupAction : public IDataAction
+class COMPLEX_EXPORT CreateDataGroupAction : public IDataCreationAction
 {
 public:
   CreateDataGroupAction() = delete;
@@ -31,13 +31,6 @@ public:
    */
   Result<> apply(DataStructure& dataStructure, Mode mode) const override;
 
-  /**
-   * @brief Returns the path of the DataGroup to be created.
-   * @return
-   */
-  [[nodiscard]] DataPath parentPath() const;
-
 private:
-  DataPath m_Path = {};
 };
 } // namespace complex

--- a/src/complex/Filter/Actions/CreateImageGeometryAction.cpp
+++ b/src/complex/Filter/Actions/CreateImageGeometryAction.cpp
@@ -8,11 +8,11 @@ using namespace complex;
 
 namespace complex
 {
-CreateImageGeometryAction::CreateImageGeometryAction(DataPath path, DimensionType dims, OriginType origin, SpacingType spacing)
-: m_GeometryPath(std::move(path))
-, m_Dims(std::move(dims))
-, m_Origin(std::move(origin))
-, m_Spacing(std::move(spacing))
+CreateImageGeometryAction::CreateImageGeometryAction(const DataPath& path, const DimensionType& dims, const OriginType& origin, const SpacingType& spacing)
+: IDataCreationAction(path)
+, m_Dims(dims)
+, m_Origin(origin)
+, m_Spacing(spacing)
 {
 }
 
@@ -21,23 +21,23 @@ CreateImageGeometryAction::~CreateImageGeometryAction() noexcept = default;
 Result<> CreateImageGeometryAction::apply(DataStructure& dataStructure, Mode mode) const
 {
   // Check for empty Geometry DataPath
-  if(m_GeometryPath.empty())
+  if(getCreatedPath().empty())
   {
     return MakeErrorResult(-220, "CreateImageGeometryAction: Geometry Path cannot be empty");
   }
   // Check if the Geometry Path already exists
-  BaseGroup* parentObject = dataStructure.getDataAs<BaseGroup>(m_GeometryPath);
+  BaseGroup* parentObject = dataStructure.getDataAs<BaseGroup>(getCreatedPath());
   if(parentObject != nullptr)
   {
-    return MakeErrorResult(-222, fmt::format("CreateImageGeometryAction: DataObject already exists at path '{}'", m_GeometryPath.toString()));
+    return MakeErrorResult(-222, fmt::format("CreateImageGeometryAction: DataObject already exists at path '{}'", getCreatedPath().toString()));
   }
-  DataPath parentPath = m_GeometryPath.getParent();
+  DataPath parentPath = getCreatedPath().getParent();
   if(!parentPath.empty())
   {
     Result<LinkedPath> geomPath = dataStructure.makePath(parentPath);
     if(geomPath.invalid())
     {
-      return MakeErrorResult(-223, fmt::format("CreateGeometry2DAction: Geometry could not be created at path:'{}'", m_GeometryPath.toString()));
+      return MakeErrorResult(-223, fmt::format("CreateGeometry2DAction: Geometry could not be created at path:'{}'", getCreatedPath().toString()));
     }
   }
   // Get the Parent ID
@@ -47,7 +47,7 @@ Result<> CreateImageGeometryAction::apply(DataStructure& dataStructure, Mode mod
   }
 
   // Create the ImageGeometry
-  ImageGeom* imageGeom = ImageGeom::Create(dataStructure, m_GeometryPath.getTargetName(), dataStructure.getId(parentPath).value());
+  ImageGeom* imageGeom = ImageGeom::Create(dataStructure, getCreatedPath().getTargetName(), dataStructure.getId(parentPath).value());
   imageGeom->setDimensions(m_Dims);
   imageGeom->setOrigin(m_Origin);
   imageGeom->setSpacing(m_Spacing);
@@ -55,9 +55,9 @@ Result<> CreateImageGeometryAction::apply(DataStructure& dataStructure, Mode mod
   return {};
 }
 
-const DataPath& CreateImageGeometryAction::path() const
+DataPath CreateImageGeometryAction::path() const
 {
-  return m_GeometryPath;
+  return getCreatedPath();
 }
 
 const CreateImageGeometryAction::DimensionType& CreateImageGeometryAction::dims() const

--- a/src/complex/Filter/Actions/CreateImageGeometryAction.hpp
+++ b/src/complex/Filter/Actions/CreateImageGeometryAction.hpp
@@ -9,7 +9,7 @@ namespace complex
 /**
  * @brief Action for creating an ImageGeometry in a DataStructure
  */
-class COMPLEX_EXPORT CreateImageGeometryAction : public IDataAction
+class COMPLEX_EXPORT CreateImageGeometryAction : public IDataCreationAction
 {
 public:
   using DimensionType = std::vector<size_t>;
@@ -18,7 +18,7 @@ public:
 
   CreateImageGeometryAction() = delete;
 
-  CreateImageGeometryAction(DataPath path, DimensionType dims, OriginType origin, SpacingType spacing);
+  CreateImageGeometryAction(const DataPath& path, const DimensionType& dims, const OriginType& origin, const SpacingType& spacing);
 
   ~CreateImageGeometryAction() noexcept override;
 
@@ -37,9 +37,9 @@ public:
 
   /**
    * @brief Returns the path of the ImageGeometry to be created.
-   * @return
+   * @return DataPath
    */
-  const DataPath& path() const;
+  DataPath path() const;
 
   /**
    * @brief Returns the dimensions of the ImageGeometry to be created.
@@ -60,7 +60,6 @@ public:
   const SpacingType& spacing() const;
 
 private:
-  DataPath m_GeometryPath;
   DimensionType m_Dims;
   OriginType m_Origin;
   SpacingType m_Spacing;

--- a/src/complex/Filter/Actions/CreateNeighborListAction.cpp
+++ b/src/complex/Filter/Actions/CreateNeighborListAction.cpp
@@ -10,9 +10,9 @@ using namespace complex;
 namespace complex
 {
 CreateNeighborListAction::CreateNeighborListAction(DataType type, usize tupleCount, const DataPath& path)
-: m_Type(type)
+: IDataCreationAction(path)
+, m_Type(type)
 , m_TupleCount(tupleCount)
-, m_Path(path)
 {
 }
 
@@ -24,34 +24,34 @@ Result<> CreateNeighborListAction::apply(DataStructure& dataStructure, Mode mode
   switch(m_Type)
   {
   case DataType::int8: {
-    return CreateNeighbors<int8>(dataStructure, m_TupleCount, m_Path, mode);
+    return CreateNeighbors<int8>(dataStructure, m_TupleCount, getCreatedPath(), mode);
   }
   case DataType::uint8: {
-    return CreateNeighbors<uint8>(dataStructure, m_TupleCount, m_Path, mode);
+    return CreateNeighbors<uint8>(dataStructure, m_TupleCount, getCreatedPath(), mode);
   }
   case DataType::int16: {
-    return CreateNeighbors<int16>(dataStructure, m_TupleCount, m_Path, mode);
+    return CreateNeighbors<int16>(dataStructure, m_TupleCount, getCreatedPath(), mode);
   }
   case DataType::uint16: {
-    return CreateNeighbors<uint16>(dataStructure, m_TupleCount, m_Path, mode);
+    return CreateNeighbors<uint16>(dataStructure, m_TupleCount, getCreatedPath(), mode);
   }
   case DataType::int32: {
-    return CreateNeighbors<int32>(dataStructure, m_TupleCount, m_Path, mode);
+    return CreateNeighbors<int32>(dataStructure, m_TupleCount, getCreatedPath(), mode);
   }
   case DataType::uint32: {
-    return CreateNeighbors<uint32>(dataStructure, m_TupleCount, m_Path, mode);
+    return CreateNeighbors<uint32>(dataStructure, m_TupleCount, getCreatedPath(), mode);
   }
   case DataType::int64: {
-    return CreateNeighbors<int64>(dataStructure, m_TupleCount, m_Path, mode);
+    return CreateNeighbors<int64>(dataStructure, m_TupleCount, getCreatedPath(), mode);
   }
   case DataType::uint64: {
-    return CreateNeighbors<uint64>(dataStructure, m_TupleCount, m_Path, mode);
+    return CreateNeighbors<uint64>(dataStructure, m_TupleCount, getCreatedPath(), mode);
   }
   case DataType::float32: {
-    return CreateNeighbors<float32>(dataStructure, m_TupleCount, m_Path, mode);
+    return CreateNeighbors<float32>(dataStructure, m_TupleCount, getCreatedPath(), mode);
   }
   case DataType::float64: {
-    return CreateNeighbors<float64>(dataStructure, m_TupleCount, m_Path, mode);
+    return CreateNeighbors<float64>(dataStructure, m_TupleCount, getCreatedPath(), mode);
   }
   default:
     throw std::runtime_error(fmt::format("CreateNeighborListAction: Invalid Numeric Type '{}'", to_underlying(m_Type)));
@@ -70,6 +70,6 @@ usize CreateNeighborListAction::tupleCount() const
 
 DataPath CreateNeighborListAction::path() const
 {
-  return m_Path;
+  return getCreatedPath();
 }
 } // namespace complex

--- a/src/complex/Filter/Actions/CreateNeighborListAction.hpp
+++ b/src/complex/Filter/Actions/CreateNeighborListAction.hpp
@@ -9,7 +9,7 @@ namespace complex
  * @class CreateNeighborListAction
  * @brief Action for creating NeighborList arrays in a DataStructure
  */
-class COMPLEX_EXPORT CreateNeighborListAction : public IDataAction
+class COMPLEX_EXPORT CreateNeighborListAction : public IDataCreationAction
 {
 public:
   CreateNeighborListAction() = delete;
@@ -52,6 +52,5 @@ public:
 private:
   DataType m_Type;
   usize m_TupleCount;
-  DataPath m_Path;
 };
 } // namespace complex

--- a/src/complex/Filter/Actions/ImportObjectAction.cpp
+++ b/src/complex/Filter/Actions/ImportObjectAction.cpp
@@ -17,8 +17,8 @@ constexpr complex::int32 k_InsertFailureError = -2;
 namespace complex
 {
 ImportObjectAction::ImportObjectAction(const std::shared_ptr<DataObject>& importObject, const DataPath& path)
-: m_ImportData(importObject)
-, m_Path(path)
+: IDataCreationAction(path)
+, m_ImportData(importObject)
 {
 }
 
@@ -33,9 +33,9 @@ Result<> ImportObjectAction::apply(DataStructure& dataStructure, Mode mode) cons
     importGroup->clear();
   }
 
-  if(!dataStructure.insert(importData, m_Path.getParent()))
+  if(!dataStructure.insert(importData, getCreatedPath().getParent()))
   {
-    return {nonstd::make_unexpected(std::vector<Error>{{k_InsertFailureError, fmt::format("Unable to import DataObject at '{}'", m_Path.toString())}})};
+    return {nonstd::make_unexpected(std::vector<Error>{{k_InsertFailureError, fmt::format("Unable to import DataObject at '{}'", getCreatedPath().toString())}})};
   }
 
   return {};
@@ -48,6 +48,6 @@ std::shared_ptr<DataObject> ImportObjectAction::getImportObject() const
 
 DataPath ImportObjectAction::path() const
 {
-  return m_Path;
+  return getCreatedPath();
 }
 } // namespace complex

--- a/src/complex/Filter/Actions/ImportObjectAction.hpp
+++ b/src/complex/Filter/Actions/ImportObjectAction.hpp
@@ -7,7 +7,7 @@ namespace complex
 /**
  * @brief Action for importing DataObjects into a DataStructure.
  */
-class COMPLEX_EXPORT ImportObjectAction : public IDataAction
+class COMPLEX_EXPORT ImportObjectAction : public IDataCreationAction
 {
 public:
   ImportObjectAction() = delete;
@@ -44,6 +44,5 @@ public:
 
 private:
   std::shared_ptr<DataObject> m_ImportData;
-  DataPath m_Path;
 };
 } // namespace complex

--- a/src/complex/Filter/Output.hpp
+++ b/src/complex/Filter/Output.hpp
@@ -44,6 +44,41 @@ protected:
 };
 
 /**
+ * @brief The IDataCreationAction class is a subclass of IDataAction used for
+ * inserting a DataObject to a target DataStructure.
+ */
+class IDataCreationAction : public IDataAction
+{
+public:
+  /**
+   * @brief Constructs an IDataCreationAction that takes a DataPath specifying the path to be created.
+   * @param createdPath
+   */
+  IDataCreationAction(const DataPath& createdPath)
+  : m_CreatedPath(createdPath)
+  {
+  }
+  virtual ~IDataCreationAction() = default;
+
+  IDataCreationAction(const IDataCreationAction&) = delete;
+  IDataCreationAction(IDataCreationAction&&) noexcept = delete;
+  IDataCreationAction& operator=(const IDataCreationAction&) = delete;
+  IDataCreationAction& operator=(IDataCreationAction&&) noexcept = delete;
+
+  /**
+   * @brief Returns the DataPath to be created.
+   * @return DataPath
+   */
+  DataPath getCreatedPath() const
+  {
+    return m_CreatedPath;
+  }
+
+private:
+  DataPath m_CreatedPath;
+};
+
+/**
  * @brief Container for IDataActions
  */
 struct OutputActions

--- a/src/complex/Filter/Output.hpp
+++ b/src/complex/Filter/Output.hpp
@@ -58,7 +58,7 @@ public:
   : m_CreatedPath(createdPath)
   {
   }
-  virtual ~IDataCreationAction() = default;
+  ~IDataCreationAction() noexcept override = default;
 
   IDataCreationAction(const IDataCreationAction&) = delete;
   IDataCreationAction(IDataCreationAction&&) noexcept = delete;

--- a/src/complex/Pipeline/AbstractPipelineNode.cpp
+++ b/src/complex/Pipeline/AbstractPipelineNode.cpp
@@ -93,6 +93,12 @@ void AbstractPipelineNode::endExecution(DataStructure& dataStructure)
   setDataStructure(dataStructure);
 }
 
+bool AbstractPipelineNode::preflight(DataStructure& data)
+{
+  RenamedPaths renamedPaths;
+  return preflight(data, renamedPaths);
+}
+
 void AbstractPipelineNode::notify(const std::shared_ptr<AbstractPipelineMessage>& msg)
 {
   m_Signal(this, msg);

--- a/src/complex/Pipeline/AbstractPipelineNode.cpp
+++ b/src/complex/Pipeline/AbstractPipelineNode.cpp
@@ -93,10 +93,10 @@ void AbstractPipelineNode::endExecution(DataStructure& dataStructure)
   setDataStructure(dataStructure);
 }
 
-bool AbstractPipelineNode::preflight(DataStructure& data)
+bool AbstractPipelineNode::preflight(DataStructure& data, const std::atomic_bool& shouldCancel)
 {
   RenamedPaths renamedPaths;
-  return preflight(data, renamedPaths);
+  return preflight(data, renamedPaths, shouldCancel);
 }
 
 void AbstractPipelineNode::notify(const std::shared_ptr<AbstractPipelineMessage>& msg)

--- a/src/complex/Pipeline/AbstractPipelineNode.hpp
+++ b/src/complex/Pipeline/AbstractPipelineNode.hpp
@@ -30,6 +30,9 @@ public:
   // they contain.
   friend class Pipeline;
 
+  using RenamedPath = std::pair<DataPath, DataPath>;
+  using RenamedPaths = std::vector<RenamedPath>;
+
   using SignalType = nod::signal<void(AbstractPipelineNode*, const std::shared_ptr<AbstractPipelineMessage>&)>;
 
   using PipelineRunStateSignalType = nod::signal<void(AbstractPipelineNode*, RunState)>;
@@ -121,6 +124,16 @@ public:
    * @return bool
    */
   virtual bool preflight(DataStructure& data, const std::atomic_bool& shouldCancel) = 0;
+
+  /**
+   * @brief Attempts to preflight the node using the provided DataStructure.
+   * Returns true if preflighting succeeded. Otherwise, this returns false.
+   * @param data
+   * @param RenamedPaths& renamedPaths = {} Collection of renamed output paths.
+   * Only used for PipelineFilters.
+   * @return bool
+   */
+  virtual bool preflight(DataStructure& data, RenamedPaths& renamedPaths) = 0;
 
   /**
    * @brief Attempts to execute the node using the provided DataStructure.

--- a/src/complex/Pipeline/AbstractPipelineNode.hpp
+++ b/src/complex/Pipeline/AbstractPipelineNode.hpp
@@ -133,7 +133,7 @@ public:
    * Only used for PipelineFilters.
    * @return bool
    */
-  virtual bool preflight(DataStructure& data, RenamedPaths& renamedPaths) = 0;
+  virtual bool preflight(DataStructure& data, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel) = 0;
 
   /**
    * @brief Attempts to execute the node using the provided DataStructure.

--- a/src/complex/Pipeline/Messaging/OutputRenamedMessage.cpp
+++ b/src/complex/Pipeline/Messaging/OutputRenamedMessage.cpp
@@ -8,7 +8,7 @@ OutputRenamedMessage::OutputRenamedMessage(AbstractPipelineNode* pipeline, const
 {
 }
 
-OutputRenamedMessage::~OutputRenamedMessage() = default;
+OutputRenamedMessage::~OutputRenamedMessage() noexcept = default;
 
 PipelineFilter::RenamedPath OutputRenamedMessage::getRenamedPath() const
 {

--- a/src/complex/Pipeline/Messaging/OutputRenamedMessage.cpp
+++ b/src/complex/Pipeline/Messaging/OutputRenamedMessage.cpp
@@ -1,0 +1,31 @@
+#include "complex/Pipeline/Messaging/OutputRenamedMessage.hpp"
+
+using namespace complex;
+
+OutputRenamedMessage::OutputRenamedMessage(AbstractPipelineNode* pipeline, const PipelineFilter::RenamedPath& renamedOutput)
+: AbstractPipelineMessage(pipeline)
+, m_RenamedPath(renamedOutput)
+{
+}
+
+OutputRenamedMessage::~OutputRenamedMessage() = default;
+
+PipelineFilter::RenamedPath OutputRenamedMessage::getRenamedPath() const
+{
+  return m_RenamedPath;
+}
+
+DataPath OutputRenamedMessage::getPreviousPath() const
+{
+  return m_RenamedPath.second;
+}
+
+DataPath OutputRenamedMessage::getNewPath() const
+{
+  return m_RenamedPath.first;
+}
+
+std::string OutputRenamedMessage::toString() const
+{
+  return fmt::format("Renamed created DataPath from '{}' to '{}'", getPreviousPath().toString(), getNewPath().toString());
+}

--- a/src/complex/Pipeline/Messaging/OutputRenamedMessage.hpp
+++ b/src/complex/Pipeline/Messaging/OutputRenamedMessage.hpp
@@ -26,7 +26,7 @@ public:
    */
   OutputRenamedMessage(AbstractPipelineNode* pipeline, const PipelineFilter::RenamedPath& renamedOutput);
 
-  virtual ~OutputRenamedMessage();
+  ~OutputRenamedMessage() noexcept override;
 
   /**
    * @brief Returns the PipelineFilter::RenamedPath pair.

--- a/src/complex/Pipeline/Messaging/OutputRenamedMessage.hpp
+++ b/src/complex/Pipeline/Messaging/OutputRenamedMessage.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "complex/Common/Types.hpp"
+#include "complex/Pipeline/Messaging/AbstractPipelineMessage.hpp"
+#include "complex/Pipeline/PipelineFilter.hpp"
+
+namespace complex
+{
+class AbstractPipelineNode;
+class Pipeline;
+
+/**
+ * @class OutputRenamedMessage
+ * @brief The OutputRenamedMessage class exists to notify PipelineFilter observers that a
+ * specified node's created DataPath was changed to the a new value.
+ */
+class COMPLEX_EXPORT OutputRenamedMessage : public AbstractPipelineMessage
+{
+public:
+  /**
+   * @brief Constructs a OutputRenamedMessage specifying which AbstractPipelineNode
+   * was added to the target Pipeline and the index it was added at.
+   * @param pipeline
+   * @param newNode
+   * @param index
+   */
+  OutputRenamedMessage(AbstractPipelineNode* pipeline, const PipelineFilter::RenamedPath& renamedOutput);
+
+  virtual ~OutputRenamedMessage();
+
+  /**
+   * @brief Returns the PipelineFilter::RenamedPath pair.
+   * @return PipelineFilter::RenamedPath
+   */
+  PipelineFilter::RenamedPath getRenamedPath() const;
+
+  /**
+   * @brief Returns the previous output path
+   * @return DataPath
+   */
+  DataPath getPreviousPath() const;
+
+  /**
+   * @brief Returns the new output path
+   * @return DataPath
+   */
+  DataPath getNewPath() const;
+
+  /**
+   * @brief Returns a string representation of the message.
+   * @return std::string
+   */
+  std::string toString() const override;
+
+private:
+  PipelineFilter::RenamedPath m_RenamedPath;
+};
+} // namespace complex

--- a/src/complex/Pipeline/Pipeline.cpp
+++ b/src/complex/Pipeline/Pipeline.cpp
@@ -127,6 +127,11 @@ void Pipeline::setName(const std::string& name)
 bool Pipeline::preflight(const std::atomic_bool& shouldCancel)
 {
   DataStructure ds;
+  return preflight(ds, shouldCancel);
+}
+
+bool Pipeline::preflight(DataStructure& ds, const std::atomic_bool& shouldCancel)
+{
   RenamedPaths renamedPaths;
   return preflight(ds, renamedPaths, shouldCancel);
 }
@@ -166,7 +171,7 @@ bool Pipeline::preflightFrom(index_type index, DataStructure& ds, const std::ato
   return preflightFrom(index, ds, renamedPaths);
 }
 
-bool Pipeline::preflightFrom(index_type index, DataStructure& ds, RenamedPaths& renamedPaths)
+bool Pipeline::preflightFrom(index_type index, DataStructure& ds, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel)
 {
   if(!canPreflightFrom(index))
   {
@@ -197,7 +202,7 @@ bool Pipeline::preflightFrom(index_type index, DataStructure& ds, RenamedPaths& 
     }
     startObservingNode(iter->get());
     PipelineFilter::RenamedPaths renamedPathsRef;
-    bool succeeded = node->preflight(ds, renamedPathsRef);
+    bool succeeded = node->preflight(ds, renamedPathsRef, shouldCancel);
     stopObservingNode();
 
     renamedPaths.insert(renamedPaths.end(), renamedPathsRef.begin(), renamedPathsRef.end());
@@ -223,7 +228,7 @@ bool Pipeline::preflightFrom(index_type index, const std::atomic_bool& shouldCan
   return preflightFrom(index, renamedPaths);
 }
 
-bool Pipeline::preflightFrom(index_type index, RenamedPaths& renamedPaths)
+bool Pipeline::preflightFrom(index_type index, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel)
 {
   if(index == 0)
   {

--- a/src/complex/Pipeline/Pipeline.cpp
+++ b/src/complex/Pipeline/Pipeline.cpp
@@ -202,9 +202,8 @@ bool Pipeline::preflightFrom(index_type index, DataStructure& ds, RenamedPaths& 
 
     renamedPaths.insert(renamedPaths.end(), renamedPathsRef.begin(), renamedPathsRef.end());
 
-    bool succeeded = filter->preflight(ds);
-
-    setHasWarnings(filter->hasWarnings());
+    setHasWarnings(node->hasWarnings());
+    setHasWarnings(node->hasWarnings());
     if(!succeeded)
     {
       setHasErrors(true);

--- a/src/complex/Pipeline/Pipeline.hpp
+++ b/src/complex/Pipeline/Pipeline.hpp
@@ -122,9 +122,10 @@ public:
    * Returns true if the pipeline segment completes without errors. Returns
    * false otherwise.
    * @param ds
+   * @param renamedPaths
    * @return bool
    */
-  bool preflight(DataStructure& ds, const std::atomic_bool& shouldCancel) override;
+  bool preflight(DataStructure& ds, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel) override;
 
   /**
    * @brief Executes the pipeline segment using the provided DataStructure.
@@ -149,14 +150,39 @@ public:
 
   /**
    * @brief Preflights the pipeline segment from a target position using the
+   * provided DataStructure.
+   *
+   * Returns true if the pipeline segment completes without errors. Returns
+   * false otherwise. Returns false if the starting index is out of bounds.
+   * @param index
+   * @param ds
+   * @param renamedPaths
+   * @return bool
+   */
+  bool preflightFrom(index_type index, DataStructure& ds, RenamedPaths& renamedPaths);
+
+  /**
+   * @brief Preflights the pipeline segment from a target position using the
    * DataStructure at the previous index. Uses an empty DataStructure if index is 0.
    *
    * Returns true if the pipeline segment completes without errors. Returns
    * false otherwise. Returns false if the starting index is out of bounds.
    * @param index
-   * @return
+   * @return bool
    */
   bool preflightFrom(index_type index, const std::atomic_bool& shouldCancel = false);
+
+  /**
+   * @brief Preflights the pipeline segment from a target position using the
+   * DataStructure at the previous index. Uses an empty DataStructure if index is 0.
+   *
+   * Returns true if the pipeline segment completes without errors. Returns
+   * false otherwise. Returns false if the starting index is out of bounds.
+   * @param index
+   * @param renamedPaths
+   * @return bool
+   */
+  bool preflightFrom(index_type index, RenamedPaths& renamedPaths);
 
   /**
    * @brief Checks if the pipeline can be preflighted at the target index.

--- a/src/complex/Pipeline/Pipeline.hpp
+++ b/src/complex/Pipeline/Pipeline.hpp
@@ -110,6 +110,16 @@ public:
   bool preflight(const std::atomic_bool& shouldCancel = false);
 
   /**
+   * @brief Preflights the pipeline segment using the provided DataStructure.
+   * Returns true if the pipeline segment completes without errors. Returns
+   * false otherwise.
+   * @param ds
+   * @param renamedPaths
+   * @return bool
+   */
+  bool preflight(DataStructure& ds, const std::atomic_bool& shouldCancel) override;
+
+  /**
    * @brief Executes the pipeline segment using an empty DataStructure.
    * Returns true if the pipeline segment completes without errors. Returns
    * false otherwise.
@@ -159,7 +169,7 @@ public:
    * @param renamedPaths
    * @return bool
    */
-  bool preflightFrom(index_type index, DataStructure& ds, RenamedPaths& renamedPaths);
+  bool preflightFrom(index_type index, DataStructure& ds, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel = false);
 
   /**
    * @brief Preflights the pipeline segment from a target position using the
@@ -170,7 +180,7 @@ public:
    * @param index
    * @return bool
    */
-  bool preflightFrom(index_type index, const std::atomic_bool& shouldCancel = false);
+  bool preflightFrom(index_type index, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel = false);
 
   /**
    * @brief Preflights the pipeline segment from a target position using the
@@ -182,7 +192,7 @@ public:
    * @param renamedPaths
    * @return bool
    */
-  bool preflightFrom(index_type index, RenamedPaths& renamedPaths);
+  bool preflightFrom(index_type index, const std::atomic_bool& shouldCancel = false);
 
   /**
    * @brief Checks if the pipeline can be preflighted at the target index.

--- a/src/complex/Pipeline/PipelineFilter.cpp
+++ b/src/complex/Pipeline/PipelineFilter.cpp
@@ -305,8 +305,8 @@ void removeOverlap(std::vector<DataPath>& group1, std::vector<DataPath>& group2)
   auto overlap = getOverlap(group1, group2);
   for(const auto& value : overlap)
   {
-    std::remove(group1.begin(), group1.end(), value);
-    std::remove(group2.begin(), group2.end(), value);
+    group1.erase(std::remove(group1.begin(), group1.end(), value), group1.end());
+    group2.erase(std::remove(group2.begin(), group2.end(), value), group2.end());
   }
 }
 

--- a/src/complex/Pipeline/PipelineFilter.cpp
+++ b/src/complex/Pipeline/PipelineFilter.cpp
@@ -81,6 +81,71 @@ void PipelineFilter::setIndex(int32 index)
 }
 
 // -----------------------------------------------------------------------------
+bool PipelineFilter::preflight(DataStructure& data, const std::atomic_bool& shouldCancel)
+{
+  sendFilterRunStateMessage(m_Index, RunState::Preflighting);
+
+  std::vector<DataPath> oldCreatedPaths = m_CreatedPaths;
+
+  IFilter::MessageHandler messageHandler{[this](const IFilter::Message& message) { this->notifyFilterMessage(message); }};
+
+  clearFaultState();
+  IFilter::PreflightResult result = m_Filter->preflight(data, getArguments(), messageHandler, shouldCancel);
+  m_Warnings = std::move(result.outputActions.warnings());
+  setHasWarnings(!m_Warnings.empty());
+  m_PreflightValues = std::move(result.outputValues);
+  if(result.outputActions.invalid())
+  {
+    m_Errors = std::move(result.outputActions.errors());
+    setHasErrors();
+    setPreflightStructure(data, false);
+    sendFilterFaultMessage(m_Index, getFaultState());
+    sendFilterFaultDetailMessage(m_Index, m_Warnings, m_Errors);
+    return false;
+  }
+
+  m_Errors.clear();
+
+  std::vector<DataPath> newCreatedPaths;
+  for(const auto& action : result.outputActions.value().actions)
+  {
+    Result<> actionResult = action->apply(data, IDataAction::Mode::Preflight);
+    for(auto&& warning : actionResult.warnings())
+    {
+      m_Warnings.push_back(std::move(warning));
+    }
+    setHasWarnings(!m_Warnings.empty());
+    if(actionResult.invalid())
+    {
+      m_Errors = std::move(actionResult.errors());
+      setPreflightStructure(data, false);
+      setHasErrors();
+      sendFilterFaultMessage(m_Index, getFaultState());
+      sendFilterFaultDetailMessage(m_Index, m_Warnings, m_Errors);
+      return false;
+    }
+    if(auto* creationAction = dynamic_cast<IDataCreationAction*>(action.get()))
+    {
+      newCreatedPaths.push_back(creationAction->getCreatedPath());
+    }
+  }
+
+  // Do not clear the created paths unless the preflight succeeded
+  m_CreatedPaths = newCreatedPaths;
+
+  setPreflightStructure(data);
+  sendFilterFaultMessage(m_Index, getFaultState());
+  if(!m_Warnings.empty() || !m_Errors.empty())
+  {
+    sendFilterFaultDetailMessage(m_Index, m_Warnings, m_Errors);
+  }
+  auto renamedPaths = checkForRenamedPaths(oldCreatedPaths);
+
+  notifyRenamedPaths(renamedPaths);
+  sendFilterRunStateMessage(m_Index, RunState::Idle);
+  return true;
+}
+
 bool PipelineFilter::preflight(DataStructure& data, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel)
 {
   sendFilterRunStateMessage(m_Index, RunState::Preflighting);

--- a/src/complex/Pipeline/PipelineFilter.cpp
+++ b/src/complex/Pipeline/PipelineFilter.cpp
@@ -1,8 +1,11 @@
 #include "PipelineFilter.hpp"
 
+#include <algorithm>
+
 #include "complex/Core/Application.hpp"
 #include "complex/Filter/FilterList.hpp"
 #include "complex/Pipeline/Messaging/FilterPreflightMessage.hpp"
+#include "complex/Pipeline/Messaging/OutputRenamedMessage.hpp"
 #include "complex/Pipeline/Messaging/PipelineFilterMessage.hpp"
 
 #include <nlohmann/json.hpp>
@@ -78,9 +81,11 @@ void PipelineFilter::setIndex(int32 index)
 }
 
 // -----------------------------------------------------------------------------
-bool PipelineFilter::preflight(DataStructure& data, const std::atomic_bool& shouldCancel)
+bool PipelineFilter::preflight(DataStructure& data, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel)
 {
   sendFilterRunStateMessage(m_Index, RunState::Preflighting);
+
+  std::vector<DataPath> oldCreatedPaths = m_CreatedPaths;
 
   IFilter::MessageHandler messageHandler{[this](const IFilter::Message& message) { this->notifyFilterMessage(message); }};
 
@@ -101,6 +106,7 @@ bool PipelineFilter::preflight(DataStructure& data, const std::atomic_bool& shou
 
   m_Errors.clear();
 
+  std::vector<DataPath> newCreatedPaths;
   for(const auto& action : result.outputActions.value().actions)
   {
     Result<> actionResult = action->apply(data, IDataAction::Mode::Preflight);
@@ -118,7 +124,14 @@ bool PipelineFilter::preflight(DataStructure& data, const std::atomic_bool& shou
       sendFilterFaultDetailMessage(m_Index, m_Warnings, m_Errors);
       return false;
     }
+    if(auto* creationAction = dynamic_cast<IDataCreationAction*>(action.get()))
+    {
+      newCreatedPaths.push_back(creationAction->getCreatedPath());
+    }
   }
+
+  // Do not clear the created paths unless the preflight succeeded
+  m_CreatedPaths = newCreatedPaths;
 
   setPreflightStructure(data);
   sendFilterFaultMessage(m_Index, getFaultState());
@@ -126,7 +139,9 @@ bool PipelineFilter::preflight(DataStructure& data, const std::atomic_bool& shou
   {
     sendFilterFaultDetailMessage(m_Index, m_Warnings, m_Errors);
   }
+  renamedPaths = checkForRenamedPaths(oldCreatedPaths);
 
+  notifyRenamedPaths(renamedPaths);
   sendFilterRunStateMessage(m_Index, RunState::Idle);
   return true;
 }
@@ -168,6 +183,162 @@ bool PipelineFilter::execute(DataStructure& data, const std::atomic_bool& should
   return result.result.valid();
 }
 
+std::vector<DataPath> PipelineFilter::getCreatedPaths() const
+{
+  return m_CreatedPaths;
+}
+
+namespace
+{
+/**
+ * @brief Checks if one path could be a rename of another path.
+ * Returns false if the lengths do not match or more than one segment has a different name.
+ * @param path1
+ * @param path2
+ * @return bool
+ */
+bool checkIfRename(const DataPath& path1, const DataPath& path2)
+{
+  if(path1.getLength() != path2.getLength())
+  {
+    return false;
+  }
+
+  usize count = path1.getLength();
+  usize numDifferences = 0;
+  for(size_t i = 0; i < count; i++)
+  {
+    if(path1[i] != path2[i])
+    {
+      numDifferences++;
+    }
+  }
+
+  return numDifferences == 1;
+}
+
+/**
+ * @brief Finds and returns the overlap between two collections of DataPaths.
+ * @param group1
+ * @param group2
+ * @return std::vector<DataPath>
+ */
+std::vector<DataPath> getOverlap(const std::vector<DataPath>& group1, const std::vector<DataPath>& group2)
+{
+  std::vector<DataPath> overlap;
+  std::set_intersection(group1.begin(), group1.end(), group2.begin(), group2.end(), std::inserter(overlap, overlap.begin()));
+  return overlap;
+}
+
+/**
+ * @brief Removes the overlap between two groups of DataPaths
+ * @param group1
+ * @param group2
+ */
+void removeOverlap(std::vector<DataPath>& group1, std::vector<DataPath>& group2)
+{
+  auto overlap = getOverlap(group1, group2);
+  for(const auto& value : overlap)
+  {
+    std::remove(group1.begin(), group1.end(), value);
+    std::remove(group2.begin(), group2.end(), value);
+  }
+}
+
+/**
+ * @brief Finds and returns all detected rename paths between two collections of created DataPaths.
+ * @param oldCreatedPaths
+ * @param newCreatedPaths
+ * @return PipelineFilter::RenamedPaths
+ */
+PipelineFilter::RenamedPaths findAllRenamePaths(const std::vector<DataPath>& oldCreatedPaths, const std::vector<DataPath>& newCreatedPaths)
+{
+  PipelineFilter::RenamedPaths renamedPairs;
+  std::vector<DataPath> remainingPaths = oldCreatedPaths;
+  for(const auto& createdPath : newCreatedPaths)
+  {
+    for(const auto& oldPath : remainingPaths)
+    {
+      if(checkIfRename(createdPath, oldPath))
+      {
+        renamedPairs.push_back({createdPath, oldPath});
+      }
+    }
+  }
+  return renamedPairs;
+}
+
+/**
+ * @brief Takes a collection of possible renamed paths and returns a collection
+ * of pairs that can be determined with a reasonable degree of certainty.
+ *
+ * Rename pairs that could have been between multiple sets of DataPaths are rejected.
+ * @param renamedPairs
+ * @return PipelineFilter::RenamedPaths
+ */
+PipelineFilter::RenamedPaths getConfirmedRenamePaths(const PipelineFilter::RenamedPaths& renamedPairs)
+{
+  std::vector<DataPath> rejectedFirstPaths;
+  std::vector<DataPath> rejectedSecondPaths;
+
+  // Find rejected RenamedPaths
+  auto size = renamedPairs.size();
+  for(usize i = 0; i + 1 < size; i++)
+  {
+    const auto& pair1 = renamedPairs[i];
+
+    for(usize j = i; j < size; j++)
+    {
+      const auto& pair2 = renamedPairs[j];
+
+      // Check for repeated paths
+      if(pair1.first == pair2.first)
+      {
+        rejectedFirstPaths.push_back(pair1.first);
+      }
+      if(pair1.second == pair2.second)
+      {
+        rejectedSecondPaths.push_back(pair1.second);
+      }
+    }
+  }
+
+  PipelineFilter::RenamedPaths confirmed;
+  for(const auto& renamedPair : renamedPairs)
+  {
+    if(std::find(rejectedFirstPaths.begin(), rejectedFirstPaths.end(), renamedPair.first) != rejectedFirstPaths.end())
+    {
+      continue;
+    }
+    if(std::find(rejectedSecondPaths.begin(), rejectedSecondPaths.end(), renamedPair.second) != rejectedSecondPaths.end())
+    {
+      continue;
+    }
+    confirmed.push_back(renamedPair);
+  }
+
+  return confirmed;
+}
+} // namespace
+
+PipelineFilter::RenamedPaths PipelineFilter::checkForRenamedPaths(std::vector<DataPath> oldCreatedPaths) const
+{
+  // If created path sizes do not match, the values cannot be compared
+  if(oldCreatedPaths.size() != m_CreatedPaths.size())
+  {
+    return {};
+  }
+
+  // Create a copy of the created paths to edit in removeOverlap(...)
+  std::vector<DataPath> newCreatedPaths = m_CreatedPaths;
+
+  removeOverlap(oldCreatedPaths, newCreatedPaths);
+  auto renamedPairs = findAllRenamePaths(oldCreatedPaths, newCreatedPaths);
+  renamedPairs = getConfirmedRenamePaths(renamedPairs);
+
+  return renamedPairs;
+}
+
 std::vector<complex::Warning> PipelineFilter::getWarnings() const
 {
   return m_Warnings;
@@ -206,6 +377,14 @@ void PipelineFilter::notifyFilterMessage(const IFilter::Message& message)
   else if(message.type == IFilter::Message::Type::Warning)
   {
     sendFilterFaultMessage(m_Index, complex::FaultState::Warnings);
+  }
+}
+
+void PipelineFilter::notifyRenamedPaths(const RenamedPaths& renamedPathPairs)
+{
+  for(const auto& renamedPath : renamedPathPairs)
+  {
+    notify(std::make_shared<OutputRenamedMessage>(this, renamedPath));
   }
 }
 
@@ -283,4 +462,39 @@ Result<std::unique_ptr<PipelineFilter>> PipelineFilter::FromJson(const nlohmann:
   Result<std::unique_ptr<PipelineFilter>> result{std::make_unique<PipelineFilter>(std::move(filter), std::move(argsResult.value()))};
   result.warnings() = std::move(argsResult.warnings());
   return result;
+}
+
+bool isDataPath(const std::any& value)
+{
+  return value.type() == typeid(DataPath);
+}
+
+bool attemptRenamePath(DataPath& path, const AbstractPipelineNode::RenamedPaths& renamedPaths)
+{
+  bool pathChanged = false;
+  for(const auto& renamedPath : renamedPaths)
+  {
+    if(path.attemptRename(renamedPath.second, renamedPath.first))
+    {
+      pathChanged = true;
+    }
+  }
+
+  return pathChanged;
+}
+
+void PipelineFilter::renamePathArgs(const RenamedPaths& renamedPaths)
+{
+  for(const auto& arg : m_Arguments)
+  {
+    const std::any& argValue = arg.second;
+    if(isDataPath(argValue))
+    {
+      auto argPath = std::any_cast<DataPath>(argValue);
+      if(attemptRenamePath(argPath, renamedPaths))
+      {
+        m_Arguments.insertOrAssign(arg.first, std::make_any<DataPath>(argPath));
+      }
+    }
+  }
 }

--- a/src/complex/Pipeline/PipelineFilter.hpp
+++ b/src/complex/Pipeline/PipelineFilter.hpp
@@ -110,7 +110,16 @@ public:
    * @param renamedPaths Collection of renamed output paths.
    * @return bool
    */
-  bool preflight(DataStructure& data RenamedPathgs& renamedPaths, const std::atomic_bool& shouldCancel) override;
+  bool preflight(DataStructure& data, const std::atomic_bool& shouldCancel) override;
+
+  /**
+   * @brief Attempts to preflight the node using the provided DataStructure.
+   * Returns true if preflighting succeeded. Otherwise, this returns false.
+   * @param data
+   * @param renamedPaths Collection of renamed output paths.
+   * @return bool
+   */
+  bool preflight(DataStructure& data, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel) override;
 
   /**
    * @brief Attempts to execute the node using the provided DataStructure.

--- a/src/complex/Pipeline/PipelineFilter.hpp
+++ b/src/complex/Pipeline/PipelineFilter.hpp
@@ -107,9 +107,10 @@ public:
    * @brief Attempts to preflight the node using the provided DataStructure.
    * Returns true if preflighting succeeded. Otherwise, this returns false.
    * @param data
+   * @param renamedPaths Collection of renamed output paths.
    * @return bool
    */
-  bool preflight(DataStructure& data, const std::atomic_bool& shouldCancel) override;
+  bool preflight(DataStructure& data RenamedPathgs& renamedPaths, const std::atomic_bool& shouldCancel) override;
 
   /**
    * @brief Attempts to execute the node using the provided DataStructure.
@@ -118,6 +119,12 @@ public:
    * @return bool
    */
   bool execute(DataStructure& data, const std::atomic_bool& shouldCancel) override;
+
+  /**
+   * @brief Returns a vector of DataPaths created when preflighting the node.
+   * @return std::vector<DataPath>
+   */
+  std::vector<DataPath> getCreatedPaths() const;
 
   /**
    * @brief Returns a collection of warnings returned by the target filter.
@@ -152,6 +159,12 @@ public:
    */
   nlohmann::json toJson() const override;
 
+  /**
+   * @brief Adjusts arguments for renamed DataPaths.
+   * @param renamedPaths
+   */
+  void renamePathArgs(const RenamedPaths& renamedPaths);
+
 protected:
   /**
    * @brief Notifies observers to an IFilter::Message emitted by the IFilter
@@ -159,6 +172,23 @@ protected:
    * @param message
    */
   void notifyFilterMessage(const IFilter::Message& message);
+
+  /**
+   * @brief Notifies observers to a set of renamed DataPaths.
+   * @param renamedPathPairs
+   */
+  void notifyRenamedPaths(const RenamedPaths& renamedPathPairs);
+
+  /**
+   * @brief Checks for the renaming of created DataPaths.
+   * Emits notifications when a renaming is detected.
+   *
+   * This method does nothing if the number of created paths does not match
+   * the current count.
+   * @param oldCreatedPaths
+   * @return RenamedTypes
+   */
+  RenamedPaths checkForRenamedPaths(std::vector<DataPath> oldCreatedPaths) const;
 
 private:
   IFilter::UniquePointer m_Filter;
@@ -168,5 +198,6 @@ private:
   std::vector<complex::Warning> m_Warnings;
   std::vector<complex::Error> m_Errors;
   std::vector<IFilter::PreflightValue> m_PreflightValues;
+  std::vector<DataPath> m_CreatedPaths;
 };
 } // namespace complex


### PR DESCRIPTION
* PipelineFilter now checks for renamed outputs between preflights. A signal is emitted when the change in arguments results in a created DataObject having a different DataPath.
* Added IDataCreationAction as a subclass of IDataAction specific for the creation of DataObjects in the DataStructure.
* Pipelines adjust the arguments of PipelineFilter nodes following a renamed DataPath creation.
* Added a renamed output test to PipelineTest.cpp