### PR TITLE
FILTER: ExtractInternalSurfacesFromTriangleGeometry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,7 @@ set(COMPLEX_HDRS
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateImageGeometryAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateGeometry2DAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateNeighborListAction.hpp
+  ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateTriangleGeomAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateVertexGeometryAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/DeleteDataAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/ImportObjectAction.hpp
@@ -410,6 +411,7 @@ set(COMPLEX_SRCS
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateDataGroupAction.cpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateImageGeometryAction.cpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateNeighborListAction.cpp
+  ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateTriangleGeomAction.cpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/DeleteDataAction.cpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/ImportObjectAction.cpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/RenameDataAction.cpp

--- a/src/Plugins/ComplexCore/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/CMakeLists.txt
@@ -19,6 +19,7 @@ set(FilterList
   CreateImageGeometry
   CropImageGeometry
   DeleteData
+  ExtractInternalSurfacesFromTriangleGeometry
   ExportDREAM3DFilter
   FindDifferencesMap
   FindFeaturePhasesFilter

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.hpp
@@ -28,38 +28,38 @@ public:
   static inline constexpr StringLiteral k_InitilizationValue_Key = "initialization_value";
 
   /**
-   * @brief
-   * @return
+   * @brief Returns the filter's name.
+   * @return std::string
    */
   std::string name() const override;
 
   /**
    * @brief Returns the C++ classname of this filter.
-   * @return
+   * @return std::string
    */
   std::string className() const override;
 
   /**
-   * @brief
-   * @return
+   * @brief Returns the filter's UUID.
+   * @return Uuid
    */
   Uuid uuid() const override;
 
   /**
-   * @brief
-   * @return
+   * @brief Returns the filter name as a human-readable string.
+   * @return std::string
    */
   std::string humanName() const override;
 
   /**
-   * @brief
-   * @return
+   * @brief Returns a collection of parameters required to execute the filter.
+   * @return Parameters
    */
   Parameters parameters() const override;
 
   /**
-   * @brief
-   * @return
+   * @brief Creates and returns a copy of the filter.
+   * @return UniquePointer
    */
   UniquePointer clone() const override;
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -1,6 +1,7 @@
 #include "ExtractInternalSurfacesFromTriangleGeometry.hpp"
 
 #include <string>
+#include <unordered_map>
 
 #include "fmt/format.h"
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -56,7 +56,7 @@ struct CopyDataFunctor
         ptrIndex = nComps * elementMap[i] + d;
         outputData[tmpIndex] = inputData[ptrIndex];
       }
-      }
+    }
   }
 };
 } // namespace
@@ -314,14 +314,14 @@ Result<> ExtractInternalSurfacesFromTriangleGeometry::executeImpl(DataStructure&
       triCounter++;
     }
 
-      // if(counter > prog)
-      //{
-      // progressInt = static_cast<int64>((static_cast<float>(counter) / numTris) * 100.0f);
-      // std::string ss = fmt::format("Checking Triangle {} of {} || {}% Completed", counter, numTris, progressInt);
-      // notifyStatusMessage(ss);
-      // prog = prog + progIncrement;
-      //}
-      // counter++;
+    // if(counter > prog)
+    //{
+    // progressInt = static_cast<int64>((static_cast<float>(counter) / numTris) * 100.0f);
+    // std::string ss = fmt::format("Checking Triangle {} of {} || {}% Completed", counter, numTris, progressInt);
+    // notifyStatusMessage(ss);
+    // prog = prog + progIncrement;
+    //}
+    // counter++;
   }
 
   tmpVerts.shrink_to_fit();

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -56,7 +56,7 @@ struct CopyDataFunctor
         ptrIndex = nComps * elementMap[i] + d;
         outputData[tmpIndex] = inputData[ptrIndex];
       }
-    }
+      }
   }
 };
 } // namespace
@@ -227,8 +227,8 @@ Result<> ExtractInternalSurfacesFromTriangleGeometry::executeImpl(DataStructure&
     }
   };
 
-  typedef std::array<int64, 3> Triangle;
-  typedef std::unordered_map<Vertex, int64, ArrayHasher> VertexMap;
+  using Triangle = std::array<int64, 3>;
+  using VertexMap = std::unordered_map<Vertex, int64, ArrayHasher>;
   VertexMap vertexMap;
   std::unordered_map<int64, int64> internalVertexMap;
   std::unordered_map<int64, int64> internalTriMap;
