### PR TITLE
Add optional parameters that skip validation when inactive

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApplyTransformationToGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApplyTransformationToGeometryFilter.cpp
@@ -137,7 +137,7 @@ Parameters ApplyTransformationToGeometryFilter::parameters() const
       std::make_unique<ChoicesParameter>(k_TransformType_Key, "Transformation Type", "", 0,
                                          ChoicesParameter::Choices{"No Transformation", "Pre-Computed Transformation Matrix", "Manual Transformation Matrix", "Rotation", "Translation", "Scale"}));
 
-  params.insert(std::make_unique<ArraySelectionParameter>(k_ComputedTransformationMatrix_Key, "Transformation Matrix", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::float32}, true));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_ComputedTransformationMatrix_Key, "Transformation Matrix", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::float32}));
 
   DynamicTableParameter::ValueType dynamicTable{{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}, {"R0", "R1", "R2", "R3"}, {"C0", "C1", "C2", "C3"}};
   dynamicTable.setMinCols(4);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateFeatureSizesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateFeatureSizesFilter.cpp
@@ -54,7 +54,7 @@ Parameters CalculateFeatureSizesFilter::parameters() const
   params.insert(std::make_unique<BoolParameter>(k_SaveElementSizes_Key, "Save Element Sizes", "Save element sizes", false));
   params.insert(std::make_unique<DataPathSelectionParameter>(k_GeometryPath_Key, "Target Geometry", "DataPath to target geometry", DataPath{}));
   params.insert(
-      std::make_unique<ArraySelectionParameter>(k_FeatureIdsPath_Key, "Feature IDs", "DataPath to Feature IDs array", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}, true));
+      std::make_unique<ArraySelectionParameter>(k_FeatureIdsPath_Key, "Feature IDs", "DataPath to Feature IDs array", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
 
   params.insert(std::make_unique<ArrayCreationParameter>(k_VolumesPath_Key, "Volumes array", "DataPath to volumes array", DataPath{}));
   params.insert(std::make_unique<ArrayCreationParameter>(k_EquivalentDiametersPath_Key, "Equivalent Diameters", "DataPath to equivalent diameters array", DataPath{}));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateFeatureSizesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateFeatureSizesFilter.cpp
@@ -53,8 +53,7 @@ Parameters CalculateFeatureSizesFilter::parameters() const
   Parameters params;
   params.insert(std::make_unique<BoolParameter>(k_SaveElementSizes_Key, "Save Element Sizes", "Save element sizes", false));
   params.insert(std::make_unique<DataPathSelectionParameter>(k_GeometryPath_Key, "Target Geometry", "DataPath to target geometry", DataPath{}));
-  params.insert(
-      std::make_unique<ArraySelectionParameter>(k_FeatureIdsPath_Key, "Feature IDs", "DataPath to Feature IDs array", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIdsPath_Key, "Feature IDs", "DataPath to Feature IDs array", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
 
   params.insert(std::make_unique<ArrayCreationParameter>(k_VolumesPath_Key, "Volumes array", "DataPath to volumes array", DataPath{}));
   params.insert(std::make_unique<ArrayCreationParameter>(k_EquivalentDiametersPath_Key, "Equivalent Diameters", "DataPath to equivalent diameters array", DataPath{}));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ChangeAngleRepresentation.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ChangeAngleRepresentation.cpp
@@ -89,7 +89,7 @@ Parameters ChangeAngleRepresentation::parameters() const
   Parameters params;
   params.insert(std::make_unique<ChoicesParameter>(k_ConversionType_Key, "Conversion Type", "", 0, ChoicesParameter::Choices{"Degrees to Radians", "Radians to Degrees"}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_AnglesArrayPath_Key, "Angles", "The DataArray containing the angles to be converted.", DataPath{},
-                                                          ArraySelectionParameter::AllowedTypes{DataType::float32}, false));
+                                                          ArraySelectionParameter::AllowedTypes{DataType::float32}));
 
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
@@ -49,7 +49,7 @@ Parameters ConditionalSetValue::parameters() const
   params.insert(std::make_unique<StringParameter>(k_ReplaceValue_Key, "New Value", "The value that will be used as the replacement value", ""));
   params.insert(std::make_unique<ArraySelectionParameter>(k_ConditionalArrayPath_Key, "Conditional Array",
                                                           "The complete path to the conditional array that will determine which values/entries will be replaced", DataPath{},
-                                                          ArraySelectionParameter::AllowedTypes{DataType::boolean, DataType::uint8, DataType::int8}, false));
+                                                          ArraySelectionParameter::AllowedTypes{DataType::boolean, DataType::uint8, DataType::int8}));
   params.insert(
       std::make_unique<ArraySelectionParameter>(k_SelectedArrayPath_Key, "Attribute Array", "The complete path to array that will have values replaced", DataPath{}, complex::GetAllDataTypes()));
   return params;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyFeatureArrayToElementArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyFeatureArrayToElementArray.cpp
@@ -80,7 +80,7 @@ Parameters CopyFeatureArrayToElementArray::parameters() const
   //  params.insertSeparator(Parameters::Separator{"Feature Data"});
   params.insert(std::make_unique<ArraySelectionParameter>(k_SelectedFeatureArrayPath_Key, "Feature Data to Copy to Element Data", "", DataPath{}, complex::GetAllDataTypes()));
   //  params.insertSeparator(Parameters::Separator{"Element Data"});
-  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIdsArrayPath_Key, "Feature Ids", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}, false));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIdsArrayPath_Key, "Feature Ids", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
   //  params.insertSeparator(Parameters::Separator{"Element Data"});
   params.insert(std::make_unique<ArrayCreationParameter>(k_CreatedArrayName_Key, "Copied Attribute Array", "", DataPath{}));
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropImageGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropImageGeometry.cpp
@@ -152,8 +152,9 @@ Parameters CropImageGeometry::parameters() const
 
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_VoxelArrays_Key, "Voxel Arrays", "DataPaths to related DataArrays", std::vector<DataPath>(), complex::GetAllDataTypes()));
 
-  params.insert(std::make_unique<BoolParameter>(k_RenumberFeatures_Key, "Renumber Features", "Specifies if the feature IDs should be renumbered", false));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIds_Key, "Feature IDs", "DataPath to Feature IDs array", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}, true));
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_RenumberFeatures_Key, "Renumber Features", "Specifies if the feature IDs should be renumbered", false));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIds_Key, "Feature IDs", "DataPath to Feature IDs array", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
+  params.linkParameters(k_RenumberFeatures_Key, k_FeatureIds_Key, true);
 
   params.insert(std::make_unique<StringParameter>(k_NewFeaturesName_Key, "New Cell Features Group Name", "Name of the new DataGroup containing updated updated Voxel Arrays", "Cell Features"));
   return params;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -124,9 +124,9 @@ Parameters ExtractInternalSurfacesFromTriangleGeometry::parameters() const
 
   params.insertSeparator(Parameters::Separator{"Optional Transferred Data"});
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_CopyVertexPaths_Key, "Copy Vertex Arrays", "Paths to vertex-related DataArrays that should be copied to the new geometry",
-                                                               std::vector<DataPath>{}, complex::GetAllDataTypes(), true));
+                                                               std::vector<DataPath>{}, complex::GetAllDataTypes()));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_CopyTrianglePaths_Key, "Copy Triangle Arrays", "Paths to face-related DataArrays that should be copied to the new geometry",
-                                                               std::vector<DataPath>{}, complex::GetAllDataTypes(), true));
+                                                               std::vector<DataPath>{}, complex::GetAllDataTypes()));
   return params;
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindFeaturePhasesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindFeaturePhasesFilter.cpp
@@ -45,8 +45,8 @@ Parameters FindFeaturePhasesFilter::parameters() const
 {
   Parameters params;
   // Create the parameter descriptors that are needed for this filter
-  params.insert(std::make_unique<ArraySelectionParameter>(k_CellPhasesArrayPath_Key, "Cell Phases", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}, false));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIdsArrayPath_Key, "Feature Ids", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}, false));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_CellPhasesArrayPath_Key, "Cell Phases", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIdsArrayPath_Key, "Feature Ids", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
   params.insert(std::make_unique<ArrayCreationParameter>(k_FeaturePhasesArrayPath_Key, "Feature Phases", "", DataPath{}));
 
   return params;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighbors.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighbors.cpp
