### PR TITLE
Topic/update h5 wrapper api

### DIFF
--- a/src/Plugins/ComplexCore/test/ImportHDF5DatasetTest.cpp
+++ b/src/Plugins/ComplexCore/test/ImportHDF5DatasetTest.cpp
@@ -157,13 +157,11 @@ void writeHDF5File()
   auto writerResults = H5::FileWriter::CreateFile(m_FilePath);
   REQUIRE(writerResults.valid());
   H5::FileWriter fileWriter = std::move(writerResults.value());
-  hid_t file_id = fileWriter.getId();
-  REQUIRE(file_id > 0);
+  REQUIRE(fileWriter.isValid());
 
   // Create the Pointer group
   H5::GroupWriter ptrGroupWriter = fileWriter.createGroupWriter("Pointer");
-  hid_t ptrId = ptrGroupWriter.getId();
-  REQUIRE(ptrId > 0);
+  REQUIRE(ptrGroupWriter.isValid());
 
   REQUIRE(writePointer1DArrayDataset<int8_t>(ptrGroupWriter) >= 0);
   REQUIRE(writePointer1DArrayDataset<uint8_t>(ptrGroupWriter) >= 0);

--- a/src/complex/Utilities/Parsing/HDF5/H5AttributeReader.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5AttributeReader.cpp
@@ -75,6 +75,12 @@ H5::Type H5::AttributeReader::getType() const
   return H5::getTypeFromId(getTypeId());
 }
 
+H5::IdType H5::AttributeReader::getClassType() const
+{
+  auto typeId = getTypeId();
+  return H5Tget_class(typeId);
+}
+
 H5::IdType H5::AttributeReader::getTypeId() const
 {
   return H5Aget_type(getAttributeId());

--- a/src/complex/Utilities/Parsing/HDF5/H5AttributeReader.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5AttributeReader.cpp
@@ -184,13 +184,13 @@ std::string H5::AttributeReader::readAsString() const
 }
 
 // declare readAsValue
-template int8_t H5::AttributeReader::readAsValue<int8_t>() const;
-template int16_t H5::AttributeReader::readAsValue<int16_t>() const;
-template int32_t H5::AttributeReader::readAsValue<int32_t>() const;
-template int64_t H5::AttributeReader::readAsValue<int64_t>() const;
-template uint8_t H5::AttributeReader::readAsValue<uint8_t>() const;
-template uint16_t H5::AttributeReader::readAsValue<uint16_t>() const;
-template uint32_t H5::AttributeReader::readAsValue<uint32_t>() const;
-template uint64_t H5::AttributeReader::readAsValue<uint64_t>() const;
-template float H5::AttributeReader::readAsValue<float>() const;
-template double H5::AttributeReader::readAsValue<double>() const;
+template COMPLEX_EXPORT int8_t H5::AttributeReader::readAsValue<int8_t>() const;
+template COMPLEX_EXPORT int16_t H5::AttributeReader::readAsValue<int16_t>() const;
+template COMPLEX_EXPORT int32_t H5::AttributeReader::readAsValue<int32_t>() const;
+template COMPLEX_EXPORT int64_t H5::AttributeReader::readAsValue<int64_t>() const;
+template COMPLEX_EXPORT uint8_t H5::AttributeReader::readAsValue<uint8_t>() const;
+template COMPLEX_EXPORT uint16_t H5::AttributeReader::readAsValue<uint16_t>() const;
+template COMPLEX_EXPORT uint32_t H5::AttributeReader::readAsValue<uint32_t>() const;
+template COMPLEX_EXPORT uint64_t H5::AttributeReader::readAsValue<uint64_t>() const;
+template COMPLEX_EXPORT float H5::AttributeReader::readAsValue<float>() const;
+template COMPLEX_EXPORT double H5::AttributeReader::readAsValue<double>() const;

