### PR TITLE
Added MoveData filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ set(COMPLEX_HDRS
 
   ${COMPLEX_SOURCE_DIR}/Plugin/AbstractPlugin.hpp
   ${COMPLEX_SOURCE_DIR}/Plugin/PluginLoader.hpp
-  
+
   ${COMPLEX_SOURCE_DIR}/DataStructure/Montage/AbstractMontage.hpp
   ${COMPLEX_SOURCE_DIR}/DataStructure/Montage/AbstractTileIndex.hpp
   ${COMPLEX_SOURCE_DIR}/DataStructure/Montage/GridMontage.hpp
@@ -268,6 +268,7 @@ set(COMPLEX_HDRS
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/ImportH5ObjectPathsAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/ImportObjectAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/EmptyAction.hpp
+  ${COMPLEX_SOURCE_DIR}/Filter/Actions/MoveDataAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/RenameDataAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/UpdateImageGeomAction.hpp
 
@@ -333,7 +334,6 @@ set(COMPLEX_HDRS
   ${COMPLEX_SOURCE_DIR}/Utilities/Parsing/HDF5/H5ObjectWriter.hpp
   ${COMPLEX_SOURCE_DIR}/Utilities/Parsing/HDF5/H5Support.hpp
   ${COMPLEX_SOURCE_DIR}/Utilities/Parsing/HDF5/H5Constants.hpp
-
 
   ${COMPLEX_SOURCE_DIR}/Utilities/Parsing/Text/CsvParser.hpp
 )
@@ -427,6 +427,7 @@ set(COMPLEX_SRCS
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/DeleteDataAction.cpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/ImportH5ObjectPathsAction.cpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/ImportObjectAction.cpp
+  ${COMPLEX_SOURCE_DIR}/Filter/Actions/MoveDataAction.cpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/RenameDataAction.cpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/UpdateImageGeomAction.cpp
 
@@ -488,7 +489,7 @@ set(COMPLEX_SRCS
   ${COMPLEX_SOURCE_DIR}/Utilities/Parsing/HDF5/H5Support.cpp
 
   ${COMPLEX_SOURCE_DIR}/Utilities/Parsing/Text/CsvParser.cpp
-  )
+)
 
 
 # Add Core FilterParameters

--- a/src/Plugins/ComplexCore/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/CMakeLists.txt
@@ -3,7 +3,7 @@ include("${complex_SOURCE_DIR}/cmake/Plugin.cmake")
 set(PLUGIN_NAME "ComplexCore")
 set(${PLUGIN_NAME}_SOURCE_DIR ${complex_SOURCE_DIR}/src/Plugins/${PLUGIN_NAME})
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # These are all the filters in the plugin. All filters should be kept in the
 # PLUGIN_NAME/src/PLUGIN_NAME/Filters/ directory.
 set(FilterList
@@ -41,6 +41,7 @@ set(FilterList
   LinkGeometryDataFilter
   MapPointCloudToRegularGridFilter
   MinNeighbors
+  MoveData
   MultiThresholdObjects
   PointSampleTriangleGeometryFilter
   QuickSurfaceMeshFilter

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MoveData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MoveData.cpp
@@ -1,0 +1,66 @@
+#include "MoveData.hpp"
+
+#include "complex/DataStructure/BaseGroup.hpp"
+#include "complex/Filter/Actions/MoveDataAction.hpp"
+#include "complex/Parameters/DataGroupSelectionParameter.hpp"
+#include "complex/Parameters/DataPathSelectionParameter.hpp"
+
+namespace complex
+{
+namespace
+{
+constexpr int64 k_TupleCountInvalidError = -250;
+constexpr int64 k_MissingFeaturePhasesError = -251;
+
+} // namespace
+
+std::string MoveData::name() const
+{
+  return FilterTraits<MoveData>::name;
+}
+
+std::string MoveData::className() const
+{
+  return FilterTraits<MoveData>::className;
+}
+
+Uuid MoveData::uuid() const
+{
+  return FilterTraits<MoveData>::uuid;
+}
+
+std::string MoveData::humanName() const
+{
+  return "Move Data";
+}
+
+Parameters MoveData::parameters() const
+{
+  Parameters params;
+  params.insert(std::make_unique<DataPathSelectionParameter>(k_Data_Key, "Data to Move", "", DataPath()));
+  params.insert(std::make_unique<DataGroupSelectionParameter>(k_NewParent_Key, "New Parent", "", DataPath()));
+  return params;
+}
+
+IFilter::UniquePointer MoveData::clone() const
+{
+  return std::make_unique<MoveData>();
+}
+
+IFilter::PreflightResult MoveData::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+{
+  auto dataPath = args.value<DataPath>(k_Data_Key);
+  auto newParentPath = args.value<DataPath>(k_NewParent_Key);
+
+  auto moveDataAction = std::make_unique<MoveDataAction>(dataPath, newParentPath);
+
+  OutputActions actions;
+  actions.actions.push_back(std::move(moveDataAction));
+  return {std::move(actions)};
+}
+
+Result<> MoveData::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+{
+  return {};
+}
+} // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MoveData.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MoveData.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "ComplexCore/ComplexCore_export.hpp"
+
+#include "complex/Common/StringLiteral.hpp"
+#include "complex/Filter/FilterTraits.hpp"
+#include "complex/Filter/IFilter.hpp"
+
+namespace complex
+{
+class COMPLEXCORE_EXPORT MoveData : public IFilter
+{
+public:
+  MoveData() = default;
+  ~MoveData() noexcept override = default;
+
+  MoveData(const MoveData&) = delete;
+  MoveData(MoveData&&) noexcept = delete;
+
+  MoveData& operator=(const MoveData&) = delete;
+  MoveData& operator=(MoveData&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_Data_Key = "data";
+  static inline constexpr StringLiteral k_OriginalParent_Key = "original_parent";
+  static inline constexpr StringLiteral k_NewParent_Key = "new_parent";
+
+  /**
+   * @brief
+   * @return std::name
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the C++ classname of this filter.
+   * @return std::string
+   */
+  std::string className() const override;
+
+  /**
+   * @brief
+   * @return Uuid
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief
+   * @return std::string
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief
+   * @return Parameters
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief
+   * @return IFilter::UniquePointer
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief
+   * @param data
+   * @param args
+   * @param messageHandler
+   * @return PreflightResult
+   */
+  PreflightResult preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+
+  /**
+   * @brief
+   * @param data
+   * @param args
+   * @param pipelineNode
+   * @param messageHandler
+   * @return Result<>
+   */
+  Result<> executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+};
+} // namespace complex
+
+COMPLEX_DEF_FILTER_TRAITS(complex, MoveData, "651e5894-ab7c-4176-b7f0-ea466c521753");

--- a/src/Plugins/ComplexCore/test/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/test/CMakeLists.txt
@@ -33,6 +33,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   LaplacianSmoothingFilterTest.cpp
   MapPointCloudToRegularGridTest.cpp
   MinNeighborsTest.cpp
+  MoveDataTest.cpp
   PointSampleTriangleGeometryFilterTest.cpp
   QuickSurfaceMeshFilterTest.cpp
   ImportCSVDataTest.cpp

--- a/src/Plugins/ComplexCore/test/MoveDataTest.cpp
+++ b/src/Plugins/ComplexCore/test/MoveDataTest.cpp
@@ -29,7 +29,7 @@ DataStructure createDataStructure()
 }
 } // namespace
 
-TEST_CASE("Move Data Successful", "MoveData")
+TEST_CASE("ComplexCore::MoveData Successful", "[Complex::Core][MoveData]")
 {
   MoveData filter;
   Arguments args;
@@ -61,7 +61,7 @@ TEST_CASE("Move Data Successful", "MoveData")
   REQUIRE(dataGraph.getDataAs<DataGroup>(newGroup3Path) != nullptr);
 }
 
-TEST_CASE("Move Data Unsuccessful", "MoveData")
+TEST_CASE("ComplexCore::MoveData Unsuccessful", "[Complex::Core][MoveData]")
 {
   MoveData filter;
   Arguments args;

--- a/src/Plugins/ComplexCore/test/MoveDataTest.cpp
+++ b/src/Plugins/ComplexCore/test/MoveDataTest.cpp
@@ -1,0 +1,79 @@
+#include <catch2/catch.hpp>
+
+#include "ComplexCore/Filters/MoveData.hpp"
+
+#include "complex/DataStructure/DataGroup.hpp"
+#include "complex/UnitTest/UnitTestCommon.hpp"
+
+#include <set>
+
+using namespace complex;
+
+namespace
+{
+constexpr StringLiteral k_Group1Name = "Group1";
+constexpr StringLiteral k_Group2Name = "Group2";
+constexpr StringLiteral k_Group3Name = "Group3";
+constexpr StringLiteral k_Group4Name = "Group4";
+
+DataStructure createDataStructure()
+{
+  DataStructure data;
+  auto group1 = DataGroup::Create(data, k_Group1Name);
+  auto group2 = DataGroup::Create(data, k_Group2Name);
+  auto group3 = DataGroup::Create(data, k_Group3Name, group2->getId());
+  auto group4 = DataGroup::Create(data, k_Group4Name, group2->getId());
+
+  data.setAdditionalParent(group4->getId(), group3->getId());
+  return data;
+}
+} // namespace
+
+TEST_CASE("Move Data Successful", "MoveData")
+{
+  MoveData filter;
+  Arguments args;
+  DataStructure dataGraph = createDataStructure();
+
+  const DataPath k_Group1Path({k_Group1Name});
+  const DataPath k_Group3Path({k_Group2Name, k_Group3Name});
+
+  args.insertOrAssign(MoveData::k_Data_Key, std::make_any<DataPath>(k_Group3Path));
+  args.insertOrAssign(MoveData::k_NewParent_Key, std::make_any<DataPath>(k_Group1Path));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataGraph, args);
+  COMPLEX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataGraph, args);
+  COMPLEX_RESULT_REQUIRE_VALID(executeResult.result);
+
+  const auto* group1 = dataGraph.getDataAs<DataGroup>(k_Group1Path);
+  REQUIRE(group1->getDataMap().getSize() == 1);
+
+  const auto* group2 = dataGraph.getDataAs<DataGroup>(DataPath({k_Group2Name}));
+  REQUIRE(group2->getDataMap().getSize() == 1);
+
+  REQUIRE(dataGraph.getDataAs<DataGroup>(k_Group3Path) == nullptr);
+
+  const DataPath newGroup3Path = k_Group1Path.createChildPath(k_Group3Name);
+  REQUIRE(dataGraph.getDataAs<DataGroup>(newGroup3Path) != nullptr);
+}
+
+TEST_CASE("Move Data Unsuccessful", "MoveData")
+{
+  MoveData filter;
+  Arguments args;
+  DataStructure dataGraph = createDataStructure();
+
+  const DataPath k_Group2Path({k_Group2Name});
+  const DataPath k_Group3Path({k_Group3Name});
+
+  args.insertOrAssign(MoveData::k_Data_Key, std::make_any<DataPath>(k_Group3Path));
+  args.insertOrAssign(MoveData::k_NewParent_Key, std::make_any<DataPath>(k_Group2Path));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataGraph, args);
+  COMPLEX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+}

--- a/src/complex/Filter/Actions/MoveDataAction.cpp
+++ b/src/complex/Filter/Actions/MoveDataAction.cpp
@@ -1,0 +1,101 @@
+#include "MoveDataAction.hpp"
+
+#include <fmt/core.h>
+
+#include "complex/DataStructure/BaseGroup.hpp"
+#include "complex/Utilities/DataArrayUtilities.hpp"
+
+using namespace complex;
+
+namespace
+{
+constexpr int32 k_MissingDataObjectCode = -40;
+constexpr int32 k_HasParentCode = -41;
+constexpr int32 k_MissingParentObjectCode = -42;
+constexpr int32 k_FailedAddParentCode = -43;
+constexpr int32 k_FailedRemoveParentCode = -44;
+constexpr int32 k_FailedFindOldParentCode = -45;
+} // namespace
+
+namespace complex
+{
+MoveDataAction::MoveDataAction(const DataPath& path, const DataPath& newParentPath)
+: m_NewParentPath(newParentPath)
+, m_Path(path)
+{
+}
+
+MoveDataAction::~MoveDataAction() noexcept = default;
+
+Result<> MoveDataAction::apply(DataStructure& dataStructure, Mode mode) const
+{
+  auto dataObject = dataStructure.getData(m_Path);
+  if(dataObject == nullptr)
+  {
+    std::string ss = fmt::format("Could not find DataObject at '{}'", m_Path.toString());
+    return MakeErrorResult(k_MissingDataObjectCode, ss);
+  }
+
+  auto parentIds = dataObject->getParentIds();
+  for(const auto parentId : parentIds)
+  {
+    auto parentPaths = dataStructure.getDataPathsForId(parentId);
+    for(const auto parentPath : parentPaths)
+    {
+      if(m_NewParentPath == parentPath)
+      {
+        std::string ss = fmt::format("Could not move data from '{}' to '{}' as it already exists under the new parent", m_Path.toString(), parentPath.toString());
+        return MakeErrorResult(k_HasParentCode, ss);
+      }
+    }
+  }
+  const auto* newParent = dataStructure.getDataAs<BaseGroup>(m_NewParentPath);
+  if(newParent == nullptr)
+  {
+    std::string ss = fmt::format("Could not find a possible parent object at '{}'", m_NewParentPath.toString());
+    return MakeErrorResult(k_MissingParentObjectCode, ss);
+  }
+
+  if(!dataStructure.setAdditionalParent(dataObject->getId(), newParent->getId()))
+  {
+    std::string ss = fmt::format("Could not add new parent at '{}' to DataObject at '{}' ", m_NewParentPath.toString(), m_Path.toString());
+    return MakeErrorResult(k_FailedAddParentCode, ss);
+  }
+
+  const DataPath parentPath = m_Path.getParent();
+  const auto* oldParent = dataStructure.getDataAs<BaseGroup>(parentPath);
+  // If no parent exists
+  if(parentPath.empty())
+  {
+    if(!dataStructure.removeParent(dataObject->getId(), 0))
+    {
+      std::string ss = fmt::format("Could not remove parent at '{}'", parentPath.toString());
+      return MakeErrorResult(k_FailedRemoveParentCode, ss);
+    }
+  }
+  else
+  {
+    if(oldParent == nullptr)
+    {
+      std::string ss = fmt::format("Could not find a possible parent object at '{}'", parentPath.toString());
+      return MakeErrorResult(k_FailedFindOldParentCode, ss);
+    }
+    if(!dataStructure.removeParent(dataObject->getId(), oldParent->getId()))
+    {
+      std::string ss = fmt::format("Could not remove parent at '{}'", parentPath.toString());
+      return MakeErrorResult(k_FailedRemoveParentCode, ss);
+    }
+  }
+  return {};
+}
+
+DataPath MoveDataAction::newParentPath() const
+{
+  return m_NewParentPath;
+}
+
+const DataPath& MoveDataAction::path() const
+{
+  return m_Path;
+}
+} // namespace complex

--- a/src/complex/Filter/Actions/MoveDataAction.hpp
+++ b/src/complex/Filter/Actions/MoveDataAction.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "complex/Filter/Output.hpp"
+#include "complex/complex_export.hpp"
+
+namespace complex
+{
+/**
+ * @brief Action for renaming DataObjects in a DataStructure
+ */
+class COMPLEX_EXPORT MoveDataAction : public IDataAction
+{
+public:
+  MoveDataAction() = delete;
+
+  MoveDataAction(const DataPath& path, const DataPath& newParentPath);
+
+  ~MoveDataAction() noexcept override;
+
+  MoveDataAction(const MoveDataAction&) = delete;
+  MoveDataAction(MoveDataAction&&) noexcept = delete;
+  MoveDataAction& operator=(const MoveDataAction&) = delete;
+  MoveDataAction& operator=(MoveDataAction&&) noexcept = delete;
+
+  /**
+   * @brief Applies this action's change to the given DataStructure in the given mode.
+   * Returns any warnings/errors. On error, DataStructure is not guaranteed to be consistent.
+   * @param dataStructure
+   * @return
+   */
+  Result<> apply(DataStructure& dataStructure, Mode mode) const override;
+
+  /**
+   * @brief Returns the target name.
+   * @return std::string
+   */
+  DataPath newParentPath() const;
+
+  /**
+   * @brief Returns the path of the DataArray to be created.
+   * @return
+   */
+  const DataPath& path() const;
+
+private:
+  DataPath m_NewParentPath;
+  DataPath m_Path;
+};
+} // namespace complex


### PR DESCRIPTION
* Added filter, action, and unit test
* Filter moves a DataObject from one parent to another using the DataPath provided for the target DataObject.
* Cannot move to one of the DataObject's existing parents.