### PR TITLE
Fixed BoolArray to/from HDF5 changes type

### DIFF
--- a/src/complex/DataStructure/DataStore.hpp
+++ b/src/complex/DataStructure/DataStore.hpp
@@ -400,6 +400,7 @@ using Int32DataStore = DataStore<int32>;
 using Int64DataStore = DataStore<int64>;
 
 using USizeDataStore = DataStore<usize>;
+using BoolDataStore = DataStore<bool>;
 
 using Float32DataStore = DataStore<float32>;
 using Float64DataStore = DataStore<float64>;

--- a/src/complex/DataStructure/Factory/DataArrayFactory.hpp
+++ b/src/complex/DataStructure/Factory/DataArrayFactory.hpp
@@ -94,6 +94,9 @@ public:
     std::string dataArrayName = datasetReader.getName();
     DataObject::IdType importId = ReadObjectId(datasetReader);
 
+    auto dataTypeAttribute = datasetReader.getAttribute(complex::Constants::k_ObjectTypeTag);
+    const bool isBoolArray = (dataTypeAttribute.isValid() && dataTypeAttribute.readAsString().compare("DataArray<bool>") == 0);
+
     // Check importablility
     auto importableAttribute = datasetReader.getAttribute(complex::Constants::k_ImportableTag);
     if(importableAttribute.isValid() && importableAttribute.readAsValue<int32>() == 0)
@@ -122,7 +125,14 @@ public:
       importDataArray<int64>(dataStructureReader.getDataStructure(), datasetReader, dataArrayName, importId, err, parentId, preflight);
       break;
     case H5::Type::uint8:
-      importDataArray<uint8>(dataStructureReader.getDataStructure(), datasetReader, dataArrayName, importId, err, parentId, preflight);
+      if(isBoolArray)
+      {
+        importDataArray<bool>(dataStructureReader.getDataStructure(), datasetReader, dataArrayName, importId, err, parentId, preflight);
+      }
+      else
+      {
+        importDataArray<uint8>(dataStructureReader.getDataStructure(), datasetReader, dataArrayName, importId, err, parentId, preflight);
+      }
       break;
     case H5::Type::uint16:
       importDataArray<uint16>(dataStructureReader.getDataStructure(), datasetReader, dataArrayName, importId, err, parentId, preflight);

--- a/src/complex/Utilities/Parsing/HDF5/H5DatasetReader.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5DatasetReader.cpp
@@ -336,6 +336,7 @@ template COMPLEX_EXPORT bool H5::DatasetReader::readIntoSpan<uint8>(nonstd::span
 template COMPLEX_EXPORT bool H5::DatasetReader::readIntoSpan<uint16>(nonstd::span<uint16>) const;
 template COMPLEX_EXPORT bool H5::DatasetReader::readIntoSpan<uint32>(nonstd::span<uint32>) const;
 template COMPLEX_EXPORT bool H5::DatasetReader::readIntoSpan<uint64>(nonstd::span<uint64>) const;
+template COMPLEX_EXPORT bool H5::DatasetReader::readIntoSpan<bool>(nonstd::span<bool>) const;
 #ifdef __APPLE__
 template COMPLEX_EXPORT bool H5::DatasetReader::readIntoSpan<usize>(nonstd::span<usize>) const;
 #endif

--- a/src/complex/Utilities/Parsing/HDF5/H5DatasetReader.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5DatasetReader.hpp
@@ -124,6 +124,7 @@ protected:
    */
   void closeHdf5() override;
 };
+extern template bool DatasetReader::readIntoSpan<bool>(nonstd::span<bool>) const;
 extern template bool DatasetReader::readIntoSpan<int8>(nonstd::span<int8>) const;
 extern template bool DatasetReader::readIntoSpan<int16>(nonstd::span<int16>) const;
 extern template bool DatasetReader::readIntoSpan<int32>(nonstd::span<int32>) const;


### PR DESCRIPTION
* Fixes DataArray<bool> converting to DataArray<uint8> when reading from HDF5.
* Added DataStore<bool> alias.
* Added unit test checking HDF5 DataArray type consistency round trip.
* Tests bool array value consistent between reading and writing.

fixes #247