### PR TITLE
Update legacy import of node-based geometries

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
@@ -111,16 +111,18 @@ IFilter::PreflightResult RemoveFlaggedVertices::preflightImpl(const DataStructur
     std::string errorMsg = fmt::format("Vertex Geometry not found at path: '{}'", vertexGeomPath.toString());
     return {MakeErrorResult<OutputActions>(::k_VertexGeomNotFound, errorMsg)};
   }
-  if(vertex->getVertices() == nullptr)
+  auto verticesId = vertex->getVerticesId();
+  auto* verticesArray = dataStructure.getDataAs<Float32Array>(verticesId);
+  if(verticesArray == nullptr)
   {
     std::string errorMsg = fmt::format("Vertex Geometry does not have a vertex list");
     return {MakeErrorResult<OutputActions>(::k_VertexGeomNotFound, errorMsg)};
   }
-  dataArrayPaths.push_back(vertex->getVertices()->getDataPaths()[0]);
+  // dataArrayPaths.push_back(verticesArray->getDataPaths()[0]);
 
   std::vector<size_t> cDims(1, 1);
 
-  const auto* maskArray = dataStructure.getDataAs<DataArray<bool>>(maskArrayPath);
+  const auto* maskArray = dataStructure.getDataAs<DataArray<uint8>>(maskArrayPath);
   if(maskArray != nullptr)
   {
     dataArrayPaths.push_back(maskArrayPath);
@@ -171,7 +173,7 @@ Result<> RemoveFlaggedVertices::executeImpl(DataStructure& data, const Arguments
   auto reducedVertexPath = args.value<DataPath>(k_ReducedVertexPath_Key);
 
   VertexGeom& vertex = data.getDataRefAs<VertexGeom>(vertexGeomPath);
-  auto& mask = data.getDataRefAs<BoolArray>(maskArrayPath);
+  auto& mask = data.getDataRefAs<UInt8Array>(maskArrayPath);
 
   size_t numMaskTuples = mask.getSize();
   size_t trueCount = std::count(mask.begin(), mask.end(), true);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
@@ -122,7 +122,7 @@ IFilter::PreflightResult RemoveFlaggedVertices::preflightImpl(const DataStructur
 
   std::vector<size_t> cDims(1, 1);
 
-  const auto* maskArray = dataStructure.getDataAs<DataArray<uint8>>(maskArrayPath);
+  const auto* maskArray = dataStructure.getDataAs<BoolArray>(maskArrayPath);
   if(maskArray != nullptr)
   {
     dataArrayPaths.push_back(maskArrayPath);
@@ -173,7 +173,7 @@ Result<> RemoveFlaggedVertices::executeImpl(DataStructure& data, const Arguments
   auto reducedVertexPath = args.value<DataPath>(k_ReducedVertexPath_Key);
 
   VertexGeom& vertex = data.getDataRefAs<VertexGeom>(vertexGeomPath);
-  auto& mask = data.getDataRefAs<UInt8Array>(maskArrayPath);
+  auto& mask = data.getDataRefAs<BoolArray>(maskArrayPath);
 
   size_t numMaskTuples = mask.getSize();
   size_t trueCount = std::count(mask.begin(), mask.end(), true);

--- a/src/Plugins/ComplexCore/test/RemoveFlaggedVerticesTest.cpp
+++ b/src/Plugins/ComplexCore/test/RemoveFlaggedVerticesTest.cpp
@@ -43,7 +43,7 @@ TEST_CASE("RemoveFlaggedVertices: Test Algorithm", "[ComplexCore][RemoveFlaggedV
   Int32Array* slipVector = UnitTest::CreateTestDataArray<int32>(dataGraph, Constants::k_SlipVector, vertexTupleDims, vertexCompDims, vertexGeom->getId());
   Int32Array* featureIds = UnitTest::CreateTestDataArray<int32>(dataGraph, Constants::k_FeatureIds, vertexTupleDims, {1}, vertexGeom->getId());
 
-  UInt8Array* conditionalArray = UnitTest::CreateTestDataArray<uint8>(dataGraph, Constants::k_ConditionalArray, vertexTupleDims, {1}, vertexGeom->getId());
+  BoolArray* conditionalArray = UnitTest::CreateTestDataArray<bool>(dataGraph, Constants::k_ConditionalArray, vertexTupleDims, {1}, vertexGeom->getId());
   conditionalArray->fill(true);
   // initialize the coords just to have something other than 0.0
   // Set the first 25 values of the conditional array to false, thus keeping 75 vertices

--- a/src/Plugins/ComplexCore/test/RemoveFlaggedVerticesTest.cpp
+++ b/src/Plugins/ComplexCore/test/RemoveFlaggedVerticesTest.cpp
@@ -43,7 +43,7 @@ TEST_CASE("RemoveFlaggedVertices: Test Algorithm", "[ComplexCore][RemoveFlaggedV
   Int32Array* slipVector = UnitTest::CreateTestDataArray<int32>(dataGraph, Constants::k_SlipVector, vertexTupleDims, vertexCompDims, vertexGeom->getId());
   Int32Array* featureIds = UnitTest::CreateTestDataArray<int32>(dataGraph, Constants::k_FeatureIds, vertexTupleDims, {1}, vertexGeom->getId());
 
-  BoolArray* conditionalArray = UnitTest::CreateTestDataArray<bool>(dataGraph, Constants::k_ConditionalArray, vertexTupleDims, {1}, vertexGeom->getId());
+  UInt8Array* conditionalArray = UnitTest::CreateTestDataArray<uint8>(dataGraph, Constants::k_ConditionalArray, vertexTupleDims, {1}, vertexGeom->getId());
   conditionalArray->fill(true);
   // initialize the coords just to have something other than 0.0
   // Set the first 25 values of the conditional array to false, thus keeping 75 vertices

--- a/src/complex/DataStructure/Geometry/VertexGeom.cpp
+++ b/src/complex/DataStructure/Geometry/VertexGeom.cpp
@@ -162,6 +162,11 @@ const AbstractGeometry::SharedVertexList* VertexGeom::getVertices() const
   return dataStructure->getDataAs<SharedVertexList>(m_VertexListId);
 }
 
+std::optional<DataObject::IdType> VertexGeom::getVerticesId() const
+{
+  return m_VertexListId;
+}
+
 Point3D<float32> VertexGeom::getCoords(usize vertId) const
 {
   auto vertices = getVertices();

--- a/src/complex/DataStructure/Geometry/VertexGeom.hpp
+++ b/src/complex/DataStructure/Geometry/VertexGeom.hpp
@@ -118,6 +118,12 @@ public:
   const SharedVertexList* getVertices() const;
 
   /**
+   * @brief Returns the DataObject ID for the vertices array. Returns an empty optional if no vertex array has been set.
+   * @return std::optional<IdType>
+   */
+  std::optional<IdType> getVerticesId() const;
+
+  /**
    * @brief Gets the coordinates at the target vertex ID.
    * @param vertId
    */

--- a/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -46,6 +46,14 @@ constexpr StringLiteral TupleDims = "TupleDimensions";
 
 constexpr StringLiteral FileVersion = "7.0";
 
+constexpr StringLiteral VertexListName = "SharedVertexList";
+constexpr StringLiteral EdgeListName = "SharedEdgeList";
+constexpr StringLiteral TriListName = "SharedTriList";
+constexpr StringLiteral QuadListName = "SharedQuadList";
+constexpr StringLiteral TetraListName = "SharedTetList";
+constexpr StringLiteral HexListName = "SharedHexList";
+constexpr StringLiteral VerticesName = "Verts";
+
 namespace Type
 {
 constexpr StringLiteral ImageGeom = "ImageGeometry";
@@ -105,7 +113,7 @@ DataStructure ImportDataStructureV8(const H5::FileReader& fileReader, H5::ErrorT
  * @param cDims
  */
 template <typename T>
-void createLegacyDataArray(DataStructure& ds, DataObject::IdType parentId, const H5::DatasetReader& dataArrayReader, const std::vector<usize>& tDims, const std::vector<usize>& cDims,
+IDataArray* createLegacyDataArray(DataStructure& ds, DataObject::IdType parentId, const H5::DatasetReader& dataArrayReader, const std::vector<usize>& tDims, const std::vector<usize>& cDims,
                            bool preflight = false)
 {
   using DataArrayType = DataArray<T>;
@@ -132,7 +140,7 @@ void createLegacyDataArray(DataStructure& ds, DataObject::IdType parentId, const
     dataStore->setValue(i, data.at(i));
   }
   // Insert the DataArray into the DataStructure
-  auto dataArray = DataArrayType::Create(ds, daName, std::move(dataStore), parentId);
+  return DataArray<T>::Create(ds, daName, std::move(dataStore), parentId);
 }
 
 /**
@@ -166,7 +174,7 @@ void readLegacyDataArrayDims(const H5::DatasetReader& dataArrayReader, std::vect
   }
 }
 
-void readLegacyDataArray(DataStructure& ds, const H5::DatasetReader& dataArrayReader, DataObject::IdType parentId, bool preflight = false)
+IDataArray* readLegacyDataArray(DataStructure& ds, const H5::DatasetReader& dataArrayReader, DataObject::IdType parentId, bool preflight = false)
 {
   auto size = H5Dget_storage_size(dataArrayReader.getId());
   auto typeId = dataArrayReader.getTypeId();
@@ -175,48 +183,52 @@ void readLegacyDataArray(DataStructure& ds, const H5::DatasetReader& dataArrayRe
   std::vector<usize> cDims;
   readLegacyDataArrayDims(dataArrayReader, tDims, cDims);
 
+  IDataArray* dataArray = nullptr;
+
   if(H5Tequal(typeId, H5T_NATIVE_FLOAT) > 0)
   {
-    createLegacyDataArray<float32>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
+    dataArray = createLegacyDataArray<float32>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
   }
   else if(H5Tequal(typeId, H5T_NATIVE_DOUBLE) > 0)
   {
-    createLegacyDataArray<float64>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
+    dataArray = createLegacyDataArray<float64>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
   }
   else if(H5Tequal(typeId, H5T_NATIVE_INT8) > 0)
   {
-    createLegacyDataArray<int8>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
+    dataArray = createLegacyDataArray<int8>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
   }
   else if(H5Tequal(typeId, H5T_NATIVE_INT16) > 0)
   {
-    createLegacyDataArray<int16>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
+    dataArray = createLegacyDataArray<int16>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
   }
   else if(H5Tequal(typeId, H5T_NATIVE_INT32) > 0)
   {
-    createLegacyDataArray<int32>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
+    dataArray = createLegacyDataArray<int32>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
   }
   else if(H5Tequal(typeId, H5T_NATIVE_INT64) > 0)
   {
-    createLegacyDataArray<int64>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
+    dataArray = createLegacyDataArray<int64>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
   }
   else if(H5Tequal(typeId, H5T_NATIVE_UINT8) > 0)
   {
-    createLegacyDataArray<uint8>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
+    dataArray = createLegacyDataArray<uint8>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
   }
   else if(H5Tequal(typeId, H5T_NATIVE_UINT16) > 0)
   {
-    createLegacyDataArray<uint16>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
+    dataArray = createLegacyDataArray<uint16>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
   }
   else if(H5Tequal(typeId, H5T_NATIVE_UINT32) > 0)
   {
-    createLegacyDataArray<uint32>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
+    dataArray = createLegacyDataArray<uint32>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
   }
   else if(H5Tequal(typeId, H5T_NATIVE_UINT64) > 0)
   {
-    createLegacyDataArray<uint64>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
+    dataArray = createLegacyDataArray<uint64>(ds, parentId, dataArrayReader, tDims, cDims, preflight);
   }
 
   H5Tclose(typeId);
+
+  return dataArray;
 }
 
 void readLegacyAttributeMatrix(DataStructure& ds, const H5::GroupReader& amGroupReader, DataObject::IdType parentId, bool preflight = false)
@@ -248,10 +260,26 @@ void readGenericGeomDims(AbstractGeometry* geom, const H5::GroupReader& geomGrou
   geom->setUnitDimensionality(uDims);
 }
 
+IDataArray* readLegacyGeomArray(DataStructure& ds, AbstractGeometry* geometry, const H5::GroupReader& geomGroup, const std::string& arrayName)
+{
+  auto dataArraySet = geomGroup.openDataset(arrayName);
+  return readLegacyDataArray(ds, dataArraySet, geometry->getId());
+}
+
+template <typename T>
+T* readLegacyGeomArrayAs(DataStructure& ds, AbstractGeometry* geometry, const H5::GroupReader& geomGroup, const std::string& arrayName)
+{
+  return dynamic_cast<T*>(readLegacyGeomArray(ds, geometry, geomGroup, arrayName));
+}
+
 DataObject* readLegacyVertexGeom(DataStructure& ds, const H5::GroupReader& geomGroup, const std::string& name)
 {
-  auto geom = VertexGeom::Create(ds, name);
+  auto* geom = VertexGeom::Create(ds, name);
   readGenericGeomDims(geom, geomGroup);
+  auto* sharedVertexList = readLegacyGeomArrayAs<Float32Array>(ds, geom, geomGroup, Legacy::VertexListName);
+  auto* verts = readLegacyGeomArray(ds, geom, geomGroup, Legacy::VerticesName);
+
+  geom->setVertices(sharedVertexList);
   return geom;
 }
 
@@ -259,6 +287,12 @@ DataObject* readLegacyTriangleGeom(DataStructure& ds, const H5::GroupReader& geo
 {
   auto geom = TriangleGeom::Create(ds, name);
   readGenericGeomDims(geom, geomGroup);
+  auto* sharedVertexList = readLegacyGeomArrayAs<Float32Array>(ds, geom, geomGroup, Legacy::VertexListName);
+  auto* sharedTriList = readLegacyGeomArrayAs<UInt64Array>(ds, geom, geomGroup, Legacy::TriListName);
+
+  geom->setVertices(sharedVertexList);
+  geom->setEdges(sharedTriList);
+
   return geom;
 }
 
@@ -266,6 +300,12 @@ DataObject* readLegacyTetrahedralGeom(DataStructure& ds, const H5::GroupReader& 
 {
   auto geom = TetrahedralGeom::Create(ds, name);
   readGenericGeomDims(geom, geomGroup);
+  auto* sharedVertexList = readLegacyGeomArrayAs<Float32Array>(ds, geom, geomGroup, Legacy::VertexListName);
+  auto* sharedTetList = readLegacyGeomArrayAs<UInt64Array>(ds, geom, geomGroup, Legacy::TetraListName);
+
+  geom->setVertices(sharedVertexList);
+  geom->setEdges(sharedTetList);
+
   return geom;
 }
 
@@ -280,6 +320,12 @@ DataObject* readLegacyQuadGeom(DataStructure& ds, const H5::GroupReader& geomGro
 {
   auto geom = QuadGeom::Create(ds, name);
   readGenericGeomDims(geom, geomGroup);
+  auto* sharedVertexList = readLegacyGeomArrayAs<Float32Array>(ds, geom, geomGroup, Legacy::VertexListName);
+  auto* sharedQuadList = readLegacyGeomArrayAs<UInt64Array>(ds, geom, geomGroup, Legacy::QuadListName);
+
+  geom->setVertices(sharedVertexList);
+  geom->setEdges(sharedQuadList);
+
   return geom;
 }
 
@@ -287,6 +333,12 @@ DataObject* readLegacyHexGeom(DataStructure& ds, const H5::GroupReader& geomGrou
 {
   auto geom = HexahedralGeom::Create(ds, name);
   readGenericGeomDims(geom, geomGroup);
+  auto* sharedVertexList = readLegacyGeomArrayAs<Float32Array>(ds, geom, geomGroup, Legacy::VertexListName);
+  auto* sharedHexList = readLegacyGeomArrayAs<UInt64Array>(ds, geom, geomGroup, Legacy::HexListName);
+
+  geom->setVertices(sharedVertexList);
+  geom->setEdges(sharedHexList);
+
   return geom;
 }
 
@@ -295,6 +347,12 @@ DataObject* readLegacyEdgeGeom(DataStructure& ds, const H5::GroupReader& geomGro
   auto geom = EdgeGeom::Create(ds, name);
   auto edge = dynamic_cast<EdgeGeom*>(geom);
   readGenericGeomDims(geom, geomGroup);
+  auto* sharedVertexList = readLegacyGeomArrayAs<Float32Array>(ds, geom, geomGroup, Legacy::VertexListName);
+  auto* sharedEdgeList = readLegacyGeomArrayAs<UInt64Array>(ds, geom, geomGroup, Legacy::EdgeListName);
+
+  geom->setVertices(sharedVertexList);
+  geom->setEdges(sharedEdgeList);
+
   return geom;
 }
 

--- a/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -128,8 +128,7 @@ IDataArray* createLegacyDataArray(DataStructure& ds, DataObject::IdType parentId
 
   if(preflight)
   {
-    DataArrayType::template CreateWithStore<EmptyDataStoreType>(ds, daName, tDims, cDims, parentId);
-    return;
+    return DataArrayType::template CreateWithStore<EmptyDataStoreType>(ds, daName, tDims, cDims, parentId);
   }
   auto dataStore = std::make_unique<DataStoreType>(tDims, cDims);
 

--- a/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -15,6 +15,7 @@
 #include "complex/DataStructure/Geometry/TetrahedralGeom.hpp"
 #include "complex/DataStructure/Geometry/TriangleGeom.hpp"
 #include "complex/DataStructure/Geometry/VertexGeom.hpp"
+#include "complex/DataStructure/NeighborList.hpp"
 #include "complex/Pipeline/Pipeline.hpp"
 #include "complex/Utilities/Parsing/HDF5/H5DataStructureReader.hpp"
 #include "complex/Utilities/Parsing/HDF5/H5DataStructureWriter.hpp"
@@ -53,6 +54,9 @@ constexpr StringLiteral QuadListName = "SharedQuadList";
 constexpr StringLiteral TetraListName = "SharedTetList";
 constexpr StringLiteral HexListName = "SharedHexList";
 constexpr StringLiteral VerticesName = "Verts";
+constexpr StringLiteral XBoundsName = "xBounds";
+constexpr StringLiteral YBoundsName = "yBounds";
+constexpr StringLiteral ZBoundsName = "zBounds";
 
 namespace Type
 {
@@ -151,8 +155,6 @@ IDataArray* createLegacyDataArray(DataStructure& ds, DataObject::IdType parentId
  */
 void readLegacyDataArrayDims(const H5::DatasetReader& dataArrayReader, std::vector<usize>& tDims, std::vector<usize>& cDims)
 {
-  hid_t compType = H5::Support::HdfTypeForPrimitive<int64>();
-
   {
     auto compAttrib = dataArrayReader.getAttribute(Legacy::CompDims);
     if(!compAttrib.isValid())
@@ -231,6 +233,81 @@ IDataArray* readLegacyDataArray(DataStructure& ds, const H5::DatasetReader& data
   return dataArray;
 }
 
+template <typename T>
+void createLegacyNeighborList(DataStructure& ds, DataObject ::IdType parentId, const H5::GroupReader& parentReader, const H5::DatasetReader& datasetReader, const std::vector<usize>& tupleDims)
+{
+  auto numTuples = std::accumulate(std::begin(tupleDims), std::end(tupleDims), 1, std::multiplies<float>());
+  auto data = NeighborList<T>::ReadHdf5Data(parentReader, datasetReader);
+  auto* neighborList = NeighborList<T>::Create(ds, datasetReader.getName(), numTuples, parentId);
+  for(usize i = 0; i < data.size(); ++i)
+  {
+    neighborList->setList(i, data[i]);
+  }
+}
+
+void readLegacyNeighborList(DataStructure& ds, const H5::GroupReader& parentReader, const H5::DatasetReader& datasetReader, DataObject::IdType parentId)
+{
+  auto typeId = datasetReader.getTypeId();
+
+  auto tupleAttrib = datasetReader.getAttribute(Legacy::TupleDims);
+  if(!tupleAttrib.isValid())
+  {
+    throw std::runtime_error("Error reading legacy DataArray dimensions");
+  }
+
+  auto tDims = tupleAttrib.readAsVector<usize>();
+
+  if(H5Tequal(typeId, H5T_NATIVE_FLOAT) > 0)
+  {
+    createLegacyNeighborList<float32>(ds, parentId, parentReader, datasetReader, tDims);
+  }
+  else if(H5Tequal(typeId, H5T_NATIVE_DOUBLE) > 0)
+  {
+    createLegacyNeighborList<float64>(ds, parentId, parentReader, datasetReader, tDims);
+  }
+  else if(H5Tequal(typeId, H5T_NATIVE_INT8) > 0)
+  {
+    createLegacyNeighborList<int8>(ds, parentId, parentReader, datasetReader, tDims);
+  }
+  else if(H5Tequal(typeId, H5T_NATIVE_INT16) > 0)
+  {
+    createLegacyNeighborList<int16>(ds, parentId, parentReader, datasetReader, tDims);
+  }
+  else if(H5Tequal(typeId, H5T_NATIVE_INT32) > 0)
+  {
+    createLegacyNeighborList<int32>(ds, parentId, parentReader, datasetReader, tDims);
+  }
+  else if(H5Tequal(typeId, H5T_NATIVE_INT64) > 0)
+  {
+    createLegacyNeighborList<int64>(ds, parentId, parentReader, datasetReader, tDims);
+  }
+  else if(H5Tequal(typeId, H5T_NATIVE_UINT8) > 0)
+  {
+    createLegacyNeighborList<uint8>(ds, parentId, parentReader, datasetReader, tDims);
+  }
+  else if(H5Tequal(typeId, H5T_NATIVE_UINT16) > 0)
+  {
+    createLegacyNeighborList<uint16>(ds, parentId, parentReader, datasetReader, tDims);
+  }
+  else if(H5Tequal(typeId, H5T_NATIVE_UINT32) > 0)
+  {
+    createLegacyNeighborList<uint32>(ds, parentId, parentReader, datasetReader, tDims);
+  }
+  else if(H5Tequal(typeId, H5T_NATIVE_UINT64) > 0)
+  {
+    createLegacyNeighborList<uint64>(ds, parentId, parentReader, datasetReader, tDims);
+  }
+
+  H5Tclose(typeId);
+}
+
+bool isLegacyNeighborList(const H5::DatasetReader& arrayReader)
+{
+  auto objectTypeAttribute = arrayReader.getAttribute("ObjectType");
+  std::string objectType = objectTypeAttribute.readAsString();
+  return objectType == "NeighborList<T>";
+}
+
 void readLegacyAttributeMatrix(DataStructure& ds, const H5::GroupReader& amGroupReader, DataObject::IdType parentId, bool preflight = false)
 {
   const std::string amName = amGroupReader.getName();
@@ -239,10 +316,15 @@ void readLegacyAttributeMatrix(DataStructure& ds, const H5::GroupReader& amGroup
   auto dataArrayNames = amGroupReader.getChildNames();
   for(const auto& daName : dataArrayNames)
   {
-    if(daName != "NeighborList")
+    auto dataArraySet = amGroupReader.openDataset(daName);
+
+    if(!isLegacyNeighborList(dataArraySet))
     {
-      auto dataArraySet = amGroupReader.openDataset(daName);
-      readLegacyDataArray(ds, dataArraySet, attributeMatrix->getId(), preflight);
+      readLegacyDataArray(ds, dataArraySet, attributeMatrix->getId());
+    }
+    else
+    {
+      readLegacyNeighborList(ds, amGroupReader, dataArraySet, attributeMatrix->getId());
     }
   }
 }
@@ -313,6 +395,20 @@ DataObject* readLegacyRectGridGeom(DataStructure& ds, const H5::GroupReader& geo
 {
   auto geom = RectGridGeom::Create(ds, name);
   readGenericGeomDims(geom, geomGroup);
+
+  // DIMENSIONS array
+  {
+    auto dimsDataset = geomGroup.openDataset("DIMENSIONS");
+    auto dims = dimsDataset.readAsVector<int64>();
+    geom->setDimensions(SizeVec3(dims[0], dims[1], dims[2]));
+  }
+
+  auto* xBoundsArray = readLegacyGeomArrayAs<Float32Array>(ds, geom, geomGroup, Legacy::XBoundsName);
+  auto* yBoundsArray = readLegacyGeomArrayAs<Float32Array>(ds, geom, geomGroup, Legacy::YBoundsName);
+  auto* zBoundsArray = readLegacyGeomArrayAs<Float32Array>(ds, geom, geomGroup, Legacy::ZBoundsName);
+
+  geom->setBounds(xBoundsArray, yBoundsArray, zBoundsArray);
+
   return geom;
 }
 

--- a/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -118,7 +118,7 @@ DataStructure ImportDataStructureV8(const H5::FileReader& fileReader, H5::ErrorT
  */
 template <typename T>
 IDataArray* createLegacyDataArray(DataStructure& ds, DataObject::IdType parentId, const H5::DatasetReader& dataArrayReader, const std::vector<usize>& tDims, const std::vector<usize>& cDims,
-                           bool preflight = false)
+                                  bool preflight = false)
 {
   using DataArrayType = DataArray<T>;
   using EmptyDataStoreType = EmptyDataStore<T>;


### PR DESCRIPTION
* Import shared vertex, edge, triangle, quad, hexahedral, and tetrahedral arrays.
* Imported node arrays do not link to any existing DataArrays.