### PR TITLE
Add a check for the existence of the file before trying to open it.

### DIFF
--- a/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -622,6 +622,10 @@ complex::Pipeline complex::DREAM3D::ImportPipelineFromFile(const H5::FileReader&
 
 Result<complex::Pipeline> complex::DREAM3D::ImportPipelineFromFile(const std::filesystem::path& filePath)
 {
+  if(!std::filesystem::exists(filePath))
+  {
+    return MakeErrorResult<Pipeline>(-1, fmt::format("complex::DREAM3D::ImportPipelineFromFile: File does not exist. '{}'", filePath.string()));
+  }
   H5::FileReader fileReader(filePath);
   if(!fileReader.isValid())
   {


### PR DESCRIPTION
Cuts down on spurious HDF5 warnings.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>