### PR TITLE
Geometry: Update classes to reuse functionality from higher level classes and rename methods

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/PointSampleTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/PointSampleTriangleGeometry.cpp
@@ -94,9 +94,7 @@ Result<> PointSampleTriangleGeometry::operator()()
   int64_t progressInt = 0;
   int64_t counter = 0;
 
-  Point3Df a(0.0F, 0.0F, 0.0F);
-  Point3Df b(0.0F, 0.0F, 0.0F);
-  Point3Df c(0.0F, 0.0F, 0.0F);
+  std::vector<Point3Df> faceVerts = {{0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 0.0F}};
 
   // We get the pointer to the Array instead of a reference because it might not have been set because
   // the bool "use_mask" might have been false, but we do NOT want to try to get the array
@@ -154,7 +152,7 @@ Result<> PointSampleTriangleGeometry::operator()()
       }
     }
 
-    triangle.getVertexCoordsForFace(randomTri, a, b, c);
+    triangle.getFaceCoordinates(randomTri, faceVerts);
 
     float r1 = static_cast<float>(distribution(generator));
     float r2 = static_cast<float>(distribution(generator));
@@ -163,9 +161,9 @@ Result<> PointSampleTriangleGeometry::operator()()
     float prefactorB = sqrtf(r1) * (1 - r2);
     float prefactorC = sqrtf(r1) * r2;
 
-    (*vertices)[curVertex * 3 + 0] = (prefactorA * a[0]) + (prefactorB * b[0]) + (prefactorC * c[0]);
-    (*vertices)[curVertex * 3 + 1] = (prefactorA * a[1]) + (prefactorB * b[1]) + (prefactorC * c[1]);
-    (*vertices)[curVertex * 3 + 2] = (prefactorA * a[2]) + (prefactorB * b[2]) + (prefactorC * c[2]);
+    (*vertices)[curVertex * 3 + 0] = (prefactorA * faceVerts[0][0]) + (prefactorB * faceVerts[1][0]) + (prefactorC * faceVerts[2][0]);
+    (*vertices)[curVertex * 3 + 1] = (prefactorA * faceVerts[0][1]) + (prefactorB * faceVerts[1][1]) + (prefactorC * faceVerts[2][1]);
+    (*vertices)[curVertex * 3 + 2] = (prefactorA * faceVerts[0][2]) + (prefactorB * faceVerts[1][2]) + (prefactorC * faceVerts[2][2]);
 
     // Transfer the face data to the vertex data
     for(size_t dataVectorIndex = 0; dataVectorIndex < m_Inputs->pSelectedDataArrayPaths.size(); dataVectorIndex++)

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
@@ -231,7 +231,7 @@ Result<> ScalarSegmentFeatures::operator()()
   // By default we randomize grains
   if(m_InputValues->pShouldRandomizeFeatureIds)
   {
-    totalPoints = gridGeom->getNumberOfElements();
+    totalPoints = gridGeom->getNumberOfCells();
     randomizeFeatureIds(m_FeatureIdsArray, totalPoints, totalFeatures, distribution);
   }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.cpp
