### PR TITLE
Fixed deepCopy() for DataGroup, geometries, and montage

### DIFF
--- a/src/complex/DataStructure/DataGroup.cpp
+++ b/src/complex/DataStructure/DataGroup.cpp
@@ -55,12 +55,7 @@ DataGroup* DataGroup::Import(DataStructure& ds, std::string name, IdType importI
 
 DataObject* DataGroup::deepCopy()
 {
-  auto copy = new DataGroup(*getDataStructure(), getName(), getId());
-  for(auto& [id, childPtr] : getDataMap())
-  {
-    copy->insert(childPtr);
-  }
-  return copy;
+  return new DataGroup(*this);
 }
 
 DataObject* DataGroup::shallowCopy()

--- a/src/complex/DataStructure/Geometry/EdgeGeom.cpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.cpp
@@ -92,20 +92,7 @@ DataObject* EdgeGeom::shallowCopy()
 
 DataObject* EdgeGeom::deepCopy()
 {
-  auto copy = new EdgeGeom(*getDataStructure(), getName(), getId());
-
-  copy->m_VertexListId = m_VertexListId;
-  copy->m_EdgeListId = m_EdgeListId;
-  copy->m_EdgesContainingVertId = m_EdgesContainingVertId;
-  copy->m_EdgeNeighborsId = m_EdgeNeighborsId;
-  copy->m_EdgeCentroidsId = m_EdgeCentroidsId;
-  copy->m_EdgeSizesId = m_EdgeSizesId;
-
-  for(auto& [id, childPtr] : getDataMap())
-  {
-    copy->insert(childPtr);
-  }
-  return copy;
+  return new EdgeGeom(*this);
 }
 
 std::string EdgeGeom::getGeometryTypeAsString() const

--- a/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
@@ -93,19 +93,7 @@ DataObject* HexahedralGeom::shallowCopy()
 
 DataObject* HexahedralGeom::deepCopy()
 {
-  auto* copy = new HexahedralGeom(*getDataStructure(), getName(), getId());
-
-  copy->m_HexListId = m_HexListId;
-  copy->m_HexasContainingVertId = m_HexasContainingVertId;
-  copy->m_HexNeighborsId = m_HexNeighborsId;
-  copy->m_HexCentroidsId = m_HexCentroidsId;
-  copy->m_HexSizesId = m_HexSizesId;
-
-  for(auto& [id, childPtr] : getDataMap())
-  {
-    copy->insert(childPtr);
-  }
-  return copy;
+  return new HexahedralGeom(*this);
 }
 
 std::string HexahedralGeom::getGeometryTypeAsString() const

--- a/src/complex/DataStructure/Geometry/ImageGeom.cpp
+++ b/src/complex/DataStructure/Geometry/ImageGeom.cpp
@@ -83,18 +83,7 @@ DataObject* ImageGeom::shallowCopy()
 
 DataObject* ImageGeom::deepCopy()
 {
-  auto copy = new ImageGeom(*getDataStructure(), getName(), getId());
-
-  copy->m_VoxelSizesId = m_VoxelSizesId;
-  copy->m_Spacing = m_Spacing;
-  copy->m_Origin = m_Origin;
-  copy->m_Dimensions = m_Dimensions;
-
-  for(auto& [id, childPtr] : getDataMap())
-  {
-    copy->insert(childPtr);
-  }
-  return copy;
+  return new ImageGeom(*this);
 }
 
 std::string ImageGeom::getGeometryTypeAsString() const

--- a/src/complex/DataStructure/Geometry/QuadGeom.cpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.cpp
@@ -94,19 +94,7 @@ DataObject* QuadGeom::shallowCopy()
 
 DataObject* QuadGeom::deepCopy()
 {
-  auto copy = new QuadGeom(*getDataStructure(), getName(), getId());
-
-  copy->m_QuadListId = m_QuadListId;
-  copy->m_QuadsContainingVertId = m_QuadsContainingVertId;
-  copy->m_QuadNeighborsId = m_QuadNeighborsId;
-  copy->m_QuadCentroidsId = m_QuadCentroidsId;
-  copy->m_QuadSizesId = m_QuadSizesId;
-
-  for(auto& [id, childPtr] : getDataMap())
-  {
-    copy->insert(childPtr);
-  }
-  return copy;
+  return new QuadGeom(*this);
 }
 
 std::string QuadGeom::getGeometryTypeAsString() const

--- a/src/complex/DataStructure/Geometry/RectGridGeom.cpp
+++ b/src/complex/DataStructure/Geometry/RectGridGeom.cpp
@@ -85,19 +85,7 @@ DataObject* RectGridGeom::shallowCopy()
 
 DataObject* RectGridGeom::deepCopy()
 {
-  auto copy = new RectGridGeom(*getDataStructure(), getName(), getId());
-
-  copy->m_xBoundsId = m_xBoundsId;
-  copy->m_yBoundsId = m_yBoundsId;
-  copy->m_zBoundsId = m_zBoundsId;
-  copy->m_VoxelSizesId = m_VoxelSizesId;
-  copy->m_Dimensions = m_Dimensions;
-
-  for(auto& [id, childPtr] : getDataMap())
-  {
-    copy->insert(childPtr);
-  }
-  return copy;
+  return new RectGridGeom(*this);
 }
 
 std::string RectGridGeom::getGeometryTypeAsString() const

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
@@ -98,21 +98,7 @@ DataObject* TetrahedralGeom::shallowCopy()
 
 DataObject* TetrahedralGeom::deepCopy()
 {
-  auto copy = new TetrahedralGeom(*getDataStructure(), getName(), getId());
-
-  copy->m_TriListId = m_TriListId;
-  copy->m_UnsharedTriListId = m_UnsharedTriListId;
-  copy->m_TetListId = m_TetListId;
-  copy->m_TetsContainingVertId = m_TetsContainingVertId;
-  copy->m_TetNeighborsId = m_TetNeighborsId;
-  copy->m_TetCentroidsId = m_TetCentroidsId;
-  copy->m_TetSizesId = m_TetSizesId;
-
-  for(auto& [id, childPtr] : getDataMap())
-  {
-    copy->insert(childPtr);
-  }
-  return copy;
+  return new TetrahedralGeom(*this);
 }
 
 std::string TetrahedralGeom::getGeometryTypeAsString() const

--- a/src/complex/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.cpp
@@ -95,19 +95,7 @@ DataObject* TriangleGeom::shallowCopy()
 
 DataObject* TriangleGeom::deepCopy()
 {
-  auto copy = new TriangleGeom(*getDataStructure(), getName(), getId());
-
-  copy->m_TriListId = m_TriListId;
-  copy->m_TrianglesContainingVertId = m_TrianglesContainingVertId;
-  copy->m_TriangleNeighborsId = m_TriangleNeighborsId;
-  copy->m_TriangleCentroidsId = m_TriangleCentroidsId;
-  copy->m_TriangleSizesId = m_TriangleSizesId;
-
-  for(auto& [id, childPtr] : getDataMap())
-  {
-    copy->insert(childPtr);
-  }
-  return copy;
+  return new TriangleGeom(*this);
 }
 
 std::string TriangleGeom::getGeometryTypeAsString() const

--- a/src/complex/DataStructure/Geometry/VertexGeom.cpp
+++ b/src/complex/DataStructure/Geometry/VertexGeom.cpp
@@ -89,16 +89,7 @@ DataObject* VertexGeom::shallowCopy()
 
 DataObject* VertexGeom::deepCopy()
 {
-  auto copy = new VertexGeom(*getDataStructure(), getName(), getId());
-
-  copy->m_VertexListId = m_VertexListId;
-  copy->m_VertexSizesId = m_VertexSizesId;
-
-  for(auto& [id, childPtr] : getDataMap())
-  {
-    copy->insert(childPtr);
-  }
-  return copy;
+  return new VertexGeom(*this);
 }
 
 std::string VertexGeom::getGeometryTypeAsString() const

--- a/src/complex/DataStructure/Montage/GridMontage.cpp
+++ b/src/complex/DataStructure/Montage/GridMontage.cpp
@@ -63,17 +63,7 @@ DataObject* GridMontage::shallowCopy()
 
 DataObject* GridMontage::deepCopy()
 {
-  auto copy = new GridMontage(*getDataStructure(), getName(), getId());
-
-  copy->m_RowCount = m_RowCount;
-  copy->m_ColumnCount = m_ColumnCount;
-  copy->m_DepthCount = m_DepthCount;
-
-  for(auto& [id, childPtr] : getDataMap())
-  {
-    copy->insert(childPtr);
-  }
-  return copy;
+  return new GridMontage(*this);
 }
 
 usize GridMontage::getRowCount() const


### PR DESCRIPTION
* Not all information was copied previously (e.g. TriangleGeom didn't copy the vertices id)