### PR TITLE
Updated baseline nlohmann-json to 3.11.2

### DIFF
--- a/src/complex/Common/StringLiteral.hpp
+++ b/src/complex/Common/StringLiteral.hpp
@@ -132,27 +132,75 @@ private:
 };
 
 template <class T>
-constexpr bool operator==(const std::basic_string<T>& lhs, BasicStringLiteral<T> rhs)
+bool operator==(const std::basic_string<T>& lhs, BasicStringLiteral<T> rhs)
 {
   return lhs == rhs.view();
 }
 
 template <class T>
-constexpr bool operator==(BasicStringLiteral<T> lhs, const std::basic_string<T>& rhs)
+bool operator==(BasicStringLiteral<T> lhs, const std::basic_string<T>& rhs)
 {
   return rhs == lhs;
 }
 
 template <class T>
-constexpr bool operator!=(const std::basic_string<T>& lhs, BasicStringLiteral<T> rhs)
+bool operator!=(const std::basic_string<T>& lhs, BasicStringLiteral<T> rhs)
 {
   return lhs != rhs.view();
 }
 
 template <class T>
-constexpr bool operator!=(BasicStringLiteral<T> lhs, const std::basic_string<T>& rhs)
+bool operator!=(BasicStringLiteral<T> lhs, const std::basic_string<T>& rhs)
 {
   return rhs != lhs;
+}
+
+template <class T>
+bool operator<(const std::basic_string<T>& lhs, BasicStringLiteral<T> rhs)
+{
+  return lhs < rhs.view();
+}
+
+template <class T>
+bool operator<(BasicStringLiteral<T> lhs, const std::basic_string<T>& rhs)
+{
+  return lhs.view() < rhs;
+}
+
+template <class T>
+bool operator>(const std::basic_string<T>& lhs, BasicStringLiteral<T> rhs)
+{
+  return lhs > rhs.view();
+}
+
+template <class T>
+bool operator>(BasicStringLiteral<T> lhs, const std::basic_string<T>& rhs)
+{
+  return lhs.view() > rhs;
+}
+
+template <class T>
+bool operator<=(const std::basic_string<T>& lhs, BasicStringLiteral<T> rhs)
+{
+  return lhs <= rhs.view();
+}
+
+template <class T>
+bool operator<=(BasicStringLiteral<T> lhs, const std::basic_string<T>& rhs)
+{
+  return lhs.view() <= rhs;
+}
+
+template <class T>
+bool operator>=(const std::basic_string<T>& lhs, BasicStringLiteral<T> rhs)
+{
+  return lhs >= rhs.view();
+}
+
+template <class T>
+bool operator>=(BasicStringLiteral<T> lhs, const std::basic_string<T>& rhs)
+{
+  return lhs.view() >= rhs;
 }
 
 using StringLiteral = BasicStringLiteral<char>;

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -22,7 +22,7 @@
         "vcpkg-cmake",
         "vcpkg-cmake-config"
       ],
-      "baseline": "d31bbc80580a9e73a8d2128cf7af1c5ca2e0688b"
+      "baseline": "7a69aa6ae4936ba54651c4139c4884cafce1bde7"
     }
   ]
 }


### PR DESCRIPTION
* Added more comparison operators to StringLiteral to allow it to be used in nlohmann::json for key access
* Removed constexpr from existing comparison functions for StringLiteral since std::string isn't constexpr until C++20