@@ -170,7 +170,7 @@ Result<> ApproximatePointCloudHull::executeImpl(DataStructure& data, const Argum
   samplingGrid->setDimensions(dims);
 
   int64 multiplier[3] = {1, static_cast<int64>(samplingGrid->getNumXPoints()), static_cast<int64>(samplingGrid->getNumXPoints() * samplingGrid->getNumYPoints())};
-  std::vector<std::vector<int64>> vertsInVoxels(samplingGrid->getNumberOfElements());
+  std::vector<std::vector<int64>> vertsInVoxels(samplingGrid->getNumberOfCells());
 
   int64 progIncrement = numVerts / 100;
   int64 prog = 1;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
@@ -204,8 +204,8 @@ Result<> CropVertexGeometry::executeImpl(DataStructure& dataStructure, const Arg
     {
       return {};
     }
-    auto coords = vertices.getCoords(croppedPoints[i]);
-    crop.setCoords(i, coords);
+    auto coords = vertices.getVertexCoordinate(croppedPoints[i]);
+    crop.setVertexCoordinate(i, coords);
   }
 
   for(auto&& targetArrayPath : targetArrays)

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.cpp
@@ -373,7 +373,7 @@ Result<> MapPointCloudToRegularGridFilter::executeImpl(DataStructure& data, cons
   {
     if(!useMask || (useMask && (*maskPtr)[i]))
     {
-      auto coords = vertices->getCoords(i);
+      auto coords = vertices->getVertexCoordinate(i);
 
       for(usize j = 0; j < 3; j++)
       {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
@@ -226,7 +226,7 @@ nonstd::expected<std::vector<bool>, Error> mergeContainedFeatures(DataStructure&
   }
 
   bool good = false;
-  usize totalPoints = data.getDataRefAs<ImageGeom>(imageGeomPath).getNumberOfElements();
+  usize totalPoints = data.getDataRefAs<ImageGeom>(imageGeomPath).getNumberOfCells();
   usize totalFeatures = numNeighborsArray.getNumberOfTuples();
 
   std::vector<bool> activeObjects(totalFeatures, true);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
@@ -147,7 +147,7 @@ IFilter::PreflightResult QuickSurfaceMeshFilter::preflightImpl(const DataStructu
   {
     return {MakeErrorResult<OutputActions>(-76530, fmt::format("Could not find find selected grid geometry at path '{}'", pGridGeomDataPath.toString()))};
   }
-  auto numElements = gridGeom->getNumberOfElements();
+  auto numElements = gridGeom->getNumberOfCells();
 
   // Create the Triangle Geometry action and store it
   {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
@@ -198,8 +198,8 @@ Result<> RemoveFlaggedVertices::executeImpl(DataStructure& data, const Arguments
 
   for(size_t i = 0; i < trueCount; i++)
   {
-    Point3D<float> coords = std::move(vertex.getCoords(trueIndices[i]));
-    reducedVertex.setCoords(i, coords);
+    Point3D<float> coords = std::move(vertex.getVertexCoordinate(trueIndices[i]));
+    reducedVertex.setVertexCoordinate(i, coords);
   }
 
   for(const auto& targetArrayPath : targetArrayPaths)

--- a/src/Plugins/ComplexCore/test/RemoveFlaggedVerticesTest.cpp
+++ b/src/Plugins/ComplexCore/test/RemoveFlaggedVerticesTest.cpp
@@ -97,7 +97,7 @@ TEST_CASE("ComplexCore::RemoveFlaggedVertices: Test Algorithm", "[ComplexCore][R
 
   for(size_t i = 0; i < reducedTupleCount; i++)
   {
-    Point3D<float> coord = reducedVertexGeom->getCoords(i);
+    Point3D<float> coord = reducedVertexGeom->getVertexCoordinate(i);
     float compValue = static_cast<float>(i) + 25.0F;
     REQUIRE(((coord[0] == compValue) && (coord[1] == compValue) && (coord[2] == compValue)));
 

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -830,7 +830,10 @@ void DataStructure::resetIds(DataObject::IdType startingId)
   for(auto& dataObjectIter : m_DataObjects)
   {
     auto dataObjectPtr = dataObjectIter.second.lock();
-    dataObjectPtr->checkUpdatedIds(updatedIds);
+    if(dataObjectPtr != nullptr)
+    {
+      dataObjectPtr->checkUpdatedIds(updatedIds);
+    }
   }
 }
 

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -151,6 +151,11 @@ bool DataStructure::containsData(DataObject::IdType id) const
   return getData(id) != nullptr;
 }
 
+bool DataStructure::containsData(const DataPath& path) const
+{
+  return getData(path) != nullptr;
+}
+
 Result<LinkedPath> DataStructure::makePath(const DataPath& path)
 {
   try

--- a/src/complex/DataStructure/DataStructure.hpp
+++ b/src/complex/DataStructure/DataStructure.hpp
@@ -123,6 +123,14 @@ public:
   bool containsData(DataObject::IdType id) const;
 
   /**
+   * @brief Returns true if the DataStructure contains a DataObject with the
+   * given path. Returns false otherwise.
+   * @param path The DataPath to the DataObject
+   * @return bool
+   */
+  bool containsData(const DataPath& path) const;
+
+  /**
    * @brief Returns a pointer to the DataObject with the specified IdType.
    * If no such object exists, this method returns nullptr.
    * @param id

--- a/src/complex/DataStructure/Geometry/EdgeGeom.cpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.cpp
@@ -112,7 +112,7 @@ IGeometry::StatusCode EdgeGeom::findElementsContainingVert()
   {
     return -1;
   }
-  m_ElementContainingVertId = containsVert->getId();
+  m_CellContainingVertId = containsVert->getId();
   return 1;
 }
 
@@ -133,11 +133,11 @@ IGeometry::StatusCode EdgeGeom::findElementNeighbors()
     err = -1;
     return err;
   }
-  m_ElementNeighborsId = edgeNeighbors->getId();
+  m_CellNeighborsId = edgeNeighbors->getId();
   err = GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getEdges(), getElementsContainingVert(), edgeNeighbors, IGeometry::Type::Edge);
   if(getElementNeighbors() == nullptr)
   {
-    m_ElementNeighborsId.reset();
+    m_CellNeighborsId.reset();
     err = -1;
   }
   return err;
@@ -152,7 +152,7 @@ IGeometry::StatusCode EdgeGeom::findElementCentroids()
   {
     return -1;
   }
-  m_ElementCentroidsId = edgeCentroids->getId();
+  m_CellCentroidsId = edgeCentroids->getId();
   return 1;
 }
 

--- a/src/complex/DataStructure/Geometry/EdgeGeom.cpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.cpp
@@ -71,71 +71,9 @@ DataObject* EdgeGeom::deepCopy()
   return new EdgeGeom(*this);
 }
 
-void EdgeGeom::setCoords(usize vertId, const Point3D<float32>& coords)
-{
-  auto& vertices = getVerticesRef();
-  for(usize i = 0; i < 3; i++)
-  {
-    vertices[vertId * 3 + i] = coords[i];
-  }
-}
-
-Point3D<float32> EdgeGeom::getCoords(usize vertId) const
-{
-  auto& vertices = getVerticesRef();
-  Point3D<float32> coord;
-  for(usize i = 0; i < 3; i++)
-  {
-    coord[i] = vertices[vertId * 3 + i];
-  }
-  return coord;
-}
-
-void EdgeGeom::setVertsAtEdge(usize edgeId, const usize verts[2])
-{
-  auto& edges = getEdgesRef();
-  const usize offset = edgeId * k_NumVerts;
-  if(offset + k_NumVerts >= edges.getSize())
-  {
-    return;
-  }
-  for(usize i = 0; i < k_NumVerts; i++)
-  {
-    edges[offset + i] = verts[i];
-  }
-}
-
-void EdgeGeom::getVertsAtEdge(usize edgeId, usize verts[2]) const
-{
-  auto& cells = getEdgesRef();
-  const usize offset = edgeId * k_NumVerts;
-  if(offset + k_NumVerts >= cells.getSize())
-  {
-    return;
-  }
-  for(usize i = 0; i < k_NumVerts; i++)
-  {
-    verts[i] = cells.at(offset + i);
-  }
-}
-
-void EdgeGeom::getVertCoordsAtEdge(usize edgeId, Point3D<float32>& vert1, Point3D<float32>& vert2) const
-{
-  usize verts[k_NumVerts];
-  getVertsAtEdge(edgeId, verts);
-  vert1 = getCoords(verts[0]);
-  vert2 = getCoords(verts[1]);
-}
-
-usize EdgeGeom::getNumberOfElements() const
-{
-  auto& edges = getEdgesRef();
-  return edges.getNumberOfTuples();
-}
-
 IGeometry::StatusCode EdgeGeom::findElementSizes()
 {
-  auto dataStore = std::make_unique<DataStore<float32>>(getNumberOfElements(), 0.0f);
+  auto dataStore = std::make_unique<DataStore<float32>>(getNumberOfCells(), 0.0f);
   auto* sizes = DataArray<float32>::Create(*getDataStructure(), "Edge Lengths", std::move(dataStore), getId());
   if(sizes == nullptr)
   {
@@ -143,16 +81,15 @@ IGeometry::StatusCode EdgeGeom::findElementSizes()
   }
   m_ElementSizesId = sizes->getId();
 
-  Point3D<float32> vert0 = {0.0f, 0.0f, 0.0f};
-  Point3D<float32> vert1 = {0.0f, 0.0f, 0.0f};
+  std::array<Point3Df, 2> verts = {Point3Df(0.0f, 0.0f, 0.0f), Point3Df(0.0f, 0.0f, 0.0f)};
 
-  for(usize i = 0; i < getNumberOfEdges(); i++)
+  for(usize i = 0; i < INodeGeometry1D::getNumberOfCells(); i++)
   {
-    getVertCoordsAtEdge(i, vert0, vert1);
+    getEdgeCoordinates(i, verts);
     float32 length = 0.0f;
     for(usize j = 0; j < 3; j++)
     {
-      length += (vert0[j] - vert1[j]) * (vert0[j] - vert1[j]);
+      length += (verts[0][j] - verts[1][j]) * (verts[0][j] - verts[1][j]);
     }
     (*sizes)[i] = std::sqrt(length);
   }
@@ -205,7 +142,7 @@ IGeometry::StatusCode EdgeGeom::findElementNeighbors()
 
 IGeometry::StatusCode EdgeGeom::findElementCentroids()
 {
-  auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfElements()}, std::vector<usize>{3}, 0.0f);
+  auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfCells()}, std::vector<usize>{3}, 0.0f);
   auto* edgeCentroids = DataArray<float32>::Create(*getDataStructure(), "Edge Centroids", std::move(dataStore), getId());
   GeometryHelpers::Topology::FindElementCentroids(getEdges(), getVertices(), edgeCentroids);
   if(getElementCentroids() == nullptr)

--- a/src/complex/DataStructure/Geometry/EdgeGeom.cpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.cpp
@@ -20,15 +20,6 @@ EdgeGeom::EdgeGeom(DataStructure& ds, std::string name, IdType importId)
 {
 }
 
-EdgeGeom::EdgeGeom(const EdgeGeom&) = default;
-
-EdgeGeom::EdgeGeom(EdgeGeom&& other)
-: INodeGeometry1D(other)
-{
-}
-
-EdgeGeom::~EdgeGeom() noexcept = default;
-
 DataObject::Type EdgeGeom::getDataObjectType() const
 {
   return DataObject::Type::EdgeGeom;

--- a/src/complex/DataStructure/Geometry/EdgeGeom.cpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.cpp
@@ -94,49 +94,37 @@ Point3D<float32> EdgeGeom::getCoords(usize vertId) const
 void EdgeGeom::setVertsAtEdge(usize edgeId, const usize verts[2])
 {
   auto& edges = getEdgesRef();
-  usize numEdges = edges.getNumberOfTuples();
-  if(edgeId >= numEdges)
+  const usize offset = edgeId * k_NumVerts;
+  if(offset + k_NumVerts >= edges.getSize())
   {
     return;
   }
-
-  for(usize i = 0; i < 2; i++)
+  for(usize i = 0; i < k_NumVerts; i++)
   {
-    edges[edgeId + i] = verts[i];
+    edges[offset + i] = verts[i];
   }
 }
 
 void EdgeGeom::getVertsAtEdge(usize edgeId, usize verts[2]) const
 {
-  auto& edges = getEdgesRef();
-  usize numEdges = edges.getNumberOfTuples();
-  if(edgeId >= numEdges)
+  auto& cells = getEdgesRef();
+  const usize offset = edgeId * k_NumVerts;
+  if(offset + k_NumVerts >= cells.getSize())
   {
     return;
   }
-
-  for(usize i = 0; i < 2; i++)
+  for(usize i = 0; i < k_NumVerts; i++)
   {
-    verts[i] = edges[edgeId + i];
+    verts[i] = cells.at(offset + i);
   }
 }
 
 void EdgeGeom::getVertCoordsAtEdge(usize edgeId, Point3D<float32>& vert1, Point3D<float32>& vert2) const
 {
-  auto& edges = getEdgesRef();
-  usize numEdges = edges.getNumberOfTuples();
-  if(edgeId >= numEdges)
-  {
-    return;
-  }
-
-  auto& vertices = getVerticesRef();
-
-  MeshIndexType vert1Id = edges[edgeId];
-  MeshIndexType vert2Id = edges[edgeId + 1];
-
-  vert1 = &vertices[vert1Id];
-  vert2 = &vertices[vert2Id];
+  usize verts[k_NumVerts];
+  getVertsAtEdge(edgeId, verts);
+  vert1 = getCoords(verts[0]);
+  vert2 = getCoords(verts[1]);
 }
 
 usize EdgeGeom::getNumberOfElements() const

--- a/src/complex/DataStructure/Geometry/EdgeGeom.cpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.cpp
@@ -22,7 +22,7 @@ EdgeGeom::EdgeGeom(DataStructure& ds, std::string name, IdType importId)
 
 EdgeGeom::EdgeGeom(const EdgeGeom&) = default;
 
-EdgeGeom::EdgeGeom(EdgeGeom&& other) noexcept
+EdgeGeom::EdgeGeom(EdgeGeom&& other)
 : INodeGeometry1D(other)
 {
 }

--- a/src/complex/DataStructure/Geometry/EdgeGeom.cpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.cpp
@@ -22,7 +22,10 @@ EdgeGeom::EdgeGeom(DataStructure& ds, std::string name, IdType importId)
 
 EdgeGeom::EdgeGeom(const EdgeGeom&) = default;
 
-EdgeGeom::EdgeGeom(EdgeGeom&&) = default;
+EdgeGeom::EdgeGeom(EdgeGeom&& other) noexcept
+: INodeGeometry1D(other)
+{
+}
 
 EdgeGeom::~EdgeGeom() noexcept = default;
 

--- a/src/complex/DataStructure/Geometry/EdgeGeom.hpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.hpp
@@ -47,7 +47,7 @@ public:
    * @brief
    * @param other
    */
-  EdgeGeom(EdgeGeom&& other) noexcept;
+  EdgeGeom(EdgeGeom&& other) ;
 
   ~EdgeGeom() noexcept override;
 

--- a/src/complex/DataStructure/Geometry/EdgeGeom.hpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.hpp
@@ -41,15 +41,15 @@ public:
    * @brief
    * @param other
    */
-  EdgeGeom(const EdgeGeom& other);
+  EdgeGeom(const EdgeGeom& other) = default;
 
   /**
    * @brief
    * @param other
    */
-  EdgeGeom(EdgeGeom&& other);
+  EdgeGeom(EdgeGeom&& other) = default;
 
-  ~EdgeGeom() noexcept override;
+  ~EdgeGeom() noexcept override = default;
 
   EdgeGeom& operator=(const EdgeGeom&) = delete;
   EdgeGeom& operator=(EdgeGeom&&) noexcept = delete;

--- a/src/complex/DataStructure/Geometry/EdgeGeom.hpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.hpp
@@ -16,6 +16,7 @@ public:
   friend class DataStructure;
 
   static inline constexpr usize k_NumVerts = 2;
+  static inline constexpr usize k_NumEdgeVerts = 2;
 
   /**
    * @brief
@@ -82,48 +83,6 @@ public:
    * @return DataObject*
    */
   DataObject* deepCopy() override;
-
-  /**
-   * @brief
-   * @param vertId
-   * @param coords
-   */
-  void setCoords(usize vertId, const Point3D<float32>& coords) override;
-
-  /**
-   * @brief
-   * @param vertId
-   * @return Point3D<float32>
-   */
-  Point3D<float32> getCoords(usize vertId) const override;
-
-  /**
-   * @brief
-   * @param edgeId
-   * @param verts
-   */
-  void setVertsAtEdge(usize edgeId, const usize verts[2]) override;
-
-  /**
-   * @brief
-   * @param edgeId
-   * @param verts
-   */
-  void getVertsAtEdge(usize edgeId, usize verts[2]) const override;
-
-  /**
-   * @brief
-   * @param edgeId
-   * @param vert1
-   * @param vert2
-   */
-  void getVertCoordsAtEdge(usize edgeId, Point3D<float32>& vert1, Point3D<float32>& vert2) const override;
-
-  /**
-   * @brief
-   * @return usize
-   */
-  usize getNumberOfElements() const override;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/EdgeGeom.hpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.hpp
@@ -47,7 +47,7 @@ public:
    * @brief
    * @param other
    */
-  EdgeGeom(EdgeGeom&& other) ;
+  EdgeGeom(EdgeGeom&& other);
 
   ~EdgeGeom() noexcept override;
 

--- a/src/complex/DataStructure/Geometry/EdgeGeom.hpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.hpp
@@ -47,7 +47,7 @@ public:
    * @brief
    * @param other
    */
-  EdgeGeom(EdgeGeom&& other);
+  EdgeGeom(EdgeGeom&& other) noexcept;
 
   ~EdgeGeom() noexcept override;
 

--- a/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
@@ -22,7 +22,10 @@ HexahedralGeom::HexahedralGeom(DataStructure& ds, std::string name, IdType impor
 
 HexahedralGeom::HexahedralGeom(const HexahedralGeom&) = default;
 
-HexahedralGeom::HexahedralGeom(HexahedralGeom&& other) noexcept = default;
+HexahedralGeom::HexahedralGeom(HexahedralGeom&& other) noexcept
+: INodeGeometry3D(std::move(other))
+{
+}
 
 HexahedralGeom::~HexahedralGeom() noexcept = default;
 
@@ -71,9 +74,14 @@ DataObject* HexahedralGeom::deepCopy()
   return new HexahedralGeom(*this);
 }
 
-usize HexahedralGeom::getVertsPerFace() const
+usize HexahedralGeom::getNumberOfVerticesPerFace() const
 {
   return k_NumFaceVerts;
+}
+
+usize HexahedralGeom::getNumberOfVerticesPerCell() const
+{
+  return k_NumVerts;
 }
 
 void HexahedralGeom::setCellPointIds(usize polyhedraId, nonstd::span<usize> vertexIds)

--- a/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
@@ -22,7 +22,7 @@ HexahedralGeom::HexahedralGeom(DataStructure& ds, std::string name, IdType impor
 
 HexahedralGeom::HexahedralGeom(const HexahedralGeom&) = default;
 
-HexahedralGeom::HexahedralGeom(HexahedralGeom&& other) noexcept
+HexahedralGeom::HexahedralGeom(HexahedralGeom&& other)
 : INodeGeometry3D(std::move(other))
 {
 }

--- a/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
@@ -20,15 +20,6 @@ HexahedralGeom::HexahedralGeom(DataStructure& ds, std::string name, IdType impor
 {
 }
 
-HexahedralGeom::HexahedralGeom(const HexahedralGeom&) = default;
-
-HexahedralGeom::HexahedralGeom(HexahedralGeom&& other)
-: INodeGeometry3D(std::move(other))
-{
-}
-
-HexahedralGeom::~HexahedralGeom() noexcept = default;
-
 DataObject::Type HexahedralGeom::getDataObjectType() const
 {
   return DataObject::Type::HexahedralGeom;

--- a/src/complex/DataStructure/Geometry/HexahedralGeom.hpp
+++ b/src/complex/DataStructure/Geometry/HexahedralGeom.hpp
@@ -15,6 +15,10 @@ class COMPLEX_EXPORT HexahedralGeom : public INodeGeometry3D
 public:
   friend class DataStructure;
 
+  static inline constexpr usize k_NumEdgeVerts = 2;
+  static inline constexpr usize k_NumFaceVerts = 4;
+  static inline constexpr usize k_NumVerts = 8;
+
   /**
    * @brief
    * @param ds
@@ -44,7 +48,7 @@ public:
    * @brief
    * @param other
    */
-  HexahedralGeom(HexahedralGeom&& other);
+  HexahedralGeom(HexahedralGeom&& other) noexcept;
 
   ~HexahedralGeom() noexcept override;
 
@@ -82,76 +86,37 @@ public:
   DataObject* deepCopy() override;
 
   /**
-   * @brief Returns the number of quads in the geometry. Returns 0 if there is
-   * no quads array stored in the geometry.
+   * @brief
+   * @return
+   */
+  usize getVertsPerFace() const override;
+
+  /**
+   * @brief
+   * @param tetId
+   * @param vertexIds The index into the shared vertex list of each vertex
+   */
+  void setCellPointIds(usize tetId, nonstd::span<usize> vertexIds) override;
+
+  /**
+   * @brief
+   * @param tetId
+   * @param vertexIds The index into the shared vertex list of each vertex
+   */
+  void getCellPointIds(usize tetId, nonstd::span<usize> vertexIds) const override;
+
+  /**
+   * @brief
+   * @param tetId
+   * @param coords The coordinates of each vertex
+   */
+  void getCellCoordinates(usize tetId, nonstd::span<Point3Df> coords) const override;
+
+  /**
+   * @brief Returns the number of hexahedrons in this geometry
    * @return usize
    */
-  usize getNumberOfQuads() const;
-
-  /**
-   * @brief
-   * @param quadId
-   * @param verts
-   */
-  void setVertsAtQuad(usize quadId, usize verts[4]);
-
-  /**
-   * @brief
-   * @param quadId
-   * @param verts
-   */
-  void getVertsAtQuad(usize quadId, usize verts[4]) const;
-
-  /**
-   * @brief
-   * @param quadId
-   * @param vert1
-   * @param vert2
-   * @param vert3
-   * @param vert4
-   */
-  void getVertCoordsAtQuad(usize quadId, complex::Point3D<float32>& vert1, complex::Point3D<float32>& vert2, complex::Point3D<float32>& vert3, complex::Point3D<float32>& vert4) const;
-
-  /**
-   * @brief
-   * @param hexId
-   * @param verts
-   */
-  void setVertsAtHex(usize hexId, usize verts[8]);
-
-  /**
-   * @brief
-   * @param hexId
-   * @param verts
-   */
-  void getVertsAtHex(usize hexId, usize verts[8]) const;
-
-  /**
-   * @brief
-   * @param hexId
-   * @param vert1
-   * @param vert2
-   * @param vert3
-   * @param vert4
-   * @param vert5
-   * @param vert6
-   * @param vert7
-   * @param vert8
-   */
-  void getVertCoordsAtHex(usize hexId, Point3D<float32>& vert1, Point3D<float32>& vert2, Point3D<float32>& vert3, Point3D<float32>& vert4, Point3D<float32>& vert5, Point3D<float32>& vert6,
-                          Point3D<float32>& vert7, Point3D<float32>& vert8) const;
-
-  /**
-   * @brief
-   * @return usize
-   */
-  usize getNumberOfHexas() const;
-
-  /**
-   * @brief
-   * @return usize
-   */
-  usize getNumberOfElements() const override;
+  usize getNumberOfCells() const override;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/HexahedralGeom.hpp
+++ b/src/complex/DataStructure/Geometry/HexahedralGeom.hpp
@@ -89,7 +89,13 @@ public:
    * @brief
    * @return
    */
-  usize getVertsPerFace() const override;
+  usize getNumberOfVerticesPerFace() const override;
+
+  /**
+   * @brief
+   * @return
+   */
+  usize getNumberOfVerticesPerCell() const override;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/HexahedralGeom.hpp
+++ b/src/complex/DataStructure/Geometry/HexahedralGeom.hpp
@@ -98,27 +98,6 @@ public:
   usize getNumberOfVerticesPerCell() const override;
 
   /**
-   * @brief
-   * @param tetId
-   * @param vertexIds The index into the shared vertex list of each vertex
-   */
-  void setCellPointIds(usize tetId, nonstd::span<usize> vertexIds) override;
-
-  /**
-   * @brief
-   * @param tetId
-   * @param vertexIds The index into the shared vertex list of each vertex
-   */
-  void getCellPointIds(usize tetId, nonstd::span<usize> vertexIds) const override;
-
-  /**
-   * @brief
-   * @param tetId
-   * @param coords The coordinates of each vertex
-   */
-  void getCellCoordinates(usize tetId, nonstd::span<Point3Df> coords) const override;
-
-  /**
    * @brief Returns the number of hexahedrons in this geometry
    * @return usize
    */

--- a/src/complex/DataStructure/Geometry/HexahedralGeom.hpp
+++ b/src/complex/DataStructure/Geometry/HexahedralGeom.hpp
@@ -48,7 +48,7 @@ public:
    * @brief
    * @param other
    */
-  HexahedralGeom(HexahedralGeom&& other) noexcept;
+  HexahedralGeom(HexahedralGeom&& other);
 
   ~HexahedralGeom() noexcept override;
 

--- a/src/complex/DataStructure/Geometry/HexahedralGeom.hpp
+++ b/src/complex/DataStructure/Geometry/HexahedralGeom.hpp
@@ -42,15 +42,15 @@ public:
    * @brief
    * @param other
    */
-  HexahedralGeom(const HexahedralGeom& other);
+  HexahedralGeom(const HexahedralGeom& other) = default;
 
   /**
    * @brief
    * @param other
    */
-  HexahedralGeom(HexahedralGeom&& other);
+  HexahedralGeom(HexahedralGeom&& other) = default;
 
-  ~HexahedralGeom() noexcept override;
+  ~HexahedralGeom() noexcept override = default;
 
   HexahedralGeom& operator=(const HexahedralGeom&) = delete;
   HexahedralGeom& operator=(HexahedralGeom&&) noexcept = delete;

--- a/src/complex/DataStructure/Geometry/IGeometry.hpp
+++ b/src/complex/DataStructure/Geometry/IGeometry.hpp
@@ -81,10 +81,10 @@ public:
   virtual IGeometry::Type getGeomType() const = 0;
 
   /**
-   * @brief
+   * @brief Returns the number of Cells (NOT POINTS) of a Geometry
    * @return usize
    */
-  virtual usize getNumberOfElements() const = 0;
+  virtual usize getNumberOfCells() const = 0;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/IGeometry.hpp
+++ b/src/complex/DataStructure/Geometry/IGeometry.hpp
@@ -202,11 +202,9 @@ public:
   H5::ErrorType writeHdf5(H5::DataStructureWriter& dataStructureWriter, H5::GroupWriter& parentGroupWriter, bool importable) const override;
 
 protected:
-
   IGeometry(DataStructure& ds, std::string name);
 
   IGeometry(DataStructure& ds, std::string name, IdType importId);
-
 
   /**
    * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.

--- a/src/complex/DataStructure/Geometry/IGeometry.hpp
+++ b/src/complex/DataStructure/Geometry/IGeometry.hpp
@@ -72,6 +72,14 @@ public:
     Unknown = 101U
   };
 
+  IGeometry() = delete;
+
+  IGeometry(const IGeometry&) = default;
+  IGeometry(IGeometry&&) = default;
+
+  IGeometry& operator=(const IGeometry&) = delete;
+  IGeometry& operator=(IGeometry&&) noexcept = delete;
+
   ~IGeometry() noexcept override = default;
 
   /**
@@ -194,17 +202,11 @@ public:
   H5::ErrorType writeHdf5(H5::DataStructureWriter& dataStructureWriter, H5::GroupWriter& parentGroupWriter, bool importable) const override;
 
 protected:
-  IGeometry() = delete;
 
   IGeometry(DataStructure& ds, std::string name);
 
   IGeometry(DataStructure& ds, std::string name, IdType importId);
 
-  IGeometry(const IGeometry&) = default;
-  IGeometry(IGeometry&&) = default;
-
-  IGeometry& operator=(const IGeometry&) = delete;
-  IGeometry& operator=(IGeometry&&) noexcept = delete;
 
   /**
    * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.

--- a/src/complex/DataStructure/Geometry/IGridGeometry.hpp
+++ b/src/complex/DataStructure/Geometry/IGridGeometry.hpp
@@ -10,6 +10,13 @@ class COMPLEX_EXPORT IGridGeometry : public IGeometry
 public:
   static inline constexpr StringLiteral k_CellDataName = "Cell Data";
 
+  IGridGeometry() = delete;
+  IGridGeometry(const IGridGeometry&) = default;
+  IGridGeometry(IGridGeometry&&) = default;
+
+  IGridGeometry& operator=(const IGridGeometry&) = delete;
+  IGridGeometry& operator=(IGridGeometry&&) noexcept = delete;
+
   ~IGridGeometry() noexcept override = default;
 
   /**
@@ -211,17 +218,9 @@ public:
   H5::ErrorType writeHdf5(H5::DataStructureWriter& dataStructureWriter, H5::GroupWriter& parentGroupWriter, bool importable) const override;
 
 protected:
-  IGridGeometry() = delete;
-
   IGridGeometry(DataStructure& ds, std::string name);
 
   IGridGeometry(DataStructure& ds, std::string name, IdType importId);
-
-  IGridGeometry(const IGridGeometry&) = default;
-  IGridGeometry(IGridGeometry&&) = default;
-
-  IGridGeometry& operator=(const IGridGeometry&) = delete;
-  IGridGeometry& operator=(IGridGeometry&&) noexcept = delete;
 
   /**
    * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.

--- a/src/complex/DataStructure/Geometry/INodeGeometry0D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry0D.cpp
@@ -57,6 +57,12 @@ usize INodeGeometry0D::getNumberOfVertices() const
   return vertices.getNumberOfTuples();
 }
 
+usize INodeGeometry0D::getNumberOfCells() const
+{
+  const auto& vertices = getVerticesRef();
+  return vertices.getNumberOfTuples();
+}
+
 void INodeGeometry0D::setVertexCoordinate(usize vertId, const Point3D<float32>& coordinate)
 {
   auto& vertices = getVerticesRef();

--- a/src/complex/DataStructure/Geometry/INodeGeometry0D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry0D.cpp
@@ -57,6 +57,28 @@ usize INodeGeometry0D::getNumberOfVertices() const
   return vertices.getNumberOfTuples();
 }
 
+void INodeGeometry0D::setVertexCoordinate(usize vertId, const Point3D<float32>& coordinate)
+{
+  auto& vertices = getVerticesRef();
+  const usize offset = vertId * 3;
+  for(usize i = 0; i < 3; i++)
+  {
+    vertices[offset + i] = coordinate[i];
+  }
+}
+
+Point3D<float32> INodeGeometry0D::getVertexCoordinate(usize vertId) const
+{
+  auto& vertices = getVerticesRef();
+  const usize offset = vertId * 3;
+  Point3D<float32> coordinate;
+  for(usize i = 0; i < 3; i++)
+  {
+    coordinate[i] = vertices.at(offset + i);
+  }
+  return coordinate;
+}
+
 const std::optional<INodeGeometry0D::IdType>& INodeGeometry0D::getVertexDataId() const
 {
   return m_VertexDataId;

--- a/src/complex/DataStructure/Geometry/INodeGeometry0D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry0D.hpp
@@ -45,18 +45,24 @@ public:
   usize getNumberOfVertices() const;
 
   /**
+   * @brief Returns the number of vertices for this geometry
+   * @return
+   */
+  usize getNumberOfCells() const override;
+
+  /**
    * @brief Gets the coordinates at the target vertex ID.
    * @param vertId
    * @return
    */
-  virtual Point3D<float32> getVertexCoordinate(usize vertId) const;
+  Point3D<float32> getVertexCoordinate(usize vertId) const;
 
   /**
    * @brief Sets the coordinates for the specified vertex ID.
    * @param vertId
    * @param coords
    */
-  virtual void setVertexCoordinate(usize vertId, const Point3D<float32>& coords);
+  void setVertexCoordinate(usize vertId, const Point3D<float32>& coords);
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/INodeGeometry0D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry0D.hpp
@@ -11,6 +11,13 @@ class COMPLEX_EXPORT INodeGeometry0D : public IGeometry
 public:
   static inline constexpr StringLiteral k_VertexDataName = "Vertex Data";
 
+  INodeGeometry0D() = delete;
+  INodeGeometry0D(const INodeGeometry0D&) = default;
+  INodeGeometry0D(INodeGeometry0D&&) = default;
+
+  INodeGeometry0D& operator=(const INodeGeometry0D&) = delete;
+  INodeGeometry0D& operator=(INodeGeometry0D&&) noexcept = delete;
+
   ~INodeGeometry0D() noexcept override = default;
 
   const std::optional<IdType>& getVertexListId() const;
@@ -42,14 +49,14 @@ public:
    * @param vertId
    * @return
    */
-  virtual Point3D<float32> getCoords(usize vertId) const = 0;
+  virtual Point3D<float32> getVertexCoordinate(usize vertId) const;
 
   /**
    * @brief Sets the coordinates for the specified vertex ID.
    * @param vertId
    * @param coords
    */
-  virtual void setCoords(usize vertId, const Point3D<float32>& coords) = 0;
+  virtual void setVertexCoordinate(usize vertId, const Point3D<float32>& coords);
 
   /**
    * @brief
@@ -110,17 +117,9 @@ public:
   H5::ErrorType writeHdf5(H5::DataStructureWriter& dataStructureWriter, H5::GroupWriter& parentGroupWriter, bool importable) const override;
 
 protected:
-  INodeGeometry0D() = delete;
-
   INodeGeometry0D(DataStructure& ds, std::string name);
 
   INodeGeometry0D(DataStructure& ds, std::string name, IdType importId);
-
-  INodeGeometry0D(const INodeGeometry0D&) = default;
-  INodeGeometry0D(INodeGeometry0D&&) = default;
-
-  INodeGeometry0D& operator=(const INodeGeometry0D&) = delete;
-  INodeGeometry0D& operator=(INodeGeometry0D&&) noexcept = delete;
 
   /**
    * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.

--- a/src/complex/DataStructure/Geometry/INodeGeometry0D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry0D.hpp
@@ -127,6 +127,9 @@ protected:
    */
   void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
 
+  /* ***************************************************************************
+   * These variables are the Ids of the arrays from the complex::DataStructure object.
+   */
   std::optional<IdType> m_VertexListId;
   std::optional<IdType> m_VertexDataId;
 };

--- a/src/complex/DataStructure/Geometry/INodeGeometry1D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry1D.cpp
@@ -100,35 +100,35 @@ void INodeGeometry1D::getEdgeCoordinates(usize edgeId, nonstd::span<Point3Df> co
 
 const INodeGeometry1D::ElementDynamicList* INodeGeometry1D::getElementsContainingVert() const
 {
-  return getDataStructureRef().getDataAs<ElementDynamicList>(m_ElementContainingVertId);
+  return getDataStructureRef().getDataAs<ElementDynamicList>(m_CellContainingVertId);
 }
 
 void INodeGeometry1D::deleteElementsContainingVert()
 {
-  getDataStructureRef().removeData(m_ElementContainingVertId);
-  m_ElementContainingVertId.reset();
+  getDataStructureRef().removeData(m_CellContainingVertId);
+  m_CellContainingVertId.reset();
 }
 
 const INodeGeometry1D::ElementDynamicList* INodeGeometry1D::getElementNeighbors() const
 {
-  return getDataStructureRef().getDataAs<ElementDynamicList>(m_ElementNeighborsId);
+  return getDataStructureRef().getDataAs<ElementDynamicList>(m_CellNeighborsId);
 }
 
 void INodeGeometry1D::deleteElementNeighbors()
 {
-  getDataStructureRef().removeData(m_ElementNeighborsId);
-  m_ElementNeighborsId.reset();
+  getDataStructureRef().removeData(m_CellNeighborsId);
+  m_CellNeighborsId.reset();
 }
 
 const Float32Array* INodeGeometry1D::getElementCentroids() const
 {
-  return getDataStructureRef().getDataAs<Float32Array>(m_ElementCentroidsId);
+  return getDataStructureRef().getDataAs<Float32Array>(m_CellCentroidsId);
 }
 
 void INodeGeometry1D::deleteElementCentroids()
 {
-  getDataStructureRef().removeData(m_ElementCentroidsId);
-  m_ElementCentroidsId.reset();
+  getDataStructureRef().removeData(m_CellCentroidsId);
+  m_CellCentroidsId.reset();
 }
 
 const std::optional<INodeGeometry1D::IdType>& INodeGeometry1D::getEdgeDataId() const
@@ -176,9 +176,9 @@ H5::ErrorType INodeGeometry1D::readHdf5(H5::DataStructureReader& dataStructureRe
 
   m_EdgeListId = ReadH5DataId(groupReader, H5Constants::k_EdgeListTag);
   m_EdgeDataId = ReadH5DataId(groupReader, H5Constants::k_EdgeDataTag);
-  m_ElementContainingVertId = ReadH5DataId(groupReader, H5Constants::k_ElementContainingVertTag);
-  m_ElementNeighborsId = ReadH5DataId(groupReader, H5Constants::k_ElementNeighborsTag);
-  m_ElementCentroidsId = ReadH5DataId(groupReader, H5Constants::k_ElementCentroidTag);
+  m_CellContainingVertId = ReadH5DataId(groupReader, H5Constants::k_ElementContainingVertTag);
+  m_CellNeighborsId = ReadH5DataId(groupReader, H5Constants::k_ElementNeighborsTag);
+  m_CellCentroidsId = ReadH5DataId(groupReader, H5Constants::k_ElementCentroidTag);
 
   return error;
 }
@@ -204,19 +204,19 @@ H5::ErrorType INodeGeometry1D::writeHdf5(H5::DataStructureWriter& dataStructureW
     return error;
   }
 
-  error = WriteH5DataId(groupWriter, m_ElementContainingVertId, H5Constants::k_ElementContainingVertTag);
+  error = WriteH5DataId(groupWriter, m_CellContainingVertId, H5Constants::k_ElementContainingVertTag);
   if(error < 0)
   {
     return error;
   }
 
-  error = WriteH5DataId(groupWriter, m_ElementNeighborsId, H5Constants::k_ElementNeighborsTag);
+  error = WriteH5DataId(groupWriter, m_CellNeighborsId, H5Constants::k_ElementNeighborsTag);
   if(error < 0)
   {
     return error;
   }
 
-  error = WriteH5DataId(groupWriter, m_ElementCentroidsId, H5Constants::k_ElementCentroidTag);
+  error = WriteH5DataId(groupWriter, m_CellCentroidsId, H5Constants::k_ElementCentroidTag);
   if(error < 0)
   {
     return error;
@@ -246,19 +246,19 @@ void INodeGeometry1D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, Id
       m_EdgeListId = updatedId.second;
     }
 
-    if(m_ElementContainingVertId == updatedId.first)
+    if(m_CellContainingVertId == updatedId.first)
     {
-      m_ElementContainingVertId = updatedId.second;
+      m_CellContainingVertId = updatedId.second;
     }
 
-    if(m_ElementNeighborsId == updatedId.first)
+    if(m_CellNeighborsId == updatedId.first)
     {
-      m_ElementNeighborsId = updatedId.second;
+      m_CellNeighborsId = updatedId.second;
     }
 
-    if(m_ElementCentroidsId == updatedId.first)
+    if(m_CellCentroidsId == updatedId.first)
     {
-      m_ElementCentroidsId = updatedId.second;
+      m_CellCentroidsId = updatedId.second;
     }
 
     if(m_ElementSizesId == updatedId.first)

--- a/src/complex/DataStructure/Geometry/INodeGeometry1D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry1D.cpp
@@ -50,10 +50,46 @@ void INodeGeometry1D::resizeEdgeList(usize size)
   getEdgesRef().getIDataStoreRef().reshapeTuples({size});
 }
 
-usize INodeGeometry1D::getNumberOfEdges() const
+usize INodeGeometry1D::getNumberOfCells() const
 {
-  const auto& edges = getEdgesRef();
+  auto& edges = getEdgesRef();
   return edges.getNumberOfTuples();
+}
+
+void INodeGeometry1D::setEdgePointIds(usize edgeId, nonstd::span<usize> vertexIds)
+{
+  auto& edges = getEdgesRef();
+  const usize offset = edgeId * k_NumEdgeVerts;
+  if(offset + k_NumEdgeVerts >= edges.getSize())
+  {
+    return;
+  }
+  for(usize i = 0; i < k_NumEdgeVerts; i++)
+  {
+    edges[offset + i] = vertexIds[i];
+  }
+}
+
+void INodeGeometry1D::getEdgePointIds(usize edgeId, nonstd::span<usize> vertexIds) const
+{
+  auto& cells = getEdgesRef();
+  const usize offset = edgeId * k_NumEdgeVerts;
+  if(offset + k_NumEdgeVerts >= cells.getSize())
+  {
+    return;
+  }
+  for(usize i = 0; i < k_NumEdgeVerts; i++)
+  {
+    vertexIds[i] = cells.at(offset + i);
+  }
+}
+
+void INodeGeometry1D::getEdgeCoordinates(usize edgeId, nonstd::span<Point3Df> coords) const
+{
+  std::array<usize, k_NumEdgeVerts> verts = {0, 0};
+  getEdgePointIds(edgeId, verts);
+  coords[0] = getVertexCoordinate(verts[0]);
+  coords[1] = getVertexCoordinate(verts[1]);
 }
 
 const INodeGeometry1D::ElementDynamicList* INodeGeometry1D::getElementsContainingVert() const

--- a/src/complex/DataStructure/Geometry/INodeGeometry1D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry1D.cpp
@@ -56,6 +56,12 @@ usize INodeGeometry1D::getNumberOfCells() const
   return edges.getNumberOfTuples();
 }
 
+usize INodeGeometry1D::getNumberOfEdges() const
+{
+  auto& edges = getEdgesRef();
+  return edges.getNumberOfTuples();
+}
+
 void INodeGeometry1D::setEdgePointIds(usize edgeId, nonstd::span<usize> vertexIds)
 {
   auto& edges = getEdgesRef();

--- a/src/complex/DataStructure/Geometry/INodeGeometry1D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry1D.hpp
@@ -45,6 +45,12 @@ public:
   virtual usize getNumberOfCells() const override;
 
   /**
+   * @brief returns the number of edges in the geometry
+   * @return
+   */
+  virtual usize getNumberOfEdges() const;
+
+  /**
    * @brief Sets the vertex IDs making up the specified edge. This method does
    * nothing if the edge list could not be found.
    * @param edgeId

--- a/src/complex/DataStructure/Geometry/INodeGeometry1D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry1D.hpp
@@ -9,6 +9,15 @@ class COMPLEX_EXPORT INodeGeometry1D : public INodeGeometry0D
 public:
   static inline constexpr StringLiteral k_EdgeDataName = "Edge Data";
 
+  static inline constexpr usize k_NumEdgeVerts = 2;
+
+  INodeGeometry1D() = delete;
+  INodeGeometry1D(const INodeGeometry1D&) = default;
+  INodeGeometry1D(INodeGeometry1D&&) = default;
+
+  INodeGeometry1D& operator=(const INodeGeometry1D&) = delete;
+  INodeGeometry1D& operator=(INodeGeometry1D&&) noexcept = delete;
+
   ~INodeGeometry1D() noexcept override = default;
 
   const std::optional<IdType>& getEdgeListId() const;
@@ -33,7 +42,23 @@ public:
    * @brief Returns the number of edges in the geometry.
    * @return usize
    */
-  usize getNumberOfEdges() const;
+  virtual usize getNumberOfCells() const override;
+
+  /**
+   * @brief Sets the vertex IDs making up the specified edge. This method does
+   * nothing if the edge list could not be found.
+   * @param edgeId
+   * @param vertexIds The index into the shared vertex list of each vertex
+   */
+  virtual void setEdgePointIds(usize edgeId, nonstd::span<usize> vertexIds);
+
+  /**
+   * @brief Returns the vertices that make up the specified edge by reference.
+   * This method does nothing if the edge list could not be found.
+   * @param edgeId
+   * @param vertexIds The index into the shared vertex list of each vertex
+   */
+  virtual void getEdgePointIds(usize edgeId, nonstd::span<usize> vertexIds) const;
 
   /**
    * @brief Returns the vertex coordinates for a specified edge by reference.
@@ -42,7 +67,7 @@ public:
    * @param vert1
    * @param vert2
    */
-  virtual void getVertCoordsAtEdge(usize edgeId, Point3D<float32>& vert1, Point3D<float32>& vert2) const = 0;
+  virtual void getEdgeCoordinates(usize edgeId, nonstd::span<Point3Df> coords) const;
 
   /**
    * @brief
@@ -94,22 +119,6 @@ public:
    * @brief
    */
   void deleteElementCentroids();
-
-  /**
-   * @brief Sets the vertex IDs making up the specified edge. This method does
-   * nothing if the edge list could not be found.
-   * @param edgeId
-   * @param verts
-   */
-  virtual void setVertsAtEdge(usize edgeId, const usize verts[2]) = 0;
-
-  /**
-   * @brief Returns the vertices that make up the specified edge by reference.
-   * This method does nothing if the edge list could not be found.
-   * @param edgeId
-   * @param verts
-   */
-  virtual void getVertsAtEdge(usize edgeId, usize verts[2]) const = 0;
 
   /**
    * @brief
@@ -170,17 +179,9 @@ public:
   H5::ErrorType writeHdf5(H5::DataStructureWriter& dataStructureWriter, H5::GroupWriter& parentGroupWriter, bool importable) const override;
 
 protected:
-  INodeGeometry1D() = delete;
-
   INodeGeometry1D(DataStructure& ds, std::string name);
 
   INodeGeometry1D(DataStructure& ds, std::string name, IdType importId);
-
-  INodeGeometry1D(const INodeGeometry1D&) = default;
-  INodeGeometry1D(INodeGeometry1D&&) = default;
-
-  INodeGeometry1D& operator=(const INodeGeometry1D&) = delete;
-  INodeGeometry1D& operator=(INodeGeometry1D&&) noexcept = delete;
 
   /**
    * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.

--- a/src/complex/DataStructure/Geometry/INodeGeometry1D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry1D.hpp
@@ -48,7 +48,7 @@ public:
    * @brief returns the number of edges in the geometry
    * @return
    */
-  virtual usize getNumberOfEdges() const;
+  usize getNumberOfEdges() const;
 
   /**
    * @brief Sets the vertex IDs making up the specified edge. This method does
@@ -56,7 +56,7 @@ public:
    * @param edgeId
    * @param vertexIds The index into the shared vertex list of each vertex
    */
-  virtual void setEdgePointIds(usize edgeId, nonstd::span<usize> vertexIds);
+  void setEdgePointIds(usize edgeId, nonstd::span<usize> vertexIds);
 
   /**
    * @brief Returns the vertices that make up the specified edge by reference.
@@ -64,7 +64,7 @@ public:
    * @param edgeId
    * @param vertexIds The index into the shared vertex list of each vertex
    */
-  virtual void getEdgePointIds(usize edgeId, nonstd::span<usize> vertexIds) const;
+  void getEdgePointIds(usize edgeId, nonstd::span<usize> vertexIds) const;
 
   /**
    * @brief Returns the vertex coordinates for a specified edge by reference.
@@ -73,7 +73,7 @@ public:
    * @param vert1
    * @param vert2
    */
-  virtual void getEdgeCoordinates(usize edgeId, nonstd::span<Point3Df> coords) const;
+  void getEdgeCoordinates(usize edgeId, nonstd::span<Point3Df> coords) const;
 
   /**
    * @brief
@@ -195,10 +195,13 @@ protected:
    */
   void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
 
+  /* ***************************************************************************
+   * These variables are the Ids of the arrays from the complex::DataStructure object.
+   */
   std::optional<IdType> m_EdgeListId;
   std::optional<IdType> m_EdgeDataId;
-  std::optional<IdType> m_ElementContainingVertId;
-  std::optional<IdType> m_ElementNeighborsId;
-  std::optional<IdType> m_ElementCentroidsId;
+  std::optional<IdType> m_CellContainingVertId;
+  std::optional<IdType> m_CellNeighborsId;
+  std::optional<IdType> m_CellCentroidsId;
 };
 } // namespace complex

--- a/src/complex/DataStructure/Geometry/INodeGeometry1D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry1D.hpp
@@ -42,7 +42,7 @@ public:
    * @brief Returns the number of edges in the geometry.
    * @return usize
    */
-  virtual usize getNumberOfCells() const override;
+  usize getNumberOfCells() const override;
 
   /**
    * @brief returns the number of edges in the geometry

--- a/src/complex/DataStructure/Geometry/INodeGeometry2D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry2D.cpp
@@ -59,12 +59,12 @@ usize INodeGeometry2D::getNumberOfFaces() const
 void INodeGeometry2D::setFacePointIds(usize faceId, nonstd::span<usize> vertexIds)
 {
   auto& faces = getFacesRef();
-  const usize offset = faceId * getVertsPerFace();
-  if(offset + getVertsPerFace() >= faces.getSize())
+  const usize offset = faceId * getNumberOfVerticesPerFace();
+  if(offset + getNumberOfVerticesPerFace() >= faces.getSize())
   {
     return;
   }
-  for(usize i = 0; i < getVertsPerFace(); i++)
+  for(usize i = 0; i < getNumberOfVerticesPerFace(); i++)
   {
     faces[offset + i] = vertexIds[i];
   }
@@ -73,12 +73,12 @@ void INodeGeometry2D::setFacePointIds(usize faceId, nonstd::span<usize> vertexId
 void INodeGeometry2D::getFacePointIds(usize faceId, nonstd::span<usize> vertexIds) const
 {
   auto& cells = getFacesRef();
-  const usize offset = faceId * getVertsPerFace();
-  if(offset + getVertsPerFace() >= cells.getSize())
+  const usize offset = faceId * getNumberOfVerticesPerFace();
+  if(offset + getNumberOfVerticesPerFace() >= cells.getSize())
   {
     return;
   }
-  for(usize i = 0; i < getVertsPerFace(); i++)
+  for(usize i = 0; i < getNumberOfVerticesPerFace(); i++)
   {
     vertexIds[i] = cells.at(offset + i);
   }
@@ -86,7 +86,7 @@ void INodeGeometry2D::getFacePointIds(usize faceId, nonstd::span<usize> vertexId
 
 void INodeGeometry2D::getFaceCoordinates(usize faceId, nonstd::span<Point3Df> coords) const
 {
-  std::vector<usize> verts(getVertsPerFace());
+  std::vector<usize> verts(getNumberOfVerticesPerFace());
   getFacePointIds(faceId, verts);
   for(usize index = 0; index < verts.size(); index++)
   {

--- a/src/complex/DataStructure/Geometry/INodeGeometry2D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry2D.cpp
@@ -56,6 +56,44 @@ usize INodeGeometry2D::getNumberOfFaces() const
   return faces.getNumberOfTuples();
 }
 
+void INodeGeometry2D::setFacePointIds(usize faceId, nonstd::span<usize> vertexIds)
+{
+  auto& faces = getFacesRef();
+  const usize offset = faceId * getVertsPerFace();
+  if(offset + getVertsPerFace() >= faces.getSize())
+  {
+    return;
+  }
+  for(usize i = 0; i < getVertsPerFace(); i++)
+  {
+    faces[offset + i] = vertexIds[i];
+  }
+}
+
+void INodeGeometry2D::getFacePointIds(usize faceId, nonstd::span<usize> vertexIds) const
+{
+  auto& cells = getFacesRef();
+  const usize offset = faceId * getVertsPerFace();
+  if(offset + getVertsPerFace() >= cells.getSize())
+  {
+    return;
+  }
+  for(usize i = 0; i < getVertsPerFace(); i++)
+  {
+    vertexIds[i] = cells.at(offset + i);
+  }
+}
+
+void INodeGeometry2D::getFaceCoordinates(usize faceId, nonstd::span<Point3Df> coords) const
+{
+  std::vector<usize> verts(getVertsPerFace());
+  getFacePointIds(faceId, verts);
+  for(usize index = 0; index < verts.size(); index++)
+  {
+    coords[index] = getVertexCoordinate(verts[index]);
+  }
+}
+
 void INodeGeometry2D::deleteEdges()
 {
   getDataStructureRef().removeData(m_EdgeListId);
@@ -76,20 +114,6 @@ void INodeGeometry2D::deleteUnsharedEdges()
 {
   getDataStructureRef().removeData(m_UnsharedEdgeListId);
   m_UnsharedEdgeListId.reset();
-}
-
-void INodeGeometry2D::setVertsAtEdge(usize edgeId, const usize verts[2])
-{
-  auto& edges = getEdgesRef();
-  edges[edgeId * 2] = verts[0];
-  edges[edgeId * 2 + 1] = verts[1];
-}
-
-void INodeGeometry2D::getVertsAtEdge(usize edgeId, usize verts[2]) const
-{
-  auto& edges = getEdgesRef();
-  verts[0] = edges.at(edgeId * 2);
-  verts[1] = edges.at(edgeId * 2 + 1);
 }
 
 const std::optional<INodeGeometry2D::IdType>& INodeGeometry2D::getFaceDataId() const

--- a/src/complex/DataStructure/Geometry/INodeGeometry2D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry2D.hpp
@@ -57,7 +57,7 @@ public:
    * @brief
    * @return
    */
-  virtual usize getVertsPerFace() const = 0;
+  virtual usize getNumberOfVerticesPerFace() const = 0;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/INodeGeometry2D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry2D.hpp
@@ -20,6 +20,13 @@ class COMPLEX_EXPORT INodeGeometry2D : public INodeGeometry1D
 public:
   static inline constexpr StringLiteral k_FaceDataName = "Face Data";
 
+  INodeGeometry2D() = delete;
+  INodeGeometry2D(const INodeGeometry2D&) = default;
+  INodeGeometry2D(INodeGeometry2D&&) = default;
+
+  INodeGeometry2D& operator=(const INodeGeometry2D&) = delete;
+  INodeGeometry2D& operator=(INodeGeometry2D&&) noexcept = delete;
+
   ~INodeGeometry2D() noexcept override = default;
 
   const std::optional<IdType>& getFaceListId() const;
@@ -45,6 +52,33 @@ public:
    * @return usize
    */
   usize getNumberOfFaces() const;
+
+  /**
+   * @brief
+   * @return
+   */
+  virtual usize getVertsPerFace() const = 0;
+
+  /**
+   * @brief
+   * @param triId
+   * @param vertexIds The index into the shared vertex list of each vertex
+   */
+  virtual void setFacePointIds(usize triId, nonstd::span<usize> vertexIds);
+
+  /**
+   * @brief
+   * @param faceId
+   * @param vertexIds The index into the shared vertex list of each vertex
+   */
+  virtual void getFacePointIds(usize faceId, nonstd::span<usize> vertexIds) const;
+
+  /**
+   * @brief
+   * @param faceId
+   * @param coords The coordinates of each vertex
+   */
+  virtual void getFaceCoordinates(usize faceId, nonstd::span<Point3Df> coords) const;
 
   /**
    * @brief
@@ -80,22 +114,6 @@ public:
    * @brief Deletes the unshared edge list and removes it from the DataStructure.
    */
   void deleteUnsharedEdges();
-
-  /**
-   * @brief Sets the vertex IDs making up the specified edge. This method does
-   * nothing if the edge list could not be found.
-   * @param edgeId
-   * @param verts
-   */
-  void setVertsAtEdge(usize edgeId, const usize verts[2]) override;
-
-  /**
-   * @brief Returns the vertices that make up the specified edge by reference.
-   * This method does nothing if the edge list could not be found.
-   * @param edgeId
-   * @param verts
-   */
-  void getVertsAtEdge(usize edgeId, usize verts[2]) const override;
 
   /**
    * @brief
@@ -156,17 +174,9 @@ public:
   H5::ErrorType writeHdf5(H5::DataStructureWriter& dataStructureWriter, H5::GroupWriter& parentGroupWriter, bool importable) const override;
 
 protected:
-  INodeGeometry2D() = delete;
-
   INodeGeometry2D(DataStructure& ds, std::string name);
 
   INodeGeometry2D(DataStructure& ds, std::string name, IdType importId);
-
-  INodeGeometry2D(const INodeGeometry2D&) = default;
-  INodeGeometry2D(INodeGeometry2D&&) = default;
-
-  INodeGeometry2D& operator=(const INodeGeometry2D&) = delete;
-  INodeGeometry2D& operator=(INodeGeometry2D&&) noexcept = delete;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/INodeGeometry2D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry2D.hpp
@@ -64,21 +64,21 @@ public:
    * @param triId
    * @param vertexIds The index into the shared vertex list of each vertex
    */
-  virtual void setFacePointIds(usize triId, nonstd::span<usize> vertexIds);
+  void setFacePointIds(usize triId, nonstd::span<usize> vertexIds);
 
   /**
    * @brief
    * @param faceId
    * @param vertexIds The index into the shared vertex list of each vertex
    */
-  virtual void getFacePointIds(usize faceId, nonstd::span<usize> vertexIds) const;
+  void getFacePointIds(usize faceId, nonstd::span<usize> vertexIds) const;
 
   /**
    * @brief
    * @param faceId
    * @param coords The coordinates of each vertex
    */
-  virtual void getFaceCoordinates(usize faceId, nonstd::span<Point3Df> coords) const;
+  void getFaceCoordinates(usize faceId, nonstd::span<Point3Df> coords) const;
 
   /**
    * @brief
@@ -191,6 +191,9 @@ protected:
    */
   void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
 
+  /* ***************************************************************************
+   * These variables are the Ids of the arrays from the complex::DataStructure object.
+   */
   std::optional<IdType> m_FaceListId;
   std::optional<IdType> m_FaceDataId;
   std::optional<IdType> m_UnsharedEdgeListId;

--- a/src/complex/DataStructure/Geometry/INodeGeometry3D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry3D.cpp
@@ -78,42 +78,6 @@ void INodeGeometry3D::deleteUnsharedFaces()
   m_UnsharedFaceListId.reset();
 }
 
-void INodeGeometry3D::setCoords(usize vertId, const Point3D<float32>& coords)
-{
-  auto& vertices = getVerticesRef();
-
-  usize index = vertId * 3;
-  for(usize i = 0; i < 3; i++)
-  {
-    vertices[index + i] = coords[i];
-  }
-}
-
-Point3D<float32> INodeGeometry3D::getCoords(usize vertId) const
-{
-  auto& vertices = getVerticesRef();
-
-  usize index = vertId * 3;
-  auto x = vertices[index];
-  auto y = vertices[index + 1];
-  auto z = vertices[index + 2];
-  return Point3D<float32>(x, y, z);
-}
-
-void INodeGeometry3D::getVertCoordsAtEdge(usize edgeId, Point3D<float32>& vert1, Point3D<float32>& vert2) const
-{
-  auto& vertices = getVerticesRef();
-
-  usize verts[2];
-  getVertsAtEdge(edgeId, verts);
-
-  for(usize i = 0; i < 3; i++)
-  {
-    vert1[i] = vertices[verts[0] * 3 + i];
-    vert2[i] = vertices[verts[1] * 3 + i];
-  }
-}
-
 const std::optional<INodeGeometry3D::IdType>& INodeGeometry3D::getPolyhedraDataId() const
 {
   return m_PolyhedronDataId;

--- a/src/complex/DataStructure/Geometry/INodeGeometry3D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry3D.cpp
@@ -56,6 +56,37 @@ usize INodeGeometry3D::getNumberOfPolyhedra() const
   return polyhedra.getNumberOfTuples();
 }
 
+void INodeGeometry3D::setCellPointIds(usize polyhedraId, nonstd::span<usize> vertexIds)
+{
+  auto& polyhedra = getPolyhedraRef();
+  usize numVerts = getNumberOfVerticesPerCell();
+  for(usize i = 0; i < numVerts; i++)
+  {
+    polyhedra[polyhedraId * numVerts + i] = vertexIds[i];
+  }
+}
+
+void INodeGeometry3D::getCellPointIds(usize polyhedraId, nonstd::span<usize> vertexIds) const
+{
+  auto& polyhedra = getPolyhedraRef();
+  usize numVerts = getNumberOfVerticesPerCell();
+  for(usize i = 0; i < numVerts; i++)
+  {
+    vertexIds[i] = polyhedra[polyhedraId * numVerts + i];
+  }
+}
+
+void INodeGeometry3D::getCellCoordinates(usize hexId, nonstd::span<Point3Df> coords) const
+{
+  usize numVerts = getNumberOfVerticesPerCell();
+  std::vector<usize> vertIds(numVerts, 0);
+  getCellPointIds(hexId, vertIds);
+  for(usize index = 0; index < numVerts; index++)
+  {
+    coords[index] = getVertexCoordinate(vertIds[index]);
+  }
+}
+
 void INodeGeometry3D::deleteFaces()
 {
   getDataStructureRef().removeData(m_FaceListId);

--- a/src/complex/DataStructure/Geometry/INodeGeometry3D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry3D.hpp
@@ -76,6 +76,12 @@ public:
   void deleteUnsharedFaces();
 
   /**
+   * @brief Returns the number of vertices in the cell.
+   * @return
+   */
+  virtual usize getNumberOfVerticesPerCell() const = 0;
+
+  /**
    * @brief
    * @param tetId
    * @param vertexIds The index into the shared vertex list of each vertex

--- a/src/complex/DataStructure/Geometry/INodeGeometry3D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry3D.hpp
@@ -9,6 +9,13 @@ class COMPLEX_EXPORT INodeGeometry3D : public INodeGeometry2D
 public:
   static inline constexpr StringLiteral k_PolyhedronDataName = "Polyhedron Data";
 
+  INodeGeometry3D() = delete;
+  INodeGeometry3D(const INodeGeometry3D&) = default;
+  INodeGeometry3D(INodeGeometry3D&&) = default;
+
+  INodeGeometry3D& operator=(const INodeGeometry3D&) = delete;
+  INodeGeometry3D& operator=(INodeGeometry3D&&) noexcept = delete;
+
   ~INodeGeometry3D() noexcept override = default;
 
   const std::optional<IdType>& getPolyhedronListId() const;
@@ -69,30 +76,25 @@ public:
   void deleteUnsharedFaces();
 
   /**
-   * @brief Assigns a new coordinate to the target vertex.
-   *
-   * If the SharedVertexList has not been assigned or cannot be found, this
-   * method does nothing. If the vertex index extends beyond the bounds of the
-   * array, this method falls into undefined behavior.
-   * @param vertId
-   * @param coords
+   * @brief
+   * @param tetId
+   * @param vertexIds The index into the shared vertex list of each vertex
    */
-  void setCoords(usize vertId, const Point3D<float32>& coords) override;
+  virtual void setCellPointIds(usize tetId, nonstd::span<usize> vertexIds) = 0;
 
   /**
-   * @brief Returns the 3D coordinates of the specified vertex as a Point3D<float32>.
-   * @param vertId
-   * @return Point3D<float32>
+   * @brief
+   * @param tetId
+   * @param vertexIds The index into the shared vertex list of each vertex
    */
-  Point3D<float32> getCoords(usize vertId) const override;
+  virtual void getCellPointIds(usize tetId, nonstd::span<usize> vertexIds) const = 0;
 
   /**
-   * @brief Gets the vertex coordinates for the specified edge.
-   * @param edgeId
-   * @param vert1
-   * @param vert2
+   * @brief
+   * @param tetId
+   * @param coords The coordinates of each vertex
    */
-  void getVertCoordsAtEdge(usize edgeId, Point3D<float32>& vert1, Point3D<float32>& vert2) const override;
+  virtual void getCellCoordinates(usize tetId, nonstd::span<Point3Df> coords) const = 0;
 
   /**
    * @brief
@@ -153,17 +155,9 @@ public:
   H5::ErrorType writeHdf5(H5::DataStructureWriter& dataStructureWriter, H5::GroupWriter& parentGroupWriter, bool importable) const override;
 
 protected:
-  INodeGeometry3D() = delete;
-
   INodeGeometry3D(DataStructure& ds, std::string name);
 
   INodeGeometry3D(DataStructure& ds, std::string name, IdType importId);
-
-  INodeGeometry3D(const INodeGeometry3D&) = default;
-  INodeGeometry3D(INodeGeometry3D&&) = default;
-
-  INodeGeometry3D& operator=(const INodeGeometry3D&) = delete;
-  INodeGeometry3D& operator=(INodeGeometry3D&&) noexcept = delete;
 
   SharedQuadList* createSharedQuadList(usize numQuads);
 

--- a/src/complex/DataStructure/Geometry/INodeGeometry3D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry3D.hpp
@@ -86,21 +86,21 @@ public:
    * @param tetId
    * @param vertexIds The index into the shared vertex list of each vertex
    */
-  virtual void setCellPointIds(usize tetId, nonstd::span<usize> vertexIds) = 0;
+  void setCellPointIds(usize tetId, nonstd::span<usize> vertexIds);
 
   /**
    * @brief
    * @param tetId
    * @param vertexIds The index into the shared vertex list of each vertex
    */
-  virtual void getCellPointIds(usize tetId, nonstd::span<usize> vertexIds) const = 0;
+  void getCellPointIds(usize tetId, nonstd::span<usize> vertexIds) const;
 
   /**
    * @brief
    * @param tetId
    * @param coords The coordinates of each vertex
    */
-  virtual void getCellCoordinates(usize tetId, nonstd::span<Point3Df> coords) const = 0;
+  void getCellCoordinates(usize tetId, nonstd::span<Point3Df> coords) const;
 
   /**
    * @brief
@@ -175,6 +175,9 @@ protected:
    */
   void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
 
+  /* ***************************************************************************
+   * These variables are the Ids of the arrays from the complex::DataStructure object.
+   */
   std::optional<IdType> m_PolyhedronListId;
   std::optional<IdType> m_PolyhedronDataId;
   std::optional<IdType> m_UnsharedFaceListId;

--- a/src/complex/DataStructure/Geometry/ImageGeom.cpp
+++ b/src/complex/DataStructure/Geometry/ImageGeom.cpp
@@ -116,7 +116,7 @@ BoundingBox<float64> ImageGeom::getBoundingBox() const
   return BoundingBox<float64>(arr);
 }
 
-usize ImageGeom::getNumberOfElements() const
+usize ImageGeom::getNumberOfCells() const
 {
   return (m_Dimensions[0] * m_Dimensions[1] * m_Dimensions[2]);
 }
@@ -130,7 +130,7 @@ IGeometry::StatusCode ImageGeom::findElementSizes()
     return -1;
   }
   float32 initValue = res[0] * res[1] * res[2];
-  auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfElements()}, std::vector<usize>{1}, initValue);
+  auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfCells()}, std::vector<usize>{1}, initValue);
   auto voxelSizes = DataArray<float32>::Create(*getDataStructure(), "Voxel Sizes", std::move(dataStore), getId());
   m_ElementSizesId = voxelSizes->getId();
   return 1;

--- a/src/complex/DataStructure/Geometry/ImageGeom.cpp
+++ b/src/complex/DataStructure/Geometry/ImageGeom.cpp
@@ -21,12 +21,6 @@ ImageGeom::ImageGeom(DataStructure& ds, std::string name, IdType importId)
 {
 }
 
-ImageGeom::ImageGeom(const ImageGeom& other) = default;
-
-ImageGeom::ImageGeom(ImageGeom&& other) = default;
-
-ImageGeom::~ImageGeom() noexcept = default;
-
 IGeometry::Type ImageGeom::getGeomType() const
 {
   return IGeometry::Type::Image;

--- a/src/complex/DataStructure/Geometry/ImageGeom.hpp
+++ b/src/complex/DataStructure/Geometry/ImageGeom.hpp
@@ -57,15 +57,15 @@ public:
    * @brief
    * @param other
    */
-  ImageGeom(const ImageGeom& other);
+  ImageGeom(const ImageGeom& other) = default;
 
   /**
    * @brief
    * @param other
    */
-  ImageGeom(ImageGeom&& other);
+  ImageGeom(ImageGeom&& other) = default;
 
-  ~ImageGeom() noexcept override;
+  ~ImageGeom() noexcept override = default;
 
   /**
    * @brief Returns the type of geometry.

--- a/src/complex/DataStructure/Geometry/ImageGeom.hpp
+++ b/src/complex/DataStructure/Geometry/ImageGeom.hpp
@@ -153,7 +153,7 @@ public:
    * @brief
    * @return usize
    */
-  usize getNumberOfElements() const override;
+  usize getNumberOfCells() const override;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/QuadGeom.cpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.cpp
@@ -20,18 +20,6 @@ QuadGeom::QuadGeom(DataStructure& ds, std::string name, IdType importId)
 {
 }
 
-QuadGeom::QuadGeom(const QuadGeom& other)
-: INodeGeometry2D(other)
-{
-}
-
-QuadGeom::QuadGeom(QuadGeom&& other)
-: INodeGeometry2D(std::move(other))
-{
-}
-
-QuadGeom::~QuadGeom() noexcept = default;
-
 IGeometry::Type QuadGeom::getGeomType() const
 {
   return IGeometry::Type::Quad;

--- a/src/complex/DataStructure/Geometry/QuadGeom.cpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.cpp
@@ -83,7 +83,7 @@ usize QuadGeom::getNumberOfCells() const
   return quads.getNumberOfTuples();
 }
 
-usize QuadGeom::getVertsPerFace() const
+usize QuadGeom::getNumberOfVerticesPerFace() const
 {
   return k_NumFaceVerts;
 }

--- a/src/complex/DataStructure/Geometry/QuadGeom.cpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.cpp
@@ -108,10 +108,10 @@ IGeometry::StatusCode QuadGeom::findElementsContainingVert()
   GeometryHelpers::Connectivity::FindElementsContainingVert<uint16, MeshIndexType>(getFaces(), quadsContainingVert, getNumberOfVertices());
   if(quadsContainingVert == nullptr)
   {
-    m_ElementContainingVertId.reset();
+    m_CellContainingVertId.reset();
     return -1;
   }
-  m_ElementContainingVertId = quadsContainingVert->getId();
+  m_CellContainingVertId = quadsContainingVert->getId();
   return 1;
 }
 
@@ -129,10 +129,10 @@ IGeometry::StatusCode QuadGeom::findElementNeighbors()
   StatusCode err = GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getFaces(), getElementsContainingVert(), quadNeighbors, IGeometry::Type::Quad);
   if(quadNeighbors == nullptr)
   {
-    m_ElementNeighborsId.reset();
+    m_CellNeighborsId.reset();
     return -1;
   }
-  m_ElementNeighborsId = quadNeighbors->getId();
+  m_CellNeighborsId = quadNeighbors->getId();
   return err;
 }
 
@@ -143,10 +143,10 @@ IGeometry::StatusCode QuadGeom::findElementCentroids()
   GeometryHelpers::Topology::FindElementCentroids(getFaces(), getVertices(), quadCentroids);
   if(quadCentroids == nullptr)
   {
-    m_ElementCentroidsId.reset();
+    m_CellCentroidsId.reset();
     return -1;
   }
-  m_ElementCentroidsId = quadCentroids->getId();
+  m_CellCentroidsId = quadCentroids->getId();
   return 1;
 }
 