--- a/src/complex/Utilities/Parsing/HDF5/H5AttributeReader.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5AttributeReader.hpp
@@ -83,6 +83,12 @@ public:
   H5::Type getType() const;
 
   /**
+   * @brief Returns an H5T_class_t enum representation of the attribute's class type.
+   * @return H5::Type
+   */
+  H5::IdType getClassType() const;
+
+  /**
    * @brief Returns the HDF5 type ID for the attribute. Returns 0 if the
    * attribute is invalid.
    * @return H5::TypeId

--- a/src/complex/Utilities/Parsing/HDF5/H5DatasetReader.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5DatasetReader.cpp
@@ -293,7 +293,7 @@ std::vector<hsize_t> H5::DatasetReader::getDimensions() const
   auto dataspaceId = getDataspaceId();
   if(dataspaceId >= 0)
   {
-    if(getType() == Type::string)
+    if(getClassType() == H5T_STRING)
     {
       auto typeId = getTypeId();
       size_t typeSize = H5Tget_size(typeId);

--- a/src/complex/Utilities/Parsing/HDF5/H5DatasetReader.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5DatasetReader.cpp
@@ -15,9 +15,8 @@ H5::DatasetReader::DatasetReader()
 }
 
 H5::DatasetReader::DatasetReader(H5::IdType parentId, const std::string& dataName)
-: ObjectReader(parentId)
+: ObjectReader(parentId, H5Dopen(parentId, dataName.c_str(), H5P_DEFAULT))
 {
-  m_DatasetId = H5Dopen(parentId, dataName.c_str(), H5P_DEFAULT);
 }
 
 H5::DatasetReader::~DatasetReader()
@@ -29,14 +28,9 @@ void H5::DatasetReader::closeHdf5()
 {
   if(isValid())
   {
-    H5Dclose(m_DatasetId);
-    m_DatasetId = 0;
+    H5Dclose(getId());
+    setId(0);
   }
-}
-
-H5::IdType H5::DatasetReader::getId() const
-{
-  return m_DatasetId;
 }
 
 H5::IdType H5::DatasetReader::getDataspaceId() const

--- a/src/complex/Utilities/Parsing/HDF5/H5DatasetReader.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5DatasetReader.cpp
@@ -50,6 +50,12 @@ H5::Type H5::DatasetReader::getType() const
   return H5::getTypeFromId(typeId);
 }
 
+H5::IdType H5::DatasetReader::getClassType() const
+{
+  auto typeId = getTypeId();
+  return H5Tget_class(typeId);
+}
+
 Result<DataType> H5::DatasetReader::getDataType() const
 {
   switch(getType())

--- a/src/complex/Utilities/Parsing/HDF5/H5DatasetReader.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5DatasetReader.hpp
@@ -53,6 +53,12 @@ public:
   H5::Type getType() const;
 
   /**
+   * @brief Returns an H5T_class_t enum representation of the attribute's class type.
+   * @return H5::Type
+   */
+  H5::IdType getClassType() const;
+
+  /**
    * @brief Returns a complex::DataType enum representation of the attribute's type or an error if there is no conversion.
    * @return DataType
    */

--- a/src/complex/Utilities/Parsing/HDF5/H5DatasetReader.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5DatasetReader.hpp
@@ -34,12 +34,6 @@ public:
   virtual ~DatasetReader();
 
   /**
-   * @brief Returns the dataset's ID. Returns 0 if the object is invalid.
-   * @return H5::IdType
-   */
-  H5::IdType getId() const override;
-
-  /**
    * @brief Returns the dataspace's HDF5 ID. Returns 0 if the attribute is
    * invalid.
    * @return IdType
@@ -129,9 +123,6 @@ protected:
    * @brief Closes the HDF5 ID and resets it to 0.
    */
   void closeHdf5() override;
-
-private:
-  H5::IdType m_DatasetId = 0;
 };
 extern template bool DatasetReader::readIntoSpan<int8>(nonstd::span<int8>) const;
 extern template bool DatasetReader::readIntoSpan<int16>(nonstd::span<int16>) const;

