### PR TITLE
Feature/multi-DREAM.3D import

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportDREAM3DFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportDREAM3DFilter.cpp
@@ -73,25 +73,10 @@ IFilter::PreflightResult ImportDREAM3DFilter::preflightImpl(const DataStructure&
     importData.DataPaths = std::nullopt;
   }
 
-  auto importedDataStructure = fileData.second;
-  importedDataStructure.resetIds(dataStructure.getNextId());
-
-  // Create target DataPaths for the output DataStructure
-  auto& importDataPaths = importData.DataPaths;
-  if(!importDataPaths.has_value())
-  {
-    return {getDataCreationResults(importedDataStructure)};
-  }
-
-  // Require at least one DataPath to import.
-  if(importDataPaths->empty())
-  {
-    return {nonstd::make_unexpected(std::vector<Error>{Error{k_NoSelectedPaths, "No paths were selected for importing"}})};
-  }
-
-  // Import shortest paths first
-  std::sort(importDataPaths->begin(), importDataPaths->end(), [](const DataPath& first, const DataPath& second) { return first.getLength() < second.getLength(); });
-  return {getDataCreationResults(fileData.second, importDataPaths.value())};
+  OutputActions actions;
+  auto action = std::make_unique<ImportH5ObjectPathsAction>(fileReader, importData.DataPaths);
+  actions.actions.push_back(std::move(action));
+  return {std::move(actions)};
 }
 
 Result<> ImportDREAM3DFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportDREAM3DFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportDREAM3DFilter.cpp
@@ -73,10 +73,25 @@ IFilter::PreflightResult ImportDREAM3DFilter::preflightImpl(const DataStructure&
     importData.DataPaths = std::nullopt;
   }
 
-  OutputActions actions;
-  auto action = std::make_unique<ImportH5ObjectPathsAction>(fileReader, importData.DataPaths);
-  actions.actions.push_back(std::move(action));
-  return {std::move(actions)};
+  auto importedDataStructure = fileData.second;
+  importedDataStructure.resetIds(dataStructure.getNextId());
+
+  // Create target DataPaths for the output DataStructure
+  auto& importDataPaths = importData.DataPaths;
+  if(!importDataPaths.has_value())
+  {
+    return {getDataCreationResults(importedDataStructure)};
+  }
+
+  // Require at least one DataPath to import.
+  if(importDataPaths->empty())
+  {
+    return {nonstd::make_unexpected(std::vector<Error>{Error{k_NoSelectedPaths, "No paths were selected for importing"}})};
+  }
+
+  // Import shortest paths first
+  std::sort(importDataPaths->begin(), importDataPaths->end(), [](const DataPath& first, const DataPath& second) { return first.getLength() < second.getLength(); });
+  return {getDataCreationResults(fileData.second, importDataPaths.value())};
 }
 
 Result<> ImportDREAM3DFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/complex/DataStructure/BaseGroup.cpp
+++ b/src/complex/DataStructure/BaseGroup.cpp
@@ -186,3 +186,8 @@ H5::ErrorType BaseGroup::writeHdf5(H5::DataStructureWriter& dataStructureWriter,
 
   return m_DataMap.writeH5Group(dataStructureWriter, groupWriter);
 }
+
+void BaseGroup::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+{
+  m_DataMap.updateIds(updatedIds);
+}

--- a/src/complex/DataStructure/BaseGroup.hpp
+++ b/src/complex/DataStructure/BaseGroup.hpp
@@ -263,6 +263,12 @@ protected:
   BaseGroup(DataStructure& ds, std::string name, IdType importId);
 
   /**
+   * @brief Updates the DataMap IDs. Should only be called by DataObject::checkUpdatedIds.
+   * @param updatedIds
+   */
+  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+
+  /**
    * @brief Checks if the provided DataObject can be added to the container.
    * This is a virtual method so that derived classes can modify what can or
    * cannot be added to the container. Returns true if the DataObject can be

--- a/src/complex/DataStructure/DataMap.cpp
+++ b/src/complex/DataStructure/DataMap.cpp
@@ -325,3 +325,18 @@ H5::ErrorType DataMap::writeH5Group(H5::DataStructureWriter& dataStructureWriter
   }
   return 0;
 }
+
+void DataMap::updateIds(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+{
+  for(const auto& updatedId : updatedIds)
+  {
+    if(!contains(updatedId.first))
+    {
+      continue;
+    }
+
+    auto extractedPair = m_Map.extract(updatedId.first);
+    extractedPair.key() = updatedId.second;
+    m_Map.insert(std::move(extractedPair));
+  }
+}

--- a/src/complex/DataStructure/DataMap.hpp
+++ b/src/complex/DataStructure/DataMap.hpp
@@ -292,6 +292,12 @@ public:
    */
   H5::ErrorType writeH5Group(H5::DataStructureWriter& dataStructureWriter, H5::GroupWriter& groupWriter) const;
 
