### PR TITLE
Updated geometry readHdf5 methods

### DIFF
--- a/src/complex/DataStructure/Geometry/AbstractGeometry2D.cpp
+++ b/src/complex/DataStructure/Geometry/AbstractGeometry2D.cpp
@@ -1,6 +1,7 @@
 #include "AbstractGeometry2D.hpp"
 #include "complex/DataStructure/DataStructure.hpp"
 #include "complex/Utilities/Parsing/HDF5/H5Constants.hpp"
+#include "complex/Utilities/Parsing/HDF5/H5GroupReader.hpp"
 
 using namespace complex;
 
@@ -83,6 +84,11 @@ const AbstractGeometry::SharedEdgeList* AbstractGeometry2D::getEdges() const
   return dynamic_cast<const SharedEdgeList*>(getDataStructure()->getData(m_EdgeListId));
 }
 
+std::optional<DataObject::IdType> AbstractGeometry2D::getEdgesId() const
+{
+  return m_EdgeListId;
+}
+
 usize AbstractGeometry2D::getNumberOfEdges() const
 {
   const SharedEdgeList* edges = getEdges();
@@ -150,6 +156,15 @@ void AbstractGeometry2D::setUnsharedEdges(const SharedEdgeList* bEdgeList)
     return;
   }
   m_UnsharedEdgeListId = bEdgeList->getId();
+}
+
+H5::ErrorType AbstractGeometry2D::readHdf5(H5::DataStructureReader& dataStructureReader, const H5::GroupReader& groupReader, bool preflight)
+{
+  m_VertexListId = ReadH5DataId(groupReader, H5Constants::k_VertexListTag);
+  m_EdgeListId = ReadH5DataId(groupReader, H5Constants::k_EdgeListTag);
+  m_UnsharedEdgeListId = ReadH5DataId(groupReader, H5Constants::k_UnsharedEdgeListTag);
+
+  return BaseGroup::readHdf5(dataStructureReader, groupReader, preflight);
 }
 
 H5::ErrorType AbstractGeometry2D::writeHdf5(H5::DataStructureWriter& dataStructureWriter, H5::GroupWriter& parentGroupWriter, bool importable) const

--- a/src/complex/DataStructure/Geometry/AbstractGeometry2D.hpp
+++ b/src/complex/DataStructure/Geometry/AbstractGeometry2D.hpp
@@ -111,6 +111,12 @@ public:
   const SharedEdgeList* getEdges() const;
 
   /**
+   * @brief Returns the DataObject ID for the SharedEdgeList array. Returns an empty optional if no edge list array has been set.
+   * @return std::optional<IdType>
+   */
+  std::optional<DataObject::IdType> getEdgesId() const;
+
+  /**
    * @brief Sets the vertex IDs making up the specified edge. This method does
    * nothing if the edge list could not be found.
    * @param edgeId
@@ -183,6 +189,14 @@ public:
    * @param bEdgeList
    */
   void setUnsharedEdges(const SharedEdgeList* bEdgeList);
