### PR TITLE
Geometry API: Rename methods to better convey what they do.

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/PointSampleTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/PointSampleTriangleGeometry.cpp
@@ -66,7 +66,7 @@ Result<> PointSampleTriangleGeometry::operator()()
   VertexGeom& vertex = m_DataStructure.getDataRefAs<VertexGeom>(m_Inputs->pVertexGeometryPath);
   vertex.resizeVertexList(m_Inputs->pNumberOfSamples);
   auto tupleShape = {static_cast<usize>(m_Inputs->pNumberOfSamples)};
-  ResizeAttributeMatrix(*vertex.getVertexData(), tupleShape);
+  ResizeAttributeMatrix(*vertex.getVertexAttributeMatrix(), tupleShape);
 
   std::mt19937_64::result_type seed = static_cast<std::mt19937_64::result_type>(std::chrono::steady_clock::now().time_since_epoch().count());
   std::mt19937_64 generator(seed);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/QuickSurfaceMesh.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/QuickSurfaceMesh.cpp
@@ -103,8 +103,8 @@ Result<> QuickSurfaceMesh::operator()()
   std::vector<usize> tupleShape = {triangleCount};
   triangleGeom.resizeFaceList(triangleCount);
   triangleGeom.resizeVertexList(nodeCount);
-  ResizeAttributeMatrix(*triangleGeom.getFaceData(), tupleShape);
-  ResizeAttributeMatrix(*triangleGeom.getVertexData(), {nodeCount});
+  ResizeAttributeMatrix(*triangleGeom.getFaceAttributeMatrix(), tupleShape);
+  ResizeAttributeMatrix(*triangleGeom.getVertexAttributeMatrix(), {nodeCount});
 
   // Resize the Face Arrays that are being copied over from the ImageGeom Cell Data
   for(const auto& dataPath : m_Inputs->pCreatedDataArrayPaths)
@@ -808,8 +808,8 @@ void QuickSurfaceMesh::createNodesAndTriangles(std::vector<MeshIndexType>& m_Nod
   std::vector<size_t> tDims = {nodeCount};
   triangleGeom->resizeVertexList(nodeCount);
   triangleGeom->resizeFaceList(triangleCount);
-  ResizeAttributeMatrix(*triangleGeom->getFaceData(), {triangleCount});
-  ResizeAttributeMatrix(*triangleGeom->getVertexData(), tDims);
+  ResizeAttributeMatrix(*triangleGeom->getFaceAttributeMatrix(), {triangleCount});
+  ResizeAttributeMatrix(*triangleGeom->getVertexAttributeMatrix(), tDims);
 
   // Remove and then insert a properly sized Int32Array for the FaceLabels
   m_DataStructure.removeData(m_Inputs->pFaceLabelsDataPath);
@@ -1567,5 +1567,5 @@ void QuickSurfaceMesh::generateTripleLines()
     edges->getDataStore()->setValue(idx * numComps + 0, i0);
     edges->getDataStore()->setValue(idx * numComps + 1, i1);
   }
-  tripleLineEdge->setEdges(*edges);
+  tripleLineEdge->setEdgeList(*edges);
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/StlFileReader.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/StlFileReader.cpp
@@ -386,8 +386,8 @@ Result<> StlFileReader::eliminate_duplicate_nodes()
     triangles[i * 3 + 2] = uniqueIds[node3];
   }
 