--- a/src/complex/Utilities/Parsing/HDF5/H5DatasetWriter.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5DatasetWriter.cpp
@@ -33,8 +33,8 @@ H5::DatasetWriter::~DatasetWriter()
 #if 0
 bool H5::DatasetWriter::tryOpeningDataset(const std::string& datasetName, H5::Type dataType)
 {
-  m_DatasetId = H5Dopen(getParentId(), datasetName.c_str(), H5P_DEFAULT);
-  if(m_DatasetId <= 0)
+  setId(H5Dopen(getParentId(), datasetName.c_str(), H5P_DEFAULT));
+  if(getId() <= 0)
   {
     return false;
   }
@@ -82,17 +82,17 @@ bool H5::DatasetWriter::tryCreatingDataset(const std::string& datasetName, H5::T
 {
   hid_t h5DataType = H5::getIdForType(dataType);
   hid_t dataspaceId = H5Screate_simple(getRank(), getDims().data(), nullptr);
-  m_DatasetId = H5Dcreate(getParentId(), datasetName.c_str(), h5DataType, dataspaceId, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  return m_DatasetId > 0;
+  setId(H5Dcreate(getParentId(), datasetName.c_str(), h5DataType, dataspaceId, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT));
+  return getId() > 0;
 }
 #endif
 
 void H5::DatasetWriter::closeHdf5()
 {
-  if(m_DatasetId > 0)
+  if(getId() > 0)
   {
-    H5Dclose(m_DatasetId);
-    m_DatasetId = 0;
+    H5Dclose(getId());
+    setId(0);
   }
 }
 
@@ -117,11 +117,11 @@ H5::ErrorType H5::DatasetWriter::findAndDeleteAttribute()
 void H5::DatasetWriter::createOrOpenDataset(H5::IdType typeId, H5::IdType dataspaceId)
 {
   HDF_ERROR_HANDLER_OFF
-  m_DatasetId = H5Dopen(getParentId(), getName().c_str(), H5P_DEFAULT);
+  setId(H5Dopen(getParentId(), getName().c_str(), H5P_DEFAULT));
   HDF_ERROR_HANDLER_ON
-  if(m_DatasetId < 0) // dataset does not exist so create it
+  if(getId() < 0) // dataset does not exist so create it
   {
-    m_DatasetId = H5Dcreate(getParentId(), getName().c_str(), typeId, dataspaceId, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    setId(H5Dcreate(getParentId(), getName().c_str(), typeId, dataspaceId, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT));
   }
 }
 
@@ -138,11 +138,6 @@ std::string H5::DatasetWriter::getName() const
   }
 
   return m_DatasetName;
-}
-
-H5::IdType H5::DatasetWriter::getId() const
-{
-  return m_DatasetId;
 }
 
 H5::ErrorType H5::DatasetWriter::writeString(const std::string& text)
@@ -172,11 +167,11 @@ H5::ErrorType H5::DatasetWriter::writeString(const std::string& text)
         {
           /* Create or open the dataset. */
           createOrOpenDataset(typeId, dataspaceId);
-          if(m_DatasetId >= 0)
+          if(getId() >= 0)
           {
             if(!text.empty())
             {
-              error = H5Dwrite(m_DatasetId, typeId, H5S_ALL, H5S_ALL, H5P_DEFAULT, text.c_str());
+              error = H5Dwrite(getId(), typeId, H5S_ALL, H5S_ALL, H5P_DEFAULT, text.c_str());
               if(error < 0)
               {
                 std::cout << "Error Writing String Data" << std::endl;
@@ -188,7 +183,7 @@ H5::ErrorType H5::DatasetWriter::writeString(const std::string& text)
           {
             returnError = 0;
           }
-          // H5_CLOSE_H5_DATASET(m_DatasetId, error, returnError, getName())
+          // H5_CLOSE_H5_DATASET(getId(), error, returnError, getName())
         }
         H5S_CLOSE_H5_DATASPACE(dataspaceId, error, returnError)
       }
@@ -210,8 +205,8 @@ H5::ErrorType H5::DatasetWriter::writeVectorOfStrings(std::vector<std::string>& 
   herr_t error = 0;
   herr_t returnError = 0;
 
-  m_DatasetId = H5Dopen(getParentId(), getName().c_str(), H5P_DEFAULT);
-  if(m_DatasetId < 0)
+  setId(H5Dopen(getParentId(), getName().c_str(), H5P_DEFAULT));
+  if(getId() < 0)
   {
     std::cout << "H5Lite.cpp::readVectorOfStringDataset(" << __LINE__ << ") Error opening Dataset at locationID (" << getParentId() << ") with object name (" << getParentName() << ")" << std::endl;
     return -1;
@@ -307,8 +302,8 @@ H5::ErrorType H5::DatasetWriter::writeVector(const DimsType& dims, const std::ve
     return -1;
   }
   /* Open the object */
-  m_DatasetId = H5::Support::OpenId(getParentId(), getName(), objectInfo.type);
-  if(m_DatasetId < 0)
+  setId(H5::Support::OpenId(getParentId(), getName(), objectInfo.type));
+  if(getId() < 0)
   {
     std::cout << "Error opening Object for Attribute operations." << std::endl;
     return -1;

--- a/src/complex/Utilities/Parsing/HDF5/H5DatasetWriter.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5DatasetWriter.hpp
@@ -43,13 +43,6 @@ public:
   bool isValid() const override;
 
   /**
-   * @brief Returns the dataset's HDF5 ID. Until one of the write* methods are
-   * called, this method returns 0.
-   * @return H5::IdType
-   */
-  H5::IdType getId() const override;
-
-  /**
    * @brief Returns the target dataset name. Returns an empty string if the
    * DatasetWriter is invalid.
    * @return std::string
@@ -109,8 +102,8 @@ public:
     //  return -1;
     //}
     /* Open the object */
-    // m_DatasetId = H5Dcreate(getParentId(), getName(), dataType, dataspaceId, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    // if(m_DatasetId < 0)
+    // setId(H5Dcreate(getParentId(), getName(), dataType, dataspaceId, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT));
+    // if(getId() < 0)
     //{
     //  std::cout << "Error opening Object for Attribute operations." << std::endl;
     //  return -1;
@@ -130,11 +123,11 @@ public:
         /* Create the attribute. */
         // hid_t attributeId = H5Acreate(getId(), getName().c_str(), dataType, dataspaceId, H5P_DEFAULT, H5P_DEFAULT);
         createOrOpenDataset(dataType, dataspaceId);
-        if(m_DatasetId >= 0)
+        if(getId() >= 0)
         {
           /* Write the attribute data. */
           const void* data = static_cast<const void*>(values.data());
-          error = H5Dwrite(m_DatasetId, dataType, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
+          error = H5Dwrite(getId(), dataType, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
           if(error < 0)
           {
             std::cout << "Error Writing Attribute" << std::endl;
@@ -144,7 +137,7 @@ public:
         else
         {
           std::cout << "Error Creating Dataset" << std::endl;
-          returnError = static_cast<herr_t>(m_DatasetId);
+          returnError = static_cast<herr_t>(getId());
         }
         /* Close the attribute. */
         // error = H5Aclose(attributeId);
@@ -185,19 +178,18 @@ protected:
    */
   void createOrOpenDataset(H5::IdType typeId, H5::IdType dataspaceId);
 
+  /**
+   * @brief Closes the HDF5 dataset and resets the ID to 0.
+   */
+  virtual void closeHdf5() override;
+
 private:
 #if 0
   bool tryOpeningDataset(const std::string& datasetName, H5::Type dataType);
   bool tryCreatingDataset(const std::string& datasetName, H5::Type dataType);
 #endif
 
-  /**
-   * @brief Closes the HDF5 dataset and resets the ID to 0.
-   */
-  void closeHdf5();
-
   const std::string m_DatasetName;
-  hid_t m_DatasetId = 0;
 };
 } // namespace H5
 } // namespace complex

--- a/src/complex/Utilities/Parsing/HDF5/H5DatasetWriter.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5DatasetWriter.hpp
@@ -181,7 +181,7 @@ protected:
   /**
    * @brief Closes the HDF5 dataset and resets the ID to 0.
    */
-  virtual void closeHdf5() override;
+  void closeHdf5() override;
 
 private:
 #if 0

--- a/src/complex/Utilities/Parsing/HDF5/H5FileReader.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5FileReader.cpp
@@ -7,14 +7,12 @@
 using namespace complex;
 
 H5::FileReader::FileReader(const std::filesystem::path& filepath)
-: GroupReader()
+: GroupReader(0, H5Fopen(filepath.string().c_str(), H5F_ACC_RDONLY, H5P_DEFAULT))
 {
-  m_FileId = H5Fopen(filepath.string().c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
 }
 
 H5::FileReader::FileReader(H5::IdType fileId)
-: GroupReader()
-, m_FileId(fileId)
+: GroupReader(0, fileId)
 {
 }
 
@@ -27,14 +25,9 @@ void H5::FileReader::closeHdf5()
 {
   if(isValid())
   {
-    H5Fclose(m_FileId);
-    m_FileId = 0;
+    H5Fclose(getId());
+    setId(0);
   }
-}
-
-H5::IdType H5::FileReader::getId() const
-{
-  return m_FileId;
 }
 
 std::string H5::FileReader::getName() const

--- a/src/complex/Utilities/Parsing/HDF5/H5FileReader.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5FileReader.hpp
@@ -35,12 +35,6 @@ public:
   virtual ~FileReader();
 
   /**
-   * @brief Returns the file's HDF5 ID. Returns 0 if the object is invalid.
-   * @return H5::IdType
-   */
-  H5::IdType getId() const override;
-
-  /**
    * @brief Returns the HDF5 file name. Returns an empty string if the file
    * is invalid.
    * @return std::string
@@ -52,9 +46,6 @@ protected:
    * @brief Closes the HDF5 ID and resets it to 0.
    */
   void closeHdf5() override;
-
-private:
-  H5::IdType m_FileId;
 };
 } // namespace H5
 } // namespace complex

--- a/src/complex/Utilities/Parsing/HDF5/H5FileWriter.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5FileWriter.hpp
@@ -47,12 +47,6 @@ public:
   ~FileWriter() override;
 
   /**
-   * @brief Returns the file's HDF5 ID. Returns 0 if the object is invalid.
-   * @return H5::IdType
-   */
-  H5::IdType getId() const override;
-
-  /**
    * @brief Returns the HDF5 file name. Returns an empty string if the writer
    * is invalid.
    * @return std::string
@@ -78,10 +72,7 @@ protected:
   /**
    * @brief Closes the HDF5 ID and resets it to 0.
    */
-  void closeHdf5();
-
-private:
-  H5::IdType m_FileId = 0;
+  virtual void closeHdf5() override;
 };
 } // namespace H5
 } // namespace complex

--- a/src/complex/Utilities/Parsing/HDF5/H5FileWriter.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5FileWriter.hpp
@@ -72,7 +72,7 @@ protected:
   /**
    * @brief Closes the HDF5 ID and resets it to 0.
    */
-  virtual void closeHdf5() override;
+  void closeHdf5() override;
 };
 } // namespace H5
 } // namespace complex