@@ -42,7 +42,7 @@ Parameters FindNeighbors::parameters() const
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_StoreSurface_Key, "Store Surface Features Array", "", false));
 
   params.insert(std::make_unique<GeometrySelectionParameter>(k_ImageGeom_Key, "Image Geometry", "", DataPath{}, GeometrySelectionParameter::AllowedTypes{AbstractGeometry::Type::Image}));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIds_Key, "Feature Ids", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}, false));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIds_Key, "Feature Ids", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
 
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_CellFeatures_Key, "Cell Feature Arrays", "", std::vector<DataPath>{}, MultiArraySelectionParameter::AllowedTypes{}));
   params.insert(std::make_unique<ArrayCreationParameter>(k_BoundaryCells_Key, "Boundary Cells", "", DataPath{}));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindSurfaceFeatures.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindSurfaceFeatures.cpp
@@ -228,7 +228,7 @@ Parameters FindSurfaceFeatures::parameters() const
                                                 "Marks features that are neighbors with feature 0.  If this option is off, only features that reside on the edge of the geometry will be marked.",
                                                 true));
   params.insert(std::make_unique<GeometrySelectionParameter>(k_FeatureGeometryPath_Key, "Feature Geometry", "", DataPath{}, GeometrySelectionParameter::AllowedTypes{AbstractGeometry::Type::Image}));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIdsArrayPath_Key, "Feature Ids", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}, false));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIdsArrayPath_Key, "Feature Ids", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
   params.insertSeparator(Parameters::Separator{"Cell Feature Data"});
   params.insert(std::make_unique<ArrayCreationParameter>(k_SurfaceFeaturesArrayPath_Key, "Surface Features", "", DataPath{}));
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/LaplacianSmoothingFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/LaplacianSmoothingFilter.cpp
@@ -53,7 +53,7 @@ Parameters LaplacianSmoothingFilter::parameters() const
                                                              GeometrySelectionParameter::AllowedTypes{AbstractGeometry::Type::Triangle, AbstractGeometry::Type::Tetrahedral}));
   params.insertSeparator(Parameters::Separator{"Vertex Data"});
   params.insert(std::make_unique<ArraySelectionParameter>(k_SurfaceMeshNodeTypeArrayPath_Key, "Node Type", "The complete path to the array specifying the type of node in the Geometry", DataPath{},
-                                                          ArraySelectionParameter::AllowedTypes{DataType::int8}, false));
+                                                          ArraySelectionParameter::AllowedTypes{DataType::int8}));
   params.insertSeparator(Parameters::Separator{"Smoothing Values"});
 
   params.insert(std::make_unique<Int32Parameter>(

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/LinkGeometryDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/LinkGeometryDataFilter.cpp
@@ -59,14 +59,14 @@ Parameters LinkGeometryDataFilter::parameters() const
   params.insert(std::make_unique<GeometrySelectionParameter>(k_GeometryDataPath_Key, "Selected Geometry", "The complete path to the Geometry with which to link the data", DataPath{},
                                                              GeometrySelectionParameter::AllowedTypes{AbstractGeometry::Type::Any}));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_SelectedVertexDataArrayPaths_Key, "Vertex Data Arrays to Link", "Data associated with a vertex or point",
-                                                               MultiArraySelectionParameter::ValueType{}, complex::GetAllDataTypes(), true));
+                                                               MultiArraySelectionParameter::ValueType{}, complex::GetAllDataTypes()));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_SelectedEdgeDataArrayPaths_Key, "Edge Data Arrays to Link", "Data associated with an edge", MultiArraySelectionParameter::ValueType{},
-                                                               complex::GetAllDataTypes(), true));
+                                                               complex::GetAllDataTypes()));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_SelectedFaceDataArrayPaths_Key, "Face Data Arrays to Link", "Data associated with a face", MultiArraySelectionParameter::ValueType{},
-                                                               complex::GetAllDataTypes(), true));
+                                                               complex::GetAllDataTypes()));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_SelectedVolumeDataArrayPaths_Key, "Cell Data Arrays to Link",
                                                                "Data associated with a cell or volume element such as a hexahedron or image geometry cell", MultiArraySelectionParameter::ValueType{},
