### PR TITLE
Parameters: Add API to retrieve the active value for a linked parameter.

### DIFF
--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
@@ -12,6 +12,7 @@
 #include "complex/Parameters/GeometrySelectionParameter.hpp"
 #include "complex/Parameters/MultiArraySelectionParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
+#include <any>
 
 using namespace complex;
 
@@ -62,7 +63,7 @@ Parameters ExampleFilter2::parameters() const
   Parameters params;
   params.insertSeparator({"1rst Group of Parameters"});
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_Param7, "Bool Parameter", "Example bool help text", true));
-  params.insert(std::make_unique<ChoicesParameter>(k_Param3, "ChoicesParameter", "Example choices help text", 0, ChoicesParameter::Choices{"foo", "bar", "baz"}));
+  params.insertLinkableParameter(std::make_unique<ChoicesParameter>(k_Param3, "ChoicesParameter", "Example choices help text", 0, ChoicesParameter::Choices{"foo", "bar", "baz"}));
 
   params.insertSeparator({"2nd Group of Parameters"});
   DynamicTableParameter::ValueType dynamicTable{{{10, 20}, {30, 40}}, {"Row 1", "Row2"}, {"Col 1", "Col 2"}};
@@ -78,6 +79,12 @@ Parameters ExampleFilter2::parameters() const
   params.insert(std::make_unique<GeometrySelectionParameter>(k_Param11, "GeometrySelectionParameter", "Example geometry selection help text", DataPath{}, GeometrySelectionParameter::AllowedTypes{}));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_Param12, "MultiArraySelectionParameter", "Example multiarray selection help text", MultiArraySelectionParameter::ValueType{},
                                                                complex::GetAllDataTypes()));
+
+  params.linkParameters(k_Param7, k_Param9, std::make_any<BoolParameter::ValueType>(true));
+
+  params.linkParameters(k_Param3, k_Param10, std::make_any<ChoicesParameter::ValueType>(0));
+  params.linkParameters(k_Param3, k_Param6, std::make_any<ChoicesParameter::ValueType>(1));
+  params.linkParameters(k_Param3, k_Param11, std::make_any<ChoicesParameter::ValueType>(2));
 
   // These should show up under the "Created Objects" section in the GUI
   params.insert(std::make_unique<DataGroupCreationParameter>(k_Param8, "DataGroupCreationParameter", "Example data group creation help text", DataPath{}));

--- a/src/complex/Filter/Parameters.cpp
+++ b/src/complex/Filter/Parameters.cpp
@@ -132,6 +132,12 @@ bool Parameters::isParameterActive(std::string_view key, const std::any& value) 
   return isActive;
 }
 
+std::any Parameters::parameterActiveValue(std::string_view key) const
+{
+  const auto& [groupKey, associatedValue] = MapAt(m_ParamGroups, key, "Key '{}' does not have group in Parameters");
+  return associatedValue;
+}
+
 std::string Parameters::getGroup(std::string_view key) const
 {
   if(!hasGroup(key))

--- a/src/complex/Filter/Parameters.hpp
+++ b/src/complex/Filter/Parameters.hpp
@@ -108,7 +108,6 @@ public:
   /**
    * @brief Inserts the given parameter and makes it available as a group for other parameters.
    * Requires the parameter to implement a member function bool checkActive(const std::any&, const std::any&) const.
-   * This function detemines whether a parameter in a group is active.
    * @tparam ParameterT
    * @tparam Enable if ParameterT is derived from IParameter
    * @param parameter
@@ -142,6 +141,8 @@ public:
    * @return
    */
   bool isParameterActive(std::string_view key, const std::any& groupValue) const;
+
+  std::any parameterActiveValue(std::string_view key) const;
 
   /**
    * @brief Gets the group key of the parameter with the given key.

--- a/src/complex/Filter/Parameters.hpp
+++ b/src/complex/Filter/Parameters.hpp
@@ -142,6 +142,11 @@ public:
    */
   bool isParameterActive(std::string_view key, const std::any& groupValue) const;
 
+  /**
+   * @brief Returns value from a linked parameter for the given key
+   * @param key The activation key
+   * @return The value of the parameter when using the key.
+   */
   std::any parameterActiveValue(std::string_view key) const;
 
   /**


### PR DESCRIPTION
This allows the gui side to get the specific value of a linked parameter that
would make the target parameter 'active'

Also update ExampleFilter2 to use linked parameters.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>