--- a/src/complex/DataStructure/Geometry/QuadGeom.cpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.cpp
@@ -25,7 +25,7 @@ QuadGeom::QuadGeom(const QuadGeom& other)
 {
 }
 
-QuadGeom::QuadGeom(QuadGeom&& other) noexcept
+QuadGeom::QuadGeom(QuadGeom&& other)
 : INodeGeometry2D(std::move(other))
 {
 }

--- a/src/complex/DataStructure/Geometry/QuadGeom.hpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.hpp
@@ -42,15 +42,15 @@ public:
    * @brief
    * @param other
    */
-  QuadGeom(const QuadGeom& other);
+  QuadGeom(const QuadGeom& other) = default;
 
   /**
    * @brief
    * @param other
    */
-  QuadGeom(QuadGeom&& other);
+  QuadGeom(QuadGeom&& other) = default;
 
-  ~QuadGeom() noexcept override;
+  ~QuadGeom() noexcept override = default;
 
   QuadGeom& operator=(const QuadGeom&) = delete;
   QuadGeom& operator=(QuadGeom&&) noexcept = delete;

--- a/src/complex/DataStructure/Geometry/QuadGeom.hpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.hpp
@@ -16,8 +16,9 @@ class COMPLEX_EXPORT QuadGeom : public INodeGeometry2D
 public:
   friend class DataStructure;
 
