### PR TITLE
Removed DataType::error since it is no longer used

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindDifferencesMap.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindDifferencesMap.cpp
@@ -1,5 +1,6 @@
 #include "FindDifferencesMap.hpp"
 
+#include <optional>
 #include <vector>
 
 #include "complex/DataStructure/AbstractDataStore.hpp"
@@ -19,7 +20,7 @@ constexpr int32 k_TupleCountMismatchError = -90004;
 
 IFilter::PreflightResult validateArrayTypes(const DataStructure& data, const std::vector<DataPath>& dataPaths)
 {
-  DataType dataType = DataType::error;
+  std::optional<DataType> dataType = {};
   for(const auto& dataPath : dataPaths)
   {
     if(data.getDataAs<BoolArray>(dataPath) != nullptr)
@@ -29,7 +30,7 @@ IFilter::PreflightResult validateArrayTypes(const DataStructure& data, const std
     }
     if(auto dataArray = data.getDataAs<IDataArray>(dataPath))
     {
-      if(dataType == DataType::error)
+      if(!dataType.has_value())
       {
         dataType = dataArray->getDataType();
       }
@@ -279,9 +280,6 @@ Result<> FindDifferencesMap::executeImpl(DataStructure& data, const Arguments& a
   case DataType::boolean:
     ExecuteFindDifferenceMap<bool>(firstInputArray, secondInputArray, differenceMapArray);
     break;
-  case DataType::error:
-    std::string ss = fmt::format("Cannot handle indeterminate array types");
-    return {nonstd::make_unexpected(std::vector<Error>{Error{-90006, ss}})};
   }
 
   return {};

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighborListStatistics.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighborListStatistics.cpp
@@ -184,7 +184,6 @@ void findStatistics(const IFilter* filter, INeighborList& source, bool length, b
     findStatisticsImpl<float64>(filter, source, length, min, max, mean, median, stdDeviation, summation, arrays);
     return;
   case DataType::boolean:
-  case DataType::error:
     return;
   }
 }

--- a/src/complex/Common/Types.hpp
+++ b/src/complex/Common/Types.hpp
@@ -49,8 +49,7 @@ enum class DataType : uint8
   uint64,
   float32,
   float64,
-  boolean,
-  error = 255
+  boolean
 };
 
 enum class RunState

--- a/src/complex/Common/TypesUtility.hpp
+++ b/src/complex/Common/TypesUtility.hpp
@@ -242,9 +242,6 @@ inline constexpr StringLiteral DataTypeToString(DataType dataType)
   case DataType::boolean: {
     return "boolean";
   }
-  case DataType::error: {
-    return "error";
-  }
   default:
     throw std::runtime_error("complex::DataTypeToString: Unknown DataType");
   }

--- a/src/complex/DataStructure/AbstractDataStore.cpp
+++ b/src/complex/DataStructure/AbstractDataStore.cpp
@@ -2,12 +2,6 @@
 
 using namespace complex;
 
-template <typename ValueType>
-DataType AbstractDataStore<ValueType>::getDataType() const
-{
-  return DataType::error;
-}
-
 template <>
 DataType COMPLEX_EXPORT AbstractDataStore<int8>::getDataType() const
 {

--- a/src/complex/DataStructure/IDataArray.hpp
+++ b/src/complex/DataStructure/IDataArray.hpp
@@ -136,13 +136,9 @@ public:
    * @brief Returns the DataArray's value type as an enum
    * @return DataType
    */
-  virtual DataType getDataType() const
+  DataType getDataType() const
   {
-    if(auto store = getIDataStore())
-    {
-      return store->getDataType();
-    }
-    return DataType::error;
+    return getIDataStoreRef().getDataType();
   }
 
 protected:

--- a/src/complex/DataStructure/NeighborList.cpp
+++ b/src/complex/DataStructure/NeighborList.cpp
@@ -284,12 +284,6 @@ typename NeighborList<T>::VectorType& NeighborList<T>::operator[](usize grainId)
   return *(m_Array[grainId]);
 }
 
-template <typename ValueType>
-DataType NeighborList<ValueType>::getDataType() const
-{
-  return DataType::error;
-}
-
 template <>
 DataType COMPLEX_EXPORT NeighborList<int8>::getDataType() const
 {

--- a/src/complex/Utilities/DataArrayUtilities.cpp
+++ b/src/complex/Utilities/DataArrayUtilities.cpp
@@ -149,8 +149,6 @@ Result<> ConditionalReplaceValueInArray(const std::string& valueAsStr, DataObjec
   case complex::DataType::boolean:
     return ConditionalReplaceValueInArrayFromString<bool>(valueAsStr, inputDataObject, conditionalDataArray);
     break;
-  case complex::DataType::error:
-    return {MakeErrorResult(-260, fmt::format("Input DataObject could not be cast to any primitive type."))};
   }
   return {};
 }


### PR DESCRIPTION
* Used to be for NeighborList when it inherited from IDataArray