--- a/src/complex/Utilities/Parsing/HDF5/H5GroupReader.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5GroupReader.cpp
@@ -12,9 +12,13 @@ using namespace complex;
 H5::GroupReader::GroupReader() = default;
 
 H5::GroupReader::GroupReader(H5::IdType parentId, const std::string& groupName)
-: ObjectReader(parentId)
+: ObjectReader(parentId, H5Gopen(parentId, groupName.c_str(), H5P_DEFAULT))
 {
-  m_GroupId = H5Gopen(parentId, groupName.c_str(), H5P_DEFAULT);
+}
+
+H5::GroupReader::GroupReader(H5::IdType parentId, H5::IdType objectId)
+: ObjectReader(parentId, objectId)
+{
 }
 
 H5::GroupReader::~GroupReader()
@@ -26,14 +30,9 @@ void H5::GroupReader::closeHdf5()
 {
   if(isValid())
   {
-    H5Gclose(m_GroupId);
-    m_GroupId = 0;
+    H5Gclose(getId());
+    setId(0);
   }
-}
-
-H5::IdType H5::GroupReader::getId() const
-{
-  return m_GroupId;
 }
 
 H5::GroupReader H5::GroupReader::openGroup(const std::string& name) const

--- a/src/complex/Utilities/Parsing/HDF5/H5GroupReader.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5GroupReader.hpp
@@ -27,12 +27,6 @@ public:
   virtual ~GroupReader();
 
   /**
-   * @brief Returns the wrapped HDF5 group ID.
-   * @return H5::IdType
-   */
-  H5::IdType getId() const override;
-
-  /**
    * @brief Attempts to open a nested HDF5 group with the specified name.
    * The created GroupReader is returned. If the process fails, the returned
    * GroupReader is invalid.
@@ -99,8 +93,14 @@ protected:
    */
   void closeHdf5() override;
 