+  static inline constexpr usize k_NumEdgeVerts = 2;
+  static inline constexpr usize k_NumFaceVerts = 4;
   static inline constexpr usize k_NumVerts = 4;
-
   /**
    * @brief
    * @param ds
@@ -86,40 +87,15 @@ public:
 
   /**
    * @brief
-   * @param quadId
-   * @param verts
-   */
-  void setVertexIdsForFace(usize quadId, usize verts[4]);
-
-  /**
-   * @brief
-   * @param faceId
-   * @param verts
-   */
-  void getVertexIdsForFace(usize faceId, usize verts[4]) const;
-
-  /**
-   * @brief
-   * @param faceId
-   * @param vert1
-   * @param vert2
-   * @param vert3
-   * @param vert4
-   */
-  void getVertexCoordsForFace(usize faceId, Point3D<float32>& vert1, Point3D<float32>& vert2, Point3D<float32>& vert3, Point3D<float32>& vert4) const;
-
-  /**
-   * @brief Returns the number of quads in the geometry. If the quad list has
-   * not been set, this method returns 0.
    * @return usize
    */
-  usize getNumberOfQuads() const;
+  usize getNumberOfCells() const override;
 
   /**
    * @brief
-   * @return usize
+   * @return
    */
-  usize getNumberOfElements() const override;
+  usize getVertsPerFace() const override;
 
   /**
    * @brief
@@ -157,28 +133,6 @@ public:
    * @param shape
    */
   void getShapeFunctions(const Point3D<float64>& pCoords, float64* shape) const override;