+  /**
+   * @brief Updates the map IDs using a vector of updated IDs and their new values.
+   * @param updatedIds
+   */
+  void updateIds(const std::vector<std::pair<IdType, IdType>>& updatedIds);
+
 private:
   MapType m_Map;
 };

--- a/src/complex/DataStructure/DataObject.cpp
+++ b/src/complex/DataStructure/DataObject.cpp
@@ -88,6 +88,11 @@ DataObject::Type DataObject::getDataObjectType() const
   return Type::DataObject;
 }
 
+void DataObject::setId(IdType newId)
+{
+  m_Id = newId;
+}
+
 bool DataObject::AttemptToAddObject(DataStructure& ds, const std::shared_ptr<DataObject>& data, const std::optional<IdType>& parentId)
 {
   return ds.finishAddingObject(data, parentId);

--- a/src/complex/DataStructure/DataObject.cpp
+++ b/src/complex/DataStructure/DataObject.cpp
@@ -93,6 +93,22 @@ void DataObject::setId(IdType newId)
   m_Id = newId;
 }
 
+void DataObject::checkUpdatedIds(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+{
+  for(const auto& updatedId : updatedIds)
+  {
+    // Update parent list
+    std::replace(m_ParentList.begin(), m_ParentList.end(), updatedId.first, updatedId.second);
+  }
+
+  // For derived classes
+  checkUpdatedIdsImpl(updatedIds);
+}
+
+void DataObject::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+{
+}
+
 bool DataObject::AttemptToAddObject(DataStructure& ds, const std::shared_ptr<DataObject>& data, const std::optional<IdType>& parentId)
 {
   return ds.finishAddingObject(data, parentId);

--- a/src/complex/DataStructure/DataObject.hpp
+++ b/src/complex/DataStructure/DataObject.hpp
@@ -250,6 +250,18 @@ protected:
   void setId(IdType newId);
 
   /**
+   * @brief Notifies the DataObject of DataObject IDs that have been changed by the DataStructure.
+   * @param updatedIds std::pair ordered as {old ID, new ID}
+   */
+  void checkUpdatedIds(const std::vector<std::pair<IdType, IdType>>& updatedIds);
+
+  /**
+   * @brief Calls specialized checks for derived classes. Should only be called by checkUpdatedIds.
+   * @param updatedIds
+   */
+  virtual void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds);
+
+  /**
    * @brief Attempts to add the specified DataObject to the target DataStructure.
    * If a parentId is provided, then the DataObject will be added as a child to
    * the target DataObject. Otherwise, the DataObject will be added directly

--- a/src/complex/DataStructure/DataObject.hpp
+++ b/src/complex/DataStructure/DataObject.hpp
@@ -243,6 +243,13 @@ protected:
   DataObject(DataStructure& ds, std::string name, IdType importId);
 
   /**
+   * @brief Updates the data ID for lookup within the DataStructure.
+   * This method should only be called from within the DataStructure.
+   * @param newId 
+   */
+  void setId(IdType newId);
+
+  /**
    * @brief Attempts to add the specified DataObject to the target DataStructure.
    * If a parentId is provided, then the DataObject will be added as a child to
    * the target DataObject. Otherwise, the DataObject will be added directly

--- a/src/complex/DataStructure/DataObject.hpp
+++ b/src/complex/DataStructure/DataObject.hpp
@@ -245,7 +245,7 @@ protected:
   /**
    * @brief Updates the data ID for lookup within the DataStructure.
    * This method should only be called from within the DataStructure.
-   * @param newId 
+   * @param newId
    */
   void setId(IdType newId);
 

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -517,6 +517,16 @@ DataStructure::ConstIterator DataStructure::end() const
 
 bool DataStructure::insert(const std::shared_ptr<DataObject>& dataObject, const DataPath& dataPath)
 {
+  if(dataObject == nullptr)
+  {
+    return false;
+  }
+
+  if(getData(dataObject->getId()) != nullptr)
+  {
+    dataObject->setId(generateId());
+  }
+
   if(dataPath.empty())
   {
     return insertIntoRoot(dataObject);

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -522,6 +522,11 @@ bool DataStructure::insert(const std::shared_ptr<DataObject>& dataObject, const 
     return false;
   }
 
+  if(dataObject.get() == getData(dataObject->getId()))
+  {
+    return false;
+  }
+
   if(getData(dataObject->getId()) != nullptr)
   {
     dataObject->setId(generateId());

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -745,7 +745,7 @@ void DataStructure::resetIds(DataObject::IdType startingId)
     {
       continue;
     }
-    
+
     auto oldId = dataObjectIter.first;
     auto newId = generateId();
 

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -536,6 +536,11 @@ bool DataStructure::insert(const std::shared_ptr<DataObject>& dataObject, const 
   return insertIntoParent(dataObject, parentGroup);
 }
 
+DataObject::IdType DataStructure::getNextId() const
+{
+  return m_NextId;
+}
+
 bool DataStructure::insertIntoRoot(const std::shared_ptr<DataObject>& dataObject)
 {
   if(dataObject == nullptr)
@@ -718,4 +723,47 @@ bool DataStructure::validateNumberOfTuples(const std::vector<DataPath>& dataPath
   }
   return true;
 }
+
+void DataStructure::resetIds(DataObject::IdType startingId)
+{
+  // 0 is reserved
+  if(startingId == 0)
+  {
+    startingId = 1;
+  }
+
+  m_NextId = startingId;
+
+  // Update DataObject IDs and track changes
+  WeakCollectionType newCollection;
+  using UpdatedId = std::pair<DataObject::IdType, DataObject::IdType>;
+  std::vector<UpdatedId> updatedIds;
+  for(auto& dataObjectIter : m_DataObjects)
+  {
+    auto dataObjectPtr = dataObjectIter.second.lock();
+    if(dataObjectPtr == nullptr)
+    {
+      continue;
+    }
+    
+    auto oldId = dataObjectIter.first;
+    auto newId = generateId();
+
+    dataObjectPtr->setId(newId);
+    updatedIds.push_back({oldId, newId});
+
+    newCollection.insert({newId, dataObjectPtr});
+  }
+
+  // Update m_DataObjects collection
+  m_DataObjects = newCollection;
+
+  // Update ID references between DataObjects
+  for(auto& dataObjectIter : m_DataObjects)
+  {
+    auto dataObjectPtr = dataObjectIter.second.lock();
+    dataObjectPtr->checkUpdatedIds(updatedIds);
+  }
+}
+
 } // namespace complex

--- a/src/complex/DataStructure/DataStructure.hpp
+++ b/src/complex/DataStructure/DataStructure.hpp
@@ -457,9 +457,19 @@ public:
   const DataMap& getDataMap() const;
 
   /**
-   * @brief Inserts a DataObject into the DataStructure nested under the given
+   * @brief Inserts a new DataObject into the DataStructure nested under the given
    * DataPath. If the DataPath is empty, the DataObject is added directly to
-   * the DataStructure.
+   * the DataStructure. The provided DataObject can exist outside of the DataStructure,
+   * but calling this method with a DataObject already contained within the DataStructure
+   * is undefined behavior.
+   *
+   * This method is a purely for inserting DataObjects new to the DataStructure.
+   *
+   * This method is not meant to add additional parents to a DataObject already
+   * existing in the DataStructure. Use addAdditionalParent for that purpose.
+   *
+   * This method is not meant to replace the DataObject at a given DataPath.
+   * Using it as such is undefined behavior within the DataStructure.
    *
    * Returns true if the process succeeds. Returns false otherwise. Returns false if dataObject is null.
    * @param dataObject

--- a/src/complex/DataStructure/DataStructure.hpp
+++ b/src/complex/DataStructure/DataStructure.hpp
@@ -48,6 +48,8 @@ class FileWriter;
  */
 class COMPLEX_EXPORT DataStructure
 {
+  using WeakCollectionType = std::map<DataObject::IdType, std::weak_ptr<DataObject>>;
+
 protected:
   /**
    * @brief Finalizes adding a DataObject to the DataStructure. This should
@@ -467,6 +469,12 @@ public:
   bool insert(const std::shared_ptr<DataObject>& dataObject, const DataPath& dataPath);
 
   /**
+   * @brief Returns the next ID value to use in the DataStructure
+   * @return DataObject::IdType
+   */
+  DataObject::IdType getNextId() const;
+
+  /**
    * @brief Adds an additional parent to the target DataObject.
    * @param targetId
    * @param newParent
@@ -534,6 +542,13 @@ public:
    * @return bool
    */
   bool validateNumberOfTuples(const std::vector<DataPath>& dataPaths) const;
+
+  /**
+   * @brief Resets DataObject IDs starting at the provided value.
+   * Because 0 is a reserved value, if the starting value is set to 0, this method will use 1 instead.
+   * @param startingId
+   */
+  void resetIds(DataObject::IdType startingId);
 
   /**
    * @brief Copy assignment operator. The copied DataStructure's observers are not retained.
@@ -648,7 +663,7 @@ private:
   ////////////
   // Variables
   SignalType m_Signal;
-  std::map<DataObject::IdType, std::weak_ptr<DataObject>> m_DataObjects;
+  WeakCollectionType m_DataObjects;
   DataMap m_RootGroup;
   bool m_IsValid = false;
   DataObject::IdType m_NextId = 1;

--- a/src/complex/DataStructure/DataStructure.hpp
+++ b/src/complex/DataStructure/DataStructure.hpp
@@ -459,7 +459,7 @@ public:
    * DataPath. If the DataPath is empty, the DataObject is added directly to
    * the DataStructure.
    *
-   * Returns true if the process succeeds. Returns false otherwise.
+   * Returns true if the process succeeds. Returns false otherwise. Returns false if dataObject is null.
    * @param dataObject
    * @param dataPath
    * @return bool

--- a/src/complex/DataStructure/Geometry/AbstractGeometry2D.cpp
+++ b/src/complex/DataStructure/Geometry/AbstractGeometry2D.cpp
@@ -178,3 +178,24 @@ H5::ErrorType AbstractGeometry2D::writeHdf5(H5::DataStructureWriter& dataStructu
 
   return errorCode;
 }
+
+void AbstractGeometry2D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+{
+  for(const auto& updatedId : updatedIds)
+  {
+    if(m_VertexListId == updatedId.first)
+    {
+      m_VertexListId = updatedId.second;
+    }
+
+    if(m_EdgeListId == updatedId.first)
+    {
+      m_EdgeListId = updatedId.second;
+    }
+
+    if(m_UnsharedEdgeListId == updatedId.first)
+    {
+      m_UnsharedEdgeListId = updatedId.second;
+    }
+  }
+}

--- a/src/complex/DataStructure/Geometry/AbstractGeometry2D.cpp
+++ b/src/complex/DataStructure/Geometry/AbstractGeometry2D.cpp
@@ -181,6 +181,8 @@ H5::ErrorType AbstractGeometry2D::writeHdf5(H5::DataStructureWriter& dataStructu
 
 void AbstractGeometry2D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
 {
+  BaseGroup::checkUpdatedIdsImpl(updatedIds);
+
   for(const auto& updatedId : updatedIds)
   {
     if(m_VertexListId == updatedId.first)

--- a/src/complex/DataStructure/Geometry/AbstractGeometry2D.hpp
+++ b/src/complex/DataStructure/Geometry/AbstractGeometry2D.hpp
@@ -217,6 +217,12 @@ protected:
    */
   AbstractGeometry2D(AbstractGeometry2D&& other) noexcept;
 
+  /**
+   * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
+   * @param updatedIds
+   */
+  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+
 private:
   std::optional<IdType> m_VertexListId;
   std::optional<IdType> m_EdgeListId;

--- a/src/complex/DataStructure/Geometry/AbstractGeometry3D.cpp
+++ b/src/complex/DataStructure/Geometry/AbstractGeometry3D.cpp
@@ -336,3 +336,34 @@ H5::ErrorType AbstractGeometry3D::writeHdf5(H5::DataStructureWriter& dataStructu
   }
   return errorCode;
 }
+
+void AbstractGeometry3D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+{
+  for(const auto& updatedId : updatedIds)
+  {
+    if(m_VertexListId == updatedId.first)
+    {
+      m_VertexListId = updatedId.second;
+    }
+
+    if(m_EdgeListId == updatedId.first)
+    {
+      m_EdgeListId = updatedId.second;
+    }
+
+    if(m_UnsharedEdgeListId == updatedId.first)
+    {
+      m_UnsharedEdgeListId = updatedId.second;
+    }
+
+    if(m_FaceListId == updatedId.first)
+    {
+      m_FaceListId = updatedId.second;
+    }
+
+    if(m_UnsharedFaceListId == updatedId.first)
+    {
+      m_UnsharedFaceListId = updatedId.second;
+    }
+  }
+}

--- a/src/complex/DataStructure/Geometry/AbstractGeometry3D.cpp
+++ b/src/complex/DataStructure/Geometry/AbstractGeometry3D.cpp
@@ -339,6 +339,8 @@ H5::ErrorType AbstractGeometry3D::writeHdf5(H5::DataStructureWriter& dataStructu
 
 void AbstractGeometry3D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
 {
+  BaseGroup::checkUpdatedIdsImpl(updatedIds);
+
   for(const auto& updatedId : updatedIds)
   {
     if(m_VertexListId == updatedId.first)

--- a/src/complex/DataStructure/Geometry/AbstractGeometry3D.hpp
+++ b/src/complex/DataStructure/Geometry/AbstractGeometry3D.hpp
@@ -270,6 +270,12 @@ protected:
    */
   SharedTriList* createSharedTriList(usize numTris);
 
+  /**
+   * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
+   * @param updatedIds
+   */
+  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+
 private:
   std::optional<IdType> m_VertexListId;
   std::optional<IdType> m_EdgeListId;

--- a/src/complex/DataStructure/Geometry/EdgeGeom.cpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.cpp
@@ -581,6 +581,8 @@ H5::ErrorType EdgeGeom::writeHdf5(H5::DataStructureWriter& dataStructureWriter, 
 
 void EdgeGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
 {
+  AbstractGeometry::checkUpdatedIdsImpl(updatedIds);
+
   for(const auto& updatedId : updatedIds)
   {
     if(m_VertexListId == updatedId.first)

--- a/src/complex/DataStructure/Geometry/EdgeGeom.cpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.cpp
@@ -578,3 +578,39 @@ H5::ErrorType EdgeGeom::writeHdf5(H5::DataStructureWriter& dataStructureWriter, 
 
   return getDataMap().writeH5Group(dataStructureWriter, groupWriter);
 }
+
+void EdgeGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+{
+  for(const auto& updatedId : updatedIds)
+  {
+    if(m_VertexListId == updatedId.first)
+    {
+      m_VertexListId = updatedId.second;
+    }
+
+    if(m_EdgeListId == updatedId.first)
+    {
+      m_EdgeListId = updatedId.second;
+    }
+
+    if(m_EdgesContainingVertId == updatedId.first)
+    {
+      m_EdgesContainingVertId = updatedId.second;
+    }
+
+    if(m_EdgeNeighborsId == updatedId.first)
+    {
+      m_EdgeNeighborsId = updatedId.second;
+    }
+
+    if(m_EdgeCentroidsId == updatedId.first)
+    {
+      m_EdgeCentroidsId = updatedId.second;
+    }
+
+    if(m_EdgeSizesId == updatedId.first)
+    {
+      m_EdgeSizesId = updatedId.second;
+    }
+  }
+}

--- a/src/complex/DataStructure/Geometry/EdgeGeom.hpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.hpp
@@ -362,6 +362,12 @@ protected:
    */
   void setElementSizes(const Float32Array* elementSizes) override;
 
+  /**
+   * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
+   * @param updatedIds
+   */
+  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+
 private:
   std::optional<IdType> m_VertexListId;
   std::optional<IdType> m_EdgeListId;

--- a/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
@@ -630,3 +630,34 @@ H5::ErrorType HexahedralGeom::writeHdf5(H5::DataStructureWriter& dataStructureWr
 
   return getDataMap().writeH5Group(dataStructureWriter, groupWriter);
 }
+
+void HexahedralGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+{
+  for(const auto& updatedId : updatedIds)
+  {
+    if(m_HexListId == updatedId.first)
+    {
+      m_HexListId = updatedId.second;
+    }
+
+    if(m_HexasContainingVertId == updatedId.first)
+    {
+      m_HexasContainingVertId = updatedId.second;
+    }
+
+    if(m_HexNeighborsId == updatedId.first)
+    {
+      m_HexNeighborsId = updatedId.second;
+    }
+
+    if(m_HexCentroidsId == updatedId.first)
+    {
+      m_HexCentroidsId = updatedId.second;
+    }
+
+    if(m_HexSizesId == updatedId.first)
+    {
+      m_HexSizesId = updatedId.second;
+    }
+  }
+}

--- a/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
@@ -633,6 +633,8 @@ H5::ErrorType HexahedralGeom::writeHdf5(H5::DataStructureWriter& dataStructureWr
 
 void HexahedralGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
 {
+  AbstractGeometry3D::checkUpdatedIdsImpl(updatedIds);
+
   for(const auto& updatedId : updatedIds)
   {
     if(m_HexListId == updatedId.first)

--- a/src/complex/DataStructure/Geometry/HexahedralGeom.hpp
+++ b/src/complex/DataStructure/Geometry/HexahedralGeom.hpp
@@ -412,6 +412,12 @@ protected:
    */
   void setElementSizes(const Float32Array* elementSizes) override;
 
+  /**
+   * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
+   * @param updatedIds
+   */
+  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+
 private:
   std::optional<IdType> m_HexListId;
   std::optional<IdType> m_HexasContainingVertId;

--- a/src/complex/DataStructure/Geometry/ImageGeom.cpp
+++ b/src/complex/DataStructure/Geometry/ImageGeom.cpp
@@ -637,3 +637,14 @@ H5::ErrorType ImageGeom::writeHdf5(H5::DataStructureWriter& dataStructureWriter,
 
   return getDataMap().writeH5Group(dataStructureWriter, groupWriter);
 }
+
+void ImageGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+{
+  for(const auto& updatedId : updatedIds)
+  {
+    if(m_VoxelSizesId == updatedId.first)
+    {
+      m_VoxelSizesId = updatedId.second;
+    }
+  }
+}

--- a/src/complex/DataStructure/Geometry/ImageGeom.cpp
+++ b/src/complex/DataStructure/Geometry/ImageGeom.cpp
@@ -640,6 +640,8 @@ H5::ErrorType ImageGeom::writeHdf5(H5::DataStructureWriter& dataStructureWriter,
 
 void ImageGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
 {
+  AbstractGeometryGrid::checkUpdatedIdsImpl(updatedIds);
+
   for(const auto& updatedId : updatedIds)
   {
     if(m_VoxelSizesId == updatedId.first)

--- a/src/complex/DataStructure/Geometry/ImageGeom.hpp
+++ b/src/complex/DataStructure/Geometry/ImageGeom.hpp
@@ -496,6 +496,12 @@ protected:
    */
   void setElementSizes(const Float32Array* elementSizes) override;
 
+  /**
+   * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
+   * @param updatedIds
+   */
+  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+
 private:
   std::optional<IdType> m_VoxelSizesId;
   FloatVec3 m_Spacing;

--- a/src/complex/DataStructure/Geometry/QuadGeom.cpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.cpp
@@ -555,3 +555,34 @@ H5::ErrorType QuadGeom::writeHdf5(H5::DataStructureWriter& dataStructureWriter, 
 
   return getDataMap().writeH5Group(dataStructureWriter, groupWriter);
 }
+
+void QuadGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+{
+  for(const auto& updatedId : updatedIds)
+  {
+    if(m_QuadListId == updatedId.first)
+    {
+      m_QuadListId = updatedId.second;
+    }
+
+    if(m_QuadsContainingVertId == updatedId.first)
+    {
+      m_QuadsContainingVertId = updatedId.second;
+    }
+
+    if(m_QuadNeighborsId == updatedId.first)
+    {
+      m_QuadNeighborsId = updatedId.second;
+    }
+
+    if(m_QuadCentroidsId == updatedId.first)
+    {
+      m_QuadCentroidsId = updatedId.second;
+    }
+
+    if(m_QuadSizesId == updatedId.first)
+    {
+      m_QuadSizesId = updatedId.second;
+    }
+  }
+}

--- a/src/complex/DataStructure/Geometry/QuadGeom.cpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.cpp
@@ -558,6 +558,8 @@ H5::ErrorType QuadGeom::writeHdf5(H5::DataStructureWriter& dataStructureWriter, 
 
 void QuadGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
 {
+  AbstractGeometry2D::checkUpdatedIdsImpl(updatedIds);
+
   for(const auto& updatedId : updatedIds)
   {
     if(m_QuadListId == updatedId.first)

--- a/src/complex/DataStructure/Geometry/QuadGeom.hpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.hpp
@@ -379,6 +379,12 @@ protected:
    */
   void setElementSizes(const Float32Array* elementSizes) override;
 
+  /**
+   * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
+   * @param updatedIds
+   */
+  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+
 private:
   std::optional<IdType> m_QuadListId;
   std::optional<IdType> m_QuadsContainingVertId;

--- a/src/complex/DataStructure/Geometry/RectGridGeom.cpp
+++ b/src/complex/DataStructure/Geometry/RectGridGeom.cpp
@@ -706,3 +706,29 @@ H5::ErrorType RectGridGeom::writeHdf5(H5::DataStructureWriter& dataStructureWrit
 
   return getDataMap().writeH5Group(dataStructureWriter, groupWriter);
 }
+
+void RectGridGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+{
+  for(const auto& updatedId : updatedIds)
+  {
+    if(m_xBoundsId == updatedId.first)
+    {
+      m_xBoundsId = updatedId.second;
+    }
+
+    if(m_yBoundsId == updatedId.first)
+    {
+      m_yBoundsId = updatedId.second;
+    }
+
+    if(m_zBoundsId == updatedId.first)
+    {
+      m_zBoundsId = updatedId.second;
+    }
+
+    if(m_VoxelSizesId == updatedId.first)
+    {
+      m_VoxelSizesId = updatedId.second;
+    }
+  }
+}

--- a/src/complex/DataStructure/Geometry/RectGridGeom.cpp
+++ b/src/complex/DataStructure/Geometry/RectGridGeom.cpp
@@ -709,6 +709,8 @@ H5::ErrorType RectGridGeom::writeHdf5(H5::DataStructureWriter& dataStructureWrit
 
 void RectGridGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
 {
+  AbstractGeometryGrid::checkUpdatedIdsImpl(updatedIds);
+
   for(const auto& updatedId : updatedIds)
   {
     if(m_xBoundsId == updatedId.first)

--- a/src/complex/DataStructure/Geometry/RectGridGeom.hpp
+++ b/src/complex/DataStructure/Geometry/RectGridGeom.hpp
@@ -455,6 +455,12 @@ protected:
    */
   void setElementSizes(const Float32Array* elementSizes) override;
 
+  /**
+   * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
+   * @param updatedIds
+   */
+  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+
 private:
   std::optional<IdType> m_xBoundsId;
   std::optional<IdType> m_yBoundsId;

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
@@ -602,3 +602,44 @@ H5::ErrorType TetrahedralGeom::writeHdf5(H5::DataStructureWriter& dataStructureW
 
   return getDataMap().writeH5Group(dataStructureWriter, groupWriter);
 }
+
+void TetrahedralGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+{
+  for(const auto& updatedId : updatedIds)
+  {
+    if(m_TriListId == updatedId.first)
+    {
+      m_TriListId = updatedId.second;
+    }
+
+    if(m_UnsharedTriListId == updatedId.first)
+    {
+      m_UnsharedTriListId = updatedId.second;
+    }
+
+    if(m_TetListId == updatedId.first)
+    {
+      m_TetListId = updatedId.second;
+    }
+
+    if(m_TetsContainingVertId == updatedId.first)
+    {
+      m_TetsContainingVertId = updatedId.second;
+    }
+
+    if(m_TetNeighborsId == updatedId.first)
+    {
+      m_TetNeighborsId = updatedId.second;
+    }
+
+    if(m_TetCentroidsId == updatedId.first)
+    {
+      m_TetCentroidsId = updatedId.second;
+    }
+
+    if(m_TetSizesId == updatedId.first)
+    {
+      m_TetSizesId = updatedId.second;
+    }
+  }
+}

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
@@ -605,6 +605,8 @@ H5::ErrorType TetrahedralGeom::writeHdf5(H5::DataStructureWriter& dataStructureW
 
 void TetrahedralGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
 {
+  AbstractGeometry3D::checkUpdatedIdsImpl(updatedIds);
+
   for(const auto& updatedId : updatedIds)
   {
     if(m_TriListId == updatedId.first)

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.hpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.hpp
@@ -397,6 +397,12 @@ protected:
    */
   void setElementCentroids(const Float32Array* elementCentroids) override;
 
+  /**
+   * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
+   * @param updatedIds
+   */
+  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+
 private:
   std::optional<IdType> m_TriListId;
   std::optional<IdType> m_UnsharedTriListId;

--- a/src/complex/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.cpp
@@ -553,3 +553,34 @@ H5::ErrorType TriangleGeom::writeHdf5(H5::DataStructureWriter& dataStructureWrit
 
   return getDataMap().writeH5Group(dataStructureWriter, groupWriter);
 }
+
+void TriangleGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+{
+  for(const auto& updatedId : updatedIds)
+  {
+    if(m_TriListId == updatedId.first)
+    {
+      m_TriListId = updatedId.second;
+    }
+
+    if(m_TrianglesContainingVertId == updatedId.first)
+    {
+      m_TrianglesContainingVertId = updatedId.second;
+    }
+
+    if(m_TriangleNeighborsId == updatedId.first)
+    {
+      m_TriangleNeighborsId = updatedId.second;
+    }
+
+    if(m_TriangleCentroidsId == updatedId.first)
+    {
+      m_TriangleCentroidsId = updatedId.second;
+    }
+
+    if(m_TriangleSizesId == updatedId.first)
+    {
+      m_TriangleSizesId = updatedId.second;
+    }
+  }
+}

--- a/src/complex/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.cpp
@@ -556,6 +556,8 @@ H5::ErrorType TriangleGeom::writeHdf5(H5::DataStructureWriter& dataStructureWrit
 
 void TriangleGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
 {
+  AbstractGeometry2D::checkUpdatedIdsImpl(updatedIds);
+
   for(const auto& updatedId : updatedIds)
   {
     if(m_TriListId == updatedId.first)

--- a/src/complex/DataStructure/Geometry/TriangleGeom.hpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.hpp
@@ -379,6 +379,12 @@ protected:
    */
   void setElementSizes(const Float32Array* elementSizes) override;
 
+  /**
+   * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
+   * @param updatedIds
+   */
+  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+
 private:
   std::optional<IdType> m_TriListId;
   std::optional<IdType> m_TrianglesContainingVertId;

--- a/src/complex/DataStructure/Geometry/VertexGeom.cpp
+++ b/src/complex/DataStructure/Geometry/VertexGeom.cpp
@@ -373,3 +373,19 @@ H5::ErrorType VertexGeom::writeHdf5(H5::DataStructureWriter& dataStructureWriter
 
   return getDataMap().writeH5Group(dataStructureWriter, groupWriter);
 }
+
+void VertexGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+{
+  for(const auto& updatedId : updatedIds)
+  {
+    if(m_VertexListId == updatedId.first)
+    {
+      m_VertexListId = updatedId.second;
+    }
+
+    if(m_VertexSizesId == updatedId.first)
+    {
+      m_VertexSizesId = updatedId.second;
+    }
+  }
+}

--- a/src/complex/DataStructure/Geometry/VertexGeom.cpp
+++ b/src/complex/DataStructure/Geometry/VertexGeom.cpp
@@ -376,6 +376,8 @@ H5::ErrorType VertexGeom::writeHdf5(H5::DataStructureWriter& dataStructureWriter
 
 void VertexGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
 {
+  AbstractGeometry::checkUpdatedIdsImpl(updatedIds);
+
   for(const auto& updatedId : updatedIds)
   {
     if(m_VertexListId == updatedId.first)

--- a/src/complex/DataStructure/Geometry/VertexGeom.hpp
+++ b/src/complex/DataStructure/Geometry/VertexGeom.hpp
@@ -323,6 +323,12 @@ protected:
    */
   void setElementSizes(const Float32Array* elementSizes) override;
 
+  /**
+   * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
+   * @param updatedIds
+   */
+  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+
 private:
   std::optional<IdType> m_VertexListId;
   std::optional<IdType> m_VertexSizesId;

--- a/src/complex/Filter/Actions/ImportH5ObjectPathsAction.cpp
+++ b/src/complex/Filter/Actions/ImportH5ObjectPathsAction.cpp
@@ -54,7 +54,9 @@ Result<> ImportH5ObjectPathsAction::apply(DataStructure& dataStructure, Mode mod
     return {nonstd::make_unexpected(std::vector<Error>{Error{errorCode, "Failed to import a DataStructure from the target HDF5 file."}})};
   }
 
-  const auto& importStructure = fileData.second;
+  // Ensure there are no conflicting DataObject ID values
+  DataStructure importStructure = fileData.second;
+  importStructure.resetIds(dataStructure.getNextId());
 
   auto importPaths = getImportPaths(importStructure, m_Paths);
   for(const auto& targetPath : importPaths)

--- a/src/complex/Filter/Actions/ImportObjectAction.cpp
+++ b/src/complex/Filter/Actions/ImportObjectAction.cpp
@@ -28,7 +28,7 @@ Result<> ImportObjectAction::apply(DataStructure& dataStructure, Mode mode) cons
 {
   auto importData = std::shared_ptr<DataObject>(getImportObject()->deepCopy());
   // Clear all children before inserting into the DataStructure
-  if(auto importGroup = std::dynamic_pointer_cast<BaseGroup>(importData))
+  if(auto importGroup = std::dynamic_pointer_cast<BaseGroup>(importData); importGroup != nullptr)
   {
     importGroup->clear();
   }


### PR DESCRIPTION
* Fixed importing multiple .dream3d files overwriting existing DataObjects.
* Imported DataObjects have their IDs reset and existing references updated to accommodate the updated values.