-                                                               complex::GetAllDataTypes(), true));
+                                                               complex::GetAllDataTypes()));
 
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.cpp
@@ -226,9 +226,8 @@ Parameters MapPointCloudToRegularGridFilter::parameters() const
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_ArraysToMap_Key, "Arrays to Map", "Paths to map to the grid geometry", std::vector<DataPath>(), complex::GetAllDataTypes()));
 
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_UseMask_Key, "Use Mask", "Specifies if a mask array should be used", false));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_MaskPath_Key, "Mask", "Path to the target mask array", DataPath(), ArraySelectionParameter::AllowedTypes{DataType::boolean}, false));
-  params.insert(
-      std::make_unique<ArraySelectionParameter>(k_VoxelIndices_Key, "Voxel Indices", "Path to the Voxel Indices array", DataPath(), ArraySelectionParameter::AllowedTypes{DataType::uint64}, false));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_MaskPath_Key, "Mask", "Path to the target mask array", DataPath(), ArraySelectionParameter::AllowedTypes{DataType::boolean}));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_VoxelIndices_Key, "Voxel Indices", "Path to the Voxel Indices array", DataPath(), ArraySelectionParameter::AllowedTypes{DataType::uint64}));
 
   params.linkParameters(k_UseMask_Key, k_MaskPath_Key, std::make_any<bool>(true));
   params.linkParameters(k_SamplingGridType_Key, k_GridDimensions_Key, std::make_any<ChoicesParameter::ValueType>(0));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
@@ -280,7 +280,7 @@ Parameters MinNeighbors::parameters() const
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_ApplyToSinglePhase_Key, "Apply to Single Phase Only", "", true));
   params.insert(std::make_unique<UInt64Parameter>(k_PhaseNumber_Key, "Phase Index", "", 0));
   params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIds_Key, "Feature IDs", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_FeaturePhases_Key, "Feature Phases", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}, true));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_FeaturePhases_Key, "Feature Phases", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_NumNeighbors_Key, "Number of Neighbors", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_VoxelArrays_Key, "Voxel Arrays", "", std::vector<DataPath>{}, MultiArraySelectionParameter::AllowedTypes{}));
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
@@ -279,9 +279,9 @@ Parameters MinNeighbors::parameters() const
   params.insert(std::make_unique<UInt64Parameter>(k_MinNumNeighbors_Key, "Minimum Number Neighbors", "", 0));
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_ApplyToSinglePhase_Key, "Apply to Single Phase Only", "", true));
   params.insert(std::make_unique<UInt64Parameter>(k_PhaseNumber_Key, "Phase Index", "", 0));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIds_Key, "Feature IDs", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}, false));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIds_Key, "Feature IDs", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_FeaturePhases_Key, "Feature Phases", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}, true));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_NumNeighbors_Key, "Number of Neighbors", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}, false));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_NumNeighbors_Key, "Number of Neighbors", "", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_VoxelArrays_Key, "Voxel Arrays", "", std::vector<DataPath>{}, MultiArraySelectionParameter::AllowedTypes{}));
 
   params.linkParameters(k_ApplyToSinglePhase_Key, k_PhaseNumber_Key, std::make_any<bool>(true));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.cpp
@@ -64,7 +64,7 @@ Parameters PointSampleTriangleGeometryFilter::parameters() const
       std::make_unique<BoolParameter>(k_UseMask_Key, "Use Mask", "Whether to use a boolean mask array to ignore certain Trianlges flagged as false from the sampling algorithm", false));
   params.insertSeparator(Parameters::Separator{"Face Data"});
   params.insert(std::make_unique<ArraySelectionParameter>(k_TriangleAreasArrayPath_Key, "Face Areas", "The complete path to the array specifying the area of each Face", DataPath{},
-                                                          ArraySelectionParameter::AllowedTypes{DataType::float64}, false));
+                                                          ArraySelectionParameter::AllowedTypes{DataType::float64}));
 
   params.insert(std::make_unique<ArraySelectionParameter>(k_MaskArrayPath_Key, "Mask", "The complete path to the array specifying if the Face can be sampled, if Use Mask is checked", DataPath{},
                                                           ArraySelectionParameter::AllowedTypes{DataType::boolean}, true));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.cpp
