### PR TITLE
DataObject::getParentDataPaths() and BaseGroup::empty()

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
@@ -114,8 +114,7 @@ IFilter::PreflightResult RemoveFlaggedVertices::preflightImpl(const DataStructur
     std::string errorMsg = fmt::format("Vertex Geometry does not have a vertex list");
     return {MakeErrorResult<OutputActions>(::k_VertexGeomNotFound, errorMsg)};
   }
-
-  dataArrayPaths.push_back(vertex->getVertices()->getDataPaths()[0]);
+  dataArrayPaths.push_back(vertex->getVertices()->getParentDataPaths()[0]);
 
   std::vector<size_t> cDims(1, 1);
 

--- a/src/complex/DataStructure/BaseGroup.cpp
+++ b/src/complex/DataStructure/BaseGroup.cpp
@@ -51,6 +51,11 @@ usize BaseGroup::getSize() const
   return m_DataMap.getSize();
 }
 
+bool BaseGroup::empty() const
+{
+  return m_DataMap.getSize() == 0;
+}
+
 DataMap& BaseGroup::getDataMap()
 {
   return m_DataMap;

--- a/src/complex/DataStructure/BaseGroup.cpp
+++ b/src/complex/DataStructure/BaseGroup.cpp
@@ -53,7 +53,7 @@ usize BaseGroup::getSize() const
 
 bool BaseGroup::empty() const
 {
-  return m_DataMap.getSize() == 0;
+  return m_DataMap.empty();
 }
 
 DataMap& BaseGroup::getDataMap()

--- a/src/complex/DataStructure/BaseGroup.hpp
+++ b/src/complex/DataStructure/BaseGroup.hpp
@@ -73,6 +73,12 @@ public:
   usize getSize() const;
 
   /**
+   * @brief Returns if there are any DataObjects in the group
+   * @return bool
+   */
+  bool empty() const;
+
+  /**
    * @brief Returns the underlying DataMap by value.
    * @return const DataMap&
    */

--- a/src/complex/DataStructure/DataMap.cpp
+++ b/src/complex/DataStructure/DataMap.cpp
@@ -44,6 +44,11 @@ usize DataMap::getSize() const
   return m_Map.size();
 }
 
+bool DataMap::empty() const
+{
+  return m_Map.empty();
+}
+
 bool DataMap::insert(const std::shared_ptr<DataObject>& obj)
 {
   if(obj == nullptr)

--- a/src/complex/DataStructure/DataMap.hpp
+++ b/src/complex/DataStructure/DataMap.hpp
@@ -73,6 +73,11 @@ public:
   usize getSize() const;
 
   /**
+   * @brief Returns if the DataMap is empty (true) or has elements (false)
+   */
+  bool empty() const;
+
+  /**
    * @brief Attempts to insert the target DataObject into the map.
    * Returns true if it succeeded. Returns false otherwise.
    * @param obj

--- a/src/complex/DataStructure/DataObject.cpp
+++ b/src/complex/DataStructure/DataObject.cpp
@@ -152,7 +152,7 @@ void DataObject::replaceParent(BaseGroup* oldParent, BaseGroup* newParent)
   std::replace(m_ParentList.begin(), m_ParentList.end(), oldParent->getId(), newParent->getId());
 }
 
-std::vector<DataPath> DataObject::getDataPaths() const
+std::vector<DataPath> DataObject::getParentDataPaths() const
 {
   if(getDataStructure() == nullptr)
   {
@@ -173,7 +173,7 @@ std::vector<DataPath> DataObject::getDataPaths() const
       continue;
     }
 
-    auto parentPaths = parent->getDataPaths();
+    auto parentPaths = parent->getParentDataPaths();
     for(auto& dataPath : parentPaths)
     {
       paths.push_back(dataPath.createChildPath(m_Name));

--- a/src/complex/DataStructure/DataObject.hpp
+++ b/src/complex/DataStructure/DataObject.hpp
@@ -198,10 +198,10 @@ public:
   ParentCollectionType getParentIds() const;
 
   /**
-   * @brief Returns a vector of DataPaths.
+   * @brief Returns a vector of the parent DataPaths.
    * @return std::vector<DataPath>
    */
-  std::vector<DataPath> getDataPaths() const;
+  std::vector<DataPath> getParentDataPaths() const;
 
   /**
    * @brief Returns a reference to the object's Metadata.

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -190,7 +190,7 @@ std::vector<DataPath> DataStructure::getAllDataPaths() const
       continue;
     }
 
-    auto localPaths = sharedPtr->getDataPaths();
+    auto localPaths = sharedPtr->getParentDataPaths();
     dataPaths.insert(dataPaths.end(), localPaths.begin(), localPaths.end());
   }
   return dataPaths;
@@ -395,7 +395,7 @@ bool DataStructure::removeData(DataObject* data)
     return false;
   }
 
-  auto pathsToData = data->getDataPaths();
+  auto pathsToData = data->getParentDataPaths();
   auto parentIds = data->getParentIds();
   if(parentIds.size() == 0)
   {

--- a/src/complex/DataStructure/Messaging/DataAddedMessage.cpp
+++ b/src/complex/DataStructure/Messaging/DataAddedMessage.cpp
@@ -41,5 +41,5 @@ const DataObject* DataAddedMessage::getData() const
 
 std::vector<DataPath> DataAddedMessage::getDataPaths() const
 {
-  return getData()->getDataPaths();
+  return getData()->getParentDataPaths();
 }


### PR DESCRIPTION
Empty is convenient to use and is STL compliant
DataObject::getParentDataPaths is more descriptive and is not ambiguous concerning what is returned.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>