-  ResizeAttributeMatrix(*triangleGeom.getFaceData(), {triangleGeom.getNumberOfFaces()});
-  ResizeAttributeMatrix(*triangleGeom.getVertexData(), {triangleGeom.getNumberOfVertices()});
+  ResizeAttributeMatrix(*triangleGeom.getFaceAttributeMatrix(), {triangleGeom.getNumberOfFaces()});
+  ResizeAttributeMatrix(*triangleGeom.getVertexAttributeMatrix(), {triangleGeom.getNumberOfVertices()});
 
   return {};
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateTriangleAreasFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateTriangleAreasFilter.cpp
@@ -142,7 +142,7 @@ IFilter::PreflightResult CalculateTriangleAreasFilter::preflightImpl(const DataS
   const TriangleGeom* triangleGeom = dataStructure.getDataAs<TriangleGeom>(pTriangleGeometryDataPath);
 
   // Get the Face AttributeMatrix from the Geometry (It should have been set at construction of the Triangle Geometry)
-  const AttributeMatrix* faceAttributeMatrix = triangleGeom->getFaceData();
+  const AttributeMatrix* faceAttributeMatrix = triangleGeom->getFaceAttributeMatrix();
   if(faceAttributeMatrix == nullptr)
   {
     return {nonstd::make_unexpected(std::vector<Error>{
@@ -168,7 +168,7 @@ Result<> CalculateTriangleAreasFilter::executeImpl(DataStructure& dataStructure,
   auto pTriangleGeometryDataPath = filterArgs.value<DataPath>(k_TriangleGeometryDataPath_Key);
 
   const TriangleGeom& triangleGeom = dataStructure.getDataRefAs<TriangleGeom>(pTriangleGeometryDataPath);
-  const AttributeMatrix& faceAttributeMatrix = triangleGeom.getFaceDataRef();
+  const AttributeMatrix& faceAttributeMatrix = triangleGeom.getFaceAttributeMatrixRef();
 
   DataPath pCalculatedAreasDataPath = pTriangleGeometryDataPath.createChildPath(faceAttributeMatrix.getName()).createChildPath(pCalculatedAreasName);
   auto& faceAreas = dataStructure.getDataRefAs<Float64Array>(pCalculatedAreasDataPath);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
@@ -126,7 +126,7 @@ IFilter::PreflightResult CropVertexGeometry::preflightImpl(const DataStructure& 
     }
   }
 
-  auto* vertexAM = vertexGeom.getVertexData();
+  auto* vertexAM = vertexGeom.getVertexAttributeMatrix();
   if(vertexAM == nullptr)
   {
     return {MakeErrorResult<OutputActions>(-5551, "Could not find vertex data AttributeMatrix in selected Vertex Geometry"), {}};

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -253,7 +253,7 @@ Result<> ExtractInternalSurfacesFromTriangleGeometry::executeImpl(DataStructure&
   internalTriangleGeom.setVertices(*data.getDataAs<Float32Array>(internalVerticesPath));
 
   auto internalFacesPath = internalTrianglesPath.createChildPath(CreateTriangleGeometryAction::k_DefaultFacesName);
-  internalTriangleGeom.setFaces(*data.getDataAs<UInt64Array>(internalFacesPath));
+  internalTriangleGeom.setFaceList(*data.getDataAs<UInt64Array>(internalFacesPath));
 
   // int64 progIncrement = numTris / 100;
   // int64 prog = 1;
@@ -307,8 +307,8 @@ Result<> ExtractInternalSurfacesFromTriangleGeometry::executeImpl(DataStructure&
   // Resize the vertex and triangle arrays
   internalTriangleGeom.resizeVertexList(currentNewVertIndex);
   internalTriangleGeom.resizeFaceList(currentNewTriIndex);
-  ResizeAttributeMatrix(*internalTriangleGeom.getVertexData(), {currentNewVertIndex});
-  ResizeAttributeMatrix(*internalTriangleGeom.getFaceData(), {currentNewTriIndex});
+  ResizeAttributeMatrix(*internalTriangleGeom.getVertexAttributeMatrix(), {currentNewVertIndex});
+  ResizeAttributeMatrix(*internalTriangleGeom.getFaceAttributeMatrix(), {currentNewTriIndex});
 
   IGeometry::SharedVertexList* internalVerts = internalTriangleGeom.getVertices();
   IGeometry::SharedFaceList* internalTriangles = internalTriangleGeom.getFaces();

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
@@ -115,7 +115,7 @@ IFilter::PreflightResult RemoveFlaggedVertices::preflightImpl(const DataStructur
     std::string errorMsg = fmt::format("Vertex Geometry not found at path: '{}'", vertexGeomPath.toString());
     return {MakeErrorResult<OutputActions>(::k_VertexGeomNotFound, errorMsg)};
   }
-  auto verticesId = vertex->getVertexListId();
+  auto verticesId = vertex->getSharedVertexDataArrayId();
   auto* verticesArray = dataStructure.getDataAs<Float32Array>(verticesId);
   if(verticesArray == nullptr)
   {
@@ -194,7 +194,7 @@ Result<> RemoveFlaggedVertices::executeImpl(DataStructure& data, const Arguments
 
   VertexGeom& reducedVertex = data.getDataRefAs<VertexGeom>(reducedVertexPath);
   reducedVertex.resizeVertexList(trueCount);
-  ResizeAttributeMatrix(*reducedVertex.getVertexData(), tDims);
+  ResizeAttributeMatrix(*reducedVertex.getVertexAttributeMatrix(), tDims);
 
   for(size_t i = 0; i < trueCount; i++)
   {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleDihedralAngleFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleDihedralAngleFilter.cpp
@@ -171,20 +171,15 @@ IFilter::PreflightResult TriangleDihedralAngleFilter::preflightImpl(const DataSt
 
   const auto* triangleGeom = dataStructure.getDataAs<TriangleGeom>(pTriangleGeometryDataPath);
   // Get the Face AttributeMatrix from the Geometry (It should have been set at construction of the Triangle Geometry)
-  const AttributeMatrix* faceAttributeMatrix = triangleGeom->getFaceData();
+  const AttributeMatrix* faceAttributeMatrix = triangleGeom->getFaceAttributeMatrix();
   if(faceAttributeMatrix == nullptr)
   {
-<<<<<<< HEAD
-    return {nonstd::make_unexpected(std::vector<Error>{
-        Error{k_MissingFeatureAttributeMatrix, fmt::format("Could not find Triangle Face Attribute Matrix with in the Triangle Geometry '{}'", pTriangleGeometryDataPath.toString())}})};
-=======
     return {MakeErrorResult<OutputActions>(-9860, fmt::format("Cannot find the selected Triangle Geometry at path '{}'", pTriangleGeometryDataPath.toString()))};
   }
   const AttributeMatrix* faceData = triangleGeom->getFaceAttributeMatrix();
   if(faceData == nullptr)
   {
     return {MakeErrorResult<OutputActions>(-9861, fmt::format("Cannot find the face data Attribute Matrix for the selected Triangle Geometry at path '{}'", pTriangleGeometryDataPath.toString()))};
->>>>>>> f788a2be (Geometry API: Rename methods to better convey what they do.)
   }
 
   // Instantiate and move the action that will create the output array
@@ -206,18 +201,10 @@ Result<> TriangleDihedralAngleFilter::executeImpl(DataStructure& dataStructure, 
   auto pTriangleGeometryDataPath = filterArgs.value<DataPath>(k_TGeometryDataPath_Key);
   auto pMinDihedralAnglesName = filterArgs.value<std::string>(k_SurfaceMeshTriangleDihedralAnglesArrayName_Key);
 
-<<<<<<< HEAD
-  const TriangleGeom& triangleGeom = dataStructure.getDataRefAs<TriangleGeom>(pTriangleGeometryDataPath);
-  const AttributeMatrix& faceAttributeMatrix = triangleGeom.getFaceDataRef();
-
-  DataPath dihedralAnglesArrayPath = pTriangleGeometryDataPath.createChildPath(faceAttributeMatrix.getName()).createChildPath(pMinDihedralAnglesName);
-  auto& dihedralAngles = dataStructure.getDataRefAs<Float64Array>(dihedralAnglesArrayPath);
-=======
   TriangleGeom& triangleGeom = dataStructure.getDataRefAs<TriangleGeom>(pTriangleGeometryDataPath);
   AttributeMatrix* faceData = triangleGeom.getFaceAttributeMatrix();
-  DataPath dihedralAnglesArrayPath = pTriangleGeometryDataPath.createChildPath(faceData->getName()).createChildPath(pSurfaceMeshTriangleDihedralAnglesName);
+  DataPath dihedralAnglesArrayPath = pTriangleGeometryDataPath.createChildPath(faceData->getName()).createChildPath(pMinDihedralAnglesName);
   Float64Array& dihedralAngles = dataStructure.getDataRefAs<Float64Array>(dihedralAnglesArrayPath);
->>>>>>> f788a2be (Geometry API: Rename methods to better convey what they do.)
 
   ParallelDataAlgorithm dataAlg;
   dataAlg.setParallelizationEnabled(false);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleDihedralAngleFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleDihedralAngleFilter.cpp
@@ -170,14 +170,13 @@ IFilter::PreflightResult TriangleDihedralAngleFilter::preflightImpl(const DataSt
   std::vector<PreflightValue> preflightUpdatedValues;
 
   const auto* triangleGeom = dataStructure.getDataAs<TriangleGeom>(pTriangleGeometryDataPath);
-  // Get the Face AttributeMatrix from the Geometry (It should have been set at construction of the Triangle Geometry)
-  const AttributeMatrix* faceAttributeMatrix = triangleGeom->getFaceAttributeMatrix();
-  if(faceAttributeMatrix == nullptr)
+  if(triangleGeom == nullptr)
   {
     return {MakeErrorResult<OutputActions>(-9860, fmt::format("Cannot find the selected Triangle Geometry at path '{}'", pTriangleGeometryDataPath.toString()))};
   }
-  const AttributeMatrix* faceData = triangleGeom->getFaceAttributeMatrix();
-  if(faceData == nullptr)
+  // Get the Face AttributeMatrix from the Geometry (It should have been set at construction of the Triangle Geometry)
+  const AttributeMatrix* faceAttributeMatrix = triangleGeom->getFaceAttributeMatrix();
+  if(faceAttributeMatrix == nullptr)
   {
     return {MakeErrorResult<OutputActions>(-9861, fmt::format("Cannot find the face data Attribute Matrix for the selected Triangle Geometry at path '{}'", pTriangleGeometryDataPath.toString()))};
   }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleDihedralAngleFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleDihedralAngleFilter.cpp
@@ -174,8 +174,17 @@ IFilter::PreflightResult TriangleDihedralAngleFilter::preflightImpl(const DataSt
   const AttributeMatrix* faceAttributeMatrix = triangleGeom->getFaceData();
   if(faceAttributeMatrix == nullptr)
   {
+<<<<<<< HEAD
     return {nonstd::make_unexpected(std::vector<Error>{
         Error{k_MissingFeatureAttributeMatrix, fmt::format("Could not find Triangle Face Attribute Matrix with in the Triangle Geometry '{}'", pTriangleGeometryDataPath.toString())}})};
+=======
+    return {MakeErrorResult<OutputActions>(-9860, fmt::format("Cannot find the selected Triangle Geometry at path '{}'", pTriangleGeometryDataPath.toString()))};
+  }
+  const AttributeMatrix* faceData = triangleGeom->getFaceAttributeMatrix();
+  if(faceData == nullptr)
+  {
+    return {MakeErrorResult<OutputActions>(-9861, fmt::format("Cannot find the face data Attribute Matrix for the selected Triangle Geometry at path '{}'", pTriangleGeometryDataPath.toString()))};
+>>>>>>> f788a2be (Geometry API: Rename methods to better convey what they do.)
   }
 
   // Instantiate and move the action that will create the output array
@@ -197,11 +206,18 @@ Result<> TriangleDihedralAngleFilter::executeImpl(DataStructure& dataStructure, 
   auto pTriangleGeometryDataPath = filterArgs.value<DataPath>(k_TGeometryDataPath_Key);
   auto pMinDihedralAnglesName = filterArgs.value<std::string>(k_SurfaceMeshTriangleDihedralAnglesArrayName_Key);
 
+<<<<<<< HEAD
   const TriangleGeom& triangleGeom = dataStructure.getDataRefAs<TriangleGeom>(pTriangleGeometryDataPath);
   const AttributeMatrix& faceAttributeMatrix = triangleGeom.getFaceDataRef();
 
   DataPath dihedralAnglesArrayPath = pTriangleGeometryDataPath.createChildPath(faceAttributeMatrix.getName()).createChildPath(pMinDihedralAnglesName);
   auto& dihedralAngles = dataStructure.getDataRefAs<Float64Array>(dihedralAnglesArrayPath);
+=======
+  TriangleGeom& triangleGeom = dataStructure.getDataRefAs<TriangleGeom>(pTriangleGeometryDataPath);
+  AttributeMatrix* faceData = triangleGeom.getFaceAttributeMatrix();
+  DataPath dihedralAnglesArrayPath = pTriangleGeometryDataPath.createChildPath(faceData->getName()).createChildPath(pSurfaceMeshTriangleDihedralAnglesName);
+  Float64Array& dihedralAngles = dataStructure.getDataRefAs<Float64Array>(dihedralAnglesArrayPath);
+>>>>>>> f788a2be (Geometry API: Rename methods to better convey what they do.)
 
   ParallelDataAlgorithm dataAlg;
   dataAlg.setParallelizationEnabled(false);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleNormalFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleNormalFilter.cpp
@@ -136,7 +136,7 @@ IFilter::PreflightResult TriangleNormalFilter::preflightImpl(const DataStructure
 
   const auto* triangleGeom = dataStructure.getDataAs<TriangleGeom>(pTriangleGeometryDataPath);
   // Get the Face AttributeMatrix from the Geometry (It should have been set at construction of the Triangle Geometry)
-  const AttributeMatrix* faceAttributeMatrix = triangleGeom->getFaceData();
+  const AttributeMatrix* faceAttributeMatrix = triangleGeom->getFaceAttributeMatrix();
   if(faceAttributeMatrix == nullptr)
   {
     return {nonstd::make_unexpected(std::vector<Error>{
@@ -162,7 +162,7 @@ Result<> TriangleNormalFilter::executeImpl(DataStructure& dataStructure, const A
   auto pSurfaceMeshTriangleNormalsName = filterArgs.value<std::string>(k_SurfaceMeshTriangleNormalsArrayPath_Key);
 
   const TriangleGeom& triangleGeom = dataStructure.getDataRefAs<TriangleGeom>(pTriangleGeometryDataPath);
-  const AttributeMatrix& faceAttributeMatrix = triangleGeom.getFaceDataRef();
+  const AttributeMatrix& faceAttributeMatrix = triangleGeom.getFaceAttributeMatrixRef();
 
   DataPath pSurfaceMeshTriangleNormalsArrayPath = pTriangleGeometryDataPath.createChildPath(faceAttributeMatrix.getName()).createChildPath(pSurfaceMeshTriangleNormalsName);
   auto& normals = dataStructure.getDataRefAs<Float64Array>(pSurfaceMeshTriangleNormalsArrayPath);

--- a/src/Plugins/ComplexCore/test/CalculateTriangleAreasFilterTest.cpp
+++ b/src/Plugins/ComplexCore/test/CalculateTriangleAreasFilterTest.cpp
@@ -71,7 +71,7 @@ TEST_CASE("ComplexCore::CalculateTriangleAreasFilter", "[ComplexCore][CalculateT
     REQUIRE(executeResult.result.valid());
 
     auto& triangleGeom = dataGraph.getDataRefAs<TriangleGeom>(geometryPath);
-    DataPath triangleAreasDataPath = geometryPath.createChildPath(triangleGeom.getFaceData()->getName()).createChildPath(triangleAreasName);
+    DataPath triangleAreasDataPath = geometryPath.createChildPath(triangleGeom.getFaceAttributeMatrix()->getName()).createChildPath(triangleAreasName);
 
     // Let's sum up all the areas.
     Float64Array& faceAreas = dataGraph.getDataRefAs<Float64Array>(triangleAreasDataPath);

--- a/src/Plugins/ComplexCore/test/CropVertexGeometryTest.cpp
+++ b/src/Plugins/ComplexCore/test/CropVertexGeometryTest.cpp
@@ -26,7 +26,7 @@ DataStructure createTestData()
 
   auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, k_VertexDataName, vertexGeom->getId());
   vertexAttributeMatrix->setShape({k_TupleCount});
-  vertexGeom->setVertexData(*vertexAttributeMatrix);
+  vertexGeom->setVertexAttributeMatrix(*vertexAttributeMatrix);
 
   auto* dataArray = Int32Array::CreateWithStore<Int32DataStore>(dataStructure, "DataArray", {k_TupleCount}, {1}, vertexAttributeMatrix->getId());
   auto& dataStore = dataArray->getDataStoreRef();

--- a/src/Plugins/ComplexCore/test/ExtractInternalSurfacesFromTriangleGeometryTest.cpp
+++ b/src/Plugins/ComplexCore/test/ExtractInternalSurfacesFromTriangleGeometryTest.cpp
@@ -44,7 +44,7 @@ DataStructure createTestData(const std::string& triangleGeomName, const std::str
   triangles[11] = 3;
 
   triangleGeom->setVertices(*vertListdata);
-  triangleGeom->setFaces(*triangleList);
+  triangleGeom->setFaceList(*triangleList);
 
   auto* nodeArray = Int8Array::CreateWithStore<Int8DataStore>(ds, nodeTypesName, {triangleGeom->getNumberOfFaces()}, {1}, triangleGeom->getId());
   auto& nodeData = nodeArray->getDataStoreRef();
@@ -110,8 +110,8 @@ TEST_CASE("ComplexCore::ExtractInternalSurfacesFromTriangleGeometry(Data)", "[Co
   }
 
   {
-    auto* newTrianglesArray = ds.getDataAs<IDataArray>(newTrianglesGeom->getFaceListId());
-    auto* oldTrianglesArray = ds.getDataAs<IDataArray>(oldTrianglesGeom->getFaceListId());
+    auto* newTrianglesArray = ds.getDataAs<IDataArray>(newTrianglesGeom->getFaceListDataArrayId());
+    auto* oldTrianglesArray = ds.getDataAs<IDataArray>(oldTrianglesGeom->getFaceListDataArrayId());
 
     REQUIRE(newTrianglesArray != nullptr);
     REQUIRE(oldTrianglesArray != nullptr);

--- a/src/Plugins/ComplexCore/test/PointSampleTriangleGeometryFilterTest.cpp
+++ b/src/Plugins/ComplexCore/test/PointSampleTriangleGeometryFilterTest.cpp
@@ -128,7 +128,7 @@ TEST_CASE("ComplexCore::PointSampleTriangleGeometryFilter", "[DREAM3DReview][Poi
     REQUIRE(executeResult.result.valid());
 
     auto& triangleGeom = dataGraph.getDataRefAs<TriangleGeom>(geometryPath);
-    DataPath triangleAreasDataPath = geometryPath.createChildPath(triangleGeom.getFaceData()->getName()).createChildPath(triangleAreasName);
+    DataPath triangleAreasDataPath = geometryPath.createChildPath(triangleGeom.getFaceAttributeMatrix()->getName()).createChildPath(triangleAreasName);
 
     // Let's sum up all the areas.
     Float64Array& faceAreas = dataGraph.getDataRefAs<Float64Array>(triangleAreasDataPath);

--- a/src/Plugins/ComplexCore/test/RemoveFlaggedVerticesTest.cpp
+++ b/src/Plugins/ComplexCore/test/RemoveFlaggedVerticesTest.cpp
@@ -44,7 +44,7 @@ TEST_CASE("ComplexCore::RemoveFlaggedVertices: Test Algorithm", "[ComplexCore][R
 
   auto* vertexAttributeMatrix = AttributeMatrix::Create(dataGraph, Constants::k_VertexDataGroupName, vertexGeom->getId());
   vertexAttributeMatrix->setShape(vertexTupleDims);
-  vertexGeom->setVertexData(*vertexAttributeMatrix);
+  vertexGeom->setVertexAttributeMatrix(*vertexAttributeMatrix);
 
   Int32Array* slipVector = UnitTest::CreateTestDataArray<int32>(dataGraph, Constants::k_SlipVector, vertexTupleDims, vertexCompDims, vertexAttributeMatrix->getId());
   Int32Array* featureIds = UnitTest::CreateTestDataArray<int32>(dataGraph, Constants::k_FeatureIds, vertexTupleDims, {1}, vertexAttributeMatrix->getId());

--- a/src/Plugins/ComplexCore/test/TriangleDihedralAngleFilterTest.cpp
+++ b/src/Plugins/ComplexCore/test/TriangleDihedralAngleFilterTest.cpp
@@ -56,10 +56,10 @@ TEST_CASE("ComplexCore::TriangleDihedralAngleFilter[valid results]", "[ComplexCo
   TriangleGeom& acuteTriangle = *TriangleGeom::Create(dataStructure, triangleGeometryName);
   AttributeMatrix* faceData = AttributeMatrix::Create(dataStructure, INodeGeometry2D::k_FaceDataName, acuteTriangle.getId());
   faceData->setShape({k_FaceTupleCount});
-  acuteTriangle.setFaceData(*faceData);
+  acuteTriangle.setFaceAttributeMatrix(*faceData);
   AttributeMatrix* vertData = AttributeMatrix::Create(dataStructure, INodeGeometry0D::k_VertexDataName, acuteTriangle.getId());
   vertData->setShape({k_VertexTupleCount});
-  acuteTriangle.setVertexData(*vertData);
+  acuteTriangle.setVertexAttributeMatrix(*vertData);
   auto vertexList = createVertexList(acuteTriangle, vertData->getId());
   auto facesList = createFaceList(acuteTriangle, faceData->getId());
   auto underlyingStoreV = vertexList->getDataStorePtr().lock();
@@ -80,7 +80,7 @@ TEST_CASE("ComplexCore::TriangleDihedralAngleFilter[valid results]", "[ComplexCo
   {
     underlyingStoreF->setValue(count++, element);
   }
-  acuteTriangle.setFaces(*facesList);
+  acuteTriangle.setFaceList(*facesList);
   acuteTriangle.setVertices(*vertexList);
 
   TriangleDihedralAngleFilter filter;

--- a/src/complex/DataStructure/Geometry/EdgeGeom.cpp
+++ b/src/complex/DataStructure/Geometry/EdgeGeom.cpp
@@ -101,10 +101,10 @@ IGeometry::StatusCode EdgeGeom::findElementsContainingVert()
   GeometryHelpers::Connectivity::FindElementsContainingVert<uint16, MeshIndexType>(getEdges(), containsVert, getNumberOfVertices());
   if(containsVert == nullptr)
   {
-    m_CellContainingVertId.reset();
+    m_CellContainingVertDataArrayId.reset();
     return -1;
   }
-  m_CellContainingVertId = containsVert->getId();
+  m_CellContainingVertDataArrayId = containsVert->getId();
   return 1;
 }
 
@@ -125,11 +125,11 @@ IGeometry::StatusCode EdgeGeom::findElementNeighbors()
     err = -1;
     return err;
   }
-  m_CellNeighborsId = edgeNeighbors->getId();
+  m_CellNeighborsDataArrayId = edgeNeighbors->getId();
   err = GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getEdges(), getElementsContainingVert(), edgeNeighbors, IGeometry::Type::Edge);
   if(getElementNeighbors() == nullptr)
   {
-    m_CellNeighborsId.reset();
+    m_CellNeighborsDataArrayId.reset();
     err = -1;
   }
   return err;
@@ -144,7 +144,7 @@ IGeometry::StatusCode EdgeGeom::findElementCentroids()
   {
     return -1;
   }
-  m_CellCentroidsId = edgeCentroids->getId();
+  m_CellCentroidsDataArrayId = edgeCentroids->getId();
   return 1;
 }
 

--- a/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/HexahedralGeom.cpp
@@ -98,11 +98,11 @@ IGeometry::StatusCode HexahedralGeom::findElementSizes()
 IGeometry::StatusCode HexahedralGeom::findElementsContainingVert()
 {
   auto* hexasControllingVert = DynamicListArray<uint16_t, MeshIndexType>::Create(*getDataStructure(), "Hex Containing Vertices", getId());
-  m_CellContainingVertId = hexasControllingVert->getId();
+  m_CellContainingVertDataArrayId = hexasControllingVert->getId();
   GeometryHelpers::Connectivity::FindElementsContainingVert<uint16, MeshIndexType>(getPolyhedra(), hexasControllingVert, getNumberOfVertices());
   if(getElementsContainingVert() == nullptr)
   {
-    m_CellContainingVertId.reset();
+    m_CellContainingVertDataArrayId.reset();
     return -1;
   }
   return 1;
@@ -120,11 +120,11 @@ IGeometry::StatusCode HexahedralGeom::findElementNeighbors()
     }
   }
   auto* hexNeighbors = DynamicListArray<uint16_t, MeshIndexType>::Create(*getDataStructure(), "Hex Neighbors", getId());
-  m_CellNeighborsId = hexNeighbors->getId();
+  m_CellNeighborsDataArrayId = hexNeighbors->getId();
   err = GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getPolyhedra(), getElementsContainingVert(), hexNeighbors, IGeometry::Type::Hexahedral);
   if(getElementNeighbors() == nullptr)
   {
-    m_CellNeighborsId.reset();
+    m_CellNeighborsDataArrayId.reset();
     return -1;
   }
   return err;
@@ -134,11 +134,11 @@ IGeometry::StatusCode HexahedralGeom::findElementCentroids()
 {
   auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfCells()}, std::vector<usize>{3}, 0.0f);
   auto* hexCentroids = DataArray<float32>::Create(*getDataStructure(), "Hex Centroids", std::move(dataStore), getId());
-  m_CellCentroidsId = hexCentroids->getId();
+  m_CellCentroidsDataArrayId = hexCentroids->getId();
   GeometryHelpers::Topology::FindElementCentroids<uint64_t>(getPolyhedra(), getVertices(), hexCentroids);
   if(getElementCentroids() == nullptr)
   {
-    m_CellCentroidsId.reset();
+    m_CellCentroidsDataArrayId.reset();
     return -1;
   }
   return 1;
@@ -192,10 +192,10 @@ IGeometry::StatusCode HexahedralGeom::findEdges()
   GeometryHelpers::Connectivity::FindHexEdges<uint64_t>(getPolyhedra(), edgeList);
   if(getEdges() == nullptr)
   {
-    m_EdgeListId.reset();
+    m_EdgeDataArrayId.reset();
     return -1;
   }
-  m_EdgeListId = edgeList->getId();
+  m_EdgeDataArrayId = edgeList->getId();
   return 1;
 }
 

--- a/src/complex/DataStructure/Geometry/INodeGeometry0D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry0D.cpp
@@ -16,34 +16,34 @@ INodeGeometry0D::INodeGeometry0D(DataStructure& ds, std::string name, IdType imp
 {
 }
 
-const std::optional<INodeGeometry0D::IdType>& INodeGeometry0D::getVertexListId() const
+const std::optional<INodeGeometry0D::IdType>& INodeGeometry0D::getSharedVertexDataArrayId() const
 {
-  return m_VertexListId;
+  return m_VertexDataArrayId;
 }
 
 INodeGeometry0D::SharedVertexList* INodeGeometry0D::getVertices()
 {
-  return getDataStructureRef().getDataAs<SharedVertexList>(m_VertexListId);
+  return getDataStructureRef().getDataAs<SharedVertexList>(m_VertexDataArrayId);
 }
 
 const INodeGeometry0D::SharedVertexList* INodeGeometry0D::getVertices() const
 {
-  return getDataStructureRef().getDataAs<SharedVertexList>(m_VertexListId);
+  return getDataStructureRef().getDataAs<SharedVertexList>(m_VertexDataArrayId);
 }
 
 INodeGeometry0D::SharedVertexList& INodeGeometry0D::getVerticesRef()
 {
-  return getDataStructureRef().getDataRefAs<SharedVertexList>(m_VertexListId.value());
+  return getDataStructureRef().getDataRefAs<SharedVertexList>(m_VertexDataArrayId.value());
 }
 
 const INodeGeometry0D::SharedVertexList& INodeGeometry0D::getVerticesRef() const
 {
-  return getDataStructureRef().getDataRefAs<SharedVertexList>(m_VertexListId.value());
+  return getDataStructureRef().getDataRefAs<SharedVertexList>(m_VertexDataArrayId.value());
 }
 
 void INodeGeometry0D::setVertices(const INodeGeometry0D::SharedVertexList& vertices)
 {
-  m_VertexListId = vertices.getId();
+  m_VertexDataArrayId = vertices.getId();
 }
 
 void INodeGeometry0D::resizeVertexList(usize size)
@@ -85,39 +85,39 @@ Point3D<float32> INodeGeometry0D::getVertexCoordinate(usize vertId) const
   return coordinate;
 }
 
-const std::optional<INodeGeometry0D::IdType>& INodeGeometry0D::getVertexDataId() const
+const std::optional<INodeGeometry0D::IdType>& INodeGeometry0D::getVertexAttributeMatrixId() const
 {
-  return m_VertexDataId;
+  return m_VertexAttributeMatrixId;
 }
 
-AttributeMatrix* INodeGeometry0D::getVertexData()
+AttributeMatrix* INodeGeometry0D::getVertexAttributeMatrix()
 {
-  return getDataStructureRef().getDataAs<AttributeMatrix>(m_VertexDataId);
+  return getDataStructureRef().getDataAs<AttributeMatrix>(m_VertexAttributeMatrixId);
 }
 
-const AttributeMatrix* INodeGeometry0D::getVertexData() const
+const AttributeMatrix* INodeGeometry0D::getVertexAttributeMatrix() const
 {
-  return getDataStructureRef().getDataAs<AttributeMatrix>(m_VertexDataId);
+  return getDataStructureRef().getDataAs<AttributeMatrix>(m_VertexAttributeMatrixId);
 }
 
-AttributeMatrix& INodeGeometry0D::getVertexDataRef()
+AttributeMatrix& INodeGeometry0D::getVertexAttributeMatrixRef()
 {
-  return getDataStructureRef().getDataRefAs<AttributeMatrix>(m_VertexDataId.value());
+  return getDataStructureRef().getDataRefAs<AttributeMatrix>(m_VertexAttributeMatrixId.value());
 }
 
-const AttributeMatrix& INodeGeometry0D::getVertexDataRef() const
+const AttributeMatrix& INodeGeometry0D::getVertexAttributeMatrixRef() const
 {
-  return getDataStructureRef().getDataRefAs<AttributeMatrix>(m_VertexDataId.value());
+  return getDataStructureRef().getDataRefAs<AttributeMatrix>(m_VertexAttributeMatrixId.value());
 }
 
-DataPath INodeGeometry0D::getVertexDataPath() const
+DataPath INodeGeometry0D::getVertexAttributeMatrixDataPath() const
 {
-  return getVertexDataRef().getDataPaths().at(0);
+  return getVertexAttributeMatrixRef().getDataPaths().at(0);
 }
 
-void INodeGeometry0D::setVertexData(const AttributeMatrix& attributeMatrix)
+void INodeGeometry0D::setVertexAttributeMatrix(const AttributeMatrix& attributeMatrix)
 {
-  m_VertexDataId = attributeMatrix.getId();
+  m_VertexAttributeMatrixId = attributeMatrix.getId();
 }
 
 H5::ErrorType INodeGeometry0D::readHdf5(H5::DataStructureReader& dataStructureReader, const H5::GroupReader& groupReader, bool preflight)
@@ -128,8 +128,8 @@ H5::ErrorType INodeGeometry0D::readHdf5(H5::DataStructureReader& dataStructureRe
     return error;
   }
 
-  m_VertexListId = ReadH5DataId(groupReader, H5Constants::k_VertexListTag);
-  m_VertexDataId = ReadH5DataId(groupReader, H5Constants::k_VertexDataTag);
+  m_VertexDataArrayId = ReadH5DataId(groupReader, H5Constants::k_VertexListTag);
+  m_VertexAttributeMatrixId = ReadH5DataId(groupReader, H5Constants::k_VertexDataTag);
 
   return error;
 }
@@ -144,13 +144,13 @@ H5::ErrorType INodeGeometry0D::writeHdf5(H5::DataStructureWriter& dataStructureW
 
   H5::GroupWriter groupWriter = parentGroupWriter.createGroupWriter(getName());
 
-  error = WriteH5DataId(groupWriter, m_VertexListId, H5Constants::k_VertexListTag);
+  error = WriteH5DataId(groupWriter, m_VertexDataArrayId, H5Constants::k_VertexListTag);
   if(error < 0)
   {
     return error;
   }
 
-  if(m_VertexListId.has_value())
+  if(m_VertexDataArrayId.has_value())
   {
     usize numVerts = getNumberOfVertices();
     auto datasetWriter = groupWriter.createDatasetWriter("_VertexIndices");
@@ -166,7 +166,7 @@ H5::ErrorType INodeGeometry0D::writeHdf5(H5::DataStructureWriter& dataStructureW
     }
   }
 
-  error = WriteH5DataId(groupWriter, m_VertexDataId, H5Constants::k_VertexDataTag);
+  error = WriteH5DataId(groupWriter, m_VertexAttributeMatrixId, H5Constants::k_VertexDataTag);
   if(error < 0)
   {
     return error;
@@ -181,13 +181,13 @@ void INodeGeometry0D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, Id
 
   for(const auto& updatedId : updatedIds)
   {
-    if(m_VertexListId == updatedId.first)
+    if(m_VertexDataArrayId == updatedId.first)
     {
-      m_VertexListId = updatedId.second;
+      m_VertexDataArrayId = updatedId.second;
     }
-    if(m_VertexDataId == updatedId.first)
+    if(m_VertexAttributeMatrixId == updatedId.first)
     {
-      m_VertexDataId = updatedId.second;
+      m_VertexAttributeMatrixId = updatedId.second;
     }
   }
 }

--- a/src/complex/DataStructure/Geometry/INodeGeometry0D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry0D.hpp
@@ -20,16 +20,34 @@ public:
 
   ~INodeGeometry0D() noexcept override = default;
 
-  const std::optional<IdType>& getVertexListId() const;
-
+  /**
+   * @brief Returns a shared pointer to the vertex coordinates array
+   * @return
+   */
   SharedVertexList* getVertices();
 
+  /**
+   * @brief Returns a shared pointer to the vertex coordinates array
+   * @return
+   */
   const SharedVertexList* getVertices() const;
 
+  /**
+   * @brief Returns a reference to the vertex coordinates array
+   * @return
+   */
   SharedVertexList& getVerticesRef();
 
+  /**
+   * @brief Returns a reference to the vertex coordinates array
+   * @return
+   */
   const SharedVertexList& getVerticesRef() const;
 
+  /**
+   * @brief Sets the internal reference to vertex coordinates to vertices
+   * @param vertices The coordinate array that will now be used for the vertex coordinates
+   */
   void setVertices(const SharedVertexList& vertices);
 
   /**
@@ -64,47 +82,58 @@ public:
    */
   void setVertexCoordinate(usize vertId, const Point3D<float32>& coords);
 
-  /**
-   * @brief
-   * @return
+  /****************************************************************************
+   * These functions get values related to where the Vertex Coordinates are
+   * stored in the DataStructure
    */
-  const std::optional<IdType>& getVertexDataId() const;
 
   /**
-   * @brief
+   * @brief Returns the DataStructure unique ID of the vertex coordinate array
    * @return
    */
-  AttributeMatrix* getVertexData();
+  const std::optional<IdType>& getSharedVertexDataArrayId() const;
 
   /**
-   * @brief
+   * @brief Returns the DataStructure unique ID of the Attribute Matrix that holds data assigned to each vertex coordinate
    * @return
    */
-  const AttributeMatrix* getVertexData() const;
+  const std::optional<IdType>& getVertexAttributeMatrixId() const;
 
   /**
-   * @brief
+   * @brief Returns pointer to the Attribute Matrix that holds data assigned to each vertex coordinate
    * @return
    */
-  AttributeMatrix& getVertexDataRef();
+  AttributeMatrix* getVertexAttributeMatrix();
 
   /**
-   * @brief
+   * @brief Returns pointer to the Attribute Matrix that holds data assigned to each vertex coordinate
    * @return
    */
-  const AttributeMatrix& getVertexDataRef() const;
+  const AttributeMatrix* getVertexAttributeMatrix() const;
 
   /**
-   * @brief
+   * @brief Returns reference to the Attribute Matrix that holds data assigned to each vertex coordinate
    * @return
    */
-  DataPath getVertexDataPath() const;
+  AttributeMatrix& getVertexAttributeMatrixRef();
 
   /**
-   * @brief
+   * @brief Returns reference to the Attribute Matrix that holds data assigned to each vertex coordinate
+   * @return
+   */
+  const AttributeMatrix& getVertexAttributeMatrixRef() const;
+
+  /**
+   * @brief Returns the DataPath to the AttributeMatrix for the vertex data
+   * @return
+   */
+  DataPath getVertexAttributeMatrixDataPath() const;
+
+  /**
+   * @brief Sets the Attribute Matrix for the data assigned to the vertex coordinates
    * @param attributeMatrix
    */
-  void setVertexData(const AttributeMatrix& attributeMatrix);
+  void setVertexAttributeMatrix(const AttributeMatrix& attributeMatrix);
 
   /**
    * @brief Reads values from HDF5
@@ -136,7 +165,7 @@ protected:
   /* ***************************************************************************
    * These variables are the Ids of the arrays from the complex::DataStructure object.
    */
-  std::optional<IdType> m_VertexListId;
-  std::optional<IdType> m_VertexDataId;
+  std::optional<IdType> m_VertexDataArrayId;
+  std::optional<IdType> m_VertexAttributeMatrixId;
 };
 } // namespace complex

--- a/src/complex/DataStructure/Geometry/INodeGeometry1D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry1D.cpp
@@ -15,34 +15,34 @@ INodeGeometry1D::INodeGeometry1D(DataStructure& ds, std::string name, IdType imp
 {
 }
 
-const std::optional<INodeGeometry1D::IdType>& INodeGeometry1D::getEdgeListId() const
+const std::optional<INodeGeometry1D::IdType>& INodeGeometry1D::getEdgeListDataArrayId() const
 {
-  return m_EdgeListId;
+  return m_EdgeDataArrayId;
 }
 
 INodeGeometry1D::SharedEdgeList* INodeGeometry1D::getEdges()
 {
-  return getDataStructureRef().getDataAs<SharedEdgeList>(m_EdgeListId);
+  return getDataStructureRef().getDataAs<SharedEdgeList>(m_EdgeDataArrayId);
 }
 
 const INodeGeometry1D::SharedEdgeList* INodeGeometry1D::getEdges() const
 {
-  return getDataStructureRef().getDataAs<SharedEdgeList>(m_EdgeListId);
+  return getDataStructureRef().getDataAs<SharedEdgeList>(m_EdgeDataArrayId);
 }
 
 INodeGeometry1D::SharedEdgeList& INodeGeometry1D::getEdgesRef()
 {
-  return getDataStructureRef().getDataRefAs<SharedEdgeList>(m_EdgeListId.value());
+  return getDataStructureRef().getDataRefAs<SharedEdgeList>(m_EdgeDataArrayId.value());
 }
 
 const INodeGeometry1D::SharedEdgeList& INodeGeometry1D::getEdgesRef() const
 {
-  return getDataStructureRef().getDataRefAs<SharedEdgeList>(m_EdgeListId.value());
+  return getDataStructureRef().getDataRefAs<SharedEdgeList>(m_EdgeDataArrayId.value());
 }
 
-void INodeGeometry1D::setEdges(const SharedEdgeList& edges)
+void INodeGeometry1D::setEdgeList(const SharedEdgeList& edges)
 {
-  m_EdgeListId = edges.getId();
+  m_EdgeDataArrayId = edges.getId();
 }
 
 void INodeGeometry1D::resizeEdgeList(usize size)
@@ -100,70 +100,70 @@ void INodeGeometry1D::getEdgeCoordinates(usize edgeId, nonstd::span<Point3Df> co
 
 const INodeGeometry1D::ElementDynamicList* INodeGeometry1D::getElementsContainingVert() const
 {
-  return getDataStructureRef().getDataAs<ElementDynamicList>(m_CellContainingVertId);
+  return getDataStructureRef().getDataAs<ElementDynamicList>(m_CellContainingVertDataArrayId);
 }
 
 void INodeGeometry1D::deleteElementsContainingVert()
 {
-  getDataStructureRef().removeData(m_CellContainingVertId);
-  m_CellContainingVertId.reset();
+  getDataStructureRef().removeData(m_CellContainingVertDataArrayId);
+  m_CellContainingVertDataArrayId.reset();
 }
 
 const INodeGeometry1D::ElementDynamicList* INodeGeometry1D::getElementNeighbors() const
 {
-  return getDataStructureRef().getDataAs<ElementDynamicList>(m_CellNeighborsId);
+  return getDataStructureRef().getDataAs<ElementDynamicList>(m_CellNeighborsDataArrayId);
 }
 
 void INodeGeometry1D::deleteElementNeighbors()
 {
-  getDataStructureRef().removeData(m_CellNeighborsId);
-  m_CellNeighborsId.reset();
+  getDataStructureRef().removeData(m_CellNeighborsDataArrayId);
+  m_CellNeighborsDataArrayId.reset();
 }
 
 const Float32Array* INodeGeometry1D::getElementCentroids() const
 {
-  return getDataStructureRef().getDataAs<Float32Array>(m_CellCentroidsId);
+  return getDataStructureRef().getDataAs<Float32Array>(m_CellCentroidsDataArrayId);
 }
 
 void INodeGeometry1D::deleteElementCentroids()
 {
-  getDataStructureRef().removeData(m_CellCentroidsId);
-  m_CellCentroidsId.reset();
+  getDataStructureRef().removeData(m_CellCentroidsDataArrayId);
+  m_CellCentroidsDataArrayId.reset();
 }
 
-const std::optional<INodeGeometry1D::IdType>& INodeGeometry1D::getEdgeDataId() const
+const std::optional<INodeGeometry1D::IdType>& INodeGeometry1D::getEdgeAttributeMatrixId() const
 {
-  return m_EdgeDataId;
+  return m_EdgeAttributeMatrixId;
 }
 
-AttributeMatrix* INodeGeometry1D::getEdgeData()
+AttributeMatrix* INodeGeometry1D::getEdgeAttributeMatrix()
 {
-  return getDataStructureRef().getDataAs<AttributeMatrix>(m_EdgeDataId);
+  return getDataStructureRef().getDataAs<AttributeMatrix>(m_EdgeAttributeMatrixId);
 }
 
-const AttributeMatrix* INodeGeometry1D::getEdgeData() const
+const AttributeMatrix* INodeGeometry1D::getEdgeAttributeMatrix() const
 {
-  return getDataStructureRef().getDataAs<AttributeMatrix>(m_EdgeDataId);
+  return getDataStructureRef().getDataAs<AttributeMatrix>(m_EdgeAttributeMatrixId);
 }
 
-AttributeMatrix& INodeGeometry1D::getEdgeDataRef()
+AttributeMatrix& INodeGeometry1D::getEdgeAttributeMatrixRef()
 {
-  return getDataStructureRef().getDataRefAs<AttributeMatrix>(m_EdgeDataId.value());
+  return getDataStructureRef().getDataRefAs<AttributeMatrix>(m_EdgeAttributeMatrixId.value());
 }
 
-const AttributeMatrix& INodeGeometry1D::getEdgeDataRef() const
+const AttributeMatrix& INodeGeometry1D::getEdgeAttributeMatrixRef() const
 {
-  return getDataStructureRef().getDataRefAs<AttributeMatrix>(m_EdgeDataId.value());
+  return getDataStructureRef().getDataRefAs<AttributeMatrix>(m_EdgeAttributeMatrixId.value());
 }
 
-DataPath INodeGeometry1D::getEdgeDataPath() const
+DataPath INodeGeometry1D::getEdgeAttributeMatrixDataPath() const
 {
-  return getEdgeDataRef().getDataPaths().at(0);
+  return getEdgeAttributeMatrixRef().getDataPaths().at(0);
 }
 
-void INodeGeometry1D::setEdgeData(const AttributeMatrix& attributeMatrix)
+void INodeGeometry1D::setEdgeAttributeMatrix(const AttributeMatrix& attributeMatrix)
 {
-  m_EdgeDataId = attributeMatrix.getId();
+  m_EdgeAttributeMatrixId = attributeMatrix.getId();
 }
 
 H5::ErrorType INodeGeometry1D::readHdf5(H5::DataStructureReader& dataStructureReader, const H5::GroupReader& groupReader, bool preflight)
@@ -174,11 +174,11 @@ H5::ErrorType INodeGeometry1D::readHdf5(H5::DataStructureReader& dataStructureRe
     return error;
   }
 
-  m_EdgeListId = ReadH5DataId(groupReader, H5Constants::k_EdgeListTag);
-  m_EdgeDataId = ReadH5DataId(groupReader, H5Constants::k_EdgeDataTag);
-  m_CellContainingVertId = ReadH5DataId(groupReader, H5Constants::k_ElementContainingVertTag);
-  m_CellNeighborsId = ReadH5DataId(groupReader, H5Constants::k_ElementNeighborsTag);
-  m_CellCentroidsId = ReadH5DataId(groupReader, H5Constants::k_ElementCentroidTag);
+  m_EdgeDataArrayId = ReadH5DataId(groupReader, H5Constants::k_EdgeListTag);
+  m_EdgeAttributeMatrixId = ReadH5DataId(groupReader, H5Constants::k_EdgeDataTag);
+  m_CellContainingVertDataArrayId = ReadH5DataId(groupReader, H5Constants::k_ElementContainingVertTag);
+  m_CellNeighborsDataArrayId = ReadH5DataId(groupReader, H5Constants::k_ElementNeighborsTag);
+  m_CellCentroidsDataArrayId = ReadH5DataId(groupReader, H5Constants::k_ElementCentroidTag);
 
   return error;
 }
@@ -192,31 +192,31 @@ H5::ErrorType INodeGeometry1D::writeHdf5(H5::DataStructureWriter& dataStructureW
   }
 
   H5::GroupWriter groupWriter = parentGroupWriter.createGroupWriter(getName());
-  error = WriteH5DataId(groupWriter, m_EdgeListId, H5Constants::k_EdgeListTag);
+  error = WriteH5DataId(groupWriter, m_EdgeDataArrayId, H5Constants::k_EdgeListTag);
   if(error < 0)
   {
     return error;
   }
 
-  error = WriteH5DataId(groupWriter, m_EdgeDataId, H5Constants::k_EdgeDataTag);
+  error = WriteH5DataId(groupWriter, m_EdgeAttributeMatrixId, H5Constants::k_EdgeDataTag);
   if(error < 0)
   {
     return error;
   }
 
-  error = WriteH5DataId(groupWriter, m_CellContainingVertId, H5Constants::k_ElementContainingVertTag);
+  error = WriteH5DataId(groupWriter, m_CellContainingVertDataArrayId, H5Constants::k_ElementContainingVertTag);
   if(error < 0)
   {
     return error;
   }
 
-  error = WriteH5DataId(groupWriter, m_CellNeighborsId, H5Constants::k_ElementNeighborsTag);
+  error = WriteH5DataId(groupWriter, m_CellNeighborsDataArrayId, H5Constants::k_ElementNeighborsTag);
   if(error < 0)
   {
     return error;
   }
 
-  error = WriteH5DataId(groupWriter, m_CellCentroidsId, H5Constants::k_ElementCentroidTag);
+  error = WriteH5DataId(groupWriter, m_CellCentroidsDataArrayId, H5Constants::k_ElementCentroidTag);
   if(error < 0)
   {
     return error;
@@ -231,34 +231,34 @@ void INodeGeometry1D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, Id
 
   for(const auto& updatedId : updatedIds)
   {
-    if(m_VertexListId == updatedId.first)
+    if(m_VertexDataArrayId == updatedId.first)
     {
-      m_VertexListId = updatedId.second;
+      m_VertexDataArrayId = updatedId.second;
     }
 
-    if(m_EdgeDataId == updatedId.first)
+    if(m_EdgeAttributeMatrixId == updatedId.first)
     {
-      m_EdgeDataId = updatedId.second;
+      m_EdgeAttributeMatrixId = updatedId.second;
     }
 
-    if(m_EdgeListId == updatedId.first)
+    if(m_EdgeDataArrayId == updatedId.first)
     {
-      m_EdgeListId = updatedId.second;
+      m_EdgeDataArrayId = updatedId.second;
     }
 
-    if(m_CellContainingVertId == updatedId.first)
+    if(m_CellContainingVertDataArrayId == updatedId.first)
     {
-      m_CellContainingVertId = updatedId.second;
+      m_CellContainingVertDataArrayId = updatedId.second;
     }
 
-    if(m_CellNeighborsId == updatedId.first)
+    if(m_CellNeighborsDataArrayId == updatedId.first)
     {
-      m_CellNeighborsId = updatedId.second;
+      m_CellNeighborsDataArrayId = updatedId.second;
     }
 
-    if(m_CellCentroidsId == updatedId.first)
+    if(m_CellCentroidsDataArrayId == updatedId.first)
     {
-      m_CellCentroidsId = updatedId.second;
+      m_CellCentroidsDataArrayId = updatedId.second;
     }
 
     if(m_ElementSizesId == updatedId.first)

--- a/src/complex/DataStructure/Geometry/INodeGeometry1D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry1D.hpp
@@ -20,17 +20,35 @@ public:
 
   ~INodeGeometry1D() noexcept override = default;
 
-  const std::optional<IdType>& getEdgeListId() const;
-
+  /**
+   * @brief
+   * @return
+   */
   SharedEdgeList* getEdges();
 
+  /**
+   * @brief
+   * @return
+   */
   const SharedEdgeList* getEdges() const;
 
+  /**
+   * @brief
+   * @return
+   */
   SharedEdgeList& getEdgesRef();
 
+  /**
+   * @brief
+   * @return
+   */
   const SharedEdgeList& getEdgesRef() const;
 
-  void setEdges(const SharedEdgeList& edges);
+  /**
+   * @brief
+   * @return
+   */
+  void setEdgeList(const SharedEdgeList& edges);
 
   /**
    * @brief Resizes the edge list to the target size.
@@ -126,47 +144,54 @@ public:
    */
   void deleteElementCentroids();
 
-  /**
-   * @brief
-   * @return
+  /****************************************************************************
+   * These functions get values related to where the Vertex Coordinates are
+   * stored in the DataStructure
    */
-  const std::optional<IdType>& getEdgeDataId() const;
+
+  const std::optional<IdType>& getEdgeListDataArrayId() const;
 
   /**
    * @brief
    * @return
    */
-  AttributeMatrix* getEdgeData();
+  const std::optional<IdType>& getEdgeAttributeMatrixId() const;
 
   /**
-   * @brief
+   * @brief Returns pointer to the Attribute Matrix that holds data assigned to each edge
    * @return
    */
-  const AttributeMatrix* getEdgeData() const;
+  AttributeMatrix* getEdgeAttributeMatrix();
 
   /**
-   * @brief
+   * @brief Returns pointer to the Attribute Matrix that holds data assigned to each edge
    * @return
    */
-  AttributeMatrix& getEdgeDataRef();
+  const AttributeMatrix* getEdgeAttributeMatrix() const;
 
   /**
-   * @brief
+   * @brief Returns reference to the Attribute Matrix that holds data assigned to each edge
    * @return
    */
-  const AttributeMatrix& getEdgeDataRef() const;
+  AttributeMatrix& getEdgeAttributeMatrixRef();
 
   /**
-   * @brief
+   * @brief Returns reference to the Attribute Matrix that holds data assigned to each edge
    * @return
    */
-  DataPath getEdgeDataPath() const;
+  const AttributeMatrix& getEdgeAttributeMatrixRef() const;
 
   /**
-   * @brief
+   * @brief Returns the DataPath to the AttributeMatrix for the edge data
+   * @return
+   */
+  DataPath getEdgeAttributeMatrixDataPath() const;
+
+  /**
+   * @brief Sets the Attribute Matrix for the data assigned to the edges
    * @param attributeMatrix
    */
-  void setEdgeData(const AttributeMatrix& attributeMatrix);
+  void setEdgeAttributeMatrix(const AttributeMatrix& attributeMatrix);
 
   /**
    * @brief Reads values from HDF5
@@ -198,10 +223,10 @@ protected:
   /* ***************************************************************************
    * These variables are the Ids of the arrays from the complex::DataStructure object.
    */
-  std::optional<IdType> m_EdgeListId;
-  std::optional<IdType> m_EdgeDataId;
-  std::optional<IdType> m_CellContainingVertId;
-  std::optional<IdType> m_CellNeighborsId;
-  std::optional<IdType> m_CellCentroidsId;
+  std::optional<IdType> m_EdgeDataArrayId;
+  std::optional<IdType> m_EdgeAttributeMatrixId;
+  std::optional<IdType> m_CellContainingVertDataArrayId;
+  std::optional<IdType> m_CellNeighborsDataArrayId;
+  std::optional<IdType> m_CellCentroidsDataArrayId;
 };
 } // namespace complex

--- a/src/complex/DataStructure/Geometry/INodeGeometry2D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry2D.cpp
@@ -15,7 +15,7 @@ INodeGeometry2D::INodeGeometry2D(DataStructure& ds, std::string name, IdType imp
 {
 }
 
-const std::optional<INodeGeometry2D::IdType>& INodeGeometry2D::getFaceListId() const
+const std::optional<INodeGeometry2D::IdType>& INodeGeometry2D::getFaceListDataArrayId() const
 {
   return m_FaceListId;
 }
@@ -40,7 +40,7 @@ const INodeGeometry2D::SharedFaceList& INodeGeometry2D::getFacesRef() const
   return getDataStructureRef().getDataRefAs<SharedFaceList>(m_FaceListId.value());
 }
 
-void INodeGeometry2D::setFaces(const SharedFaceList& faces)
+void INodeGeometry2D::setFaceList(const SharedFaceList& faces)
 {
   m_FaceListId = faces.getId();
 }
@@ -96,8 +96,8 @@ void INodeGeometry2D::getFaceCoordinates(usize faceId, nonstd::span<Point3Df> co
 
 void INodeGeometry2D::deleteEdges()
 {
-  getDataStructureRef().removeData(m_EdgeListId);
-  m_EdgeListId.reset();
+  getDataStructureRef().removeData(m_EdgeDataArrayId);
+  m_EdgeDataArrayId.reset();
 }
 
 const std::optional<INodeGeometry2D::IdType>& INodeGeometry2D::getUnsharedEdgesId() const
@@ -116,37 +116,37 @@ void INodeGeometry2D::deleteUnsharedEdges()
   m_UnsharedEdgeListId.reset();
 }
 
-const std::optional<INodeGeometry2D::IdType>& INodeGeometry2D::getFaceDataId() const
+const std::optional<INodeGeometry2D::IdType>& INodeGeometry2D::getFaceAttributeMatrixId() const
 {
   return m_FaceDataId;
 }
 
-AttributeMatrix* INodeGeometry2D::getFaceData()
+AttributeMatrix* INodeGeometry2D::getFaceAttributeMatrix()
 {
   return getDataStructureRef().getDataAs<AttributeMatrix>(m_FaceDataId);
 }
 
-const AttributeMatrix* INodeGeometry2D::getFaceData() const
+const AttributeMatrix* INodeGeometry2D::getFaceAttributeMatrix() const
 {
   return getDataStructureRef().getDataAs<AttributeMatrix>(m_FaceDataId);
 }
 
-AttributeMatrix& INodeGeometry2D::getFaceDataRef()
+AttributeMatrix& INodeGeometry2D::getFaceAttributeMatrixRef()
 {
   return getDataStructureRef().getDataRefAs<AttributeMatrix>(m_FaceDataId.value());
 }
 
-const AttributeMatrix& INodeGeometry2D::getFaceDataRef() const
+const AttributeMatrix& INodeGeometry2D::getFaceAttributeMatrixRef() const
 {
   return getDataStructureRef().getDataRefAs<AttributeMatrix>(m_FaceDataId.value());
 }
 
-DataPath INodeGeometry2D::getFaceDataPath() const
+DataPath INodeGeometry2D::getFaceAttributeMatrixDataPath() const
 {
-  return getFaceDataRef().getDataPaths().at(0);
+  return getFaceAttributeMatrixRef().getDataPaths().at(0);
 }
 
-void INodeGeometry2D::setFaceData(const AttributeMatrix& attributeMatrix)
+void INodeGeometry2D::setFaceAttributeMatrix(const AttributeMatrix& attributeMatrix)
 {
   m_FaceDataId = attributeMatrix.getId();
 }

--- a/src/complex/DataStructure/Geometry/INodeGeometry2D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry2D.hpp
@@ -29,17 +29,35 @@ public:
 
   ~INodeGeometry2D() noexcept override = default;
 
-  const std::optional<IdType>& getFaceListId() const;
-
+  /**
+   * @brief Returns a pointer to the Face List
+   * @return
+   */
   SharedFaceList* getFaces();
 
+  /**
+   * @brief Returns a pointer to the Face List
+   * @return
+   */
   const SharedFaceList* getFaces() const;
 
+  /**
+   * @brief Returns a reference to the Face List
+   * @return
+   */
   SharedFaceList& getFacesRef();
 
+  /**
+   * @brief Returns a reference to the Face List
+   * @return
+   */
   const SharedFaceList& getFacesRef() const;
 
-  void setFaces(const SharedFaceList& faces);
+  /**
+   * @brief Sets the list of Faces for this geometry
+   * @param faces The new list of faces
+   */
+  void setFaceList(const SharedFaceList& faces);
 
   /**
    * @brief Resizes the face list to the target size.
@@ -115,47 +133,54 @@ public:
    */
   void deleteUnsharedEdges();
 
-  /**
-   * @brief
-   * @return
+  /****************************************************************************
+   * These functions get values related to where the Vertex Coordinates are
+   * stored in the DataStructure
    */
-  const std::optional<IdType>& getFaceDataId() const;
+
+  const std::optional<IdType>& getFaceListDataArrayId() const;
 
   /**
    * @brief
    * @return
    */
-  AttributeMatrix* getFaceData();
+  const std::optional<IdType>& getFaceAttributeMatrixId() const;
 
   /**
    * @brief
    * @return
    */
-  const AttributeMatrix* getFaceData() const;
+  AttributeMatrix* getFaceAttributeMatrix();
 
   /**
    * @brief
    * @return
    */
-  AttributeMatrix& getFaceDataRef();
+  const AttributeMatrix* getFaceAttributeMatrix() const;
 
   /**
    * @brief
    * @return
    */
-  const AttributeMatrix& getFaceDataRef() const;
+  AttributeMatrix& getFaceAttributeMatrixRef();
 
   /**
    * @brief
    * @return
    */
-  DataPath getFaceDataPath() const;
+  const AttributeMatrix& getFaceAttributeMatrixRef() const;
+
+  /**
+   * @brief
+   * @return
+   */
+  DataPath getFaceAttributeMatrixDataPath() const;
 
   /**
    * @brief
    * @param attributeMatrix
    */
-  void setFaceData(const AttributeMatrix& attributeMatrix);
+  void setFaceAttributeMatrix(const AttributeMatrix& attributeMatrix);
 
   /**
    * @brief Reads values from HDF5

--- a/src/complex/DataStructure/Geometry/INodeGeometry3D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry3D.cpp
@@ -40,12 +40,12 @@ const INodeGeometry3D::SharedFaceList& INodeGeometry3D::getPolyhedraRef() const
   return getDataStructureRef().getDataRefAs<SharedFaceList>(m_PolyhedronListId.value());
 }
 
-void INodeGeometry3D::setPolyhedra(const SharedFaceList& polyhedra)
+void INodeGeometry3D::setPolyhedraList(const SharedFaceList& polyhedra)
 {
   m_PolyhedronListId = polyhedra.getId();
 }
 
-void INodeGeometry3D::resizePolyhedronList(usize size)
+void INodeGeometry3D::resizePolyhedraList(usize size)
 {
   getPolyhedraRef().getIDataStoreRef().reshapeTuples({size});
 }
@@ -119,37 +119,37 @@ void INodeGeometry3D::deleteUnsharedFaces()
   m_UnsharedFaceListId.reset();
 }
 
-const std::optional<INodeGeometry3D::IdType>& INodeGeometry3D::getPolyhedraDataId() const
+const std::optional<INodeGeometry3D::IdType>& INodeGeometry3D::getPolyhedraAttributeMatrixId() const
 {
   return m_PolyhedronDataId;
 }
 
-AttributeMatrix* INodeGeometry3D::getPolyhedronData()
+AttributeMatrix* INodeGeometry3D::getPolyhedraAttributeMatrix()
 {
   return getDataStructureRef().getDataAs<AttributeMatrix>(m_PolyhedronDataId);
 }
 
-const AttributeMatrix* INodeGeometry3D::getPolyhedronData() const
+const AttributeMatrix* INodeGeometry3D::getPolyhedraAttributeMatrix() const
 {
   return getDataStructureRef().getDataAs<AttributeMatrix>(m_PolyhedronDataId);
 }
 
-AttributeMatrix& INodeGeometry3D::getPolyhedronDataRef()
+AttributeMatrix& INodeGeometry3D::getPolyhedraAttributeMatrixRef()
 {
   return getDataStructureRef().getDataRefAs<AttributeMatrix>(m_PolyhedronDataId.value());
 }
 
-const AttributeMatrix& INodeGeometry3D::getPolyhedronDataRef() const
+const AttributeMatrix& INodeGeometry3D::getPolyhedraAttributeMatrixRef() const
 {
   return getDataStructureRef().getDataRefAs<AttributeMatrix>(m_PolyhedronDataId.value());
 }
 
-DataPath INodeGeometry3D::getPolyhedronDataPath() const
+DataPath INodeGeometry3D::getPolyhedronAttributeMatrixDataPath() const
 {
-  return getPolyhedronDataRef().getDataPaths().at(0);
+  return getPolyhedraAttributeMatrixRef().getDataPaths().at(0);
 }
 
-void INodeGeometry3D::setPolyhedronData(const AttributeMatrix& attributeMatrix)
+void INodeGeometry3D::setPolyhedraAttributeMatrix(const AttributeMatrix& attributeMatrix)
 {
   m_PolyhedronDataId = attributeMatrix.getId();
 }

--- a/src/complex/DataStructure/Geometry/INodeGeometry3D.hpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry3D.hpp
@@ -18,23 +18,41 @@ public:
 
   ~INodeGeometry3D() noexcept override = default;
 
-  const std::optional<IdType>& getPolyhedronListId() const;
-
+  /**
+   * @brief
+   * @return
+   */
   SharedFaceList* getPolyhedra();
 
+  /**
+   * @brief
+   * @return
+   */
   const SharedFaceList* getPolyhedra() const;
 
+  /**
+   * @brief
+   * @return
+   */
   SharedFaceList& getPolyhedraRef();
 
+  /**
+   * @brief
+   * @return
+   */
   const SharedFaceList& getPolyhedraRef() const;
 
-  void setPolyhedra(const SharedFaceList& polyhedra);
+  /**
+   * @brief
+   * @param polyhedra
+   */
+  void setPolyhedraList(const SharedFaceList& polyhedra);
 
   /**
    * @brief Resizes the polyhedra list to the target size.
    * @param size
    */
-  void resizePolyhedronList(usize size);
+  void resizePolyhedraList(usize size);
 
   /**
    * @brief Returns the number of polyhedra in the geometry.
@@ -102,47 +120,58 @@ public:
    */
   void getCellCoordinates(usize tetId, nonstd::span<Point3Df> coords) const;
 
-  /**
-   * @brief
-   * @return
+  /****************************************************************************
+   * These functions get values related to where the Vertex Coordinates are
+   * stored in the DataStructure
    */
-  const std::optional<IdType>& getPolyhedraDataId() const;
 
   /**
    * @brief
    * @return
    */
-  AttributeMatrix* getPolyhedronData();
+  const std::optional<IdType>& getPolyhedronListId() const;
 
   /**
    * @brief
    * @return
    */
-  const AttributeMatrix* getPolyhedronData() const;
+  const std::optional<IdType>& getPolyhedraAttributeMatrixId() const;
 
   /**
    * @brief
    * @return
    */
-  AttributeMatrix& getPolyhedronDataRef();
+  AttributeMatrix* getPolyhedraAttributeMatrix();
 
   /**
    * @brief
    * @return
    */
-  const AttributeMatrix& getPolyhedronDataRef() const;
+  const AttributeMatrix* getPolyhedraAttributeMatrix() const;
 
   /**
    * @brief
    * @return
    */
-  DataPath getPolyhedronDataPath() const;
+  AttributeMatrix& getPolyhedraAttributeMatrixRef();
+
+  /**
+   * @brief
+   * @return
+   */
+  const AttributeMatrix& getPolyhedraAttributeMatrixRef() const;
+
+  /**
+   * @brief
+   * @return
+   */
+  DataPath getPolyhedronAttributeMatrixDataPath() const;
 
   /**
    * @brief
    * @param attributeMatrix
    */
-  void setPolyhedronData(const AttributeMatrix& attributeMatrix);
+  void setPolyhedraAttributeMatrix(const AttributeMatrix& attributeMatrix);
 
   /**
    * @brief Reads values from HDF5

--- a/src/complex/DataStructure/Geometry/QuadGeom.cpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.cpp
@@ -96,10 +96,10 @@ IGeometry::StatusCode QuadGeom::findElementsContainingVert()
   GeometryHelpers::Connectivity::FindElementsContainingVert<uint16, MeshIndexType>(getFaces(), quadsContainingVert, getNumberOfVertices());
   if(quadsContainingVert == nullptr)
   {
-    m_CellContainingVertId.reset();
+    m_CellContainingVertDataArrayId.reset();
     return -1;
   }
-  m_CellContainingVertId = quadsContainingVert->getId();
+  m_CellContainingVertDataArrayId = quadsContainingVert->getId();
   return 1;
 }
 
@@ -117,10 +117,10 @@ IGeometry::StatusCode QuadGeom::findElementNeighbors()
   StatusCode err = GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getFaces(), getElementsContainingVert(), quadNeighbors, IGeometry::Type::Quad);
   if(quadNeighbors == nullptr)
   {
-    m_CellNeighborsId.reset();
+    m_CellNeighborsDataArrayId.reset();
     return -1;
   }
-  m_CellNeighborsId = quadNeighbors->getId();
+  m_CellNeighborsDataArrayId = quadNeighbors->getId();
   return err;
 }
 
@@ -131,10 +131,10 @@ IGeometry::StatusCode QuadGeom::findElementCentroids()
   GeometryHelpers::Topology::FindElementCentroids(getFaces(), getVertices(), quadCentroids);
   if(quadCentroids == nullptr)
   {
-    m_CellCentroidsId.reset();
+    m_CellCentroidsDataArrayId.reset();
     return -1;
   }
-  m_CellCentroidsId = quadCentroids->getId();
+  m_CellCentroidsDataArrayId = quadCentroids->getId();
   return 1;
 }
 
@@ -164,10 +164,10 @@ IGeometry::StatusCode QuadGeom::findEdges()
   GeometryHelpers::Connectivity::Find2DElementEdges(getFaces(), edgeList);
   if(edgeList == nullptr)
   {
-    m_EdgeListId.reset();
+    m_EdgeDataArrayId.reset();
     return -1;
   }
-  m_EdgeListId = edgeList->getId();
+  m_EdgeDataArrayId = edgeList->getId();
   return 1;
 }
 

--- a/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TetrahedralGeom.cpp
@@ -101,10 +101,10 @@ IGeometry::StatusCode TetrahedralGeom::findElementsContainingVert()
   GeometryHelpers::Connectivity::FindElementsContainingVert<uint16, MeshIndexType>(getPolyhedra(), tetsContainingVert, getNumberOfVertices());
   if(tetsContainingVert == nullptr)
   {
-    m_CellContainingVertId.reset();
+    m_CellContainingVertDataArrayId.reset();
     return -1;
   }
-  m_CellContainingVertId = tetsContainingVert->getId();
+  m_CellContainingVertDataArrayId = tetsContainingVert->getId();
   return 1;
 }
 
@@ -123,10 +123,10 @@ IGeometry::StatusCode TetrahedralGeom::findElementNeighbors()
   err = GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getPolyhedra(), getElementsContainingVert(), tetNeighbors, IGeometry::Type::Tetrahedral);
   if(tetNeighbors == nullptr)
   {
-    m_CellNeighborsId.reset();
+    m_CellNeighborsDataArrayId.reset();
     return -1;
   }
-  m_CellNeighborsId = tetNeighbors->getId();
+  m_CellNeighborsDataArrayId = tetNeighbors->getId();
   return err;
 }
 
@@ -137,10 +137,10 @@ IGeometry::StatusCode TetrahedralGeom::findElementCentroids()
   GeometryHelpers::Topology::FindElementCentroids(getPolyhedra(), getVertices(), tetCentroids);
   if(tetCentroids == nullptr)
   {
-    m_CellCentroidsId.reset();
+    m_CellCentroidsDataArrayId.reset();
     return -1;
   }
-  m_CellCentroidsId = tetCentroids->getId();
+  m_CellCentroidsDataArrayId = tetCentroids->getId();
   return 1;
 }
 
@@ -176,10 +176,10 @@ IGeometry::StatusCode TetrahedralGeom::findEdges()
   GeometryHelpers::Connectivity::FindTetEdges(getPolyhedra(), edgeList);
   if(edgeList == nullptr)
   {
-    m_EdgeListId.reset();
+    m_EdgeDataArrayId.reset();
     return -1;
   }
-  m_EdgeListId = edgeList->getId();
+  m_EdgeDataArrayId = edgeList->getId();
   return 1;
 }
 

--- a/src/complex/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.cpp
@@ -96,10 +96,10 @@ IGeometry::StatusCode TriangleGeom::findElementsContainingVert()
   GeometryHelpers::Connectivity::FindElementsContainingVert<uint16, MeshIndexType>(getFaces(), trianglesContainingVert, getNumberOfVertices());
   if(trianglesContainingVert == nullptr)
   {
-    m_CellContainingVertId.reset();
+    m_CellContainingVertDataArrayId.reset();
     return -1;
   }
-  m_CellContainingVertId = trianglesContainingVert->getId();
+  m_CellContainingVertDataArrayId = trianglesContainingVert->getId();
   return 1;
 }
 
@@ -118,10 +118,10 @@ IGeometry::StatusCode TriangleGeom::findElementNeighbors()
   err = GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getFaces(), getElementsContainingVert(), triangleNeighbors, IGeometry::Type::Triangle);
   if(triangleNeighbors == nullptr)
   {
-    m_CellNeighborsId.reset();
+    m_CellNeighborsDataArrayId.reset();
     return -1;
   }
-  m_CellNeighborsId = triangleNeighbors->getId();
+  m_CellNeighborsDataArrayId = triangleNeighbors->getId();
   return err;
 }
 
@@ -132,10 +132,10 @@ IGeometry::StatusCode TriangleGeom::findElementCentroids()
   GeometryHelpers::Topology::FindElementCentroids(getFaces(), getVertices(), triangleCentroids);
   if(triangleCentroids == nullptr)
   {
-    m_CellCentroidsId.reset();
+    m_CellCentroidsDataArrayId.reset();
     return -1;
   }
-  m_CellCentroidsId = triangleCentroids->getId();
+  m_CellCentroidsDataArrayId = triangleCentroids->getId();
   return 1;
 }
 
@@ -164,10 +164,10 @@ IGeometry::StatusCode TriangleGeom::findEdges()
   GeometryHelpers::Connectivity::Find2DElementEdges(getFaces(), edgeList);
   if(edgeList == nullptr)
   {
-    m_EdgeListId.reset();
+    m_EdgeDataArrayId.reset();
     return -1;
   }
-  m_EdgeListId = edgeList->getId();
+  m_EdgeDataArrayId = edgeList->getId();
   return 1;
 }
 

--- a/src/complex/Filter/Actions/CreateGeometry1DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry1DAction.hpp
@@ -96,7 +96,7 @@ public:
     }
     DimensionType edgeTupleShape = {m_NumEdges};
     edgeAttributeMatrix->setShape(edgeTupleShape);
-    geometry1d->setEdgeData(*edgeAttributeMatrix);
+    geometry1d->setEdgeAttributeMatrix(*edgeAttributeMatrix);
 
     auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, geometry1d->getId());
     if(vertexAttributeMatrix == nullptr)
@@ -105,7 +105,7 @@ public:
     }
     DimensionType vertexTupleShape = {m_NumVertices}; // We probably don't know how many Vertices there are but take what ever the developer sends us
     vertexAttributeMatrix->setShape(vertexTupleShape);
-    geometry1d->setVertexData(*vertexAttributeMatrix);
+    geometry1d->setVertexAttributeMatrix(*vertexAttributeMatrix);
 
     using MeshIndexType = IGeometry::MeshIndexType;
     using SharedEdgeList = IGeometry::SharedEdgeList;
@@ -119,7 +119,7 @@ public:
       return MakeErrorResult(-226, fmt::format("CreateGeometry1DAction: Could not allocate SharedEdgeList '{}'", edgesPath.toString()));
     }
     SharedEdgeList* edges = complex::ArrayFromPath<MeshIndexType>(dataStructure, edgesPath);
-    geometry1d->setEdges(*edges);
+    geometry1d->setEdgeList(*edges);
 
     // Create the Vertex Array with a component size of 3
     DataPath vertexPath = getCreatedPath().createChildPath(k_VertexDataName);

--- a/src/complex/Filter/Actions/CreateGeometry2DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry2DAction.hpp
@@ -97,7 +97,7 @@ public:
     }
     DimensionType faceTupleShape = {m_NumFaces};
     faceAttributeMatrix->setShape(faceTupleShape);
-    geometry2d->setFaceData(*faceAttributeMatrix);
+    geometry2d->setFaceAttributeMatrix(*faceAttributeMatrix);
 
     auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, geometry2d->getId());
     if(vertexAttributeMatrix == nullptr)
@@ -106,7 +106,7 @@ public:
     }
     DimensionType vertexTupleShape = {m_NumVertices}; // We probably don't know how many Vertices there are but take what ever the developer sends us
     vertexAttributeMatrix->setShape(vertexTupleShape);
-    geometry2d->setVertexData(*vertexAttributeMatrix);
+    geometry2d->setVertexAttributeMatrix(*vertexAttributeMatrix);
 
     using MeshIndexType = IGeometry::MeshIndexType;
     using SharedTriList = IGeometry::SharedTriList;
@@ -120,7 +120,7 @@ public:
       return MakeErrorResult(-226, fmt::format("CreateGeometry2DAction: Could not allocate SharedTriList '{}'", trianglesPath.toString()));
     }
     SharedTriList* triangles = complex::ArrayFromPath<MeshIndexType>(dataStructure, trianglesPath);
-    geometry2d->setFaces(*triangles);
+    geometry2d->setFaceList(*triangles);
 
     // Create the Vertex Array with a component size of 3
     DataPath vertexPath = getCreatedPath().createChildPath(k_VertexDataName);

--- a/src/complex/Filter/Actions/CreateVertexGeometryAction.hpp
+++ b/src/complex/Filter/Actions/CreateVertexGeometryAction.hpp
@@ -100,7 +100,7 @@ public:
       return MakeErrorResult(-225, fmt::format("CreateGeometry2DAction: Failed to create attribute matrix: '{}'", getVertexDataPath().toString()));
     }
     vertexAttributeMatrix->setShape(tupleShape);
-    geometry2d->setVertexData(*vertexAttributeMatrix);
+    geometry2d->setVertexAttributeMatrix(*vertexAttributeMatrix);
 
     return {};
   }

--- a/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -588,7 +588,7 @@ void WriteXdmfGridGeometry(std::ostream& out, const IGridGeometry& gridGeometry,
 
 void WriteXdmfNodeGeometry0D(std::ostream& out, const INodeGeometry0D& nodeGeom0D, std::string_view geomName, std::string_view hdf5FilePath)
 {
-  const AttributeMatrix* vertexData = nodeGeom0D.getVertexData();
+  const AttributeMatrix* vertexData = nodeGeom0D.getVertexAttributeMatrix();
   if(vertexData == nullptr)
   {
     return;
@@ -600,7 +600,7 @@ void WriteXdmfNodeGeometry1D(std::ostream& out, const INodeGeometry1D& nodeGeom1
 {
   WriteXdmfNodeGeometry0D(out, nodeGeom1D, hdf5FilePath, geomName);
 
-  const AttributeMatrix* edgeData = nodeGeom1D.getEdgeData();
+  const AttributeMatrix* edgeData = nodeGeom1D.getEdgeAttributeMatrix();
   if(edgeData == nullptr)
   {
     return;
@@ -612,7 +612,7 @@ void WriteXdmfNodeGeometry2D(std::ostream& out, const INodeGeometry2D& nodeGeom2
 {
   WriteXdmfNodeGeometry1D(out, nodeGeom2D, hdf5FilePath, geomName);
 
-  const AttributeMatrix* faceData = nodeGeom2D.getFaceData();
+  const AttributeMatrix* faceData = nodeGeom2D.getFaceAttributeMatrix();
   if(faceData == nullptr)
   {
     return;
@@ -624,7 +624,7 @@ void WriteXdmfNodeGeometry3D(std::ostream& out, const INodeGeometry3D& nodeGeom3
 {
   WriteXdmfNodeGeometry2D(out, nodeGeom3D, hdf5FilePath, geomName);
 
-  const AttributeMatrix* polyhedraData = nodeGeom3D.getPolyhedronData();
+  const AttributeMatrix* polyhedraData = nodeGeom3D.getPolyhedraAttributeMatrix();
   if(polyhedraData == nullptr)
   {
     return;
@@ -1026,7 +1026,7 @@ void readLegacyAttributeMatrix(DataStructure& ds, const H5::GroupReader& amGroup
     auto* nodeGeom0D = dynamic_cast<INodeGeometry0D*>(&parent);
     if(nodeGeom0D != nullptr)
     {
-      nodeGeom0D->setVertexData(*attributeMatrix);
+      nodeGeom0D->setVertexAttributeMatrix(*attributeMatrix);
     }
     break;
   }
@@ -1034,7 +1034,7 @@ void readLegacyAttributeMatrix(DataStructure& ds, const H5::GroupReader& amGroup
     auto* nodeGeom1D = dynamic_cast<INodeGeometry1D*>(&parent);
     if(nodeGeom1D != nullptr)
     {
-      nodeGeom1D->setEdgeData(*attributeMatrix);
+      nodeGeom1D->setEdgeAttributeMatrix(*attributeMatrix);
     }
     break;
   }
@@ -1042,7 +1042,7 @@ void readLegacyAttributeMatrix(DataStructure& ds, const H5::GroupReader& amGroup
     auto* nodeGeom2D = dynamic_cast<INodeGeometry2D*>(&parent);
     if(nodeGeom2D != nullptr)
     {
-      nodeGeom2D->setFaceData(*attributeMatrix);
+      nodeGeom2D->setFaceAttributeMatrix(*attributeMatrix);
     }
     break;
   }
@@ -1101,7 +1101,7 @@ DataObject* readLegacyTriangleGeom(DataStructure& ds, const H5::GroupReader& geo
   auto* sharedTriList = readLegacyGeomArrayAs<UInt64Array>(ds, geom, geomGroup, Legacy::TriListName);
 
   geom->setVertices(*sharedVertexList);
-  geom->setFaces(*sharedTriList);
+  geom->setFaceList(*sharedTriList);
 
   return geom;
 }
@@ -1114,7 +1114,7 @@ DataObject* readLegacyTetrahedralGeom(DataStructure& ds, const H5::GroupReader& 
   auto* sharedTetList = readLegacyGeomArrayAs<UInt64Array>(ds, geom, geomGroup, Legacy::TetraListName);
 
   geom->setVertices(*sharedVertexList);
-  geom->setPolyhedra(*sharedTetList);
+  geom->setPolyhedraList(*sharedTetList);
 
   return geom;
 }
@@ -1148,7 +1148,7 @@ DataObject* readLegacyQuadGeom(DataStructure& ds, const H5::GroupReader& geomGro
   auto* sharedQuadList = readLegacyGeomArrayAs<UInt64Array>(ds, geom, geomGroup, Legacy::QuadListName);
 
   geom->setVertices(*sharedVertexList);
-  geom->setFaces(*sharedQuadList);
+  geom->setFaceList(*sharedQuadList);
 
   return geom;
 }
@@ -1161,7 +1161,7 @@ DataObject* readLegacyHexGeom(DataStructure& ds, const H5::GroupReader& geomGrou
   auto* sharedHexList = readLegacyGeomArrayAs<UInt64Array>(ds, geom, geomGroup, Legacy::HexListName);
 
   geom->setVertices(*sharedVertexList);
-  geom->setPolyhedra(*sharedHexList);
+  geom->setPolyhedraList(*sharedHexList);
 
   return geom;
 }
@@ -1175,7 +1175,7 @@ DataObject* readLegacyEdgeGeom(DataStructure& ds, const H5::GroupReader& geomGro
   auto* sharedEdgeList = readLegacyGeomArrayAs<UInt64Array>(ds, geom, geomGroup, Legacy::EdgeListName);
 
   geom->setVertices(*sharedVertexList);
-  geom->setEdges(*sharedEdgeList);
+  geom->setEdgeList(*sharedEdgeList);
 
   return geom;
 }

--- a/test/GeometryTest.cpp
+++ b/test/GeometryTest.cpp
@@ -65,7 +65,7 @@ void testGeom2D(INodeGeometry2D* geom)
     // edges
     {
       auto edges = createEdgeList(geom);
-      geom->setEdges(*edges);
+      geom->setEdgeList(*edges);
       REQUIRE(geom->getEdges() == edges);
       const usize numEdges = 5;
       geom->resizeEdgeList(numEdges);
@@ -109,7 +109,7 @@ void testGeom3D(INodeGeometry3D* geom)
     // edges
     {
       auto edges = createEdgeList(geom);
-      geom->setEdges(*edges);
+      geom->setEdgeList(*edges);
       REQUIRE(geom->getEdges() == edges);
       const usize numEdges = 5;
       geom->resizeEdgeList(numEdges);

--- a/test/H5Test.cpp
+++ b/test/H5Test.cpp
@@ -330,7 +330,7 @@ void CreateTriangleGeometry(DataStructure& dataGraph)
   REQUIRE(result.valid());
   auto dataArray = complex::ArrayFromPath<MeshIndexType>(dataGraph, path);
   CsvParser::ReadFile<MeshIndexType, MeshIndexType>(inputFile, *dataArray, skipLines, delimiter);
-  triangleGeom->setFaces(*dataArray);
+  triangleGeom->setFaceList(*dataArray);
 
   // Create the Vertex Array with a component size of 3
   path = DataPath({k_TriangleGroupName, k_VertexListName});
@@ -364,7 +364,7 @@ void CreateQuadGeometry(DataStructure& dataGraph)
   REQUIRE(result.valid());
   auto dataArray = complex::ArrayFromPath<MeshIndexType>(dataGraph, path);
   CsvParser::ReadFile<MeshIndexType, MeshIndexType>(inputFile, *dataArray, skipLines, delimiter);
-  geometry->setFaces(*dataArray);
+  geometry->setFaceList(*dataArray);
 
   // Create the Vertex Array with a component size of 3
   path = DataPath({k_QuadGroupName, k_VertexListName});
@@ -398,7 +398,7 @@ void CreateEdgeGeometry(DataStructure& dataGraph)
   REQUIRE(result.valid());
   auto dataArray = complex::ArrayFromPath<MeshIndexType>(dataGraph, path);
   CsvParser::ReadFile<MeshIndexType, MeshIndexType>(inputFile, *dataArray, skipLines, delimiter);
-  geometry->setEdges(*dataArray);
+  geometry->setEdgeList(*dataArray);
 
   // Create the Vertex Array with a component size of 3
   path = DataPath({k_EdgeGroupName, k_VertexListName});
@@ -537,27 +537,27 @@ NodeBasedGeomData getNodeGeomData(const DataStructure& dataStructure)
   DataPath vertexPath({k_VertexGroupName, "[Geometry] Vertex"});
   auto* vertexGeom = dataStructure.getDataAs<VertexGeom>(vertexPath);
   REQUIRE(vertexGeom != nullptr);
-  nodeData.vertexData.verticesId = vertexGeom->getVertexListId();
+  nodeData.vertexData.verticesId = vertexGeom->getSharedVertexDataArrayId();
 
   DataPath edgePath({k_EdgeGroupName, "[Geometry] Edge"});
   auto* edgeGeom = dataStructure.getDataAs<EdgeGeom>(edgePath);
   REQUIRE(edgeGeom != nullptr);
-  nodeData.edgeData.verticesId = edgeGeom->getVertexListId();
-  nodeData.edgeData.edgesId = edgeGeom->getEdgeListId();
+  nodeData.edgeData.verticesId = edgeGeom->getSharedVertexDataArrayId();
+  nodeData.edgeData.edgesId = edgeGeom->getEdgeListDataArrayId();
 
   DataPath trianglePath({k_TriangleGroupName, "[Geometry] Triangle"});
   auto* triangleGeom = dataStructure.getDataAs<TriangleGeom>(trianglePath);
   REQUIRE(triangleGeom != nullptr);
-  nodeData.triangleData.verticesId = triangleGeom->getVertexListId();
-  nodeData.triangleData.edgesId = triangleGeom->getEdgeListId();
-  nodeData.triangleData.trianglesId = triangleGeom->getFaceListId();
+  nodeData.triangleData.verticesId = triangleGeom->getSharedVertexDataArrayId();
+  nodeData.triangleData.edgesId = triangleGeom->getEdgeListDataArrayId();
+  nodeData.triangleData.trianglesId = triangleGeom->getFaceListDataArrayId();
 
   DataPath quadPath({k_QuadGroupName, "[Geometry] Quad"});
   auto* quadGeom = dataStructure.getDataAs<QuadGeom>(quadPath);
   REQUIRE(quadGeom != nullptr);
-  nodeData.quadData.verticesId = quadGeom->getVertexListId();
-  nodeData.quadData.edgesId = quadGeom->getEdgeListId();
-  nodeData.quadData.quadsId = quadGeom->getFaceListId();
+  nodeData.quadData.verticesId = quadGeom->getSharedVertexDataArrayId();
+  nodeData.quadData.edgesId = quadGeom->getEdgeListDataArrayId();
+  nodeData.quadData.quadsId = quadGeom->getFaceListDataArrayId();
 
   return nodeData;
 }
@@ -762,7 +762,7 @@ TEST_CASE("xmdf")
   auto* verts = DataArray<float32>::Create(ds, "Verts", std::move(vertsDataStore), geomId);
   auto* vertexData = AttributeMatrix::Create(ds, "VertexData", geomId);
   vertexData->setShape({numVerts});
-  vertexGeom->setVertexData(*vertexData);
+  vertexGeom->setVertexAttributeMatrix(*vertexData);
   vertexGeom->setVertices(*verts);
   auto vertexAssociatedData = std::make_unique<DataStore<int32>>(numVerts, 0);
   for(auto& item : vertexAssociatedData->createSpan())


### PR DESCRIPTION
The goal is to cut down on the confusion when writing codes that combine both the complex API and VTK APIs where the word "id" is both used to convey different meanings

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>