### PR TITLE
Update Default names of Triangle and Vertex Arrays in Triangle Geometry and fix plugin unit test

### DIFF
--- a/cmake/Plugin.cmake
+++ b/cmake/Plugin.cmake
@@ -83,10 +83,12 @@ function(complex_add_plugin)
     complex_COMPILE_PLUGIN(PLUGIN_NAME ${ARGS_PLUGIN_NAME}
                            PLUGIN_SOURCE_DIR ${COMPLEX_${ARGS_PLUGIN_NAME}_SOURCE_DIR}
     )
-    # Increment the plugin count
-    get_property(PLUGIN_COUNT GLOBAL PROPERTY COMPLEX_PLUGIN_COUNT)
-    math(EXPR PLUGIN_COUNT "${PLUGIN_COUNT}+1")
-    set_property(GLOBAL PROPERTY COMPLEX_PLUGIN_COUNT ${PLUGIN_COUNT})
+    if(COMPLEX_PLUGIN_ENABLE_${ARGS_PLUGIN_NAME})
+      # Increment the plugin count only if it is enabled
+      get_property(PLUGIN_COUNT GLOBAL PROPERTY COMPLEX_PLUGIN_COUNT)
+      math(EXPR PLUGIN_COUNT "${PLUGIN_COUNT}+1")
+      set_property(GLOBAL PROPERTY COMPLEX_PLUGIN_COUNT ${PLUGIN_COUNT})
+    endif()
   else()
     set(COMPLEX_${ARGS_PLUGIN_NAME}_SOURCE_DIR ${pluginSearchDir} CACHE PATH "" FORCE)
     message(STATUS "${ARGS_PLUGIN_NAME} [DISABLED]. Missing Source Directory. Use -DCOMPLEX_${ARGS_PLUGIN_NAME}_SOURCE_DIR=/Path/To/PluginDir")

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -113,11 +113,16 @@ std::string ExtractInternalSurfacesFromTriangleGeometry::humanName() const
 Parameters ExtractInternalSurfacesFromTriangleGeometry::parameters() const
 {
   Parameters params;
+  params.insertSeparator(Parameters::Separator{"Input Geometry and Data"});
   params.insert(std::make_unique<GeometrySelectionParameter>(k_TriangleGeom_Key, "Triangle Geometry", "Path to the existing Triangle Geometry", DataPath(),
                                                              GeometrySelectionParameter::AllowedTypes{AbstractGeometry::Type::Triangle}));
-  params.insert(std::make_unique<DataGroupCreationParameter>(k_InternalTriangleGeom_Key, "Interior Triangle Geometry", "Path to create the new Triangle Geometry", DataPath()));
   params.insert(
       std::make_unique<ArraySelectionParameter>(k_NodeTypesPath_Key, "Node Types Array", "Path to the Node Types array", DataPath(), ArraySelectionParameter::AllowedTypes{complex::DataType::int8}));
+
+  params.insertSeparator(Parameters::Separator{"Created/Output Data"});
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_InternalTriangleGeom_Key, "Created Triangle Geometry Path", "Path to create the new Triangle Geometry", DataPath()));
+
+  params.insertSeparator(Parameters::Separator{"Optional Transferred Data"});
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_CopyVertexPaths_Key, "Copy Vertex Arrays", "Paths to vertex-related DataArrays that should be copied to the new geometry",
                                                                std::vector<DataPath>{}, complex::GetAllDataTypes(), true));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_CopyTrianglePaths_Key, "Copy Triangle Arrays", "Paths to face-related DataArrays that should be copied to the new geometry",

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/LinkGeometryDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/LinkGeometryDataFilter.cpp
@@ -13,6 +13,7 @@
 #include "complex/Parameters/DataGroupCreationParameter.hpp"
 #include "complex/Parameters/DataGroupSelectionParameter.hpp"
 #include "complex/Parameters/DataPathSelectionParameter.hpp"
+#include "complex/Parameters/GeometrySelectionParameter.hpp"
 #include "complex/Parameters/MultiArraySelectionParameter.hpp"
 #include "complex/Parameters/StringParameter.hpp"
 
