### PR TITLE
Update GitHub Actions to use MacOS 11.6 (Big Sur).

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-10.15
+          - macos-11
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout


### PR DESCRIPTION
GitHub is deprecating macOS 10.15 (Catalina) in AUG 2022

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>