-
-  /**
-   * @brief
-   * @param vertId
-   * @param Point3D<float32>
-   */
-  void setCoords(usize vertId, const Point3D<float32>& coord) override;
-
-  /**
-   * @brief
-   * @param vertId
-   * @return Point3D<float32>
-   */
-  Point3D<float32> getCoords(usize vertId) const override;
-
-  /**
-   * @brief
-   * @param edgeId
-   * @param vert1
-   * @param vert2
-   */
-  void getVertCoordsAtEdge(usize edgeId, Point3D<float32>& vert1, Point3D<float32>& vert2) const override;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/QuadGeom.hpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.hpp
@@ -48,7 +48,7 @@ public:
    * @brief
    * @param other
    */
-  QuadGeom(QuadGeom&& other) noexcept;
+  QuadGeom(QuadGeom&& other);
 
   ~QuadGeom() noexcept override;
 

--- a/src/complex/DataStructure/Geometry/QuadGeom.hpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.hpp
@@ -95,7 +95,7 @@ public:
    * @brief
    * @return
    */
-  usize getVertsPerFace() const override;
+  usize getNumberOfVerticesPerFace() const override;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/RectGridGeom.cpp
+++ b/src/complex/DataStructure/Geometry/RectGridGeom.cpp
@@ -21,12 +21,6 @@ RectGridGeom::RectGridGeom(DataStructure& ds, std::string name, IdType importId)
 {
 }
 