-private:
-  H5::IdType m_GroupId = 0;
+  /**
+   * @brief Constructs a GroupReader for use in derived classes. This
+   * constructor only accepts the parent ID and the (object) ID. Derived classes are required to
+   * open their own target and provide the ID.
+   * @param parentId
+   * @param objectId
+   */
+  GroupReader(H5::IdType parentId, H5::IdType objectId);
 };
 } // namespace H5
 } // namespace complex

--- a/src/complex/Utilities/Parsing/HDF5/H5GroupWriter.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5GroupWriter.cpp
@@ -11,6 +11,11 @@ H5::GroupWriter::GroupWriter()
 {
 }
 
+H5::GroupWriter::GroupWriter(H5::IdType parentId, H5::IdType objectId)
+: ObjectWriter(parentId, objectId)
+{
+}
+
 H5::GroupWriter::GroupWriter(H5::IdType parentId, const std::string& groupName)
 : ObjectWriter(parentId)
 {
@@ -21,11 +26,11 @@ H5::GroupWriter::GroupWriter(H5::IdType parentId, const std::string& groupName)
 
   if(status == 0) // if group exists...
   {
-    m_GroupId = H5Gopen(parentId, groupName.c_str(), H5P_DEFAULT);
+    setId(H5Gopen(parentId, groupName.c_str(), H5P_DEFAULT));
   }
   else // if group does not exist...
   {
-    m_GroupId = H5Gcreate(parentId, groupName.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    setId(H5Gcreate(parentId, groupName.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT));
   }
 }
 
@@ -38,19 +43,14 @@ void H5::GroupWriter::closeHdf5()
 {
   if(isValid())
   {
-    H5Oclose(m_GroupId);
-    m_GroupId = 0;
+    H5Oclose(getId());
+    setId(0);
   }
 }
 
 bool H5::GroupWriter::isValid() const
 {
   return getId() > 0;
-}
-
-H5::IdType H5::GroupWriter::getId() const
-{
-  return m_GroupId;
 }
 
 H5::GroupWriter H5::GroupWriter::createGroupWriter(const std::string& childName)

--- a/src/complex/Utilities/Parsing/HDF5/H5GroupWriter.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5GroupWriter.hpp
@@ -68,7 +68,7 @@ protected:
   /**
    * @brief Closes the HDF5 ID and resets it to 0.
    */
-  virtual void closeHdf5() override;
+  void closeHdf5() override;
 
   /**
    * @brief Constructs a GroupWriter for use in derived classes. This

--- a/src/complex/Utilities/Parsing/HDF5/H5GroupWriter.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5GroupWriter.hpp
@@ -38,12 +38,6 @@ public:
   bool isValid() const override;
 
   /**
-   * @brief Returns the group's HDF5 ID. Returns 0 if the object is invalid.
-   * @return H5::IdType
-   */
-  H5::IdType getId() const override;
-
-  /**
    * @brief Creates a GroupWriter for writing to a child group with the
    * target name. Returns an invalid GroupWriter if the group cannot be
    * created.
@@ -74,10 +68,16 @@ protected:
   /**
    * @brief Closes the HDF5 ID and resets it to 0.
    */
-  void closeHdf5();
+  virtual void closeHdf5() override;
 
-private:
-  H5::IdType m_GroupId = 0;
+  /**
+   * @brief Constructs a GroupWriter for use in derived classes. This
+   * constructor only accepts the parent ID and the (object) ID. Derived classes are required to
+   * open their own target and provide the ID.
+   * @param parentId
+   * @param objectId
+   */
+  GroupWriter(H5::IdType parentId, H5::IdType objectId);
 };
 } // namespace H5
 } // namespace complex