@@ -67,7 +67,7 @@ Parameters PointSampleTriangleGeometryFilter::parameters() const
                                                           ArraySelectionParameter::AllowedTypes{DataType::float64}));
 
   params.insert(std::make_unique<ArraySelectionParameter>(k_MaskArrayPath_Key, "Mask", "The complete path to the array specifying if the Face can be sampled, if Use Mask is checked", DataPath{},
-                                                          ArraySelectionParameter::AllowedTypes{DataType::boolean}, true));
+                                                          ArraySelectionParameter::AllowedTypes{DataType::boolean}));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_SelectedDataArrayPaths_Key, "Face Attribute Arrays to Transfer",
                                                                "The paths to the Face Attribute Arrays to transfer to the created Vertex Geometry where the mask is false, if Use Mask is checked",
                                                                MultiArraySelectionParameter::ValueType{}, complex::GetAllDataTypes()));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
@@ -63,7 +63,7 @@ Parameters QuickSurfaceMeshFilter::parameters() const
   params.insert(
       std::make_unique<DataPathSelectionParameter>(k_GridGeometryDataPath_Key, "Grid Geometry", "The complete path to the Grid Geometry from which to create a Triangle Geometry", DataPath{}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIdsArrayPath_Key, "Feature Ids", "The complete path to the Array specifying which Feature each Cell belongs to", DataPath{},
-                                                          ArraySelectionParameter::AllowedTypes{DataType::int32}, false));
+                                                          ArraySelectionParameter::AllowedTypes{DataType::int32}));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_SelectedDataArrayPaths_Key, "Attribute Arrays to Transfer",
                                                                "The paths to the Arrays specifying which Cell Attribute Arrays to transfer to the created Triangle Geometry",
                                                                MultiArraySelectionParameter::ValueType{}, complex::GetAllDataTypes()));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
@@ -83,7 +83,7 @@ Parameters RemoveFlaggedVertices::parameters() const
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_ArraySelection_Key, "Vertex Data Arrays", "Paths to the target Vertex DataArrays to also reduce.", std::vector<DataPath>(),
                                                                complex::GetAllDataTypes()));
   params.insert(std::make_unique<ArraySelectionParameter>(k_MaskPath_Key, "Mask Array", "DataPath to the conditional array that will be used to decide which vertices are removed.", DataPath(),
-                                                          ArraySelectionParameter::AllowedTypes{DataType::boolean}, false));
+                                                          ArraySelectionParameter::AllowedTypes{DataType::boolean}));
   params.insert(
       std::make_unique<DataGroupCreationParameter>(k_ReducedVertexPath_Key, "Reduced Vertex Geometry", "Created Vertex Geometry DataPath. This will be created during the filter.", DataPath()));
   return params;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveMinimumSizeFeaturesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveMinimumSizeFeaturesFilter.cpp
@@ -288,11 +288,11 @@ Parameters RemoveMinimumSizeFeaturesFilter::parameters() const
   params.insert(std::make_unique<NumberParameter<int64>>(k_PhaseNumber_Key, "Phase Number", "Target Phase", 0));
 
   params.insert(std::make_unique<ArraySelectionParameter>(k_FeaturePhasesPath_Key, "[Feature] Phases Array", "DataPath to Feature Phases DataArray", DataPath{},
-                                                          ArraySelectionParameter::AllowedTypes{DataType::int32}, false));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_NumCellsPath_Key, "[Feature] Num Cells Array", "DataPath to NumCells DataArray", DataPath{},
-                                                          ArraySelectionParameter::AllowedTypes{DataType::int32}, false));
+                                                          ArraySelectionParameter::AllowedTypes{DataType::int32}));
+  params.insert(
+      std::make_unique<ArraySelectionParameter>(k_NumCellsPath_Key, "[Feature] Num Cells Array", "DataPath to NumCells DataArray", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::int32}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIdsPath_Key, "[Cell] FeatureIds Array", "DataPath to FeatureIds DataArray", DataPath{},
-                                                          ArraySelectionParameter::AllowedTypes{DataType::int32}, false));
+                                                          ArraySelectionParameter::AllowedTypes{DataType::int32}));
   params.insert(std::make_unique<DataPathSelectionParameter>(k_ImageGeomPath_Key, "Image Geometry", "DataPath to Image Geometry", DataPath{}));
 
   return params;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RobustAutomaticThreshold.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RobustAutomaticThreshold.cpp