-RectGridGeom::RectGridGeom(const RectGridGeom& other) = default;
-
-RectGridGeom::RectGridGeom(RectGridGeom&& other) = default;
-
-RectGridGeom::~RectGridGeom() noexcept = default;
-
 IGeometry::Type RectGridGeom::getGeomType() const
 {
   return IGeometry::Type::RectGrid;

--- a/src/complex/DataStructure/Geometry/RectGridGeom.cpp
+++ b/src/complex/DataStructure/Geometry/RectGridGeom.cpp
@@ -132,14 +132,14 @@ const Float32Array* RectGridGeom::getZBounds() const
   return dynamic_cast<const Float32Array*>(getDataStructure()->getData(m_zBoundsId));
 }
 
-usize RectGridGeom::getNumberOfElements() const
+usize RectGridGeom::getNumberOfCells() const
 {
   return m_Dimensions.getX() * m_Dimensions.getY() * m_Dimensions.getZ();
 }
 
 IGeometry::StatusCode RectGridGeom::findElementSizes()
 {
-  auto sizes = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfElements()}, std::vector<usize>{1}, 0.0f);
+  auto sizes = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfCells()}, std::vector<usize>{1}, 0.0f);
   auto xBnds = getXBounds();
   auto yBnds = getYBounds();
   auto zBnds = getZBounds();

--- a/src/complex/DataStructure/Geometry/RectGridGeom.hpp
+++ b/src/complex/DataStructure/Geometry/RectGridGeom.hpp
@@ -130,7 +130,7 @@ public:
    * @brief
    * @return usize
    */
-  usize getNumberOfElements() const override;
+  usize getNumberOfCells() const override;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/RectGridGeom.hpp
+++ b/src/complex/DataStructure/Geometry/RectGridGeom.hpp
@@ -39,15 +39,15 @@ public:
    * @brief
    * @param other
    */
-  RectGridGeom(const RectGridGeom& other);
+  RectGridGeom(const RectGridGeom& other) = default;
 
   /**
    * @brief
    * @param other
    */
-  RectGridGeom(RectGridGeom&& other);
+  RectGridGeom(RectGridGeom&& other) = default;
 
-  ~RectGridGeom() noexcept override;
+  ~RectGridGeom() noexcept override = default;
 
   RectGridGeom& operator=(const RectGridGeom&) = delete;
   RectGridGeom& operator=(RectGridGeom&&) noexcept = delete;

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
@@ -22,7 +22,7 @@ TetrahedralGeom::TetrahedralGeom(DataStructure& ds, std::string name, IdType imp
 
 TetrahedralGeom::TetrahedralGeom(const TetrahedralGeom&) = default;
 
-TetrahedralGeom::TetrahedralGeom(TetrahedralGeom&& other) noexcept
+TetrahedralGeom::TetrahedralGeom(TetrahedralGeom&& other)
 : INodeGeometry3D(std::move(other))
 {
 }

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
@@ -84,34 +84,6 @@ usize TetrahedralGeom::getNumberOfVerticesPerCell() const
   return k_NumVerts;
 }
 
-void TetrahedralGeom::setCellPointIds(usize polyhedraId, nonstd::span<usize> vertexIds)
-{
-  auto& polyhedra = getPolyhedraRef();
-  for(usize i = 0; i < k_NumVerts; i++)
-  {
-    polyhedra[polyhedraId * k_NumVerts + i] = vertexIds[i];
-  }
-}
-
-void TetrahedralGeom::getCellPointIds(usize polyhedraId, nonstd::span<usize> vertexIds) const
-{
-  auto& polyhedra = getPolyhedraRef();
-  for(usize i = 0; i < k_NumVerts; i++)
-  {
-    vertexIds[i] = polyhedra[polyhedraId * k_NumVerts + i];
-  }
-}
-
-void TetrahedralGeom::getCellCoordinates(usize tetId, nonstd::span<Point3Df> coords) const
-{
-  std::array<usize, k_NumVerts> vertIds = {0, 0, 0, 0};
-  getCellPointIds(tetId, vertIds);
-  for(usize index = 0; index < k_NumVerts; index++)
-  {
-    coords[index] = getVertexCoordinate(vertIds[index]);
-  }
-}
-
 usize TetrahedralGeom::getNumberOfCells() const
 {
   auto& tets = getPolyhedraRef();
@@ -138,10 +110,10 @@ IGeometry::StatusCode TetrahedralGeom::findElementsContainingVert()
   GeometryHelpers::Connectivity::FindElementsContainingVert<uint16, MeshIndexType>(getPolyhedra(), tetsContainingVert, getNumberOfVertices());
   if(tetsContainingVert == nullptr)
   {
-    m_ElementContainingVertId.reset();
+    m_CellContainingVertId.reset();
     return -1;
   }
-  m_ElementContainingVertId = tetsContainingVert->getId();
+  m_CellContainingVertId = tetsContainingVert->getId();
   return 1;
 }
 
@@ -160,10 +132,10 @@ IGeometry::StatusCode TetrahedralGeom::findElementNeighbors()
   err = GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getPolyhedra(), getElementsContainingVert(), tetNeighbors, IGeometry::Type::Tetrahedral);
   if(tetNeighbors == nullptr)
   {
-    m_ElementNeighborsId.reset();
+    m_CellNeighborsId.reset();
     return -1;
   }
-  m_ElementNeighborsId = tetNeighbors->getId();
+  m_CellNeighborsId = tetNeighbors->getId();
   return err;
 }
 
@@ -174,10 +146,10 @@ IGeometry::StatusCode TetrahedralGeom::findElementCentroids()
   GeometryHelpers::Topology::FindElementCentroids(getPolyhedra(), getVertices(), tetCentroids);
   if(tetCentroids == nullptr)
   {
-    m_ElementCentroidsId.reset();
+    m_CellCentroidsId.reset();
     return -1;
   }