--- a/src/complex/Utilities/Parsing/HDF5/H5ObjectReader.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5ObjectReader.cpp
@@ -13,10 +13,16 @@ H5::ObjectReader::ObjectReader(H5::IdType parentId)
 {
 }
 
+H5::ObjectReader::ObjectReader(H5::IdType parentId, H5::IdType objectId)
+: m_ParentId(parentId)
+, m_Id(objectId)
+{
+}
+
 H5::ObjectReader::ObjectReader(H5::IdType parentId, const std::string& targetName)
 : m_ParentId(parentId)
 {
-  m_ObjectId = H5Oopen(parentId, targetName.c_str(), H5P_DEFAULT);
+  m_Id = H5Oopen(parentId, targetName.c_str(), H5P_DEFAULT);
 }
 
 H5::ObjectReader::~ObjectReader()
@@ -28,8 +34,8 @@ void H5::ObjectReader::closeHdf5()
 {
   if(isValid())
   {
-    H5Oclose(m_ObjectId);
-    m_ObjectId = 0;
+    H5Oclose(m_Id);
+    m_Id = 0;
   }
 }
 
@@ -51,13 +57,18 @@ size_t H5::ObjectReader::getObjectId() const
   }
 
   H5O_info1_t info;
-  H5Oget_info(m_ObjectId, &info);
+  H5Oget_info(m_Id, &info);
   return info.addr;
 }
 
 H5::IdType H5::ObjectReader::getId() const
 {
-  return m_ObjectId;
+  return m_Id;
+}
+
+void H5::ObjectReader::setId(H5::IdType id)
+{
+  m_Id = id;
 }
 
 std::string H5::ObjectReader::getName() const