@@ -135,9 +135,9 @@ Parameters RobustAutomaticThreshold::parameters() const
 {
   Parameters params;
   // Input cannot be bool array
-  params.insert(std::make_unique<ArraySelectionParameter>(k_InputArrayPath, "Input Array", "DataArray to Threshold", DataPath(), complex::GetAllNumericTypes(), false));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_InputArrayPath, "Input Array", "DataArray to Threshold", DataPath(), complex::GetAllNumericTypes()));
   params.insert(std::make_unique<ArraySelectionParameter>(k_GradientMagnitudePath, "Gradient Magnitude Data", "The complete path to the Array specifying the gradient magnitude of the Input Array",
-                                                          DataPath(), ArraySelectionParameter::AllowedTypes{DataType::float32}, false));
+                                                          DataPath(), ArraySelectionParameter::AllowedTypes{DataType::float32}));
   params.insert(std::make_unique<ArrayCreationParameter>(k_ArrayCreationPath, "Mask", "Created mask based on Input Array and Gradient Magnitude", DataPath()));
 
   return params;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ScalarSegmentFeaturesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ScalarSegmentFeaturesFilter.cpp
@@ -73,7 +73,7 @@ Parameters ScalarSegmentFeaturesFilter::parameters() const
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_UseGoodVoxelsKey, "Use Mask Array", "Determines if a mask array is used for segmenting", false));
 
   params.insert(std::make_unique<ArraySelectionParameter>(k_InputArrayPathKey, "Scalar Array to Segment", "Path to the DataArray to segment", DataPath(), complex::GetIntegerDataTypes()));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_GoodVoxelsPathKey, "Mask", "Path to the DataArray Mask", DataPath(), ArraySelectionParameter::AllowedTypes{DataType::boolean}, true));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_GoodVoxelsPathKey, "Mask", "Path to the DataArray Mask", DataPath(), ArraySelectionParameter::AllowedTypes{DataType::boolean}));
 
   params.insert(std::make_unique<ArrayCreationParameter>(k_FeatureIdsPathKey, "Feature IDs", "Path to the created Feature IDs path", DataPath()));
 

--- a/src/complex/Filter/Parameters.cpp
+++ b/src/complex/Filter/Parameters.cpp
@@ -96,6 +96,11 @@ void Parameters::linkParameters(std::string groupKey, std::string childKey, std:
     throw std::invalid_argument(fmt::format("Parameters::linkParameters(...): Group '{}' does not exist in Parameters instance.", groupKey));
   }
 
+  if(containsGroup(childKey))
+  {
+    throw std::invalid_argument(fmt::format("Parameters::linkParameters(...): Group '{}' cannot be a child of another group", childKey));
+  }
+
   if(hasGroup(childKey))
   {
     std::string group = getGroup(childKey);

--- a/src/complex/Parameters/ArraySelectionParameter.cpp
+++ b/src/complex/Parameters/ArraySelectionParameter.cpp
@@ -31,11 +31,9 @@ struct fmt::formatter<complex::DataType>
 
 namespace complex
 {
-ArraySelectionParameter::ArraySelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, const AllowedTypes& allowedTypes,
-                                                 bool allowEmpty)
+ArraySelectionParameter::ArraySelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, const AllowedTypes& allowedTypes)
 : MutableDataParameter(name, humanName, helpText, Category::Required)
 , m_DefaultValue(defaultValue)
-, m_AllowEmpty(allowEmpty)
 , m_AllowedTypes(allowedTypes)
 {
   if(allowedTypes.empty())
@@ -83,7 +81,7 @@ Result<std::any> ArraySelectionParameter::fromJson(const nlohmann::json& json) c
 
 IParameter::UniquePointer ArraySelectionParameter::clone() const
 {
-  return std::make_unique<ArraySelectionParameter>(name(), humanName(), helpText(), m_DefaultValue, m_AllowedTypes, m_AllowEmpty);
+  return std::make_unique<ArraySelectionParameter>(name(), humanName(), helpText(), m_DefaultValue, m_AllowedTypes);
 }
 
 std::any ArraySelectionParameter::defaultValue() const
@@ -111,11 +109,6 @@ Result<> ArraySelectionParameter::validate(const DataStructure& dataStructure, c
 Result<> ArraySelectionParameter::validatePath(const DataStructure& dataStructure, const DataPath& value) const
 {
   const std::string prefix = fmt::format("FilterParameter '{}' Validation Error: ", humanName());
-
-  if(value.empty() && m_AllowEmpty)
-  {
-    return {};
-  }
 
   if(value.empty())
   {

--- a/src/complex/Parameters/ArraySelectionParameter.hpp
+++ b/src/complex/Parameters/ArraySelectionParameter.hpp
@@ -20,7 +20,7 @@ public:
   using AllowedTypes = std::set<DataType>;
 
   ArraySelectionParameter() = delete;
-  ArraySelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, const AllowedTypes& allowedTypes, bool allowEmpty = false);
+  ArraySelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, const AllowedTypes& allowedTypes);
   ~ArraySelectionParameter() override = default;
 
   ArraySelectionParameter(const ArraySelectionParameter&) = delete;
@@ -106,7 +106,6 @@ public:
 
 private:
   ValueType m_DefaultValue = {};
-  bool m_AllowEmpty = false;
   AllowedTypes m_AllowedTypes = {};
 };
 } // namespace complex