-  m_ElementCentroidsId = tetCentroids->getId();
+  m_CellCentroidsId = tetCentroids->getId();
   return 1;
 }
 

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
@@ -20,15 +20,6 @@ TetrahedralGeom::TetrahedralGeom(DataStructure& ds, std::string name, IdType imp
 {
 }
 
-TetrahedralGeom::TetrahedralGeom(const TetrahedralGeom&) = default;
-
-TetrahedralGeom::TetrahedralGeom(TetrahedralGeom&& other)
-: INodeGeometry3D(std::move(other))
-{
-}
-
-TetrahedralGeom::~TetrahedralGeom() noexcept = default;
-
 IGeometry::Type TetrahedralGeom::getGeomType() const
 {
   return IGeometry::Type::Tetrahedral;

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
@@ -22,7 +22,10 @@ TetrahedralGeom::TetrahedralGeom(DataStructure& ds, std::string name, IdType imp
 
 TetrahedralGeom::TetrahedralGeom(const TetrahedralGeom&) = default;
 
-TetrahedralGeom::TetrahedralGeom(TetrahedralGeom&&) = default;
+TetrahedralGeom::TetrahedralGeom(TetrahedralGeom&& other) noexcept
+: INodeGeometry3D(std::move(other))
+{
+}
 
 TetrahedralGeom::~TetrahedralGeom() noexcept = default;
 
@@ -71,9 +74,14 @@ DataObject* TetrahedralGeom::deepCopy()
   return new TetrahedralGeom(*this);
 }
 
-usize TetrahedralGeom::getVertsPerFace() const
+usize TetrahedralGeom::getNumberOfVerticesPerFace() const
 {
   return k_NumFaceVerts;
+}
+
+usize TetrahedralGeom::getNumberOfVerticesPerCell() const
+{
+  return k_NumVerts;
 }
 
 void TetrahedralGeom::setCellPointIds(usize polyhedraId, nonstd::span<usize> vertexIds)

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.hpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.hpp
@@ -48,7 +48,7 @@ public:
    * @brief
    * @param other
    */
-  TetrahedralGeom(TetrahedralGeom&& other);
+  TetrahedralGeom(TetrahedralGeom&& other) noexcept;
 
   ~TetrahedralGeom() noexcept override;
 
@@ -89,7 +89,13 @@ public:
    * @brief
    * @return
    */
-  usize getVertsPerFace() const override;
+  usize getNumberOfVerticesPerFace() const override;
+
+  /**
+   * @brief
+   * @return
+   */
+  usize getNumberOfVerticesPerCell() const override;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.hpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.hpp
@@ -48,7 +48,7 @@ public:
    * @brief
    * @param other
    */
-  TetrahedralGeom(TetrahedralGeom&& other) noexcept;
+  TetrahedralGeom(TetrahedralGeom&& other);
 
   ~TetrahedralGeom() noexcept override;
 

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.hpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.hpp
@@ -98,27 +98,6 @@ public:
   usize getNumberOfVerticesPerCell() const override;
 
   /**
-   * @brief
-   * @param tetId
-   * @param vertexIds The index into the shared vertex list of each vertex
-   */
-  void setCellPointIds(usize tetId, nonstd::span<usize> vertexIds) override;
-
-  /**
-   * @brief
-   * @param tetId
-   * @param vertexIds The index into the shared vertex list of each vertex
-   */
-  void getCellPointIds(usize tetId, nonstd::span<usize> vertexIds) const override;
-
-  /**
-   * @brief
-   * @param tetId
-   * @param coords The coordinates of each vertex
-   */
-  void getCellCoordinates(usize tetId, nonstd::span<Point3Df> coords) const override;
-
-  /**
    * @brief Returns the number of tetrahedrons in this geometry
    * @return usize
    */

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.hpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.hpp
@@ -42,15 +42,15 @@ public:
    * @brief
    * @param other
    */
-  TetrahedralGeom(const TetrahedralGeom& other);
+  TetrahedralGeom(const TetrahedralGeom& other) = default;
 
   /**
    * @brief
    * @param other
    */
-  TetrahedralGeom(TetrahedralGeom&& other);
+  TetrahedralGeom(TetrahedralGeom&& other) = default;
 
-  ~TetrahedralGeom() noexcept override;
+  ~TetrahedralGeom() noexcept override = default;
 
   TetrahedralGeom& operator=(const TetrahedralGeom&) = delete;
   TetrahedralGeom& operator=(TetrahedralGeom&&) noexcept = delete;

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.hpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.hpp
@@ -15,6 +15,8 @@ class COMPLEX_EXPORT TetrahedralGeom : public INodeGeometry3D
 public:
   friend class DataStructure;
 
+  static inline constexpr usize k_NumEdgeVerts = 2;
+  static inline constexpr usize k_NumFaceVerts = 3;
   static inline constexpr usize k_NumVerts = 4;
 
   /**
@@ -85,59 +87,36 @@ public:
 
   /**
    * @brief
-   * @param triId
-   * @param verts
+   * @return
    */
-  void setVertsAtTri(usize triId, usize verts[3]);
-
-  /**
-   * @brief
-   * @param triId
-   * @param verts
-   */
-  void getVertsAtTri(usize triId, usize verts[3]) const;
-
-  /**
-   * @brief
-   * @return usize
-   */
-  usize getNumberOfTris() const;
+  usize getVertsPerFace() const override;
 
   /**
    * @brief
    * @param tetId
-   * @param verts
+   * @param vertexIds The index into the shared vertex list of each vertex
    */
-  void setVertsAtTet(usize tetId, usize verts[4]);
+  void setCellPointIds(usize tetId, nonstd::span<usize> vertexIds) override;
 
   /**
    * @brief
    * @param tetId
-   * @param verts
+   * @param vertexIds The index into the shared vertex list of each vertex
    */
-  void getVertsAtTet(usize tetId, usize verts[4]) const;
+  void getCellPointIds(usize tetId, nonstd::span<usize> vertexIds) const override;
 
   /**
    * @brief
    * @param tetId
-   * @param vert1
-   * @param vert2
-   * @param vert3
-   * @param vert4
+   * @param coords The coordinates of each vertex
    */
-  void getVertCoordsAtTet(usize tetId, Point3D<float32>& vert1, Point3D<float32>& vert2, Point3D<float32>& vert3, Point3D<float32>& vert4) const;
+  void getCellCoordinates(usize tetId, nonstd::span<Point3Df> coords) const override;
 
   /**
-   * @brief
+   * @brief Returns the number of tetrahedrons in this geometry
    * @return usize
    */
-  usize getNumberOfTets() const;
-
-  /**
-   * @brief
-   * @return usize
-   */
-  usize getNumberOfElements() const override;
+  usize getNumberOfCells() const override;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.cpp
@@ -78,52 +78,14 @@ DataObject* TriangleGeom::deepCopy()
   return new TriangleGeom(*this);
 }
 
-void TriangleGeom::setVertexIdsForFace(usize faceId, usize verts[3])
-{
-  auto& faces = getFacesRef();
-  const usize offset = faceId * k_NumVerts;
-  if(offset + k_NumVerts >= faces.getSize())
-  {
-    return;
-  }
-  for(usize i = 0; i < k_NumVerts; i++)
-  {
-    faces[offset + i] = verts[i];
-  }
-}
-
-void TriangleGeom::getVertexIdsForFace(usize faceId, usize verts[3]) const
-{
-  auto& cells = getFacesRef();
-  const usize offset = faceId * k_NumVerts;
-  if(offset + k_NumVerts >= cells.getSize())
-  {
-    return;
-  }
-  for(usize i = 0; i < k_NumVerts; i++)
-  {
-    verts[i] = cells.at(offset + i);
-  }
-}
-
-void TriangleGeom::getVertexCoordsForFace(usize faceId, Point3D<float32>& vert1, Point3D<float32>& vert2, Point3D<float32>& vert3) const
-{
-  usize verts[k_NumVerts];
-  getVertexIdsForFace(faceId, verts);
-  vert1 = getCoords(verts[0]);
-  vert2 = getCoords(verts[1]);
-  vert3 = getCoords(verts[2]);
-}
-
-usize TriangleGeom::getNumberOfFaces() const
-{
-  auto& faces = getFacesRef();
-  return faces.getNumberOfTuples();
-}
-
-usize TriangleGeom::getNumberOfElements() const
+usize TriangleGeom::getNumberOfCells() const
 {
   return getFacesRef().getNumberOfTuples();
+}
+
+usize TriangleGeom::getVertsPerFace() const
+{
+  return k_NumFaceVerts;
 }
 
 IGeometry::StatusCode TriangleGeom::findElementSizes()
@@ -207,28 +169,6 @@ void TriangleGeom::getShapeFunctions([[maybe_unused]] const Point3D<float64>& pC
   shape[5] = 1.0;
 }
 
-void TriangleGeom::setCoords(usize vertId, const Point3D<float32>& coords)
-{
-  auto& vertices = getVerticesRef();
-  const usize offset = vertId * 3;
-  for(usize i = 0; i < 3; i++)
-  {
-    vertices[offset + i] = coords[i];
-  }
-}
-
-Point3D<float32> TriangleGeom::getCoords(usize vertId) const
-{
-  auto& vertices = getVerticesRef();
-  const usize offset = vertId * 3;
-  Point3D<float32> coords;
-  for(usize i = 0; i < 3; i++)
-  {
-    coords[i] = vertices.at(offset + i);
-  }
-  return coords;
-}
-
 IGeometry::StatusCode TriangleGeom::findEdges()
 {
   auto dataStore = std::make_unique<DataStore<uint64>>(std::vector<usize>{0}, std::vector<usize>{2}, 0);
@@ -241,14 +181,6 @@ IGeometry::StatusCode TriangleGeom::findEdges()
   }
   m_EdgeListId = edgeList->getId();
   return 1;
-}
-
-void TriangleGeom::getVertCoordsAtEdge(usize edgeId, Point3D<float32>& vert1, Point3D<float32>& vert2) const
-{
-  usize verts[2];
-  getVertsAtEdge(edgeId, verts);
-  vert1 = getCoords(verts[0]);
-  vert2 = getCoords(verts[1]);
 }
 
 IGeometry::StatusCode TriangleGeom::findUnsharedEdges()

--- a/src/complex/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.cpp
@@ -83,7 +83,7 @@ usize TriangleGeom::getNumberOfCells() const
   return getFacesRef().getNumberOfTuples();
 }
 
-usize TriangleGeom::getVertsPerFace() const
+usize TriangleGeom::getNumberOfVerticesPerFace() const
 {
   return k_NumFaceVerts;
 }

--- a/src/complex/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.cpp
@@ -21,18 +21,6 @@ TriangleGeom::TriangleGeom(DataStructure& ds, std::string name, IdType importId)
 {
 }
 
-TriangleGeom::TriangleGeom(const TriangleGeom& other)
-: INodeGeometry2D(other)
-{
-}
-
-TriangleGeom::TriangleGeom(TriangleGeom&& other)
-: INodeGeometry2D(std::move(other))
-{
-}
-
-TriangleGeom::~TriangleGeom() noexcept = default;
-
 IGeometry::Type TriangleGeom::getGeomType() const
 {
   return IGeometry::Type::Triangle;

--- a/src/complex/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.cpp
@@ -82,6 +82,10 @@ void TriangleGeom::setVertexIdsForFace(usize faceId, usize verts[3])
 {
   auto& faces = getFacesRef();
   const usize offset = faceId * k_NumVerts;
+  if(offset + k_NumVerts >= faces.getSize())
+  {
+    return;
+  }
   for(usize i = 0; i < k_NumVerts; i++)
   {
     faces[offset + i] = verts[i];
@@ -90,11 +94,15 @@ void TriangleGeom::setVertexIdsForFace(usize faceId, usize verts[3])
 
 void TriangleGeom::getVertexIdsForFace(usize faceId, usize verts[3]) const
 {
-  auto& faces = getFacesRef();
+  auto& cells = getFacesRef();
   const usize offset = faceId * k_NumVerts;
+  if(offset + k_NumVerts >= cells.getSize())
+  {
+    return;
+  }
   for(usize i = 0; i < k_NumVerts; i++)
   {
-    verts[i] = faces.at(offset + i);
+    verts[i] = cells.at(offset + i);
   }
 }
 

--- a/src/complex/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.cpp
@@ -26,7 +26,7 @@ TriangleGeom::TriangleGeom(const TriangleGeom& other)
 {
 }
 
-TriangleGeom::TriangleGeom(TriangleGeom&& other) noexcept
+TriangleGeom::TriangleGeom(TriangleGeom&& other)
 : INodeGeometry2D(std::move(other))
 {
 }

--- a/src/complex/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.cpp
@@ -108,10 +108,10 @@ IGeometry::StatusCode TriangleGeom::findElementsContainingVert()
   GeometryHelpers::Connectivity::FindElementsContainingVert<uint16, MeshIndexType>(getFaces(), trianglesContainingVert, getNumberOfVertices());
   if(trianglesContainingVert == nullptr)
   {
-    m_ElementContainingVertId.reset();
+    m_CellContainingVertId.reset();
     return -1;
   }
-  m_ElementContainingVertId = trianglesContainingVert->getId();
+  m_CellContainingVertId = trianglesContainingVert->getId();
   return 1;
 }
 
@@ -130,10 +130,10 @@ IGeometry::StatusCode TriangleGeom::findElementNeighbors()
   err = GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getFaces(), getElementsContainingVert(), triangleNeighbors, IGeometry::Type::Triangle);
   if(triangleNeighbors == nullptr)
   {
-    m_ElementNeighborsId.reset();
+    m_CellNeighborsId.reset();
     return -1;
   }
-  m_ElementNeighborsId = triangleNeighbors->getId();
+  m_CellNeighborsId = triangleNeighbors->getId();
   return err;
 }
 
@@ -144,10 +144,10 @@ IGeometry::StatusCode TriangleGeom::findElementCentroids()
   GeometryHelpers::Topology::FindElementCentroids(getFaces(), getVertices(), triangleCentroids);
   if(triangleCentroids == nullptr)
   {
-    m_ElementCentroidsId.reset();
+    m_CellCentroidsId.reset();
     return -1;
   }
-  m_ElementCentroidsId = triangleCentroids->getId();
+  m_CellCentroidsId = triangleCentroids->getId();
   return 1;
 }
 

--- a/src/complex/DataStructure/Geometry/TriangleGeom.hpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.hpp
@@ -97,7 +97,7 @@ public:
    * @brief
    * @return
    */
-  usize getVertsPerFace() const override;
+  usize getNumberOfVerticesPerFace() const override;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/TriangleGeom.hpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.hpp
@@ -44,15 +44,15 @@ public:
    * @brief
    * @param other
    */
-  TriangleGeom(const TriangleGeom& other);
+  TriangleGeom(const TriangleGeom& other) = default;
 
   /**
    * @brief
    * @param other
    */
-  TriangleGeom(TriangleGeom&& other);
+  TriangleGeom(TriangleGeom&& other) = default;
 
-  ~TriangleGeom() noexcept override;
+  ~TriangleGeom() noexcept override = default;
 
   TriangleGeom& operator=(const TriangleGeom&) = delete;
   TriangleGeom& operator=(TriangleGeom&&) noexcept = delete;

--- a/src/complex/DataStructure/Geometry/TriangleGeom.hpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.hpp
@@ -4,6 +4,8 @@
 
 #include "complex/complex_export.hpp"
 
+#include <nonstd/span.hpp>
+
 namespace complex
 {
 /**
@@ -15,6 +17,8 @@ class COMPLEX_EXPORT TriangleGeom : public INodeGeometry2D
 public:
   friend class DataStructure;
 
+  static inline constexpr usize k_NumEdgeVerts = 2;
+  static inline constexpr usize k_NumFaceVerts = 3;
   static inline constexpr usize k_NumVerts = 3;
 
   /**
@@ -85,38 +89,15 @@ public:
 
   /**
    * @brief
-   * @param triId
-   * @param verts
-   */
-  void setVertexIdsForFace(usize triId, usize verts[3]);
-
-  /**
-   * @brief
-   * @param faceId
-   * @param verts
-   */
-  void getVertexIdsForFace(usize faceId, usize verts[3]) const;
-
-  /**
-   * @brief
-   * @param faceId
-   * @param vert1
-   * @param vert2
-   * @param vert3
-   */
-  void getVertexCoordsForFace(usize faceId, Point3D<float32>& vert1, Point3D<float32>& vert2, Point3D<float32>& vert3) const;
-
-  /**
-   * @brief
    * @return usize
    */
-  usize getNumberOfFaces() const;
+  usize getNumberOfCells() const override;
 
   /**
    * @brief
-   * @return usize
+   * @return
    */
-  usize getNumberOfElements() const override;
+  usize getVertsPerFace() const override;
 
   /**
    * @brief
@@ -157,30 +138,9 @@ public:
 
   /**
    * @brief
-   * @param vertId
-   * @param coords
-   */
-  void setCoords(usize vertId, const Point3D<float32>& coords) override;
-
-  /**
-   * @brief
-   * @param vertId
-   */
-  Point3D<float32> getCoords(usize vertId) const override;
-
-  /**
-   * @brief
    * @return StatusCode
    */
   StatusCode findEdges() override;
-
-  /**
-   * @brief
-   * @param edgeId
-   * @param vert1
-   * @param vert2
-   */
-  void getVertCoordsAtEdge(usize edgeId, Point3D<float32>& vert1, Point3D<float32>& vert2) const override;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/TriangleGeom.hpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.hpp
@@ -50,7 +50,7 @@ public:
    * @brief
    * @param other
    */
-  TriangleGeom(TriangleGeom&& other) noexcept;
+  TriangleGeom(TriangleGeom&& other);
 
   ~TriangleGeom() noexcept override;
 

--- a/src/complex/DataStructure/Geometry/VertexGeom.cpp
+++ b/src/complex/DataStructure/Geometry/VertexGeom.cpp
@@ -73,7 +73,7 @@ DataObject* VertexGeom::deepCopy()
   return new VertexGeom(*this);
 }
 