--- a/src/complex/Utilities/Parsing/HDF5/H5ObjectReader.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5ObjectReader.cpp
@@ -84,11 +84,11 @@ size_t H5::ObjectReader::getNumAttributes() const
 
 std::vector<std::string> H5::ObjectReader::getAttributeNames() const
 {
-  std::vector<std::string> attributeNames;
   auto numAttributes = getNumAttributes();
+  std::vector<std::string> attributeNames(numAttributes);
   for(size_t i = 0; i < numAttributes; i++)
   {
-    getAttributeByIdx(i);
+    attributeNames[i] = getAttributeByIdx(i).getName();
   }
 
   return attributeNames;

--- a/src/complex/Utilities/Parsing/HDF5/H5ObjectReader.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5ObjectReader.cpp
@@ -49,7 +49,7 @@ H5::IdType H5::ObjectReader::getParentId() const
   return m_ParentId;
 }
 
-size_t H5::ObjectReader::getObjectId() const
+haddr_t H5::ObjectReader::getObjectId() const
 {
   if(!isValid())
   {

--- a/src/complex/Utilities/Parsing/HDF5/H5ObjectReader.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5ObjectReader.cpp
@@ -43,6 +43,18 @@ H5::IdType H5::ObjectReader::getParentId() const
   return m_ParentId;
 }
 
+size_t H5::ObjectReader::getObjectId() const
+{
+  if(!isValid())
+  {
+    return 0;
+  }
+
+  H5O_info1_t info;
+  H5Oget_info(m_ObjectId, &info);
+  return info.addr;
+}
+
 H5::IdType H5::ObjectReader::getId() const
 {
   return m_ObjectId;

--- a/src/complex/Utilities/Parsing/HDF5/H5ObjectReader.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5ObjectReader.hpp
@@ -55,7 +55,13 @@ public:
    * @brief Returns the object's HDF5 ID. Returns 0 if the object is invalid.
    * @return H5::IdType
    */
-  virtual H5::IdType getId() const;
+  H5::IdType getId() const;
+
+  /**
+   * @brief Sets the object's HDF5 ID.
+   * @return H5::IdType
+   */
+  void setId(H5::IdType id);
 
   /**
    * @brief Returns the HDF5 object name. Returns an empty string if the file
@@ -103,13 +109,22 @@ protected:
   ObjectReader(H5::IdType parentId);
 
   /**
+   * @brief Constructs an ObjectReader for use in derived classes. This
+   * constructor only accepts the parent ID and the (object) ID. Derived classes are required to
+   * open their own target and provide the ID.
+   * @param parentId
+   * @param objectId
+   */
+  ObjectReader(H5::IdType parentId, H5::IdType objectId);
+
+  /**
    * @brief Closes the HDF5 ID and resets it to 0.
    */
   virtual void closeHdf5();
 
 private:
   H5::IdType m_ParentId = 0;
-  H5::IdType m_ObjectId = 0;
+  H5::IdType m_Id = 0; // the object, group, file, or dataset id
 };
 } // namespace H5
 } // namespace complex