--- a/src/complex/Parameters/DataPathSelectionParameter.cpp
+++ b/src/complex/Parameters/DataPathSelectionParameter.cpp
@@ -10,10 +10,9 @@
 
 namespace complex
 {
-DataPathSelectionParameter::DataPathSelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, bool allowEmpty)
+DataPathSelectionParameter::DataPathSelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue)
 : MutableDataParameter(name, humanName, helpText, Category::Required)
 , m_DefaultValue(defaultValue)
-, m_AllowEmpty(allowEmpty)
 {
 }
 
@@ -76,10 +75,6 @@ Result<> DataPathSelectionParameter::validate(const DataStructure& dataStructure
 Result<> DataPathSelectionParameter::validatePath(const DataStructure& dataStructure, const DataPath& value) const
 {
   const std::string prefix = fmt::format("FilterParameter '{}' Validation Error: ", humanName());
-  if(value.empty() && m_AllowEmpty)
-  {
-    return {};
-  }
 
   if(value.empty())
   {

--- a/src/complex/Parameters/DataPathSelectionParameter.hpp
+++ b/src/complex/Parameters/DataPathSelectionParameter.hpp
@@ -15,7 +15,7 @@ public:
   using ValueType = DataPath;
 
   DataPathSelectionParameter() = delete;
-  DataPathSelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, bool allowEmpty = true);
+  DataPathSelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue);
   ~DataPathSelectionParameter() override = default;
 
   DataPathSelectionParameter(const DataPathSelectionParameter&) = delete;
@@ -95,7 +95,6 @@ public:
 
 private:
   ValueType m_DefaultValue = {};
-  bool m_AllowEmpty = false;
 };
 } // namespace complex
 

--- a/src/complex/Parameters/DynamicTableParameter.cpp
+++ b/src/complex/Parameters/DynamicTableParameter.cpp
@@ -10,10 +10,9 @@
 
 namespace complex
 {
-DynamicTableParameter::DynamicTableParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, bool allowEmpty)
+DynamicTableParameter::DynamicTableParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue)
 : ValueParameter(name, humanName, helpText)
 , m_DefaultValue(defaultValue)
-, m_AllowEmpty(allowEmpty)
 {
 }
 

--- a/src/complex/Parameters/DynamicTableParameter.hpp
+++ b/src/complex/Parameters/DynamicTableParameter.hpp
@@ -19,7 +19,7 @@ public:
   using ValueType = DynamicTableData;
 
   DynamicTableParameter() = delete;
-  DynamicTableParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, bool allowEmpty = true);
+  DynamicTableParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue);
   ~DynamicTableParameter() override = default;
 
   DynamicTableParameter(const DynamicTableParameter&) = delete;
@@ -82,7 +82,6 @@ public:
 
 private:
   ValueType m_DefaultValue = {};
-  bool m_AllowEmpty = false;
 };
 } // namespace complex
 

--- a/src/complex/Parameters/MultiArraySelectionParameter.cpp
+++ b/src/complex/Parameters/MultiArraySelectionParameter.cpp
@@ -9,10 +9,9 @@
 namespace complex
 {
 MultiArraySelectionParameter::MultiArraySelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue,
-                                                           const AllowedTypes& allowedTypes, bool allowEmpty)
+                                                           const AllowedTypes& allowedTypes)
 : MutableDataParameter(name, humanName, helpText, Category::Required)
 , m_DefaultValue(defaultValue)
-, m_AllowEmpty(allowEmpty)
 , m_AllowedTypes(allowedTypes)
 {
 }
