### PR TITLE
feature/DisableRenaming

### DIFF
--- a/src/complex/Pipeline/AbstractPipelineNode.cpp
+++ b/src/complex/Pipeline/AbstractPipelineNode.cpp
@@ -93,12 +93,6 @@ void AbstractPipelineNode::endExecution(DataStructure& dataStructure)
   setDataStructure(dataStructure);
 }
 
-bool AbstractPipelineNode::preflight(DataStructure& data, const std::atomic_bool& shouldCancel)
-{
-  RenamedPaths renamedPaths;
-  return preflight(data, renamedPaths, shouldCancel);
-}
-
 void AbstractPipelineNode::notify(const std::shared_ptr<AbstractPipelineMessage>& msg)
 {
   m_Signal(this, msg);

--- a/src/complex/Pipeline/AbstractPipelineNode.hpp
+++ b/src/complex/Pipeline/AbstractPipelineNode.hpp
@@ -131,9 +131,11 @@ public:
    * @param data
    * @param RenamedPaths& renamedPaths = {} Collection of renamed output paths.
    * Only used for PipelineFilters.
+   * @param shouldCancel
+   * @param allowRenaming
    * @return bool
    */
-  virtual bool preflight(DataStructure& data, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel) = 0;
+  virtual bool preflight(DataStructure& data, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel, bool allowRenaming) = 0;
 
   /**
    * @brief Attempts to execute the node using the provided DataStructure.

--- a/src/complex/Pipeline/Pipeline.hpp
+++ b/src/complex/Pipeline/Pipeline.hpp
@@ -107,17 +107,28 @@ public:
    * false otherwise.
    * @return bool
    */
-  bool preflight(const std::atomic_bool& shouldCancel = false);
+  bool preflight(const std::atomic_bool& shouldCancel = false, bool allowRenaming = false);
 
   /**
    * @brief Preflights the pipeline segment using the provided DataStructure.
    * Returns true if the pipeline segment completes without errors. Returns
    * false otherwise.
    * @param ds
-   * @param renamedPaths
+   * @param shouldCancel
    * @return bool
    */
   bool preflight(DataStructure& ds, const std::atomic_bool& shouldCancel) override;
+
+  /**
+   * @brief Preflights the pipeline segment using the provided DataStructure.
+   * Returns true if the pipeline segment completes without errors. Returns
+   * false otherwise.
+   * @param ds
+   * @param shouldCancel
+   * @param allowRenaming
+   * @return bool
+   */
+  bool preflight(DataStructure& ds, const std::atomic_bool& shouldCancel, bool allowRenaming);
 
   /**
    * @brief Executes the pipeline segment using an empty DataStructure.
@@ -133,9 +144,11 @@ public:
    * false otherwise.
    * @param ds
    * @param renamedPaths
+   * @param shouldCancel
+   * @param allowRenaming = false
    * @return bool
    */
-  bool preflight(DataStructure& ds, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel) override;
+  bool preflight(DataStructure& ds, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel, bool allowRenaming = false) override;
 
   /**
    * @brief Executes the pipeline segment using the provided DataStructure.
@@ -156,7 +169,7 @@ public:
    * @param ds
    * @return bool
    */
-  bool preflightFrom(index_type index, DataStructure& ds, const std::atomic_bool& shouldCancel = false);
+  bool preflightFrom(index_type index, DataStructure& ds, const std::atomic_bool& shouldCancel = false, bool allowRenaming = false);
 
   /**
    * @brief Preflights the pipeline segment from a target position using the
@@ -169,7 +182,7 @@ public:
    * @param renamedPaths
    * @return bool
    */
-  bool preflightFrom(index_type index, DataStructure& ds, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel = false);
+  bool preflightFrom(index_type index, DataStructure& ds, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel = false, bool allowRenaming = false);
 
   /**
    * @brief Preflights the pipeline segment from a target position using the

--- a/src/complex/Pipeline/PipelineFilter.cpp
+++ b/src/complex/Pipeline/PipelineFilter.cpp
@@ -146,7 +146,7 @@ bool PipelineFilter::preflight(DataStructure& data, const std::atomic_bool& shou
   return true;
 }
 
-bool PipelineFilter::preflight(DataStructure& data, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel)
+bool PipelineFilter::preflight(DataStructure& data, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel, bool allowRenaming)
 {
   sendFilterRunStateMessage(m_Index, RunState::Preflighting);
 
@@ -204,9 +204,13 @@ bool PipelineFilter::preflight(DataStructure& data, RenamedPaths& renamedPaths, 
   {
     sendFilterFaultDetailMessage(m_Index, m_Warnings, m_Errors);
   }
-  renamedPaths = checkForRenamedPaths(oldCreatedPaths);
 
-  notifyRenamedPaths(renamedPaths);
+  if(allowRenaming)
+  {
+    renamedPaths = checkForRenamedPaths(oldCreatedPaths);
+    notifyRenamedPaths(renamedPaths);
+  }
+
   sendFilterRunStateMessage(m_Index, RunState::Idle);
   return true;
 }

--- a/src/complex/Pipeline/PipelineFilter.hpp
+++ b/src/complex/Pipeline/PipelineFilter.hpp
@@ -119,7 +119,7 @@ public:
    * @param renamedPaths Collection of renamed output paths.
    * @return bool
    */
-  bool preflight(DataStructure& data, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel) override;
+  bool preflight(DataStructure& data, RenamedPaths& renamedPaths, const std::atomic_bool& shouldCancel, bool allowRenaming) override;
 
   /**
    * @brief Attempts to execute the node using the provided DataStructure.


### PR DESCRIPTION
Added bool parameter to disable Pipelines from testing for renaming. Argument defaults to false.