@@ -244,12 +244,12 @@ Result<> ExtractInternalSurfacesFromTriangleGeometry::executeImpl(DataStructure&
   int64 tmpVert1 = 0;
   int64 tmpVert2 = 0;
 
-  int64 progIncrement = numTris / 100;
-  int64 prog = 1;
-  int64 progressInt = 0;
-  int64 counter = 0;
+  // int64 progIncrement = numTris / 100;
+  // int64 prog = 1;
+  // int64 progressInt = 0;
+  // int64 counter = 0;
 
-  for(usize i = 0; i < numTris; i++)
+  for(int64 i = 0; i < numTris; i++)
   {
     if(shouldCancel)
     {
@@ -314,14 +314,14 @@ Result<> ExtractInternalSurfacesFromTriangleGeometry::executeImpl(DataStructure&
       triCounter++;
     }
 
-    if(counter > prog)
-    {
-      progressInt = static_cast<int64>((static_cast<float>(counter) / numTris) * 100.0f);
+      // if(counter > prog)
+      //{
+      // progressInt = static_cast<int64>((static_cast<float>(counter) / numTris) * 100.0f);
       // std::string ss = fmt::format("Checking Triangle {} of {} || {}% Completed", counter, numTris, progressInt);
       // notifyStatusMessage(ss);
-      prog = prog + progIncrement;
-    }
-    counter++;
+      // prog = prog + progIncrement;
+      //}
+      // counter++;
   }
 
   tmpVerts.shrink_to_fit();
@@ -352,6 +352,7 @@ Result<> ExtractInternalSurfacesFromTriangleGeometry::executeImpl(DataStructure&
 
     ExecuteDataFunction(CopyDataFunctor{}, src.getDataType(), src, dest, internalVertexMap);
   }
+
   for(const auto& trianglePath : copyTrianglePaths)
   {
     auto destinationPath = internalTrianglesPath.createChildPath(trianglePath.getTargetName());

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -1,0 +1,367 @@
+#include "ExtractInternalSurfacesFromTriangleGeometry.hpp"
+
+#include <string>
+
+#include "fmt/format.h"
+
+#include "complex/DataStructure/Geometry/TriangleGeom.hpp"
+#include "complex/Filter/Actions/CreateArrayAction.hpp"
+#include "complex/Filter/Actions/CreateTriangleGeomAction.hpp"
+#include "complex/Parameters/ArraySelectionParameter.hpp"
+#include "complex/Parameters/DataGroupCreationParameter.hpp"
+#include "complex/Parameters/DataGroupSelectionParameter.hpp"
+#include "complex/Parameters/MultiArraySelectionParameter.hpp"
+#include "complex/Utilities/DataArrayUtilities.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
+
+using namespace complex;
+
+namespace
+{
+constexpr complex::int32 k_EMPTY_PARAMETER = -350;
+constexpr complex::int32 k_MissingTriangleGeometry = -351;
+constexpr complex::int32 k_NoNodeTypesArray = -352;
+
+template <class T>
+inline void hashCombine(size_t& seed, const T& obj)
+{
+  std::hash<T> hasher;
+  seed ^= hasher(obj) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+struct CopyDataFunctor
+{
+  template <typename T>
+  void operator()(IDataArray* inDataPtr, IDataArray* outDataPtr, std::unordered_map<int64, int64>& elementMap) const
+  {
+    auto inputDataPtr = dynamic_cast<DataArray<T>*>(inDataPtr);
+    AbstractDataStore<T>* inputData = inputDataPtr->getDataStore();
+    auto croppedDataPtr = dynamic_cast<DataArray<T>*>(outDataPtr);
+    AbstractDataStore<T>* outputData = croppedDataPtr->getDataStore();
+
+    usize nTuples = outDataPtr->getNumberOfTuples();
+    usize nComps = inDataPtr->getNumberOfComponents();
+    usize tmpIndex = 0;
+    usize ptrIndex = 0;
+
+    for(usize i = 0; i < nTuples; i++)
+    {
+      for(usize d = 0; d < nComps; d++)
+      {
+        tmpIndex = nComps * i + d;
+        ptrIndex = nComps * elementMap[i] + d;
+        outputData->setValue(tmpIndex, inputData->getValue(ptrIndex));
+      }
+    }
+  }
+};
+} // namespace
+
+namespace complex
+{
+
+std::string ExtractInternalSurfacesFromTriangleGeometry::name() const
+{
+  return FilterTraits<ExtractInternalSurfacesFromTriangleGeometry>::name;
+}
+
+std::string ExtractInternalSurfacesFromTriangleGeometry::className() const
+{
+  return FilterTraits<ExtractInternalSurfacesFromTriangleGeometry>::className;
+}
+
+Uuid ExtractInternalSurfacesFromTriangleGeometry::uuid() const
+{
+  return FilterTraits<ExtractInternalSurfacesFromTriangleGeometry>::uuid;
+}
+
+std::string ExtractInternalSurfacesFromTriangleGeometry::humanName() const
+{
+  return "Extract Internal Surfaces From Triangle Geometry";
+}
+
+Parameters ExtractInternalSurfacesFromTriangleGeometry::parameters() const
+{
+  Parameters params;
+  params.insert(std::make_unique<DataGroupSelectionParameter>(k_TriangleGeom_Key, "Triangle Geometry", "Path to the existing Triangle Geometry", DataPath()));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_InternalTriangleGeom_Key, "Interior Triangle Geometry", "Path to create the new Triangle Geometry", DataPath()));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_NodeTypesPath_Key, "Node Types Array", "Path to the Node Types array", DataPath()));
+  params.insert(std::make_unique<MultiArraySelectionParameter>(k_CopyVertexPaths_Key, "Copy Vertex Arrays", "Paths to vertex-related DataArrays that should be copied to the new geometry",
+                                                               std::vector<DataPath>{}));
+  params.insert(std::make_unique<MultiArraySelectionParameter>(k_CopyTrianglePaths_Key, "Copy Triangle Arrays", "Paths to face-related DataArrays that should be copied to the new geometry",
+                                                               std::vector<DataPath>{}));
+  return params;
+}
+
+IFilter::UniquePointer ExtractInternalSurfacesFromTriangleGeometry::clone() const
+{
+  return std::make_unique<ExtractInternalSurfacesFromTriangleGeometry>();
+}
+
+IFilter::PreflightResult ExtractInternalSurfacesFromTriangleGeometry::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler) const
+{
+  auto triangleGeomPath = filterArgs.value<DataPath>(k_TriangleGeom_Key);
+  auto internalTrianglesGeomPath = filterArgs.value<DataPath>(k_InternalTriangleGeom_Key);
+  auto nodeTypesArrayPath = filterArgs.value<DataPath>(k_NodeTypesPath_Key);
+  auto copyVertexPaths = filterArgs.value<std::vector<DataPath>>(k_CopyVertexPaths_Key);
+  auto copyTrianglePaths = filterArgs.value<std::vector<DataPath>>(k_CopyTrianglePaths_Key);
+
+  std::vector<DataPath> arrays;
+  OutputActions actions;
+
+  auto* triangleGeom = dataStructure.getDataAs<TriangleGeom>(triangleGeomPath);
+
+  if(triangleGeom == nullptr)
+  {
+    std::string ss = fmt::format("Triangle Geometry not found at path '{}'", triangleGeomPath.toString());
+    return {{nonstd::make_unexpected(std::vector<Error>{{k_MissingTriangleGeometry, ss}})}};
+  }
+  if(triangleGeom->getVertices() == nullptr)
+  {
+    std::string ss = fmt::format("Triangle Geometry does not have an assigned vertices array");
+    return {{nonstd::make_unexpected(std::vector<Error>{{k_MissingTriangleGeometry, ss}})}};
+  }
+
+  arrays.push_back(triangleGeom->getVertices()->getDataPaths().front());
+
+  std::vector<size_t> cDims(1, 1);
+
+  auto* nodeTypesPtr = dataStructure.getDataAs<Int8Array>(nodeTypesArrayPath);
+  if(!nodeTypesPtr)
+  {
+    std::string ss("Node Types array not found at path '{}'. Array must be of type Int8");
+    return {{nonstd::make_unexpected(std::vector<Error>{{k_NoNodeTypesArray, ss}})}};
+  }
+  arrays.push_back(nodeTypesArrayPath);
+
+  dataStructure.validateNumberOfTuples(arrays);
+
+  // Create Geometry
+  IDataStore::ShapeType geomShape = {0};
+  auto createInternalTrianglesAction = std::make_unique<CreateTriangleGeomAction>(internalTrianglesGeomPath, geomShape, CreateTriangleGeomAction::AdditionalData::VerticesTriangles);
+  actions.actions.push_back(std::move(createInternalTrianglesAction));
+
+  std::vector<size_t> tDims(1, 0);
+  std::list<std::string> tempDataArrayList;
+
+  // Create arrays
+  for(const auto& data_array : copyVertexPaths)
+  {
+    auto targetDataArray = dataStructure.getDataAs<IDataArray>(data_array);
+    NumericType type = static_cast<NumericType>(targetDataArray->getDataType());
+    DataPath copyPath = internalTrianglesGeomPath.createChildPath(data_array.getTargetName());
+    auto numTuples = targetDataArray->getNumberOfTuples();
+    auto components = targetDataArray->getNumberOfComponents();
+
+    auto action = std::make_unique<CreateArrayAction>(type, std::vector<usize>{numTuples}, std::vector<usize>{components}, copyPath);
+    actions.actions.push_back(std::move(action));
+  }
+  for(const auto& data_array : copyTrianglePaths)
+  {
+    auto targetDataArray = dataStructure.getDataAs<IDataArray>(data_array);
+    NumericType type = static_cast<NumericType>(targetDataArray->getDataType());
+    DataPath copyPath = internalTrianglesGeomPath.createChildPath(data_array.getTargetName());
+    auto numTuples = targetDataArray->getNumberOfTuples();
+    auto components = targetDataArray->getNumberOfComponents();
+
+    auto action = std::make_unique<CreateArrayAction>(type, std::vector<usize>{numTuples}, std::vector<usize>{components}, copyPath);
+    actions.actions.push_back(std::move(action));
+  }
+
+  return {std::move(actions)};
+}
+
+Result<> ExtractInternalSurfacesFromTriangleGeometry::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler) const
+{
+  auto nodeTypesArrayPath = args.value<DataPath>(k_NodeTypesPath_Key);
+  auto triangleGeomPath = args.value<DataPath>(k_TriangleGeom_Key);
+  auto internalTrianglesPath = args.value<DataPath>(k_InternalTriangleGeom_Key);
+  auto copyVertexPaths = args.value<std::vector<DataPath>>(k_CopyVertexPaths_Key);
+  auto copyTrianglePaths = args.value<std::vector<DataPath>>(k_CopyTrianglePaths_Key);
+
+  auto* triangleGeom = data.getDataAs<TriangleGeom>(triangleGeomPath);
+  auto* internalTriangleGeom = data.getDataAs<TriangleGeom>(internalTrianglesPath);
+  auto& vertices = *triangleGeom->getVertices();
+  auto& triangles = *triangleGeom->getFaces();
+  auto numVerts = triangleGeom->getNumberOfVertices();
+  auto numTris = triangleGeom->getNumberOfFaces();
+
+  auto nodeTypesPtr = data.getDataAs<Int8Array>(nodeTypesArrayPath);
+  if(nullptr == nodeTypesPtr)
+  {
+    std::string ss = fmt::format("Could not find a valid NodeTypes array at path '{}'. Array must be an Int8 Array", nodeTypesArrayPath.toString());
+    return {{nonstd::make_unexpected(std::vector<Error>{{k_NoNodeTypesArray, std::move(ss)}})}};
+  }
+  Int8Array& nodeTypes = *nodeTypesPtr;
+
+  typedef std::array<float, 3> Vertex;
+
+  struct ArrayHasher
+  {
+    size_t operator()(const Vertex& vert) const
+    {
+      size_t hash = std::hash<float>()(vert[0]);
+      hashCombine(hash, vert[1]);
+      hashCombine(hash, vert[2]);
+      return hash;
+    }
+  };
+
+  typedef std::array<int64_t, 3> Triangle;
+  typedef std::unordered_map<Vertex, int64_t, ArrayHasher> VertexMap;
+  VertexMap vertexMap;
+  std::unordered_map<int64_t, int64_t> internalVertexMap;
+  std::unordered_map<int64_t, int64_t> internalTriMap;
+  std::vector<Vertex> tmpVerts;
+  tmpVerts.reserve(numVerts);
+  std::vector<Triangle> tmpTris;
+  tmpTris.reserve(numTris);
+  std::vector<int8_t> tmpNodeTypes;
+  tmpNodeTypes.reserve(numVerts);
+  int64_t vertCounter = 0;
+  int64_t triCounter = 0;
+  int64_t tmpVert0 = 0;
+  int64_t tmpVert1 = 0;
+  int64_t tmpVert2 = 0;
+
+  int64_t progIncrement = numTris / 100;
+  int64_t prog = 1;
+  int64_t progressInt = 0;
+  int64_t counter = 0;
+
+  for(usize i = 0; i < numTris; i++)
+  {
+    // if(getCancel())
+    //{
+    //  return;
+    //}
+    if((nodeTypes[triangles[3 * i + 0]] == 2 || nodeTypes[triangles[3 * i + 0]] == 3 || nodeTypes[triangles[3 * i + 0]] == 4) &&
+       (nodeTypes[triangles[3 * i + 1]] == 2 || nodeTypes[triangles[3 * i + 1]] == 3 || nodeTypes[triangles[3 * i + 1]] == 4) &&
+       (nodeTypes[triangles[3 * i + 2]] == 2 || nodeTypes[triangles[3 * i + 2]] == 3 || nodeTypes[triangles[3 * i + 2]] == 4))
+    {
+      Vertex tmpCoords1 = {{vertices[3 * triangles[3 * i + 0] + 0], vertices[3 * triangles[3 * i + 0] + 1], vertices[3 * triangles[3 * i + 0] + 2]}};
+      Vertex tmpCoords2 = {{vertices[3 * triangles[3 * i + 1] + 0], vertices[3 * triangles[3 * i + 1] + 1], vertices[3 * triangles[3 * i + 1] + 2]}};
+      Vertex tmpCoords3 = {{vertices[3 * triangles[3 * i + 2] + 0], vertices[3 * triangles[3 * i + 2] + 1], vertices[3 * triangles[3 * i + 2] + 2]}};
+
+      auto iter = vertexMap.find(tmpCoords1);
+      if(iter == vertexMap.end())
+      {
+        tmpVerts.push_back(tmpCoords1);
+        tmpNodeTypes.push_back(nodeTypes[triangles[3 * i + 0]]);
+        vertexMap[tmpCoords1] = vertCounter;
+        tmpVert0 = vertCounter;
+        internalVertexMap[tmpVert0] = triangles[3 * i + 0];
+        vertCounter++;
+      }
+      else
+      {
+        tmpVert0 = vertexMap[tmpCoords1];
+      }
+
+      iter = vertexMap.find(tmpCoords2);
+      if(iter == vertexMap.end())
+      {
+        tmpVerts.push_back(tmpCoords2);
+        tmpNodeTypes.push_back(nodeTypes[triangles[3 * i + 1]]);
+        vertexMap[tmpCoords2] = vertCounter;
+        tmpVert1 = vertCounter;
+        internalVertexMap[tmpVert1] = triangles[3 * i + 1];
+        vertCounter++;
+      }
+      else
+      {
+        tmpVert1 = vertexMap[tmpCoords2];
+      }
+
+      iter = vertexMap.find(tmpCoords3);
+      if(iter == vertexMap.end())
+      {
+        tmpVerts.push_back(tmpCoords3);
+        tmpNodeTypes.push_back(nodeTypes[triangles[3 * i + 2]]);
+        vertexMap[tmpCoords3] = vertCounter;
+        tmpVert2 = vertCounter;
+        internalVertexMap[tmpVert2] = triangles[3 * i + 2];
+        vertCounter++;
+      }
+      else
+      {
+        tmpVert2 = vertexMap[tmpCoords3];
+      }
+
+      Triangle tmpTri = {{tmpVert0, tmpVert1, tmpVert2}};
+      tmpTris.push_back(tmpTri);
+      internalTriMap[triCounter] = i;
+      triCounter++;
+    }
+
+    if(counter > prog)
+    {
+      progressInt = static_cast<int64_t>((static_cast<float>(counter) / numTris) * 100.0f);
+      // std::string ss = fmt::format("Checking Triangle {} of {} || {}% Completed", counter, numTris, progressInt);
+      // notifyStatusMessage(ss);
+      prog = prog + progIncrement;
+    }
+    counter++;
+  }
+
+  // std::string ss = fmt::format("Finished Checking Triangles || Updating Array Information...");
+  // notifyStatusMessage(ss);
+
+  tmpVerts.shrink_to_fit();
+  tmpTris.shrink_to_fit();
+
+  std::vector<size_t> vertDims(1, tmpVerts.size());
+  std::vector<size_t> triDims(1, tmpTris.size());
+
+  for(const auto& copyPath : copyVertexPaths)
+  {
+    auto destinationPath = internalTrianglesPath.createChildPath(copyPath.getTargetName());
+
+    auto* src = data.getDataAs<IDataArray>(copyPath);
+    auto* dest = data.getDataAs<IDataArray>(destinationPath);
+
+    assert(src);
+    assert(dest);
+    assert(src->getNumberOfComponents() == dest->getNumberOfComponents());
+
+    ExecuteDataFunction(CopyDataFunctor{}, src->getDataType(), src, dest, internalVertexMap);
+  }
+  for(const auto& trianglePath : copyTrianglePaths)
+  {
+    auto destinationPath = internalTrianglesPath.createChildPath(trianglePath.getTargetName());
+
+    auto* src = data.getDataAs<IDataArray>(trianglePath);
+    auto* dest = data.getDataAs<IDataArray>(destinationPath);
+
+    assert(src);
+    assert(dest);
+    assert(src->getNumberOfComponents() == dest->getNumberOfComponents());
+
+    ExecuteDataFunction(CopyDataFunctor{}, src->getDataType(), src, dest, internalTriMap);
+  }
+
+  auto* internalTris = data.getDataAs<TriangleGeom>(internalTrianglesPath);
+  internalTris->resizeVertexList(tmpVerts.size());
+  internalTris->resizeFaceList(tmpTris.size());
+  auto* internalVertices = internalTris->getVertices();
+  auto* internalTriangles = internalTris->getFaces();
+  auto numInternalTris = internalTris->getNumberOfFaces();
+  auto numInternalVerts = internalTris->getNumberOfVertices();
+
+  for(usize i = 0; i < numInternalVerts; i++)
+  {
+    (*internalVertices)[3 * i + 0] = tmpVerts[i][0];
+    (*internalVertices)[3 * i + 1] = tmpVerts[i][1];
+    (*internalVertices)[3 * i + 2] = tmpVerts[i][2];
+  }
+
+  for(usize i = 0; i < numInternalTris; i++)
+  {
+    (*internalTriangles)[3 * i + 0] = tmpTris[i][0];
+    (*internalTriangles)[3 * i + 1] = tmpTris[i][1];
+    (*internalTriangles)[3 * i + 2] = tmpTris[i][2];
+  }
+
+  return {};
+}
+} // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.hpp
@@ -69,9 +69,10 @@ protected:
    * @param data
    * @param filterArgs
    * @param messageHandler