--- a/src/complex/Utilities/Parsing/HDF5/H5ObjectReader.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5ObjectReader.hpp
@@ -49,7 +49,7 @@ public:
    * @brief Returns the object's address ID. Returns 0 if the object is invalid.
    * @return H5::IdType
    */
-  size_t getObjectId() const;
+  haddr_t getObjectId() const;
 
   /**
    * @brief Returns the object's HDF5 ID. Returns 0 if the object is invalid.

--- a/src/complex/Utilities/Parsing/HDF5/H5ObjectReader.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5ObjectReader.hpp
@@ -46,6 +46,12 @@ public:
   H5::IdType getParentId() const;
 
   /**
+   * @brief Returns the object's address ID. Returns 0 if the object is invalid.
+   * @return H5::IdType
+   */
+  size_t getObjectId() const;
+
+  /**
    * @brief Returns the object's HDF5 ID. Returns 0 if the object is invalid.
    * @return H5::IdType
    */

--- a/src/complex/Utilities/Parsing/HDF5/H5ObjectWriter.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5ObjectWriter.cpp
@@ -10,8 +10,9 @@ H5::ObjectWriter::ObjectWriter()
 {
 }
 
-H5::ObjectWriter::ObjectWriter(H5::IdType parentId)
+H5::ObjectWriter::ObjectWriter(H5::IdType parentId, H5::IdType objectId)
 : m_ParentId(parentId)
+, m_Id(objectId)
 {
 }
 
@@ -42,6 +43,16 @@ std::string H5::ObjectWriter::getParentName() const
   std::string path = H5::GetNameFromId(getParentId());
 
   return path;
+}
+
+H5::IdType H5::ObjectWriter::getId() const
+{
+  return m_Id;
+}
+
+void H5::ObjectWriter::setId(H5::IdType id)
+{
+  m_Id = id;
 }
 
 std::string H5::ObjectWriter::getName() const

--- a/src/complex/Utilities/Parsing/HDF5/H5ObjectWriter.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5ObjectWriter.hpp
@@ -23,8 +23,9 @@ public:
    * belonging to the specified parent. Opening the target HDF5 object is
    * left to the derived class.
    * @param parentId
+   * @param objectId
    */
-  ObjectWriter(H5::IdType parentId);
+  ObjectWriter(H5::IdType parentId, H5::IdType objectId = 0);
 
   /**
    * @brief Releases the wrapped HDF5 object.
@@ -61,7 +62,13 @@ public:
    * @brief Returns the group's HDF5 ID. Returns 0 if the object is invalid.
    * @return H5::IdType
    */
-  virtual H5::IdType getId() const = 0;
+  H5::IdType getId() const;
+
+  /**
+   * @brief Sets the object's HDF5 ID.
+   * @return H5::IdType
+   */
+  void setId(H5::IdType id);
 
   /**
    * @brief Returns the HDF5 object name. Returns an empty string if the writer
@@ -85,8 +92,15 @@ public:
    */
   AttributeWriter createAttribute(const std::string& name);
 
+protected:
+  /**
+   * @brief Closes the HDF5 ID and resets it to 0.
+   */
+  virtual void closeHdf5() = 0;
+
 private:
   H5::IdType m_ParentId = 0;
+  H5::IdType m_Id = 0; // the object, group, file, or dataset id
 };
 } // namespace H5
 } // namespace complex


### PR DESCRIPTION
- Add COMPLEX_EXPORT to AttributeReader template definitions for use outside of complex
- Add a getClassType function to H5DatasetReader and H5AttributeReader for returning the H5T_class_t enum value as an int64 type
- Add getObjectId function to H5ObjectReader for accessing the object's Id address
- Fix DatasetReader::getDimensions fct alg when type is a string ( DatasetReader::getType will currently never be able to return a string )
- Fix ObjectReader::getAttributeNames fct to actually populate the vector with the attribute names before returning
- Simplify id data member storage in the H5*[Reader/Writer] classes by using a single id data member in the ObjectReader class 