+
+  /**
+   * @brief Reads values from HDF5
+   * @param dataStructureReader
+   * @param groupReader
+   * @return H5::ErrorType
+   */
+  H5::ErrorType readHdf5(H5::DataStructureReader& dataStructureReader, const H5::GroupReader& groupReader, bool preflight = false) override;
 
   /**
    * @brief Writes the geometry to HDF5 using the provided parent group ID.

--- a/src/complex/DataStructure/Geometry/AbstractGeometry3D.cpp
+++ b/src/complex/DataStructure/Geometry/AbstractGeometry3D.cpp
@@ -3,6 +3,7 @@
 #include "complex/DataStructure/DataStore.hpp"
 #include "complex/DataStructure/DataStructure.hpp"
 #include "complex/Utilities/Parsing/HDF5/H5Constants.hpp"
+#include "complex/Utilities/Parsing/HDF5/H5GroupReader.hpp"
 
 using namespace complex;
 
@@ -154,6 +155,11 @@ const AbstractGeometry::SharedEdgeList* AbstractGeometry3D::getEdges() const
   return dynamic_cast<const SharedEdgeList*>(getDataStructure()->getData(m_EdgeListId));
 }
 
+std::optional<DataObject::IdType> AbstractGeometry3D::getEdgesId() const
+{
+  return m_EdgeListId;
+}
+
 void AbstractGeometry3D::setVertsAtEdge(usize edgeId, const usize verts[2])
 {
   auto edges = dynamic_cast<SharedEdgeList*>(getDataStructure()->getData(m_EdgeListId));
@@ -286,6 +292,11 @@ void AbstractGeometry3D::setFaces(const SharedFaceList* faces)
   m_FaceListId = faces->getId();
 }
 
+std::optional<DataObject::IdType> AbstractGeometry3D::getFacesId() const
+{
+  return m_FaceListId;
+}
+
 void AbstractGeometry3D::setUnsharedEdges(const SharedEdgeList* bEdgeList)
 {
   if(!bEdgeList)
@@ -304,6 +315,17 @@ void AbstractGeometry3D::setUnsharedFaces(const SharedFaceList* bFaceList)
     return;
   }
   m_UnsharedFaceListId = bFaceList->getId();
+}
+
+H5::ErrorType AbstractGeometry3D::readHdf5(H5::DataStructureReader& dataStructureReader, const H5::GroupReader& groupReader, bool preflight)
+{
+  m_VertexListId = ReadH5DataId(groupReader, H5Constants::k_VertexListTag);
+  m_EdgeListId = ReadH5DataId(groupReader, H5Constants::k_EdgeListTag);
+  m_UnsharedEdgeListId = ReadH5DataId(groupReader, H5Constants::k_UnsharedEdgeListTag);
+  m_FaceListId = ReadH5DataId(groupReader, H5Constants::k_FaceeListTag);
+  m_UnsharedFaceListId = ReadH5DataId(groupReader, H5Constants::k_UnsharedFaceeListTag);
+
+  return BaseGroup::readHdf5(dataStructureReader, groupReader, preflight);
 }
 
 H5::ErrorType AbstractGeometry3D::writeHdf5(H5::DataStructureWriter& dataStructureWriter, H5::GroupWriter& parentGroupWriter, bool importable) const

--- a/src/complex/DataStructure/Geometry/AbstractGeometry3D.hpp
+++ b/src/complex/DataStructure/Geometry/AbstractGeometry3D.hpp
@@ -114,6 +114,12 @@ public:
   const SharedEdgeList* getEdges() const;
 
   /**
+   * @brief Returns the DataObject ID for the SharedEdgeList array. Returns an empty optional if no edge list array has been set.
+   * @return std::optional<IdType>
+   */
+  std::optional<DataObject::IdType> getEdgesId() const;
+
+  /**
    * @brief Sets the vertex IDs for the specified edge.
    * @param edgeId
    * @param verts
@@ -220,6 +226,12 @@ public:
   void setFaces(const SharedFaceList* faces);
 
   /**
+   * @brief Returns the DataObject ID for the face list array. Returns an empty optional if no face list array has been set.
+   * @return std::optional<IdType>
+   */
+  std::optional<DataObject::IdType> getFacesId() const;
+
+  /**
    * @brief Sets the geometry's shared edge list array. This does not change the parentage of the provided array.
    * @param edges
    */
@@ -236,6 +248,14 @@ public:
    * @param bFaceList
    */
   void setUnsharedFaces(const SharedFaceList* bFaceList);