+   * @param shouldCancel
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& data, const Arguments& filterArgs, const MessageHandler& messageHandler) const override;
+  PreflightResult preflightImpl(const DataStructure& data, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief
@@ -79,9 +80,11 @@ protected:
    * @param args
    * @param pipelineNode
    * @param messageHandler
+   * @param shouldCancel
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                       const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace complex
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "ComplexCore/ComplexCore_export.hpp"
+
+#include "complex/Common/StringLiteral.hpp"
+#include "complex/Filter/FilterTraits.hpp"
+#include "complex/Filter/IFilter.hpp"
+
+namespace complex
+{
+class COMPLEXCORE_EXPORT ExtractInternalSurfacesFromTriangleGeometry : public IFilter
+{
+public:
+  ExtractInternalSurfacesFromTriangleGeometry() = default;
+  ~ExtractInternalSurfacesFromTriangleGeometry() noexcept override = default;
+
+  ExtractInternalSurfacesFromTriangleGeometry(const ExtractInternalSurfacesFromTriangleGeometry&) = delete;
+  ExtractInternalSurfacesFromTriangleGeometry(ExtractInternalSurfacesFromTriangleGeometry&&) noexcept = delete;
+
+  ExtractInternalSurfacesFromTriangleGeometry& operator=(const ExtractInternalSurfacesFromTriangleGeometry&) = delete;
+  ExtractInternalSurfacesFromTriangleGeometry& operator=(ExtractInternalSurfacesFromTriangleGeometry&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_TriangleGeom_Key = "triangle_geom";
+  static inline constexpr StringLiteral k_InternalTriangleGeom_Key = "internal_triangle_geom";
+  static inline constexpr StringLiteral k_NodeTypesPath_Key = "node_types";
+  static inline constexpr StringLiteral k_CopyVertexPaths_Key = "copy_vertex_array_paths";
+  static inline constexpr StringLiteral k_CopyTrianglePaths_Key = "copy_triangle_array_paths";
+
+  /**
+   * @brief Returns the filter's name.
+   * @return std::string
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the C++ classname of this filter.
+   * @return std::string
+   */
+  std::string className() const override;
+
+  /**
+   * @brief Returns the filter's UUID.
+   * @return Uuid
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief Returns the filter name as a human-readable string.
+   * @return std::string
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief Returns a collection of parameters required to execute the filter.
+   * @return Parameters
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief Creates and returns a copy of the filter.
+   * @return UniquePointer
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief
+   * @param data
+   * @param filterArgs
+   * @param messageHandler
+   * @return Result<OutputActions>
+   */
+  PreflightResult preflightImpl(const DataStructure& data, const Arguments& filterArgs, const MessageHandler& messageHandler) const override;
+
+  /**
+   * @brief
+   * @param dataStructure
+   * @param args
+   * @param pipelineNode
+   * @param messageHandler
+   * @return Result<>
+   */
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler) const override;
+};
+} // namespace complex
+
+COMPLEX_DEF_FILTER_TRAITS(complex, ExtractInternalSurfacesFromTriangleGeometry, "52a069b4-6a46-5810-b0ec-e0693c636034");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
@@ -115,7 +115,7 @@ IFilter::PreflightResult RemoveFlaggedVertices::preflightImpl(const DataStructur
     std::string errorMsg = fmt::format("Vertex Geometry does not have a vertex list");
     return {MakeErrorResult<OutputActions>(::k_VertexGeomNotFound, errorMsg)};
   }
-  dataArrayPaths.push_back(vertex->getVertices()->getParentDataPaths()[0]);
+  dataArrayPaths.push_back(vertex->getVertices()->getDataPaths()[0]);
 
   std::vector<size_t> cDims(1, 1);
 

--- a/src/Plugins/ComplexCore/test/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/test/CMakeLists.txt
@@ -15,6 +15,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   CopyFeatureArrayToElementArrayTest.cpp
   CreateImageGeometryTest.cpp
   CropImageGeomTest.cpp
+  ExtractInternalSurfacesFromTriangleGeometryTest.cpp
   FindDifferencesMapTest.cpp
   FindFeaturePhasesFilterTest.cpp
   FindNeighborListStatisticsTest.cpp

--- a/src/Plugins/ComplexCore/test/ExtractInternalSurfacesFromTriangleGeometryTest.cpp
+++ b/src/Plugins/ComplexCore/test/ExtractInternalSurfacesFromTriangleGeometryTest.cpp
@@ -1,0 +1,47 @@
+#include <catch2/catch.hpp>
+
+#include "ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.hpp"
+
+#include "ComplexCore/ComplexCore_test_dirs.hpp"
+
+#include "complex/DataStructure/Geometry/TriangleGeom.hpp"
+#include "complex/UnitTest/UnitTestCommon.hpp"
+
+using namespace complex;
+
+TEST_CASE("ExtractInternalSurfacesFromTriangleGeometry(Instantiate)", "[ComplexCore][ExtractInternalSurfacesFromTriangleGeometry]")
+{
+  constexpr StringLiteral k_TriangleGeomName = "TriangleGeom";
+  constexpr StringLiteral k_InternalTriangleGeomName = "Internal TriangleGeom";
+  constexpr StringLiteral k_NodeTypesName = "Node Types";
+
+  const DataPath k_TriangleGeomPath({k_TriangleGeomName});
+  const DataPath k_InternalTrianglePath({k_InternalTriangleGeomName});
+  const DataPath k_NodeTypesPath({k_NodeTypesName});
+  const std::vector<DataPath> k_CopyVertexPaths({DataPath({Constants::k_SmallIN100, Constants::k_EbsdScanData, Constants::k_ConfidenceIndex})});
+  const std::vector<DataPath> k_CopyTrianglePaths({DataPath({Constants::k_SmallIN100, Constants::k_EbsdScanData, "Phases"})});
+
+  ExtractInternalSurfacesFromTriangleGeometry filter;
+  DataStructure ds = UnitTest::CreateDataStructure();
+  Arguments args;
+
+  const DataPath vertexListPath({Constants::k_SmallIN100, Constants::k_EbsdScanData, Constants::k_ConfidenceIndex});
+  auto* triangleList = UInt64Array::CreateWithStore<UInt64DataStore>(ds, "Tri List", {500}, {3});
+  triangleList->fill(1);
+  auto* triangleGeom = TriangleGeom::Create(ds, k_TriangleGeomName);
+  triangleGeom->setVertices(ds.getDataAs<AbstractGeometry::SharedVertexList>(vertexListPath));
+  triangleGeom->setFaces(triangleList);
+  Int8Array::CreateWithStore<Int8DataStore>(ds, k_NodeTypesName, {triangleGeom->getNumberOfFaces()}, {3});
+
+  args.insert(ExtractInternalSurfacesFromTriangleGeometry::k_TriangleGeom_Key, std::make_any<DataPath>(k_TriangleGeomPath));
+  args.insert(ExtractInternalSurfacesFromTriangleGeometry::k_InternalTriangleGeom_Key, std::make_any<DataPath>(k_InternalTrianglePath));
+  args.insert(ExtractInternalSurfacesFromTriangleGeometry::k_NodeTypesPath_Key, std::make_any<DataPath>(k_NodeTypesPath));
+  args.insert(ExtractInternalSurfacesFromTriangleGeometry::k_CopyVertexPaths_Key, std::make_any<std::vector<DataPath>>(k_CopyVertexPaths));
+  args.insert(ExtractInternalSurfacesFromTriangleGeometry::k_CopyTrianglePaths_Key, std::make_any<std::vector<DataPath>>(k_CopyTrianglePaths));
+
+  auto preflight = filter.preflight(ds, args);
+  COMPLEX_RESULT_REQUIRE_VALID(preflight.outputActions);
+
+  auto result = filter.execute(ds, args);
+  COMPLEX_RESULT_REQUIRE_VALID(result.result);
+}

--- a/src/Plugins/ComplexCore/test/ExtractInternalSurfacesFromTriangleGeometryTest.cpp
+++ b/src/Plugins/ComplexCore/test/ExtractInternalSurfacesFromTriangleGeometryTest.cpp
@@ -37,7 +37,7 @@ DataStructure createTestData(const std::string& triangleGeomName, const std::str
   auto* triangleGeom = TriangleGeom::Create(ds, triangleGeomName);
   triangleGeom->setVertices(ds.getDataAs<AbstractGeometry::SharedVertexList>(vertexListPath));
   triangleGeom->setFaces(triangleList);
-  
+
   auto* nodeArray = Int8Array::CreateWithStore<Int8DataStore>(ds, nodeTypesName, {triangleGeom->getNumberOfFaces()}, {1});
   auto& nodeData = nodeArray->getDataStoreRef();
   nodeData.fill(2);
@@ -45,7 +45,7 @@ DataStructure createTestData(const std::string& triangleGeomName, const std::str
 
   return ds;
 }
-}
+} // namespace
 
 TEST_CASE("ExtractInternalSurfacesFromTriangleGeometry(Instantiate)", "[ComplexCore][ExtractInternalSurfacesFromTriangleGeometry]")
 {
@@ -112,7 +112,7 @@ TEST_CASE("ExtractInternalSurfacesFromTriangleGeometry(Data)", "[ComplexCore][Ex
     REQUIRE(newVerticesArray->getSize() == 3);
   }
 
-  #if 1
+#if 1
   {
     auto* newTrianglesArray = ds.getDataAs<IDataArray>(newTrianglesGeom->getTriangleArrayId());
     auto* oldTrianglesArray = ds.getDataAs<IDataArray>(oldTrianglesGeom->getTriangleArrayId());
@@ -122,5 +122,5 @@ TEST_CASE("ExtractInternalSurfacesFromTriangleGeometry(Data)", "[ComplexCore][Ex
 
     REQUIRE(newTrianglesArray->getNumberOfTuples() == 3);
   }
-  #endif
+#endif
 }

--- a/src/Plugins/ComplexCore/test/ExtractInternalSurfacesFromTriangleGeometryTest.cpp
+++ b/src/Plugins/ComplexCore/test/ExtractInternalSurfacesFromTriangleGeometryTest.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch.hpp>
 
+#include <string>
+
 #include "ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.hpp"
 
 #include "ComplexCore/ComplexCore_test_dirs.hpp"
@@ -9,12 +11,44 @@
 
 using namespace complex;
 
+namespace
+{
+constexpr StringLiteral k_TriangleGeomName = "TriangleGeom";
+constexpr StringLiteral k_InternalTriangleGeomName = "Internal TriangleGeom";
+constexpr StringLiteral k_NodeTypesName = "Node Types";
+
+DataStructure createTestData(const std::string& triangleGeomName, const std::string& nodeTypesName)
+{
+  DataStructure ds = UnitTest::CreateDataStructure();
+  const DataPath vertexListPath({Constants::k_SmallIN100, Constants::k_EbsdScanData, Constants::k_ConfidenceIndex});
+  auto* triangleList = UInt64Array::CreateWithStore<UInt64DataStore>(ds, "Tri List", {500}, {3});
+  auto& triangles = triangleList->getDataStoreRef();
+  triangles.fill(0);
+  triangles[3] = 2;
+  triangles[4] = 3;
+  triangles[5] = 4;
+  triangles[6] = 5;
+  triangles[7] = 6;
+  triangles[8] = 7;
+  triangles[9] = 2;
+  triangles[10] = 7;
+  triangles[11] = 3;
+
+  auto* triangleGeom = TriangleGeom::Create(ds, triangleGeomName);
+  triangleGeom->setVertices(ds.getDataAs<AbstractGeometry::SharedVertexList>(vertexListPath));
+  triangleGeom->setFaces(triangleList);
+  
+  auto* nodeArray = Int8Array::CreateWithStore<Int8DataStore>(ds, nodeTypesName, {triangleGeom->getNumberOfFaces()}, {1});
+  auto& nodeData = nodeArray->getDataStoreRef();
+  nodeData.fill(2);
+  nodeData[0] = 12;
+
+  return ds;
+}
+}
+
 TEST_CASE("ExtractInternalSurfacesFromTriangleGeometry(Instantiate)", "[ComplexCore][ExtractInternalSurfacesFromTriangleGeometry]")
 {
-  constexpr StringLiteral k_TriangleGeomName = "TriangleGeom";
-  constexpr StringLiteral k_InternalTriangleGeomName = "Internal TriangleGeom";
-  constexpr StringLiteral k_NodeTypesName = "Node Types";
-
   const DataPath k_TriangleGeomPath({k_TriangleGeomName});
   const DataPath k_InternalTrianglePath({k_InternalTriangleGeomName});
   const DataPath k_NodeTypesPath({k_NodeTypesName});
@@ -22,16 +56,8 @@ TEST_CASE("ExtractInternalSurfacesFromTriangleGeometry(Instantiate)", "[ComplexC
   const std::vector<DataPath> k_CopyTrianglePaths({DataPath({Constants::k_SmallIN100, Constants::k_EbsdScanData, "Phases"})});
 
   ExtractInternalSurfacesFromTriangleGeometry filter;
-  DataStructure ds = UnitTest::CreateDataStructure();
+  DataStructure ds = createTestData(k_TriangleGeomName, k_NodeTypesName);
   Arguments args;
-
-  const DataPath vertexListPath({Constants::k_SmallIN100, Constants::k_EbsdScanData, Constants::k_ConfidenceIndex});
-  auto* triangleList = UInt64Array::CreateWithStore<UInt64DataStore>(ds, "Tri List", {500}, {3});
-  triangleList->fill(1);
-  auto* triangleGeom = TriangleGeom::Create(ds, k_TriangleGeomName);
-  triangleGeom->setVertices(ds.getDataAs<AbstractGeometry::SharedVertexList>(vertexListPath));
-  triangleGeom->setFaces(triangleList);
-  Int8Array::CreateWithStore<Int8DataStore>(ds, k_NodeTypesName, {triangleGeom->getNumberOfFaces()}, {3});
 
   args.insert(ExtractInternalSurfacesFromTriangleGeometry::k_TriangleGeom_Key, std::make_any<DataPath>(k_TriangleGeomPath));
   args.insert(ExtractInternalSurfacesFromTriangleGeometry::k_InternalTriangleGeom_Key, std::make_any<DataPath>(k_InternalTrianglePath));
@@ -44,4 +70,57 @@ TEST_CASE("ExtractInternalSurfacesFromTriangleGeometry(Instantiate)", "[ComplexC
 
   auto result = filter.execute(ds, args);
   COMPLEX_RESULT_REQUIRE_VALID(result.result);
+}
+
+TEST_CASE("ExtractInternalSurfacesFromTriangleGeometry(Data)", "[ComplexCore][ExtractInternalSurfacesFromTriangleGeometry]")
+{
+  const DataPath k_TriangleGeomPath({k_TriangleGeomName});
+  const DataPath k_InternalTrianglePath({k_InternalTriangleGeomName});
+  const DataPath k_NodeTypesPath({k_NodeTypesName});
+  const std::vector<DataPath> k_CopyVertexPaths({DataPath({Constants::k_SmallIN100, Constants::k_EbsdScanData, Constants::k_ConfidenceIndex})});
+  const std::vector<DataPath> k_CopyTrianglePaths({DataPath({Constants::k_SmallIN100, Constants::k_EbsdScanData, "Phases"})});
+
+  ExtractInternalSurfacesFromTriangleGeometry filter;
+  DataStructure ds = createTestData(k_TriangleGeomName, k_NodeTypesName);
+  Arguments args;
+
+  args.insert(ExtractInternalSurfacesFromTriangleGeometry::k_TriangleGeom_Key, std::make_any<DataPath>(k_TriangleGeomPath));
+  args.insert(ExtractInternalSurfacesFromTriangleGeometry::k_InternalTriangleGeom_Key, std::make_any<DataPath>(k_InternalTrianglePath));
+  args.insert(ExtractInternalSurfacesFromTriangleGeometry::k_NodeTypesPath_Key, std::make_any<DataPath>(k_NodeTypesPath));
+  args.insert(ExtractInternalSurfacesFromTriangleGeometry::k_CopyVertexPaths_Key, std::make_any<std::vector<DataPath>>(k_CopyVertexPaths));
+  args.insert(ExtractInternalSurfacesFromTriangleGeometry::k_CopyTrianglePaths_Key, std::make_any<std::vector<DataPath>>(k_CopyTrianglePaths));
+
+  auto preflight = filter.preflight(ds, args);
+  COMPLEX_RESULT_REQUIRE_VALID(preflight.outputActions);
+
+  auto result = filter.execute(ds, args);
+  COMPLEX_RESULT_REQUIRE_VALID(result.result);
+
+  auto* newTrianglesGeom = ds.getDataAs<TriangleGeom>(k_InternalTrianglePath);
+  auto* oldTrianglesGeom = ds.getDataAs<TriangleGeom>(k_TriangleGeomPath);
+
+  REQUIRE(newTrianglesGeom != nullptr);
+  REQUIRE(oldTrianglesGeom != nullptr);
+
+  {
+    auto* newVerticesArray = newTrianglesGeom->getVertices();
+    auto* oldVerticesArray = oldTrianglesGeom->getVertices();
+
+    REQUIRE(newVerticesArray != nullptr);
+    REQUIRE(oldVerticesArray != nullptr);
+
+    REQUIRE(newVerticesArray->getSize() == 3);
+  }
+
+  #if 1
+  {
+    auto* newTrianglesArray = ds.getDataAs<IDataArray>(newTrianglesGeom->getTriangleArrayId());
+    auto* oldTrianglesArray = ds.getDataAs<IDataArray>(oldTrianglesGeom->getTriangleArrayId());
+
+    REQUIRE(newTrianglesArray != nullptr);
+    REQUIRE(oldTrianglesArray != nullptr);
+
+    REQUIRE(newTrianglesArray->getNumberOfTuples() == 3);
+  }
+  #endif
 }

--- a/src/Plugins/ComplexCore/test/ExtractInternalSurfacesFromTriangleGeometryTest.cpp
+++ b/src/Plugins/ComplexCore/test/ExtractInternalSurfacesFromTriangleGeometryTest.cpp
@@ -67,9 +67,6 @@ TEST_CASE("ExtractInternalSurfacesFromTriangleGeometry(Instantiate)", "[ComplexC
 
   auto preflight = filter.preflight(ds, args);
   COMPLEX_RESULT_REQUIRE_VALID(preflight.outputActions);
-
-  auto result = filter.execute(ds, args);
-  COMPLEX_RESULT_REQUIRE_VALID(result.result);
 }
 
 TEST_CASE("ExtractInternalSurfacesFromTriangleGeometry(Data)", "[ComplexCore][ExtractInternalSurfacesFromTriangleGeometry]")
@@ -112,7 +109,6 @@ TEST_CASE("ExtractInternalSurfacesFromTriangleGeometry(Data)", "[ComplexCore][Ex
     REQUIRE(newVerticesArray->getSize() == 3);
   }
 
-#if 1
   {
     auto* newTrianglesArray = ds.getDataAs<IDataArray>(newTrianglesGeom->getTriangleArrayId());
     auto* oldTrianglesArray = ds.getDataAs<IDataArray>(oldTrianglesGeom->getTriangleArrayId());
@@ -122,5 +118,4 @@ TEST_CASE("ExtractInternalSurfacesFromTriangleGeometry(Data)", "[ComplexCore][Ex
 
     REQUIRE(newTrianglesArray->getNumberOfTuples() == 3);
   }
-#endif
 }

--- a/src/complex/DataStructure/DataArray.hpp
+++ b/src/complex/DataStructure/DataArray.hpp
@@ -222,7 +222,7 @@ public:
   {
     if(m_DataStore == nullptr)
     {
-      throw std::runtime_error("");
+      throw std::runtime_error("DataArray::operator[] requires a valid DataStore");
     }
 
     return (*m_DataStore.get())[index];
@@ -292,7 +292,7 @@ public:
   {
     if(m_DataStore == nullptr)
     {
-      throw std::runtime_error("");
+      throw std::runtime_error("DataArray::operator[] requires a valid DataStore");
     }
 
     return (*m_DataStore.get())[index];

--- a/src/complex/DataStructure/DataObject.cpp
+++ b/src/complex/DataStructure/DataObject.cpp
@@ -152,7 +152,7 @@ void DataObject::replaceParent(BaseGroup* oldParent, BaseGroup* newParent)
   std::replace(m_ParentList.begin(), m_ParentList.end(), oldParent->getId(), newParent->getId());
 }
 
-std::vector<DataPath> DataObject::getParentDataPaths() const
+std::vector<DataPath> DataObject::getDataPaths() const
 {
   if(getDataStructure() == nullptr)
   {
@@ -173,7 +173,7 @@ std::vector<DataPath> DataObject::getParentDataPaths() const
       continue;
     }
 
-    auto parentPaths = parent->getParentDataPaths();
+    auto parentPaths = parent->getDataPaths();
     for(auto& dataPath : parentPaths)
     {
       paths.push_back(dataPath.createChildPath(m_Name));

--- a/src/complex/DataStructure/DataObject.hpp
+++ b/src/complex/DataStructure/DataObject.hpp
@@ -198,10 +198,10 @@ public:
   ParentCollectionType getParentIds() const;
 
   /**
-   * @brief Returns a vector of the parent DataPaths.
+   * @brief Returns a vector of DataPaths to the object.
    * @return std::vector<DataPath>
    */
-  std::vector<DataPath> getParentDataPaths() const;
+  std::vector<DataPath> getDataPaths() const;
 
   /**
    * @brief Returns a reference to the object's Metadata.

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -190,7 +190,7 @@ std::vector<DataPath> DataStructure::getAllDataPaths() const
       continue;
     }
 
-    auto localPaths = sharedPtr->getParentDataPaths();
+    auto localPaths = sharedPtr->getDataPaths();
     dataPaths.insert(dataPaths.end(), localPaths.begin(), localPaths.end());
   }
   return dataPaths;
@@ -395,7 +395,7 @@ bool DataStructure::removeData(DataObject* data)
     return false;
   }
 
-  auto pathsToData = data->getParentDataPaths();
+  auto pathsToData = data->getDataPaths();
   auto parentIds = data->getParentIds();
   if(parentIds.size() == 0)
   {

--- a/src/complex/DataStructure/Geometry/AbstractGeometry2D.cpp
+++ b/src/complex/DataStructure/Geometry/AbstractGeometry2D.cpp
@@ -32,7 +32,12 @@ DataObject::Type AbstractGeometry2D::getDataObjectType() const
 
 void AbstractGeometry2D::resizeVertexList(usize numVertices)
 {
-  getVertices()->getDataStore()->reshapeTuples({numVertices});
+  auto* vertices = getVertices();
+  if(vertices == nullptr)
+  {
+    return;
+  }
+  vertices->getDataStore()->reshapeTuples({numVertices});
 }
 
 void AbstractGeometry2D::setVertices(const SharedVertexList* vertices)

--- a/src/complex/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.cpp
@@ -117,7 +117,12 @@ std::string TriangleGeom::getGeometryTypeAsString() const
 
 void TriangleGeom::resizeFaceList(usize newNumTris)
 {
-  getFaces()->getDataStore()->reshapeTuples({newNumTris});
+  auto* faces = getFaces();
+  if(faces == nullptr)
+  {
+    return;
+  }
+  faces->getDataStore()->reshapeTuples({newNumTris});
 }
 
 void TriangleGeom::setFaces(const SharedTriList* triangles)

--- a/src/complex/DataStructure/Messaging/DataAddedMessage.cpp
+++ b/src/complex/DataStructure/Messaging/DataAddedMessage.cpp
@@ -41,5 +41,5 @@ const DataObject* DataAddedMessage::getData() const
 
 std::vector<DataPath> DataAddedMessage::getDataPaths() const
 {
-  return getData()->getParentDataPaths();
+  return getData()->getDataPaths();
 }

--- a/src/complex/Filter/Actions/CreateTriangleGeomAction.cpp
+++ b/src/complex/Filter/Actions/CreateTriangleGeomAction.cpp
@@ -32,7 +32,6 @@ Result<> CreateTriangleGeomAction::apply(DataStructure& dataStructure, Mode mode
   {
     return geomResult;
   }
-  
 
   if(shouldCreateVertexArray())
   {

--- a/src/complex/Filter/Actions/CreateTriangleGeomAction.cpp
+++ b/src/complex/Filter/Actions/CreateTriangleGeomAction.cpp
@@ -114,7 +114,7 @@ Result<> CreateTriangleGeomAction::createTriangleArray(DataStructure& dataStruct
 {
   DataPath arrayPath = path().createChildPath("Triangle Array");
   IDataStore::ShapeType compShape{3};
-  return CreateArray<usize>(dataStructure, m_TupleSize, compShape, arrayPath, mode);
+  return CreateArray<uint64>(dataStructure, m_TupleSize, compShape, arrayPath, mode);
 }
 
 } // namespace complex

--- a/src/complex/Filter/Actions/CreateTriangleGeomAction.cpp
+++ b/src/complex/Filter/Actions/CreateTriangleGeomAction.cpp
@@ -1,0 +1,119 @@
+#include "CreateTriangleGeomAction.hpp"
+
+#include <fmt/core.h>
+
+#include "complex/DataStructure/EmptyDataStore.hpp"
+#include "complex/DataStructure/Geometry/TriangleGeom.hpp"
+#include "complex/Utilities/DataArrayUtilities.hpp"
+
+using namespace complex;
+
+namespace complex
+{
+CreateTriangleGeomAction::CreateTriangleGeomAction(const DataPath& path, AdditionalData additional)
+: m_Path(path)
+, m_AdditionalData(additional)
+{
+}
+
+CreateTriangleGeomAction::CreateTriangleGeomAction(const DataPath& path, const ShapeType& tupleSize, AdditionalData additional)
+: m_Path(path)
+, m_TupleSize(tupleSize)
+, m_AdditionalData(additional)
+{
+}
+
+CreateTriangleGeomAction::~CreateTriangleGeomAction() noexcept = default;
+
+Result<> CreateTriangleGeomAction::apply(DataStructure& dataStructure, Mode mode) const
+{
+  auto geomResult = createGeometry(dataStructure, mode);
+  if(geomResult.invalid())
+  {
+    return geomResult;
+  }
+  
+
+  if(shouldCreateVertexArray())
+  {
+    auto vertexResult = createVertexArray(dataStructure, mode);
+    if(vertexResult.invalid())
+    {
+      return vertexResult;
+    }
+  }
+  if(shouldCreateTriangleArray())
+  {
+    auto triangleResult = createTriangleArray(dataStructure, mode);
+    if(triangleResult.invalid())
+    {
+      return triangleResult;
+    }
+  }
+}
+
+const DataPath& CreateTriangleGeomAction::path() const
+{
+  return m_Path;
+}
+
+CreateTriangleGeomAction::ShapeType CreateTriangleGeomAction::tupleSize() const
+{
+  return m_TupleSize;
+}
+
+bool CreateTriangleGeomAction::shouldCreateVertexArray() const
+{
+  auto additionalInt8 = static_cast<int8>(m_AdditionalData);
+  auto targetInt8 = static_cast<int8>(AdditionalData::Vertices);
+  return (additionalInt8 & targetInt8) != 0;
+}
+
+bool CreateTriangleGeomAction::shouldCreateTriangleArray() const
+{
+  auto additionalInt8 = static_cast<int8>(m_AdditionalData);
+  auto targetInt8 = static_cast<int8>(AdditionalData::Triangles);
+  return (additionalInt8 & targetInt8) != 0;
+}
+
+Result<> CreateTriangleGeomAction::createGeometry(DataStructure& dataStructure, Mode mode) const
+{
+  auto parentPath = path().getParent();
+
+  std::optional<DataObject::IdType> id;
+
+  if(parentPath.getLength() != 0)
+  {
+    auto* parentObject = dataStructure.getData(parentPath);
+    if(parentObject == nullptr)
+    {
+      return MakeErrorResult(-262, fmt::format("Parent object '{}' does not exist", parentPath.toString()));
+    }
+
+    id = parentObject->getId();
+  }
+  auto* geom = TriangleGeom::Create(dataStructure, path().getTargetName(), id);
+
+  if(geom == nullptr)
+  {
+    return MakeErrorResult(-263, fmt::format("Failed to create the specified geometry", parentPath.toString()));
+  }
+
+  return {};
+}
+
+Result<> CreateTriangleGeomAction::createVertexArray(DataStructure& dataStructure, Mode mode) const
+{
+  DataPath arrayPath = path().createChildPath("Vertex Array");
+  IDataStore::ShapeType compShape(3);
+  return CreateArray<float32>(dataStructure, m_TupleSize, compShape, arrayPath, mode);
+}
+
+Result<> CreateTriangleGeomAction::createTriangleArray(DataStructure& dataStructure, Mode mode) const
+{
+  DataPath arrayPath = path().createChildPath("Triangle Array");
+  IDataStore::ShapeType compShape(3);
+  return CreateArray<usize>(dataStructure, m_TupleSize, compShape, arrayPath, mode);
+}
+
+} // namespace complex

--- a/src/complex/Filter/Actions/CreateTriangleGeomAction.cpp
+++ b/src/complex/Filter/Actions/CreateTriangleGeomAction.cpp
@@ -50,6 +50,8 @@ Result<> CreateTriangleGeomAction::apply(DataStructure& dataStructure, Mode mode
       return triangleResult;
     }
   }
+
+  return {};
 }
 
 const DataPath& CreateTriangleGeomAction::path() const
@@ -105,14 +107,14 @@ Result<> CreateTriangleGeomAction::createGeometry(DataStructure& dataStructure, 
 Result<> CreateTriangleGeomAction::createVertexArray(DataStructure& dataStructure, Mode mode) const
 {
   DataPath arrayPath = path().createChildPath("Vertex Array");
-  IDataStore::ShapeType compShape(3);
+  IDataStore::ShapeType compShape{3};
   return CreateArray<float32>(dataStructure, m_TupleSize, compShape, arrayPath, mode);
 }
 
 Result<> CreateTriangleGeomAction::createTriangleArray(DataStructure& dataStructure, Mode mode) const
 {
   DataPath arrayPath = path().createChildPath("Triangle Array");
-  IDataStore::ShapeType compShape(3);
+  IDataStore::ShapeType compShape{3};
   return CreateArray<usize>(dataStructure, m_TupleSize, compShape, arrayPath, mode);
 }
 

--- a/src/complex/Filter/Actions/CreateTriangleGeomAction.hpp
+++ b/src/complex/Filter/Actions/CreateTriangleGeomAction.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "complex/Filter/Output.hpp"
+#include "complex/complex_export.hpp"
+
+namespace complex
+{
+/**
+ * @brief Action for creating a TriangleGeom in a DataStructure
+ */
+class COMPLEX_EXPORT CreateTriangleGeomAction : public IDataAction
+{
+public:
+  using ShapeType = std::vector<usize>;
+
+  enum class AdditionalData
+  {
+    None = 0,
+    Vertices = 1,
+    Triangles = 2,
+    VerticesTriangles = 3
+  };
+
+  CreateTriangleGeomAction() = delete;
+
+  CreateTriangleGeomAction(const DataPath& path, AdditionalData additional = AdditionalData::None);
+  CreateTriangleGeomAction(const DataPath& path, const ShapeType& tupleSize, AdditionalData additional);
+
+  ~CreateTriangleGeomAction() noexcept override;
+
+  CreateTriangleGeomAction(const CreateTriangleGeomAction&) = delete;
+  CreateTriangleGeomAction(CreateTriangleGeomAction&&) noexcept = delete;
+  CreateTriangleGeomAction& operator=(const CreateTriangleGeomAction&) = delete;
+  CreateTriangleGeomAction& operator=(CreateTriangleGeomAction&&) noexcept = delete;
+
+  /**
+   * @brief Applies this action's change to the given DataStructure in the given mode.
+   * Returns any warnings/errors. On error, DataStructure is not guaranteed to be consistent.
+   * @param dataStructure
+   * @return Result<>
+   */
+  Result<> apply(DataStructure& dataStructure, Mode mode) const override;
+
+  /**
+   * @brief Returns the path of the DataArray to be created.
+   * @return DataPath
+   */
+  const DataPath& path() const;
+
+  /**
+   * @brief Returns the target tuple size.
+   * @return ShapeType
+   */
+  ShapeType tupleSize() const;
+
+  /**
+   * @brief Returns true if the corresponding vertex array should be created.
+   * Returns false otherwise.
+   * @return bool
+   */
+  bool shouldCreateVertexArray() const;
+
+  /**
+   * @brief Returns true if the corresponding triangle array should be created.
+   * Returns false otherwise.
+   * @return bool
+   */
+  bool shouldCreateTriangleArray() const;
+
+private:
+  /**
+   * @brief Attempts to create the target geometry and returns the result.
+   * @param dataStructure
+   * @param mode
+   * @return Result<>
+   */
+  Result<> createGeometry(DataStructure& dataStructure, Mode mode) const;
+
+  /**
+   * @brief Attempts to create the vertex array and returns the result.
+   * @param dataStructure
+   * @param mode
+   * @return Result<>
+   */
+  Result<> createVertexArray(DataStructure& dataStructure, Mode mode) const;
+
+  /**
+   * @brief Attempts to create the triangle array and returns the result.
+   * @param dataStructure
+   * @param mode
+   * @return Result<>
+   */
+  Result<> createTriangleArray(DataStructure& dataStructure, Mode mode) const;
+
+  DataPath m_Path;
+  ShapeType m_TupleSize = {1};
+  AdditionalData m_AdditionalData = AdditionalData::None;
+};
+} // namespace complex

--- a/src/complex/Filter/Actions/CreateTriangleGeomAction.hpp
+++ b/src/complex/Filter/Actions/CreateTriangleGeomAction.hpp
@@ -21,6 +21,9 @@ public:
     VerticesTriangles = 3
   };
 
+  static constexpr StringLiteral k_DefaultVerticesName = "Vertex Array";
+  static constexpr StringLiteral k_DefaultFacesName = "Triangle Array";
+
   CreateTriangleGeomAction() = delete;
 
   CreateTriangleGeomAction(const DataPath& path, AdditionalData additional = AdditionalData::None);


### PR DESCRIPTION
* Added ExtractInternalSurvacesFromTriangleGeom filter
* Added unit test
* Added CreateTriangleGeomAction
* Renamed DataObject::getParentDataPaths to getDataPaths due to misleading name. DataObject::getParentDataPaths did not return DataPaths to known parents. It returned the DataPaths to the object calling it.