### PR TITLE
Cache the number of tuples, number of components and size.

### DIFF
--- a/src/complex/DataStructure/DataStore.hpp
+++ b/src/complex/DataStructure/DataStore.hpp
@@ -62,7 +62,6 @@ public:
   , m_TupleShape(tupleShape)
   , m_NumComponents(std::accumulate(m_ComponentShape.cbegin(), m_ComponentShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
   , m_NumTuples(std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
-  , m_Size(m_NumTuples * m_NumComponents)
   {
     reshapeTuples(m_TupleShape);
     if(initValue.has_value())
@@ -83,7 +82,6 @@ public:
   , m_Data(std::move(buffer))
   , m_NumComponents(std::accumulate(m_ComponentShape.cbegin(), m_ComponentShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
   , m_NumTuples(std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
-  , m_Size(m_NumTuples * m_NumComponents)
   {
   }
 
@@ -96,7 +94,6 @@ public:
   , m_TupleShape(other.m_TupleShape)
   , m_NumComponents(other.m_NumComponents)
   , m_NumTuples(other.m_NumTuples)
-  , m_Size(other.m_Size)
   {
     const usize count = other.getSize();
     auto data = new value_type[count];
@@ -114,7 +111,6 @@ public:
   , m_Data(std::move(other.m_Data))
   , m_NumComponents(std::move(other.m_NumComponents))
   , m_NumTuples(std::move(other.m_NumTuples))
-  , m_Size(std::move(other.m_Size))
   {
   }
 
@@ -334,7 +330,7 @@ public:
       return -1;
     }
 
-    // Consolodate the Tuple and Component Dims into a single array which is used
+    // Consolidate the Tuple and Component Dims into a single array which is used
     // to write the entire data array to HDF5
     std::vector<hsize_t> h5dims;
     for(const auto& value : m_TupleShape)
@@ -390,7 +386,6 @@ private:
   std::unique_ptr<value_type[]> m_Data = nullptr;
   size_t m_NumComponents = {0};
   size_t m_NumTuples = {0};
-  size_t m_Size = {0};
 };
 
 // Declare aliases

--- a/src/complex/DataStructure/DataStore.hpp
+++ b/src/complex/DataStructure/DataStore.hpp
@@ -49,9 +49,6 @@ public:
   DataStore(usize numTuples, std::optional<T> initValue)
   : DataStore({numTuples}, {1}, initValue)
   {
-    m_NumComponents = std::accumulate(m_ComponentShape.cbegin(), m_ComponentShape.cend(), static_cast<size_t>(1), std::multiplies<>());
-    m_NumTuples = std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>());
-    m_Size = m_NumTuples * m_NumComponents;
   }
 
   /**
@@ -97,9 +94,9 @@ public:
   DataStore(const DataStore& other)
   : m_ComponentShape(other.m_ComponentShape)
   , m_TupleShape(other.m_TupleShape)
-  , m_NumComponents(std::accumulate(m_ComponentShape.cbegin(), m_ComponentShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
-  , m_NumTuples(std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
-  , m_Size(m_NumTuples * m_NumComponents)
+  , m_NumComponents(other.m_NumComponents)
+  , m_NumTuples(other.m_NumTuples)
+  , m_Size(other.m_Size)
   {
     const usize count = other.getSize();
     auto data = new value_type[count];
@@ -112,12 +109,12 @@ public:
    * @param other
    */
   DataStore(DataStore&& other) noexcept
-  : m_TupleShape(std::move(other.m_TupleShape))
-  , m_ComponentShape(std::move(other.m_ComponentShape))
+  : m_ComponentShape(std::move(other.m_ComponentShape))
+  , m_TupleShape(std::move(other.m_TupleShape))
   , m_Data(std::move(other.m_Data))
-  , m_NumComponents(std::accumulate(m_ComponentShape.cbegin(), m_ComponentShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
-  , m_NumTuples(std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
-  , m_Size(m_NumTuples * m_NumComponents)
+  , m_NumComponents(std::move(other.m_NumComponents))
+  , m_NumTuples(std::move(other.m_NumTuples))
+  , m_Size(std::move(other.m_Size))
   {
   }
 

--- a/src/complex/DataStructure/EmptyDataStore.hpp
+++ b/src/complex/DataStructure/EmptyDataStore.hpp
@@ -31,9 +31,8 @@ public:
   /**
    * @brief Constructs an empty data store with a tuple getSize and count of 0.
    */
-  EmptyDataStore()
-  {
-  }
+  EmptyDataStore() = default;
+
 
   /**
    * @brief Constructs an empty data store with the specified tupleSize and tupleCount.
@@ -54,11 +53,11 @@ public:
    * @param other
    */
   EmptyDataStore(const EmptyDataStore& other)
-  : m_TupleShape(other.m_TupleShape)
-  , m_ComponentShape(other.m_ComponentShape)
-  , m_NumComponents(std::accumulate(m_ComponentShape.cbegin(), m_ComponentShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
-  , m_NumTuples(std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
-  , m_Size(m_NumTuples * m_NumComponents)
+  : m_ComponentShape(other.m_ComponentShape)
+  , m_TupleShape(other.m_TupleShape)
+  , m_NumComponents(other.m_NumComponents)
+  , m_NumTuples(other.m_NumTuples)
+  , m_Size(other.m_Size)
   {
   }
 
@@ -67,11 +66,11 @@ public:
    * @param other
    */
   EmptyDataStore(EmptyDataStore&& other) noexcept
-  : m_TupleShape(std::move(other.m_TupleShape))
-  , m_ComponentShape(std::move(other.m_ComponentShape))
-  , m_NumComponents(std::accumulate(m_ComponentShape.cbegin(), m_ComponentShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
-  , m_NumTuples(std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
-  , m_Size(m_NumTuples * m_NumComponents)
+  : m_ComponentShape(std::move(other.m_ComponentShape))
+  , m_TupleShape(std::move(other.m_TupleShape))
+  , m_NumComponents(std::move(other.m_NumComponents))
+  , m_NumTuples(std::move(other.m_NumTuples))
+  , m_Size(std::move(other.m_Size))
   {
   }
 

--- a/src/complex/DataStructure/EmptyDataStore.hpp
+++ b/src/complex/DataStructure/EmptyDataStore.hpp
@@ -43,6 +43,9 @@ public:
   EmptyDataStore(const ShapeType& tupleShape, const ShapeType& componentShape)
   : m_ComponentShape(componentShape)
   , m_TupleShape(tupleShape)
+  , m_NumComponents(std::accumulate(m_ComponentShape.cbegin(), m_ComponentShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
+  , m_NumTuples(std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
+  , m_Size(m_NumTuples * m_NumComponents)
   {
   }
 
@@ -53,6 +56,9 @@ public:
   EmptyDataStore(const EmptyDataStore& other)
   : m_TupleShape(other.m_TupleShape)
   , m_ComponentShape(other.m_ComponentShape)
+  , m_NumComponents(std::accumulate(m_ComponentShape.cbegin(), m_ComponentShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
+  , m_NumTuples(std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
+  , m_Size(m_NumTuples * m_NumComponents)
   {
   }
 
@@ -63,6 +69,9 @@ public:
   EmptyDataStore(EmptyDataStore&& other) noexcept
   : m_TupleShape(std::move(other.m_TupleShape))
   , m_ComponentShape(std::move(other.m_ComponentShape))
+  , m_NumComponents(std::accumulate(m_ComponentShape.cbegin(), m_ComponentShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
+  , m_NumTuples(std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
+  , m_Size(m_NumTuples * m_NumComponents)
   {
   }
 
@@ -74,7 +83,7 @@ public:
    */
   usize getNumberOfTuples() const override
   {
-    return std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>());
+    return m_NumTuples;
   }
 
   /**
@@ -83,7 +92,7 @@ public:
    */
   size_t getNumberOfComponents() const override
   {
-    return std::accumulate(m_ComponentShape.cbegin(), m_ComponentShape.cend(), static_cast<size_t>(1), std::multiplies<>());
+    return m_NumComponents;
   }
 
   /**
@@ -224,5 +233,8 @@ public:
 private:
   ShapeType m_ComponentShape;
   ShapeType m_TupleShape;
+  size_t m_NumComponents = {0};
+  size_t m_NumTuples = {0};
+  size_t m_Size = {0};
 };
 } // namespace complex

--- a/src/complex/DataStructure/EmptyDataStore.hpp
+++ b/src/complex/DataStructure/EmptyDataStore.hpp
@@ -33,7 +33,6 @@ public:
    */
   EmptyDataStore() = default;
 
-
   /**
    * @brief Constructs an empty data store with the specified tupleSize and tupleCount.
    * @param tupleSize

--- a/src/complex/DataStructure/EmptyDataStore.hpp
+++ b/src/complex/DataStructure/EmptyDataStore.hpp
@@ -43,7 +43,6 @@ public:
   , m_TupleShape(tupleShape)
   , m_NumComponents(std::accumulate(m_ComponentShape.cbegin(), m_ComponentShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
   , m_NumTuples(std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
-  , m_Size(m_NumTuples * m_NumComponents)
   {
   }
 
@@ -56,7 +55,6 @@ public:
   , m_TupleShape(other.m_TupleShape)
   , m_NumComponents(other.m_NumComponents)
   , m_NumTuples(other.m_NumTuples)
-  , m_Size(other.m_Size)
   {
   }
 
@@ -69,7 +67,6 @@ public:
   , m_TupleShape(std::move(other.m_TupleShape))
   , m_NumComponents(std::move(other.m_NumComponents))
   , m_NumTuples(std::move(other.m_NumTuples))
-  , m_Size(std::move(other.m_Size))
   {
   }
 
@@ -233,6 +230,5 @@ private:
   ShapeType m_TupleShape;
   size_t m_NumComponents = {0};
   size_t m_NumTuples = {0};
-  size_t m_Size = {0};
 };
 } // namespace complex


### PR DESCRIPTION
Methods in tight loops end up calling getNumberOfTuples() repeatedly which calculates
the same value over and over. Update the number of tuples, number of components
and size when the tuple shape is changed.

In one instance this gave a 3X speed up.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>