@@ -55,7 +56,8 @@ Parameters LinkGeometryDataFilter::parameters() const
 {
   Parameters params;
   // Create the parameter descriptors that are needed for this filter
-  params.insert(std::make_unique<DataPathSelectionParameter>(k_GeometryDataPath_Key, "Grid Geometry", "The complete path to the Geometry with which to link the data", DataPath{}));
+  params.insert(std::make_unique<GeometrySelectionParameter>(k_GeometryDataPath_Key, "Selected Geometry", "The complete path to the Geometry with which to link the data", DataPath{},
+                                                             GeometrySelectionParameter::AllowedTypes{AbstractGeometry::Type::Any}));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_SelectedVertexDataArrayPaths_Key, "Vertex Data Arrays to Link", "Data associated with a vertex or point",
                                                                MultiArraySelectionParameter::ValueType{}, complex::GetAllDataTypes(), true));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_SelectedEdgeDataArrayPaths_Key, "Edge Data Arrays to Link", "Data associated with an edge", MultiArraySelectionParameter::ValueType{},

--- a/src/complex/Filter/Actions/CreateTriangleGeomAction.cpp
+++ b/src/complex/Filter/Actions/CreateTriangleGeomAction.cpp
@@ -37,11 +37,11 @@ Result<> CreateTriangleGeomAction::apply(DataStructure& dataStructure, Mode mode
 
   if(m_AdditionalData.find(AdditionalData::CreateVertexGroup) != m_AdditionalData.end())
   {
-    dataStructure.makePath(m_Path.createChildPath("VertexData"));
+    dataStructure.makePath(m_Path.createChildPath(k_DefaultVertexGroup));
   }
   if(m_AdditionalData.find(AdditionalData::CreateTriangleGroup) != m_AdditionalData.end())
   {
-    dataStructure.makePath(m_Path.createChildPath("FaceData"));
+    dataStructure.makePath(m_Path.createChildPath(k_DefaultFacesGroup));
   }
 
   if(shouldCreateVertexArray())
@@ -119,14 +119,14 @@ Result<> CreateTriangleGeomAction::createGeometry(DataStructure& dataStructure, 
 
 Result<> CreateTriangleGeomAction::createVertexArray(DataStructure& dataStructure, Mode mode) const
 {
-  DataPath arrayPath = path().createChildPath("Vertex Array");
+  DataPath arrayPath = path().createChildPath(k_DefaultVerticesName);
   IDataStore::ShapeType compShape{3};
   return CreateArray<float32>(dataStructure, m_TupleSize, compShape, arrayPath, mode);
 }
 
 Result<> CreateTriangleGeomAction::createTriangleArray(DataStructure& dataStructure, Mode mode) const
 {
-  DataPath arrayPath = path().createChildPath("Triangle Array");
+  DataPath arrayPath = path().createChildPath(k_DefaultFacesName);
   IDataStore::ShapeType compShape{3};
   return CreateArray<uint64>(dataStructure, m_TupleSize, compShape, arrayPath, mode);
 }

--- a/src/complex/Filter/Actions/CreateTriangleGeomAction.hpp
+++ b/src/complex/Filter/Actions/CreateTriangleGeomAction.hpp
@@ -25,8 +25,10 @@ public:
 
   using AdditionalDataTypes = std::set<AdditionalData>;
 
-  static constexpr StringLiteral k_DefaultVerticesName = "Vertex Array";
-  static constexpr StringLiteral k_DefaultFacesName = "Triangle Array";
+  static constexpr StringLiteral k_DefaultVerticesName = "SharedVertexList";
+  static constexpr StringLiteral k_DefaultFacesName = "SharedTriList";
+  static constexpr StringLiteral k_DefaultFacesGroup = "FaceData";
+  static constexpr StringLiteral k_DefaultVertexGroup = "VertexData";
 
   CreateTriangleGeomAction() = delete;
 


### PR DESCRIPTION
This helps the data structure be a bit more familiar to those coming from SIMPL.

Minor filter parameters organization for ExtractInternalSrufacesFromTriangleGeometry
and LinkGeometryDataFilter.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>