### PR TITLE
Filter: Crop Image Geometry bug fixes and enhancements

### DIFF
--- a/src/Plugins/ComplexCore/docs/CropImageGeometry.md
+++ b/src/Plugins/ComplexCore/docs/CropImageGeometry.md
@@ -31,6 +31,7 @@ Normally this **Filter** will leave the origin of the volume set at (0, 0, 0), w
 | Features IDs | DataPath | DataPath to the target Feature IDs array |
 | Voxel Arrays | std::vector<DataPath> | DataArrays to crop |
 | New Cell Features Group Name | std::string | Specifies the name of the DataGroup containing cropped DataArrays |
+| Remove Original Geometry | bool | Whether the current **Geometry** should be removed after cropping |
 
 ## Required Geometry ##
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropImageGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropImageGeometry.cpp
@@ -4,7 +4,7 @@
 #include "complex/DataStructure/Geometry/ImageGeom.hpp"
 #include "complex/DataStructure/INeighborList.hpp"
 #include "complex/Filter/Actions/CopyArrayInstanceAction.hpp"
-#include "complex/Filter/Actions/CopyGroupAction.hpp"
+#include "complex/Filter/Actions/CopyDataObjectAction.hpp"
 #include "complex/Filter/Actions/CreateArrayAction.hpp"
 #include "complex/Filter/Actions/CreateAttributeMatrixAction.hpp"
 #include "complex/Filter/Actions/CreateImageGeometryAction.hpp"
@@ -520,16 +520,12 @@ IFilter::PreflightResult CropImageGeometry::preflightImpl(const DataStructure& d
             allCreatedPaths.push_back(DataPath::FromString(createdPathName).value());
           }
         }
-        resultOutputActions.value().actions.push_back(std::make_unique<CopyGroupAction>(childPath, copiedChildPath, allCreatedPaths));
+        resultOutputActions.value().actions.push_back(std::make_unique<CopyDataObjectAction>(childPath, copiedChildPath, allCreatedPaths));
       }
-      else if(data.getDataAs<IDataArray>(childPath) != nullptr)
+      else
       {
-        resultOutputActions.value().actions.push_back(std::make_unique<CopyArrayInstanceAction>(childPath, copiedChildPath));
+        resultOutputActions.value().actions.push_back(std::make_unique<CopyDataObjectAction>(childPath, copiedChildPath, std::vector<DataPath>{copiedChildPath}));
       }
-      // TODO : copy neighborlist
-      // TODO : copy string array
-      // TODO : copy scalar data
-      // TODO : copy dynamic list array
     }
   }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropImageGeometry.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropImageGeometry.hpp
@@ -29,6 +29,7 @@ public:
   static inline constexpr StringLiteral k_RenumberFeatures_Key = "renumber_features";
   static inline constexpr StringLiteral k_FeatureIds_Key = "feature_ids";
   static inline constexpr StringLiteral k_CellFeatureAttributeMatrix_Key = "cell_feature_attribute_matrix";
+  static inline constexpr StringLiteral k_RemoveOriginalGeometry_Key = "RemoveOriginalGeometry";
 
   /**
    * @brief

--- a/src/Plugins/ComplexCore/test/CropImageGeomTest.cpp
+++ b/src/Plugins/ComplexCore/test/CropImageGeomTest.cpp
@@ -89,6 +89,7 @@ TEST_CASE("ComplexCore::CropImageGeometry(Instantiate)", "[ComplexCore][CropImag
   args.insert(CropImageGeometry::k_NewImageGeom_Key, std::make_any<DataPath>(k_NewImageGeomPath));
   args.insert(CropImageGeometry::k_RenumberFeatures_Key, std::make_any<bool>(k_RenumberFeatures));
   args.insert(CropImageGeometry::k_FeatureIds_Key, std::make_any<DataPath>(k_FeatureIdsPath));
+  args.insert(CropImageGeometry::k_RemoveOriginalGeometry_Key, std::make_any<bool>(true));
 
   auto result = filter.execute(ds, args);
   COMPLEX_RESULT_REQUIRE_VALID(result.result);
@@ -120,6 +121,7 @@ TEST_CASE("ComplexCore::CropImageGeometry(Valid Parameters)", "[ComplexCore][Cro
   args.insert(CropImageGeometry::k_RenumberFeatures_Key, std::make_any<bool>(k_RenumberFeatures));
   args.insert(CropImageGeometry::k_FeatureIds_Key, std::make_any<DataPath>(k_FeatureIdsPath));
   args.insert(CropImageGeometry::k_CellFeatureAttributeMatrix_Key, std::make_any<DataPath>(k_CellFeatureAMPath));
+  args.insert(CropImageGeometry::k_RemoveOriginalGeometry_Key, std::make_any<bool>(false));
 
   const auto oldDimensions = ds.getDataRefAs<ImageGeom>(k_ImageGeomPath).getDimensions();
 


### PR DESCRIPTION
Implements the remove original geometry parameter feature and will copy over the rest of the data from the geometry that is not included in the crop algorithm