### PR TITLE
Fixed issue when trying to insert objects with duplicate names

### DIFF
--- a/src/complex/DataStructure/BaseGroup.cpp
+++ b/src/complex/DataStructure/BaseGroup.cpp
@@ -87,7 +87,7 @@ bool BaseGroup::canInsert(const DataObject* obj) const
   {
     return false;
   }
-  if(contains(obj))
+  if(contains(obj) || contains(obj->getName()))
   {
     return false;
   }

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -453,6 +453,11 @@ bool DataStructure::insertTopLevel(const std::shared_ptr<DataObject>& obj)
     return false;
   }
 
+  if(m_RootGroup.contains(obj.get()) || m_RootGroup.contains(obj->getName()))
+  {
+    return false;
+  }
+
   return m_RootGroup.insert(obj);
 }
 

--- a/test/DataStructTest.cpp
+++ b/test/DataStructTest.cpp
@@ -5,6 +5,7 @@
 
 #include "DataStructObserver.hpp"
 
+#include "complex/Common/StringLiteral.hpp"
 #include "complex/DataStructure/DataArray.hpp"
 #include "complex/DataStructure/DataGroup.hpp"
 #include "complex/DataStructure/DataStore.hpp"
@@ -346,4 +347,27 @@ TEST_CASE("ScalarDataTest")
   const int32 newValue2 = 14;
   (*scalar) = newValue2;
   REQUIRE(scalar->getValue() == newValue2);
+}
+
+TEST_CASE("DataStructureDuplicateNames")
+{
+  static constexpr StringLiteral name = "foo";
+
+  DataStructure ds;
+
+  // Top level test
+
+  DataGroup* group1 = DataGroup::Create(ds, name);
+  REQUIRE(group1 != nullptr);
+
+  DataGroup* group2 = DataGroup::Create(ds, name);
+  REQUIRE(group2 == nullptr);
+
+  // Nested test
+
+  DataGroup* childGroup1 = DataGroup::Create(ds, name, group1->getId());
+  REQUIRE(group1 != nullptr);
+
+  DataGroup* childGroup2 = DataGroup::Create(ds, name, group1->getId());
+  REQUIRE(group2 == nullptr);
 }


### PR DESCRIPTION
When creating a new `DataObject` and trying to insert into `BaseGroup`, the id is generated before the insertion. Then in `BaseGroup::canInsert(const DataObject*)`, it calls `BaseGroup::contains(const DataObject*)` which checks if the id of the `DataObject` already exists in the group. But since the id was just generated it will never be in the group and `contains` will always return `false`. So objects with the same name will exist in the group which will cause an issue when using a `DataPath` to attempt to access them.