@@ -76,7 +75,7 @@ Result<std::any> MultiArraySelectionParameter::fromJson(const nlohmann::json& js
 
 IParameter::UniquePointer MultiArraySelectionParameter::clone() const
 {
-  return std::make_unique<MultiArraySelectionParameter>(name(), humanName(), helpText(), m_DefaultValue, m_AllowedTypes, m_AllowEmpty);
+  return std::make_unique<MultiArraySelectionParameter>(name(), humanName(), helpText(), m_DefaultValue, m_AllowedTypes);
 }
 
 std::any MultiArraySelectionParameter::defaultValue() const

--- a/src/complex/Parameters/MultiArraySelectionParameter.hpp
+++ b/src/complex/Parameters/MultiArraySelectionParameter.hpp
@@ -15,8 +15,7 @@ public:
   using AllowedTypes = std::set<DataType>;
 
   MultiArraySelectionParameter() = delete;
-  MultiArraySelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, const AllowedTypes& allowedTypes,
-                               bool allowEmpty = false);
+  MultiArraySelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, const AllowedTypes& allowedTypes);
   ~MultiArraySelectionParameter() override = default;
 
   MultiArraySelectionParameter(const MultiArraySelectionParameter&) = delete;
@@ -102,7 +101,6 @@ public:
 
 private:
   ValueType m_DefaultValue = {};
-  bool m_AllowEmpty = false;
   AllowedTypes m_AllowedTypes = {};
 };
 } // namespace complex

--- a/src/complex/Parameters/NeighborListSelectionParameter.cpp
+++ b/src/complex/Parameters/NeighborListSelectionParameter.cpp
@@ -36,10 +36,9 @@ constexpr int32 k_Validate_AllowedType_Error = -206;
 namespace complex
 {
 NeighborListSelectionParameter::NeighborListSelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue,
-                                                               const AllowedTypes& allowedTypes, bool allowEmpty)
+                                                               const AllowedTypes& allowedTypes)
 : MutableDataParameter(name, humanName, helpText, Category::Required)
 , m_DefaultValue(defaultValue)
-, m_AllowEmpty(allowEmpty)
 , m_AllowedTypes(allowedTypes)
 {
   if(allowedTypes.empty())
@@ -87,7 +86,7 @@ Result<std::any> NeighborListSelectionParameter::fromJson(const nlohmann::json& 
 
 IParameter::UniquePointer NeighborListSelectionParameter::clone() const
 {
-  return std::make_unique<NeighborListSelectionParameter>(name(), humanName(), helpText(), m_DefaultValue, m_AllowedTypes, m_AllowEmpty);
+  return std::make_unique<NeighborListSelectionParameter>(name(), humanName(), helpText(), m_DefaultValue, m_AllowedTypes);
 }
 
 std::any NeighborListSelectionParameter::defaultValue() const
@@ -115,11 +114,6 @@ Result<> NeighborListSelectionParameter::validate(const DataStructure& dataStruc
 Result<> NeighborListSelectionParameter::validatePath(const DataStructure& dataStructure, const DataPath& value) const
 {
   const std::string prefix = fmt::format("FilterParameter '{}' Validation Error: ", humanName());
-
-  if(value.empty() && m_AllowEmpty)
-  {
-    return {};
-  }
 
   if(value.empty())
   {

--- a/src/complex/Parameters/NeighborListSelectionParameter.hpp
+++ b/src/complex/Parameters/NeighborListSelectionParameter.hpp
@@ -17,8 +17,7 @@ public:
   using AllowedTypes = std::set<DataType>;
 
   NeighborListSelectionParameter() = delete;
-  NeighborListSelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, const AllowedTypes& allowedTypes,
-                                 bool allowEmpty = false);
+  NeighborListSelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, const AllowedTypes& allowedTypes);
   ~NeighborListSelectionParameter() override = default;
 
   NeighborListSelectionParameter(const NeighborListSelectionParameter&) = delete;
@@ -104,7 +103,6 @@ public:
 
 private:
   ValueType m_DefaultValue = {};
-  bool m_AllowEmpty = false;
   AllowedTypes m_AllowedTypes = {};
 };
 


### PR DESCRIPTION
When a parameter is linked to another parameter (like a `BoolParameter` or `ChoicesParameter`) and is not active, its `validate` function will not be called. This replaces the `allowEmpty` option of several parameter (e.g. `ArraySelectionParameter`).