-Point3D<float32> VertexGeom::getCoords(usize vertId) const
+Point3D<float32> VertexGeom::getVertexCoordinate(usize vertId) const
 {
   const auto& vertices = getVerticesRef();
   const usize offset = vertId * 3;
@@ -85,7 +85,7 @@ Point3D<float32> VertexGeom::getCoords(usize vertId) const
   return coords;
 }
 
-void VertexGeom::setCoords(usize vertId, const Point3D<float32>& coords)
+void VertexGeom::setVertexCoordinate(usize vertId, const Point3D<float32>& coords)
 {
   auto& vertices = getVerticesRef();
   const usize offset = vertId * 3;
@@ -95,7 +95,7 @@ void VertexGeom::setCoords(usize vertId, const Point3D<float32>& coords)
   }
 }
 
-usize VertexGeom::getNumberOfElements() const
+usize VertexGeom::getNumberOfCells() const
 {
   return getNumberOfVertices();
 }
@@ -104,7 +104,7 @@ IGeometry::StatusCode VertexGeom::findElementSizes()
 {
   // Vertices are 0-dimensional (they have no getSize),
   // so simply splat 0 over the sizes array
-  auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfElements()}, std::vector<usize>{1}, 0.0f);
+  auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfCells()}, std::vector<usize>{1}, 0.0f);
 
   Float32Array* vertexSizes = DataArray<float32>::Create(getDataStructureRef(), "Voxel Sizes", std::move(dataStore), getId());
   if(vertexSizes == nullptr)

--- a/src/complex/DataStructure/Geometry/VertexGeom.cpp
+++ b/src/complex/DataStructure/Geometry/VertexGeom.cpp
@@ -73,33 +73,6 @@ DataObject* VertexGeom::deepCopy()
   return new VertexGeom(*this);
 }
 
-Point3D<float32> VertexGeom::getVertexCoordinate(usize vertId) const
-{
-  const auto& vertices = getVerticesRef();
-  const usize offset = vertId * 3;
-  Point3D<float32> coords;
-  for(usize i = 0; i < 3; i++)
-  {
-    coords[i] = vertices[offset + i];
-  }
-  return coords;
-}
-
-void VertexGeom::setVertexCoordinate(usize vertId, const Point3D<float32>& coords)
-{
-  auto& vertices = getVerticesRef();
-  const usize offset = vertId * 3;
-  for(usize i = 0; i < 3; i++)
-  {
-    vertices[offset + i] = coords[i];
-  }
-}
-
-usize VertexGeom::getNumberOfCells() const
-{
-  return getNumberOfVertices();
-}
-
 IGeometry::StatusCode VertexGeom::findElementSizes()
 {
   // Vertices are 0-dimensional (they have no getSize),

--- a/src/complex/DataStructure/Geometry/VertexGeom.hpp
+++ b/src/complex/DataStructure/Geometry/VertexGeom.hpp
@@ -88,20 +88,20 @@ public:
    * @param vertId
    * @return
    */
-  Point3D<float32> getCoords(usize vertId) const override;
+  Point3D<float32> getVertexCoordinate(usize vertId) const override;
 
   /**
    * @brief Sets the coordinates for the specified vertex ID.
    * @param vertId
    * @param coords
    */
-  void setCoords(usize vertId, const Point3D<float32>& coords) override;
+  void setVertexCoordinate(usize vertId, const Point3D<float32>& coords) override;
 
   /**
    * @brief
    * @return usize
    */
-  usize getNumberOfElements() const override;
+  usize getNumberOfCells() const override;
 
   /**
    * @brief

--- a/src/complex/DataStructure/Geometry/VertexGeom.hpp
+++ b/src/complex/DataStructure/Geometry/VertexGeom.hpp
@@ -84,26 +84,6 @@ public:
   DataObject* deepCopy() override;
 
   /**
-   * @brief Gets the coordinates at the target vertex ID.
-   * @param vertId
-   * @return
-   */
-  Point3D<float32> getVertexCoordinate(usize vertId) const override;
-
-  /**
-   * @brief Sets the coordinates for the specified vertex ID.
-   * @param vertId
-   * @param coords
-   */
-  void setVertexCoordinate(usize vertId, const Point3D<float32>& coords) override;
-
-  /**
-   * @brief
-   * @return usize
-   */
-  usize getNumberOfCells() const override;
-
-  /**
    * @brief
    * @return StatusCode
    */

--- a/src/complex/Filter/Actions/ImportH5ObjectPathsAction.cpp
+++ b/src/complex/Filter/Actions/ImportH5ObjectPathsAction.cpp
@@ -63,6 +63,10 @@ Result<> ImportH5ObjectPathsAction::apply(DataStructure& dataStructure, Mode mod
   for(const auto& targetPath : importPaths)
   {
     auto importObject = importStructure.getSharedData(targetPath);
+    if(nullptr == importObject)
+    {
+      continue;
+    }
     auto importData = std::shared_ptr<DataObject>(importObject->deepCopy());
     // Clear all children before inserting into the DataStructure
     if(auto importGroup = std::dynamic_pointer_cast<BaseGroup>(importData); importGroup != nullptr)

--- a/src/complex/Filter/Actions/ImportH5ObjectPathsAction.cpp
+++ b/src/complex/Filter/Actions/ImportH5ObjectPathsAction.cpp
@@ -62,11 +62,11 @@ Result<> ImportH5ObjectPathsAction::apply(DataStructure& dataStructure, Mode mod
   auto importPaths = getImportPaths(importStructure, m_Paths);
   for(const auto& targetPath : importPaths)
   {
-    auto importObject = importStructure.getSharedData(targetPath);
-    if(nullptr == importObject)
+    if(!importStructure.containsData(targetPath))
     {
-      continue;
+      return MakeErrorResult(-5900, fmt::format("DataStructure Object Path '{}' does not exist for importing.", targetPath.toString()));
     }
+    auto importObject = importStructure.getSharedData(targetPath);
     auto importData = std::shared_ptr<DataObject>(importObject->deepCopy());
     // Clear all children before inserting into the DataStructure
     if(auto importGroup = std::dynamic_pointer_cast<BaseGroup>(importData); importGroup != nullptr)

--- a/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -230,7 +230,7 @@ void WriteGeomXdmf(std::ostream& out, const VertexGeom& vertexGeom, std::string_
 void WriteGeomXdmf(std::ostream& out, const EdgeGeom& edgeGeom, std::string_view hdf5FilePath)
 {
   std::string name = edgeGeom.getName();
-  usize numEdges = edgeGeom.getNumberOfEdges();
+  usize numEdges = edgeGeom.getNumberOfCells();
   usize numVerts = edgeGeom.getNumberOfVertices();
 
   DataPath edgesPath = edgeGeom.getEdgesRef().getDataPaths().at(0);

--- a/src/complex/Utilities/SamplingUtils.hpp
+++ b/src/complex/Utilities/SamplingUtils.hpp
@@ -18,7 +18,7 @@ inline Result<> RenumberFeatures(DataStructure& dataStructure, const DataPath& n
   // This just sanity checks to make sure there were existing features before the cropping
   auto& destCellFeatureAM = dataStructure.getDataRefAs<AttributeMatrix>(destCellFeatAttributeMatrixPath);
 
-  usize totalPoints = destImageGeom.getNumberOfElements();
+  usize totalPoints = destImageGeom.getNumberOfCells();
 
   auto& featureIdsArray = dataStructure.getDataRefAs<IDataArray>(featureIdsArrayPath);
   usize totalFeatures = destCellFeatureAM.getNumTuples();

--- a/test/DREAM3DFileTest.cpp
+++ b/test/DREAM3DFileTest.cpp
@@ -1,12 +1,9 @@
 #include <catch2/catch.hpp>
 
 #include <filesystem>
-#include <iostream>
 #include <mutex>
 #include <string>
 #include <vector>
-
-#include "nlohmann/json.hpp"
 
 #include "complex/Core/Application.hpp"
 #include "complex/DataStructure/DataArray.hpp"
@@ -162,7 +159,7 @@ Pipeline CreateExportPipeline()
     args.insert("numeric_type", std::make_any<NumericType>(NumericType::int8));
     args.insert("component_count", std::make_any<uint64>(3));
 
-    args.insert("tuple_dimensions", DynamicTableInfo::TableDataType{{{1.0}}});
+    args.insert("tuple_dimensions", DynamicTableInfo::TableDataType{{1.0}});
     args.insert("initialization_value", std::make_any<std::string>("7"));
     args.insert("output_data_array", DataPath({DataNames::k_ArrayName}));
     pipeline.push_back(k_CreateDataArrayHandle, args);

--- a/test/GeometryTest.cpp
+++ b/test/GeometryTest.cpp
@@ -58,8 +58,8 @@ void testGeom2D(INodeGeometry2D* geom)
       geom->resizeVertexList(numVertices);
       REQUIRE(geom->getNumberOfVertices() == numVertices);
 
-      geom->setCoords(vertId, coord);
-      REQUIRE(geom->getCoords(vertId) == coord);
+      geom->setVertexCoordinate(vertId, coord);
+      REQUIRE(geom->getVertexCoordinate(vertId) == coord);
     }
 
     // edges
@@ -69,19 +69,20 @@ void testGeom2D(INodeGeometry2D* geom)
       REQUIRE(geom->getEdges() == edges);
       const usize numEdges = 5;
       geom->resizeEdgeList(numEdges);
-      REQUIRE(geom->getNumberOfEdges() == numEdges);
+      REQUIRE(geom->getNumberOfCells() == numEdges);
       const usize edgeId = 3;
-      const usize verts[2] = {vertId, vertId + 1};
-      geom->setVertsAtEdge(edgeId, verts);
-      Point3D<float32> vert1, vert2;
-      usize vertsOut[2];
-      geom->getVertsAtEdge(edgeId, vertsOut);
+      std::array<usize, 2> verts = {vertId, vertId + 1};
+      geom->setEdgePointIds(edgeId, verts);
+
+      std::array<Point3Df, 2> edge_verts;
+      std::array<usize, 2> vertsOut = {0, 0};
+      geom->getEdgePointIds(edgeId, vertsOut);
       for(usize i = 0; i < 2; i++)
       {
         REQUIRE(verts[i] == vertsOut[i]);
       }
-      geom->getVertCoordsAtEdge(edgeId, vert1, vert2);
-      REQUIRE(vert1 == coord);
+      geom->getEdgeCoordinates(edgeId, edge_verts);
+      REQUIRE(edge_verts[0] == coord);
     }
   }
 }
@@ -102,8 +103,8 @@ void testGeom3D(INodeGeometry3D* geom)
       geom->resizeVertexList(numVertices);
       REQUIRE(geom->getNumberOfVertices() == numVertices);
 
-      geom->setCoords(vertId, coord);
-      REQUIRE(geom->getCoords(vertId) == coord);
+      geom->setVertexCoordinate(vertId, coord);
+      REQUIRE(geom->getVertexCoordinate(vertId) == coord);
     }
     // edges
     {
@@ -112,19 +113,20 @@ void testGeom3D(INodeGeometry3D* geom)
       REQUIRE(geom->getEdges() == edges);
       const usize numEdges = 5;
       geom->resizeEdgeList(numEdges);
-      REQUIRE(geom->getNumberOfEdges() == numEdges);
+      REQUIRE(geom->getNumberOfCells() == numEdges);
       const usize edgeId = 3;
-      const usize verts[2] = {vertId, vertId + 1};
-      geom->setVertsAtEdge(edgeId, verts);
-      Point3D<float32> vert1, vert2;
+      std::array<usize, 2> verts = {vertId, vertId + 1};
+      geom->setEdgePointIds(edgeId, verts);
       usize vertsOut[2];
-      geom->getVertsAtEdge(edgeId, vertsOut);
+      geom->getEdgePointIds(edgeId, vertsOut);
       for(usize i = 0; i < 2; i++)
       {
         REQUIRE(verts[i] == vertsOut[i]);
       }
-      geom->getVertCoordsAtEdge(edgeId, vert1, vert2);
-      REQUIRE(vert1 == coord);
+      std::array<Point3Df, 2> edge_verts;
+
+      geom->getEdgeCoordinates(edgeId, edge_verts);
+      REQUIRE(edge_verts[0] == coord);
     }
     // faces
     {

--- a/test/GeometryTest.cpp
+++ b/test/GeometryTest.cpp
@@ -69,7 +69,7 @@ void testGeom2D(INodeGeometry2D* geom)
       REQUIRE(geom->getEdges() == edges);
       const usize numEdges = 5;
       geom->resizeEdgeList(numEdges);
-      REQUIRE(geom->getNumberOfCells() == numEdges);
+      REQUIRE(geom->getNumberOfEdges() == numEdges);
       const usize edgeId = 3;
       std::array<usize, 2> verts = {vertId, vertId + 1};
       geom->setEdgePointIds(edgeId, verts);
@@ -113,7 +113,7 @@ void testGeom3D(INodeGeometry3D* geom)
       REQUIRE(geom->getEdges() == edges);
       const usize numEdges = 5;
       geom->resizeEdgeList(numEdges);
-      REQUIRE(geom->getNumberOfCells() == numEdges);
+      REQUIRE(geom->getNumberOfEdges() == numEdges);
       const usize edgeId = 3;
       std::array<usize, 2> verts = {vertId, vertId + 1};
       geom->setEdgePointIds(edgeId, verts);


### PR DESCRIPTION
Update VertexGeometry with some sanity checks to not walk off the end of the array.