### PR TITLE
Ensure the pluginId is available in the unordered_map before using .at()

### DIFF
--- a/src/complex/Filter/FilterList.cpp
+++ b/src/complex/Filter/FilterList.cpp
@@ -48,6 +48,12 @@ IFilter::UniquePointer FilterList::createFilter(const FilterHandle& handle) cons
   {
     return nullptr;
   }
+  // Look to make sure the plugin is available. Unordered_Map.at() will throw exceptions if the key is not found.
+  if(m_PluginMap.find(handle.getPluginId()) == m_PluginMap.end())
+  {
+    return nullptr;
+  }
+
   // Plugin filter
   const auto& loader = m_PluginMap.at(handle.getPluginId());
   if(!loader->isLoaded())


### PR DESCRIPTION

std::unordered_map.at() will throw exception if the key is not in the map

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>