+
+  /**
+   * @brief Reads values from HDF5
+   * @param dataStructureReader
+   * @param groupReader
+   * @return H5::ErrorType
+   */
+  H5::ErrorType readHdf5(H5::DataStructureReader& dataStructureReader, const H5::GroupReader& groupReader, bool preflight = false) override;
 
   /**
    * @brief Writes the geometry to HDF5 using the provided parent group ID.

--- a/src/complex/DataStructure/Geometry/EdgeGeom.cpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.cpp
@@ -216,6 +216,11 @@ const AbstractGeometry::SharedEdgeList* EdgeGeom::getEdges() const
   return dynamic_cast<const SharedEdgeList*>(getDataStructure()->getData(m_EdgeListId));
 }
 
+std::optional<DataObject::IdType> EdgeGeom::getEdgesId() const
+{
+  return m_EdgeListId;
+}
+
 void EdgeGeom::setVertsAtEdge(usize edgeId, usize verts[2])
 {
   auto edges = getEdges();

--- a/src/complex/DataStructure/Geometry/EdgeGeom.hpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.hpp
@@ -165,6 +165,12 @@ public:
   const SharedEdgeList* getEdges() const;
 
   /**
+   * @brief Returns the DataObject ID for the SharedEdgeList array. Returns an empty optional if no edge list array has been set.
+   * @return std::optional<IdType>
+   */
+  std::optional<DataObject::IdType> getEdgesId() const;
+
+  /**
    * @brief
    * @param edgeId
    * @param verts

--- a/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
@@ -580,7 +580,7 @@ H5::ErrorType HexahedralGeom::readHdf5(H5::DataStructureReader& dataStructureRea
   m_HexCentroidsId = ReadH5DataId(groupReader, H5Constants::k_HexCentroidsTag);
   m_HexSizesId = ReadH5DataId(groupReader, H5Constants::k_HexSizesTag);
 
-  return BaseGroup::readHdf5(dataStructureReader, groupReader, preflight);
+  return AbstractGeometry3D::readHdf5(dataStructureReader, groupReader, preflight);
 }
 
 H5::ErrorType HexahedralGeom::writeHdf5(H5::DataStructureWriter& dataStructureWriter, H5::GroupWriter& parentGroupWriter, bool importable) const

--- a/src/complex/DataStructure/Geometry/QuadGeom.cpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.cpp
@@ -139,6 +139,11 @@ const AbstractGeometry::SharedQuadList* QuadGeom::getFaces() const
   return dynamic_cast<const SharedQuadList*>(getDataStructure()->getData(m_QuadListId));
 }
 
+std::optional<DataObject::IdType> QuadGeom::getFacesId() const
+{
+  return m_QuadListId;
+}
+
 void QuadGeom::setVertexIdsForFace(usize faceId, usize verts[4])
 {
   auto faces = getFaces();
@@ -504,7 +509,7 @@ H5::ErrorType QuadGeom::readHdf5(H5::DataStructureReader& dataStructureReader, c
   m_QuadCentroidsId = ReadH5DataId(groupReader, H5Constants::k_QuadCentroidsTag);
   m_QuadSizesId = ReadH5DataId(groupReader, H5Constants::k_QuadSizesTag);
 
-  return BaseGroup::readHdf5(dataStructureReader, groupReader, preflight);
+  return AbstractGeometry2D::readHdf5(dataStructureReader, groupReader, preflight);
 }
 
 H5::ErrorType QuadGeom::writeHdf5(H5::DataStructureWriter& dataStructureWriter, H5::GroupWriter& parentGroupWriter, bool importable) const

--- a/src/complex/DataStructure/Geometry/QuadGeom.hpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.hpp
@@ -115,6 +115,12 @@ public:
   const SharedQuadList* getFaces() const;
 
   /**
+   * @brief Returns the DataObject ID for the face list array. Returns an empty optional if no face list array has been set.
+   * @return std::optional<IdType>
+   */
+  std::optional<DataObject::IdType> getFacesId() const;
+
+  /**
    * @brief
    * @param quadId
    * @param verts

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
@@ -539,7 +539,7 @@ H5::ErrorType TetrahedralGeom::readHdf5(H5::DataStructureReader& dataStructureRe
   m_TetCentroidsId = ReadH5DataId(groupReader, H5Constants::k_TetCentroidsTag);
   m_TetSizesId = ReadH5DataId(groupReader, H5Constants::k_TetSizesTag);
 
-  return BaseGroup::readHdf5(dataStructureReader, groupReader, preflight);
+  return AbstractGeometry3D::readHdf5(dataStructureReader, groupReader, preflight);
 }
 
 H5::ErrorType TetrahedralGeom::writeHdf5(H5::DataStructureWriter& dataStructureWriter, H5::GroupWriter& parentGroupWriter, bool importable) const

--- a/src/complex/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.cpp
@@ -145,6 +145,11 @@ const AbstractGeometry::SharedTriList* TriangleGeom::getFaces() const
   return dynamic_cast<const SharedTriList*>(getDataStructure()->getData(m_TriListId));
 }
 
+std::optional<DataObject::IdType> TriangleGeom::getFacesId() const
+{
+  return m_TriListId;
+}
+
 DataObject::IdType TriangleGeom::getTriangleArrayId()
 {
   return m_TriListId.value();
@@ -502,7 +507,7 @@ H5::ErrorType TriangleGeom::readHdf5(H5::DataStructureReader& dataStructureReade
   m_TriangleCentroidsId = ReadH5DataId(groupReader, H5Constants::k_TriangleCentroidsTag);
   m_TriangleSizesId = ReadH5DataId(groupReader, H5Constants::k_TriangleSizesTag);
 
-  return BaseGroup::readHdf5(dataStructureReader, groupReader, preflight);
+  return AbstractGeometry2D::readHdf5(dataStructureReader, groupReader, preflight);
 }
 
 H5::ErrorType TriangleGeom::writeHdf5(H5::DataStructureWriter& dataStructureWriter, H5::GroupWriter& parentGroupWriter, bool importable) const

--- a/src/complex/DataStructure/Geometry/TriangleGeom.hpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.hpp
@@ -114,6 +114,12 @@ public:
    */
   const SharedTriList* getFaces() const;
 
+  /**
+   * @brief Returns the DataObject ID for the face list array. Returns an empty optional if no face list array has been set.
+   * @return std::optional<IdType>
+   */
+  std::optional<DataObject::IdType> getFacesId() const;
+
   DataObject::IdType getTriangleArrayId();
 
   /**


### PR DESCRIPTION
* Added missing geometry array ID reading from HDF5 files.
* Added `get[*]Id() const` methods for geometry array getters that return the DataObject::IdType as an optional without requiring a DataStructure.
* Updated HDF5 unit test to check vertex, edge, triangle, and quad geometry values.