### PR TITLE
CreateGeometryFilter api updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,7 @@ set(COMPLEX_HDRS
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CopyGroupAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateDataGroupAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateImageGeometryAction.hpp
+  ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateRectGridGeometryAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateGeometry1DAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateGeometry2DAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateGeometry3DAction.hpp
@@ -441,6 +442,7 @@ set(COMPLEX_SRCS
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CopyGroupAction.cpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateDataGroupAction.cpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateImageGeometryAction.cpp
+  ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateRectGridGeometryAction.cpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateNeighborListAction.cpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/DeleteDataAction.cpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/ImportH5ObjectPathsAction.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,7 @@ set(COMPLEX_HDRS
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateImageGeometryAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateGeometry1DAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateGeometry2DAction.hpp
+  ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateGeometry3DAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateNeighborListAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/CreateVertexGeometryAction.hpp
   ${COMPLEX_SOURCE_DIR}/Filter/Actions/DeleteDataAction.hpp

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.cpp
@@ -81,7 +81,7 @@ IFilter::PreflightResult ApproximatePointCloudHull::preflightImpl(const DataStru
   auto vertexGeom = data.getDataAs<VertexGeom>(vertexGeomPath);
 
   int64 numVertices = vertexGeom->getNumberOfVertices();
-  auto action = std::make_unique<CreateVertexGeometryAction>(hullVertexGeomPath, numVertices, INodeGeometry0D::k_VertexDataName);
+  auto action = std::make_unique<CreateVertexGeometryAction>(hullVertexGeomPath, numVertices, INodeGeometry0D::k_VertexDataName, CreateVertexGeometryAction::k_SharedVertexListName);
 
   OutputActions actions;
   actions.actions.push_back(std::move(action));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
@@ -133,7 +133,7 @@ IFilter::PreflightResult CropVertexGeometry::preflightImpl(const DataStructure& 
   }
   auto tupleShape = vertexAM->getShape();
   usize numTuples = std::accumulate(tupleShape.cbegin(), tupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
-  auto action = std::make_unique<CreateVertexGeometryAction>(croppedGeomPath, numTuples, vertexDataName);
+  auto action = std::make_unique<CreateVertexGeometryAction>(croppedGeomPath, numTuples, vertexDataName, CreateVertexGeometryAction::k_SharedVertexListName);
   DataPath croppedVertexDataPath = action->getVertexDataPath();
   actions.actions.push_back(std::move(action));
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -182,7 +182,8 @@ IFilter::PreflightResult ExtractInternalSurfacesFromTriangleGeometry::preflightI
   // Create Geometry
   usize numFaces = triangleGeom.getNumberOfFaces();
   usize numVertices = triangleGeom.getNumberOfVertices();
-  auto createInternalTrianglesAction = std::make_unique<CreateTriangleGeometryAction>(internalTrianglesGeomPath, numFaces, numVertices, vertexDataName, faceDataName);
+  auto createInternalTrianglesAction = std::make_unique<CreateTriangleGeometryAction>(internalTrianglesGeomPath, numFaces, numVertices, vertexDataName, faceDataName,
+                                                                                      CreateTriangleGeometryAction::k_DefaultVerticesName, CreateTriangleGeometryAction::k_DefaultFacesName);
   DataPath internalVertexDataPath = createInternalTrianglesAction->getVertexDataPath();
   DataPath internalFaceDataPath = createInternalTrianglesAction->getFaceDataPath();
   actions.actions.push_back(std::move(createInternalTrianglesAction));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.cpp
@@ -138,7 +138,7 @@ IFilter::PreflightResult PointSampleTriangleGeometryFilter::preflightImpl(const 
       numTuples = dataStructure.getDataAs<IDataArray>(pSelectedDataArrayPaths[0])->getNumberOfTuples();
     }
 
-    auto createVertexGeometryAction = std::make_unique<CreateVertexGeometryAction>(pVertexGeometryDataPath, numTuples, pVertexGroupDataName);
+    auto createVertexGeometryAction = std::make_unique<CreateVertexGeometryAction>(pVertexGeometryDataPath, numTuples, pVertexGroupDataName, CreateVertexGeometryAction::k_SharedVertexListName);
     resultOutputActions.value().actions.push_back(std::move(createVertexGeometryAction));
   }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
@@ -148,7 +148,8 @@ IFilter::PreflightResult QuickSurfaceMeshFilter::preflightImpl(const DataStructu
 
   // Create the Triangle Geometry action and store it
   {
-    auto createTriangleGeometryAction = std::make_unique<CreateTriangleGeometryAction>(pTriangleGeometryPath, numElements, 1, pVertexGroupDataName, pFaceGroupDataName);
+    auto createTriangleGeometryAction = std::make_unique<CreateTriangleGeometryAction>(pTriangleGeometryPath, numElements, 1, pVertexGroupDataName, pFaceGroupDataName,
+                                                                                       CreateTriangleGeometryAction::k_DefaultVerticesName, CreateTriangleGeometryAction::k_DefaultFacesName);
     resultOutputActions.value().actions.push_back(std::move(createTriangleGeometryAction));
   }
   // Create the face NodesType DataArray action and store it

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
@@ -134,7 +134,7 @@ IFilter::PreflightResult RemoveFlaggedVertices::preflightImpl(const DataStructur
 
   // Create vertex geometry
   uint64 numVertices = vertex->getNumberOfVertices();
-  auto reduced = std::make_unique<CreateVertexGeometryAction>(reducedVertexPath, numVertices, vertexDataName);
+  auto reduced = std::make_unique<CreateVertexGeometryAction>(reducedVertexPath, numVertices, vertexDataName, CreateVertexGeometryAction::k_SharedVertexListName);
   DataPath reducedVertexDataPath = reduced->getVertexDataPath();
   actions.actions.push_back(std::move(reduced));
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
@@ -160,7 +160,8 @@ IFilter::PreflightResult StlFileReaderFilter::preflightImpl(const DataStructure&
   // past this point, we are going to scope each section so that we don't accidentally introduce bugs
 
   // Create the Triangle Geometry action and store it
-  auto createTriangleGeometryAction = std::make_unique<CreateTriangleGeometryAction>(pTriangleGeometryPath, numTriangles, 1, INodeGeometry0D::k_VertexDataName, INodeGeometry2D::k_FaceDataName);
+  auto createTriangleGeometryAction = std::make_unique<CreateTriangleGeometryAction>(pTriangleGeometryPath, numTriangles, 1, INodeGeometry0D::k_VertexDataName, INodeGeometry2D::k_FaceDataName,
+                                                                                     CreateTriangleGeometryAction::k_DefaultVerticesName, CreateTriangleGeometryAction::k_DefaultFacesName);
   auto faceNormalsPath = createTriangleGeometryAction->getFaceDataPath().createChildPath(k_FaceNormals);
   resultOutputActions.value().actions.push_back(std::move(createTriangleGeometryAction));
   // Create the face Normals DataArray action and store it

--- a/src/Plugins/ComplexCore/test/ApproximatePointCloudHullTest.cpp
+++ b/src/Plugins/ComplexCore/test/ApproximatePointCloudHullTest.cpp
@@ -74,7 +74,7 @@ TEST_CASE("ComplexCore::ApproximatePointCloudHull: Instantiate Filter", "[Approx
     DataArray<float>* triangleVertices = triangleGeom.getVertices();
 
     DataPath vertexGeomPath({"[Vertex Geometry]"});
-    CreateVertexGeometryAction createVertexGeometryAction(vertexGeomPath, triangleVertices->getNumberOfTuples(), INodeGeometry0D::k_VertexDataName);
+    CreateVertexGeometryAction createVertexGeometryAction(vertexGeomPath, triangleVertices->getNumberOfTuples(), INodeGeometry0D::k_VertexDataName, CreateVertexGeometryAction::k_SharedVertexListName);
     Result<> createVertexResult = createVertexGeometryAction.apply(dataGraph, IDataAction::Mode::Execute);
     REQUIRE(createVertexResult.valid());
 

--- a/src/complex/Common/TypesUtility.hpp
+++ b/src/complex/Common/TypesUtility.hpp
@@ -3,6 +3,7 @@
 #include "complex/Common/StringLiteral.hpp"
 #include "complex/Common/TypeTraits.hpp"
 #include "complex/Common/Types.hpp"
+#include "complex/DataStructure/Geometry/IGeometry.hpp"
 
 #include <optional>
 #include <stdexcept>
@@ -407,4 +408,101 @@ inline constexpr DataType ConvertNumericTypeToDataType(NumericType numericType)
   }
   }
 }
+
+/**
+ * @brief Returns a string representation of the passed in IGeometry::Type
+ * @param dataType
+ * @return
+ */
+inline constexpr StringLiteral GeometryTypeToString(IGeometry::Type geomType)
+{
+  switch(geomType)
+  {
+  case IGeometry::Type::Image: {
+    return "Image";
+  }
+  case IGeometry::Type::RectGrid: {
+    return "Rectilinear Grid";
+  }
+  case IGeometry::Type::Vertex: {
+    return "Vertex";
+  }
+  case IGeometry::Type::Edge: {
+    return "Edge";
+  }
+  case IGeometry::Type::Triangle: {
+    return "Triangle";
+  }
+  case IGeometry::Type::Quad: {
+    return "Quadrilateral";
+  }
+  case IGeometry::Type::Tetrahedral: {
+    return "Tetrahedral";
+  }
+  case IGeometry::Type::Hexahedral: {
+    return "Hexahedral";
+  }
+  default:
+    throw std::runtime_error("complex::GeometryTypeToString: Unknown IGeometry::Type");
+  }
+}
+
+/**
+ * @brief Returns string representations for all DataTypes.
+ * @return
+ */
+inline const std::vector<std::string>& GetAllGeometryTypesAsStrings()
+{
+  static const std::vector<std::string> geomTypes = {GeometryTypeToString(IGeometry::Type::Image),       GeometryTypeToString(IGeometry::Type::RectGrid),
+                                                     GeometryTypeToString(IGeometry::Type::Vertex),      GeometryTypeToString(IGeometry::Type::Edge),
+                                                     GeometryTypeToString(IGeometry::Type::Triangle),    GeometryTypeToString(IGeometry::Type::Quad),
+                                                     GeometryTypeToString(IGeometry::Type::Tetrahedral), GeometryTypeToString(IGeometry::Type::Hexahedral)};
+  return geomTypes;
+}
+
+/**
+ * @brief Returns a IGeometry::Type for the passed in string representation
+ * @param geomTypeString
+ * @return
+ */
+inline constexpr IGeometry::Type StringToGeometryType(std::string_view geomTypeString)
+{
+  if(geomTypeString == GeometryTypeToString(IGeometry::Type::Image).view())
+  {
+    return IGeometry::Type::Image;
+  }
+  else if(geomTypeString == GeometryTypeToString(IGeometry::Type::RectGrid).view())
+  {
+    return IGeometry::Type::RectGrid;
+  }
+  else if(geomTypeString == GeometryTypeToString(IGeometry::Type::Vertex).view())
+  {
+    return IGeometry::Type::Vertex;
+  }
+  else if(geomTypeString == GeometryTypeToString(IGeometry::Type::Edge).view())
+  {
+    return IGeometry::Type::Edge;
+  }
+  else if(geomTypeString == GeometryTypeToString(IGeometry::Type::Triangle).view())
+  {
+    return IGeometry::Type::Triangle;
+  }
+  else if(geomTypeString == GeometryTypeToString(IGeometry::Type::Quad).view())
+  {
+    return IGeometry::Type::Quad;
+  }
+  else if(geomTypeString == GeometryTypeToString(IGeometry::Type::Tetrahedral).view())
+  {
+    return IGeometry::Type::Tetrahedral;
+  }
+  else if(geomTypeString == GeometryTypeToString(IGeometry::Type::Hexahedral).view())
+  {
+    return IGeometry::Type::Hexahedral;
+  }
+  else
+  {
+    throw std::runtime_error("complex::StringToGeometryType: No known IGeometry::Type matches the given string value.");
+  }
+}
+
 } // namespace complex

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -669,11 +669,15 @@ bool DataStructure::setAdditionalParent(DataObject::IdType targetId, DataObject:
 bool DataStructure::removeParent(DataObject::IdType targetId, DataObject::IdType parentId)
 {
   const auto& target = m_DataObjects[targetId];
-  auto parent = dynamic_cast<BaseGroup*>(getData(parentId));
-  auto targetPtr = target.lock();
+  const auto parent = dynamic_cast<BaseGroup*>(getData(parentId));
+  const auto targetPtr = target.lock();
   if(targetPtr == nullptr)
   {
     return false;
+  }
+  if(parentId == 0)
+  {
+    return removeTopLevel(targetPtr.get());
   }
   return parent->remove(targetPtr.get());
 }

--- a/src/complex/DataStructure/Geometry/RectGridGeom.cpp
+++ b/src/complex/DataStructure/Geometry/RectGridGeom.cpp
@@ -187,6 +187,33 @@ const Float32Array* RectGridGeom::getZBounds() const
   return dynamic_cast<const Float32Array*>(getDataStructure()->getData(m_zBoundsId));
 }
 
+std::shared_ptr<Float32Array> RectGridGeom::getSharedXBounds()
+{
+  if(!m_xBoundsId.has_value())
+  {
+    return nullptr;
+  }
+  return getDataStructure()->getSharedDataAs<Float32Array>(m_xBoundsId.value());
+}
+
+std::shared_ptr<Float32Array> RectGridGeom::getSharedYBounds()
+{
+  if(!m_yBoundsId.has_value())
+  {
+    return nullptr;
+  }
+  return getDataStructure()->getSharedDataAs<Float32Array>(m_yBoundsId.value());
+}
+
+std::shared_ptr<Float32Array> RectGridGeom::getSharedZBounds()
+{
+  if(!m_zBoundsId.has_value())
+  {
+    return nullptr;
+  }
+  return getDataStructure()->getSharedDataAs<Float32Array>(m_zBoundsId.value());
+}
+
 usize RectGridGeom::getNumberOfCells() const
 {
   return m_Dimensions.getX() * m_Dimensions.getY() * m_Dimensions.getZ();

--- a/src/complex/DataStructure/Geometry/RectGridGeom.hpp
+++ b/src/complex/DataStructure/Geometry/RectGridGeom.hpp
@@ -134,6 +134,24 @@ public:
 
   /**
    * @brief
+   * @return std::shared_ptr<Float32Array>
+   */
+  std::shared_ptr<Float32Array> getSharedXBounds();
+
+  /**
+   * @brief
+   * @return std::shared_ptr<Float32Array>
+   */
+  std::shared_ptr<Float32Array> getSharedYBounds();
+
+  /**
+   * @brief
+   * @return std::shared_ptr<Float32Array>
+   */
+  std::shared_ptr<Float32Array> getSharedZBounds();
+
+  /**
+   * @brief
    * @return usize
    */
   usize getNumberOfCells() const override;

--- a/src/complex/Filter/Actions/CreateGeometry1DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry1DAction.hpp
@@ -145,15 +145,11 @@ public:
       edgeTupleShape = edges->getTupleShape();
       vertexTupleShape = vertices->getTupleShape();
 
-      // std::shared_ptr<Float32Array> vertexArray = vertices->deepCopy(getCreatedPath().createChildPath(m_SharedVerticesName));
-      const auto vertexCopy = vertices->deepCopy();
-      dataStructure.insert(std::shared_ptr<DataObject>(vertexCopy), getCreatedPath());
-      const auto vertexArray = dynamic_cast<Float32Array*>(vertexCopy);
+      std::shared_ptr<DataObject> vertexCopy = vertices->deepCopy(getCreatedPath().createChildPath(m_SharedVerticesName));
+      const auto vertexArray = std::dynamic_pointer_cast<Float32Array>(vertexCopy);
 
-      // std::shared_ptr<DataArray<MeshIndexType>> edgesArray = edges->deepCopy(getCreatedPath().createChildPath(m_SharedEdgesName));
-      const auto edgesCopy = edges->deepCopy();
-      dataStructure.insert(std::shared_ptr<DataObject>(edgesCopy), getCreatedPath());
-      const auto edgesArray = dynamic_cast<DataArray<MeshIndexType>*>(edgesCopy);
+      std::shared_ptr<DataObject> edgesCopy = edges->deepCopy(getCreatedPath().createChildPath(m_SharedEdgesName));
+      const auto edgesArray = std::dynamic_pointer_cast<DataArray<MeshIndexType>>(edgesCopy);
 
       geometry1d->setEdgeList(*edgesArray);
       geometry1d->setVertices(*vertexArray);

--- a/src/complex/Filter/Actions/CreateGeometry1DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry1DAction.hpp
@@ -158,10 +158,10 @@ public:
     {
       edgeTupleShape = edges->getTupleShape();
       vertexTupleShape = vertices->getTupleShape();
-      const auto rectGeomId = geometry1d->getId();
+      const auto geomId = geometry1d->getId();
 
       const auto verticesId = vertices->getId();
-      dataStructure.setAdditionalParent(verticesId, rectGeomId);
+      dataStructure.setAdditionalParent(verticesId, geomId);
       const auto oldVertexParentId = dataStructure.getId(m_InputVertices.getParent());
       if(!oldVertexParentId.has_value())
       {
@@ -171,7 +171,7 @@ public:
       dataStructure.removeParent(verticesId, oldVertexParentId.value());
 
       const auto edgesId = edges->getId();
-      dataStructure.setAdditionalParent(edgesId, rectGeomId);
+      dataStructure.setAdditionalParent(edgesId, geomId);
       const auto oldEdgeParentId = dataStructure.getId(m_InputEdges.getParent());
       if(!oldEdgeParentId.has_value())
       {

--- a/src/complex/Filter/Actions/CreateGeometry1DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry1DAction.hpp
@@ -29,12 +29,15 @@ public:
 
   CreateGeometry1DAction() = delete;
 
-  CreateGeometry1DAction(const DataPath& geometryPath, size_t numEdges, size_t numVertices, const std::string& vertexAttributeMatrixName, const std::string& edgeAttributeMatrixName)
+  CreateGeometry1DAction(const DataPath& geometryPath, size_t numEdges, size_t numVertices, const std::string& vertexAttributeMatrixName, const std::string& edgeAttributeMatrixName,
+                         const std::string& sharedVerticesName, const std::string& sharedEdgesName)
   : IDataCreationAction(geometryPath)
   , m_NumEdges(numEdges)
   , m_NumVertices(numVertices)
   , m_VertexDataName(vertexAttributeMatrixName)
   , m_EdgeDataName(edgeAttributeMatrixName)
+  , m_SharedVerticesName(sharedVerticesName)
+  , m_SharedEdgesName(sharedEdgesName)
   {
   }
 
@@ -53,8 +56,6 @@ public:
    */
   Result<> apply(DataStructure& dataStructure, Mode mode) const override
   {
-    const std::string k_EdgeGeometryName(k_DefaultEdgesName);
-    const std::string k_VertexDataName(k_DefaultVerticesName);
     DataPath edgeDataPath = getEdgeDataPath();
     DataPath vertexDataPath = getVertexDataPath();
 
@@ -110,7 +111,7 @@ public:
     using MeshIndexType = IGeometry::MeshIndexType;
     using SharedEdgeList = IGeometry::SharedEdgeList;
 
-    DataPath edgesPath = getCreatedPath().createChildPath(k_EdgeGeometryName);
+    DataPath edgesPath = getCreatedPath().createChildPath(m_SharedEdgesName);
     // Create the default DataArray that will hold the EdgeList and Vertices. We
     // size these to 1 because the Csv parser will resize them to the appropriate number of tuples
     complex::Result result = complex::CreateArray<MeshIndexType>(dataStructure, edgeTupleShape, {2}, edgesPath, mode);
@@ -122,7 +123,7 @@ public:
     geometry1d->setEdgeList(*edges);
 
     // Create the Vertex Array with a component size of 3
-    DataPath vertexPath = getCreatedPath().createChildPath(k_VertexDataName);
+    DataPath vertexPath = getCreatedPath().createChildPath(m_SharedVerticesName);
 
     result = complex::CreateArray<float>(dataStructure, vertexTupleShape, {3}, vertexPath, mode);
     if(result.invalid())
@@ -187,7 +188,7 @@ public:
   std::vector<DataPath> getAllCreatedPaths() const override
   {
     auto topLevelCreatedPath = getCreatedPath();
-    return {topLevelCreatedPath, getEdgeDataPath(), getVertexDataPath(), topLevelCreatedPath.createChildPath(k_DefaultEdgesName), topLevelCreatedPath.createChildPath(k_DefaultVerticesName)};
+    return {topLevelCreatedPath, getEdgeDataPath(), getVertexDataPath(), topLevelCreatedPath.createChildPath(m_SharedEdgesName), topLevelCreatedPath.createChildPath(m_SharedVerticesName)};
   }
 
 private:
@@ -195,6 +196,8 @@ private:
   IGeometry::MeshIndexType m_NumVertices;
   std::string m_VertexDataName;
   std::string m_EdgeDataName;
+  std::string m_SharedVerticesName;
+  std::string m_SharedEdgesName;
 };
 
 using CreateEdgeGeometryAction = CreateGeometry1DAction<EdgeGeom>;

--- a/src/complex/Filter/Actions/CreateGeometry1DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry1DAction.hpp
@@ -16,7 +16,7 @@
 namespace complex
 {
 /**
- * @brief Action for creating an Edge or QuadGeometry in a DataStructure
+ * @brief Action for creating an Edge Geometry in a DataStructure
  */
 template <typename Geometry1DType>
 class CreateGeometry1DAction : public IDataCreationAction
@@ -29,6 +29,16 @@ public:
 
   CreateGeometry1DAction() = delete;
 
+  /**
+   * @brief Constructor to create the 1D geometry and allocate a default arrays for the shared vertex & shared edge lists
+   * @param geometryPath The path to the created geometry
+   * @param numEdges The number of edges in the geometry
+   * @param numVertices The number of vertices in the geometry
+   * @param vertexAttributeMatrixName The name of the vertex AttributeMatrix to be created
+   * @param edgeAttributeMatrixName The name of the edge AttributeMatrix to be created
+   * @param sharedVerticesName The name of the shared vertex list array to be created
+   * @param sharedEdgesName The name of the shared edge list array to be created
+   */
   CreateGeometry1DAction(const DataPath& geometryPath, size_t numEdges, size_t numVertices, const std::string& vertexAttributeMatrixName, const std::string& edgeAttributeMatrixName,
                          const std::string& sharedVerticesName, const std::string& sharedEdgesName)
   : IDataCreationAction(geometryPath)
@@ -38,6 +48,28 @@ public:
   , m_EdgeDataName(edgeAttributeMatrixName)
   , m_SharedVerticesName(sharedVerticesName)
   , m_SharedEdgesName(sharedEdgesName)
+  {
+  }
+
+  /**
+   * @brief Constructor to create the 1D geometry using existing vertices & edges arrays by either copying, moving, or referencing them
+   * @param geometryPath The path to the created geometry
+   * @param inputVerticesArrayPath The path to the existing vertices array
+   * @param inputEdgesArrayPath The path to the existing edges array
+   * @param vertexAttributeMatrixName The name of the vertex AttributeMatrix to be created
+   * @param edgeAttributeMatrixName The name of the edge AttributeMatrix to be created
+   * @param arrayType Tells whether to copy, move, or reference the existing input vertices array
+   */
+  CreateGeometry1DAction(const DataPath& geometryPath, const DataPath& inputVerticesArrayPath, const DataPath& inputEdgesArrayPath, const std::string& vertexAttributeMatrixName,
+                         const std::string& edgeAttributeMatrixName, const ArrayHandlingType& arrayType)
+  : IDataCreationAction(geometryPath)
+  , m_VertexDataName(vertexAttributeMatrixName)
+  , m_EdgeDataName(edgeAttributeMatrixName)
+  , m_SharedVerticesName(inputVerticesArrayPath.getTargetName())
+  , m_SharedEdgesName(inputEdgesArrayPath.getTargetName())
+  , m_InputVertices(inputVerticesArrayPath)
+  , m_InputEdges(inputEdgesArrayPath)
+  , m_ArrayHandlingType(arrayType)
   {
   }
 
@@ -56,20 +88,22 @@ public:
    */
   Result<> apply(DataStructure& dataStructure, Mode mode) const override
   {
+    using MeshIndexType = IGeometry::MeshIndexType;
+    using SharedEdgeList = IGeometry::SharedEdgeList;
     DataPath edgeDataPath = getEdgeDataPath();
     DataPath vertexDataPath = getVertexDataPath();
 
     // Check for empty Geometry DataPath
     if(getCreatedPath().empty())
     {
-      return MakeErrorResult(-220, "CreateGeometry1DAction: Geometry Path cannot be empty");
+      return MakeErrorResult(-120, "CreateGeometry1DAction: Geometry Path cannot be empty");
     }
 
     // Check if the Geometry Path already exists
-    BaseGroup* parentObject = dataStructure.getDataAs<BaseGroup>(getCreatedPath());
+    const BaseGroup* parentObject = dataStructure.getDataAs<BaseGroup>(getCreatedPath());
     if(parentObject != nullptr)
     {
-      return MakeErrorResult(-221, fmt::format("CreateGeometry1DAction: DataObject already exists at path '{}'", getCreatedPath().toString()));
+      return MakeErrorResult(-121, fmt::format("CreateGeometry1DAction: DataObject already exists at path '{}'", getCreatedPath().toString()));
     }
 
     DataPath parentPath = getCreatedPath().getParent();
@@ -78,60 +112,132 @@ public:
       Result<LinkedPath> geomPath = dataStructure.makePath(parentPath);
       if(geomPath.invalid())
       {
-        return MakeErrorResult(-222, fmt::format("CreateGeometry1DAction: Geometry could not be created at path:'{}'", getCreatedPath().toString()));
+        return MakeErrorResult(-122, fmt::format("CreateGeometry1DAction: Geometry could not be created at path:'{}'", getCreatedPath().toString()));
       }
     }
     // Get the Parent ID
     if(!dataStructure.getId(parentPath).has_value())
     {
-      return MakeErrorResult(-223, fmt::format("CreateGeometry1DAction: Parent Id was not available for path:'{}'", parentPath.toString()));
+      return MakeErrorResult(-123, fmt::format("CreateGeometry1DAction: Parent Id was not available for path:'{}'", parentPath.toString()));
+    }
+
+    // Get the vertices list if we are using an existing array
+    const auto vertices = dataStructure.getDataAs<Float32Array>(m_InputVertices);
+    if(m_ArrayHandlingType != ArrayHandlingType::Create && vertices == nullptr)
+    {
+      return MakeErrorResult(-124, fmt::format("CreateGeometry1DAction: Could not find vertices array at path '{}'", m_InputVertices.toString()));
+    }
+
+    // Get the faces list if we are using an existing array
+    const auto edges = dataStructure.getDataAs<DataArray<MeshIndexType>>(m_InputEdges);
+    if(m_ArrayHandlingType != ArrayHandlingType::Create && edges == nullptr)
+    {
+      return MakeErrorResult(-125, fmt::format("CreateGeometry1DAction: Could not find edges array at path '{}'", m_InputEdges.toString()));
     }
 
     // Create the EdgeGeometry
     auto geometry1d = Geometry1DType::Create(dataStructure, getCreatedPath().getTargetName(), dataStructure.getId(parentPath).value());
+    DimensionType edgeTupleShape = {m_NumEdges};
+    DimensionType vertexTupleShape = {m_NumVertices}; // We probably don't know how many Vertices there are but take what ever the developer sends us
 
+    if(m_ArrayHandlingType == ArrayHandlingType::Copy)
+    {
+      edgeTupleShape = edges->getTupleShape();
+      vertexTupleShape = vertices->getTupleShape();
+
+      // std::shared_ptr<Float32Array> vertexArray = vertices->deepCopy(getCreatedPath().createChildPath(m_SharedVerticesName));
+      const auto vertexCopy = vertices->deepCopy();
+      dataStructure.insert(std::shared_ptr<DataObject>(vertexCopy), getCreatedPath());
+      const auto vertexArray = dynamic_cast<Float32Array*>(vertexCopy);
+
+      // std::shared_ptr<DataArray<MeshIndexType>> edgesArray = edges->deepCopy(getCreatedPath().createChildPath(m_SharedEdgesName));
+      const auto edgesCopy = edges->deepCopy();
+      dataStructure.insert(std::shared_ptr<DataObject>(edgesCopy), getCreatedPath());
+      const auto edgesArray = dynamic_cast<DataArray<MeshIndexType>*>(edgesCopy);
+
+      geometry1d->setEdgeList(*edgesArray);
+      geometry1d->setVertices(*vertexArray);
+    }
+    else if(m_ArrayHandlingType == ArrayHandlingType::Move)
+    {
+      edgeTupleShape = edges->getTupleShape();
+      vertexTupleShape = vertices->getTupleShape();
+      const auto rectGeomId = geometry1d->getId();
+
+      const auto verticesId = vertices->getId();
+      dataStructure.setAdditionalParent(verticesId, rectGeomId);
+      const auto oldVertexParentId = dataStructure.getId(m_InputVertices.getParent());
+      if(!oldVertexParentId.has_value())
+      {
+        return MakeErrorResult(-126, fmt::format("CreateGeometry1DAction: Failed to remove vertices array '{}' from parent at path '{}' while moving array", m_SharedVerticesName,
+                                                 m_InputVertices.getParent().toString()));
+      }
+      dataStructure.removeParent(verticesId, oldVertexParentId.value());
+
+      const auto edgesId = edges->getId();
+      dataStructure.setAdditionalParent(edgesId, rectGeomId);
+      const auto oldEdgeParentId = dataStructure.getId(m_InputEdges.getParent());
+      if(!oldEdgeParentId.has_value())
+      {
+        return MakeErrorResult(
+            -126, fmt::format("CreateGeometry1DAction: Failed to remove edges array '{}' from parent at path '{}' while moving array", m_SharedEdgesName, m_InputEdges.getParent().toString()));
+      }
+      dataStructure.removeParent(edgesId, oldEdgeParentId.value());
+
+      geometry1d->setVertices(*vertices);
+      geometry1d->setEdgeList(*edges);
+    }
+    else if(m_ArrayHandlingType == ArrayHandlingType::Reference)
+    {
+      edgeTupleShape = edges->getTupleShape();
+      vertexTupleShape = vertices->getTupleShape();
+      const auto geomId = geometry1d->getId();
+      dataStructure.setAdditionalParent(vertices->getId(), geomId);
+      dataStructure.setAdditionalParent(edges->getId(), geomId);
+      geometry1d->setVertices(*vertices);
+      geometry1d->setEdgeList(*edges);
+    }
+    else
+    {
+      DataPath edgesPath = getCreatedPath().createChildPath(m_SharedEdgesName);
+      // Create the default DataArray that will hold the EdgeList and Vertices. We
+      // size these to 1 because the Csv parser will resize them to the appropriate number of tuples
+      complex::Result result = complex::CreateArray<MeshIndexType>(dataStructure, edgeTupleShape, {2}, edgesPath, mode);
+      if(result.invalid())
+      {
+        return MakeErrorResult(-127, fmt::format("CreateGeometry1DAction: Could not allocate SharedEdgeList '{}'", edgesPath.toString()));
+      }
+      SharedEdgeList* createdEdges = complex::ArrayFromPath<MeshIndexType>(dataStructure, edgesPath);
+      geometry1d->setEdgeList(*createdEdges);
+
+      // Create the Vertex Array with a component size of 3
+      DataPath vertexPath = getCreatedPath().createChildPath(m_SharedVerticesName);
+
+      result = complex::CreateArray<float>(dataStructure, vertexTupleShape, {3}, vertexPath, mode);
+      if(result.invalid())
+      {
+        return MakeErrorResult(-127, fmt::format("CreateGeometry1DAction: Could not allocate SharedVertList '{}'", vertexPath.toString()));
+      }
+      Float32Array* vertexArray = complex::ArrayFromPath<float>(dataStructure, vertexPath);
+      geometry1d->setVertices(*vertexArray);
+    }
+
+    // Create the vertex and edge AttributeMatrix
     auto* edgeAttributeMatrix = AttributeMatrix::Create(dataStructure, m_EdgeDataName, geometry1d->getId());
     if(edgeAttributeMatrix == nullptr)
     {
-      return MakeErrorResult(-224, fmt::format("CreateGeometry1DAction: Failed to create attribute matrix: '{}'", edgeDataPath.toString()));
+      return MakeErrorResult(-128, fmt::format("CreateGeometry1DAction: Failed to create attribute matrix: '{}'", edgeDataPath.toString()));
     }
-    DimensionType edgeTupleShape = {m_NumEdges};
     edgeAttributeMatrix->setShape(edgeTupleShape);
     geometry1d->setEdgeAttributeMatrix(*edgeAttributeMatrix);
 
     auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, geometry1d->getId());
     if(vertexAttributeMatrix == nullptr)
     {
-      return MakeErrorResult(-225, fmt::format("CreateGeometry1DAction: Failed to create attribute matrix: '{}'", vertexDataPath.toString()));
+      return MakeErrorResult(-129, fmt::format("CreateGeometry1DAction: Failed to create attribute matrix: '{}'", vertexDataPath.toString()));
     }
-    DimensionType vertexTupleShape = {m_NumVertices}; // We probably don't know how many Vertices there are but take what ever the developer sends us
     vertexAttributeMatrix->setShape(vertexTupleShape);
     geometry1d->setVertexAttributeMatrix(*vertexAttributeMatrix);
-
-    using MeshIndexType = IGeometry::MeshIndexType;
-    using SharedEdgeList = IGeometry::SharedEdgeList;
-
-    DataPath edgesPath = getCreatedPath().createChildPath(m_SharedEdgesName);
-    // Create the default DataArray that will hold the EdgeList and Vertices. We
-    // size these to 1 because the Csv parser will resize them to the appropriate number of tuples
-    complex::Result result = complex::CreateArray<MeshIndexType>(dataStructure, edgeTupleShape, {2}, edgesPath, mode);
-    if(result.invalid())
-    {
-      return MakeErrorResult(-226, fmt::format("CreateGeometry1DAction: Could not allocate SharedEdgeList '{}'", edgesPath.toString()));
-    }
-    SharedEdgeList* edges = complex::ArrayFromPath<MeshIndexType>(dataStructure, edgesPath);
-    geometry1d->setEdgeList(*edges);
-
-    // Create the Vertex Array with a component size of 3
-    DataPath vertexPath = getCreatedPath().createChildPath(m_SharedVerticesName);
-
-    result = complex::CreateArray<float>(dataStructure, vertexTupleShape, {3}, vertexPath, mode);
-    if(result.invalid())
-    {
-      return MakeErrorResult(-227, fmt::format("CreateGeometry1DAction: Could not allocate SharedVertList '{}'", vertexPath.toString()));
-    }
-    Float32Array* vertexArray = complex::ArrayFromPath<float>(dataStructure, vertexPath);
-    geometry1d->setVertices(*vertexArray);
 
     return {};
   }
@@ -188,16 +294,25 @@ public:
   std::vector<DataPath> getAllCreatedPaths() const override
   {
     auto topLevelCreatedPath = getCreatedPath();
-    return {topLevelCreatedPath, getEdgeDataPath(), getVertexDataPath(), topLevelCreatedPath.createChildPath(m_SharedEdgesName), topLevelCreatedPath.createChildPath(m_SharedVerticesName)};
+    std::vector<DataPath> createdPaths = {topLevelCreatedPath, getEdgeDataPath(), getVertexDataPath()};
+    if(m_ArrayHandlingType == ArrayHandlingType::Create || m_ArrayHandlingType == ArrayHandlingType::Copy)
+    {
+      createdPaths.push_back(topLevelCreatedPath.createChildPath(m_SharedVerticesName));
+      createdPaths.push_back(topLevelCreatedPath.createChildPath(m_SharedEdgesName));
+    }
+    return createdPaths;
   }
 
 private:
-  IGeometry::MeshIndexType m_NumEdges;
-  IGeometry::MeshIndexType m_NumVertices;
+  IGeometry::MeshIndexType m_NumEdges = 1;
+  IGeometry::MeshIndexType m_NumVertices = 2;
   std::string m_VertexDataName;
   std::string m_EdgeDataName;
   std::string m_SharedVerticesName;
   std::string m_SharedEdgesName;
+  DataPath m_InputVertices;
+  DataPath m_InputEdges;
+  ArrayHandlingType m_ArrayHandlingType = ArrayHandlingType::Create;
 };
 
 using CreateEdgeGeometryAction = CreateGeometry1DAction<EdgeGeom>;

--- a/src/complex/Filter/Actions/CreateGeometry2DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry2DAction.hpp
@@ -159,10 +159,10 @@ public:
     {
       faceTupleShape = faces->getTupleShape();
       vertexTupleShape = vertices->getTupleShape();
-      const auto rectGeomId = geometry2d->getId();
+      const auto geomId = geometry2d->getId();
 
       const auto verticesId = vertices->getId();
-      dataStructure.setAdditionalParent(verticesId, rectGeomId);
+      dataStructure.setAdditionalParent(verticesId, geomId);
       const auto oldVertexParentId = dataStructure.getId(m_InputVertices.getParent());
       if(!oldVertexParentId.has_value())
       {
@@ -172,7 +172,7 @@ public:
       dataStructure.removeParent(verticesId, oldVertexParentId.value());
 
       const auto facesId = faces->getId();
-      dataStructure.setAdditionalParent(facesId, rectGeomId);
+      dataStructure.setAdditionalParent(facesId, geomId);
       const auto oldFaceParentId = dataStructure.getId(m_InputFaces.getParent());
       if(!oldFaceParentId.has_value())
       {

--- a/src/complex/Filter/Actions/CreateGeometry2DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry2DAction.hpp
@@ -146,15 +146,11 @@ public:
       faceTupleShape = faces->getTupleShape();
       vertexTupleShape = vertices->getTupleShape();
 
-      // std::shared_ptr<Float32Array> vertexArray = vertices->deepCopy(getCreatedPath().createChildPath(m_SharedVerticesName));
-      const auto vertexCopy = vertices->deepCopy();
-      dataStructure.insert(std::shared_ptr<DataObject>(vertexCopy), getCreatedPath());
-      const auto vertexArray = dynamic_cast<Float32Array*>(vertexCopy);
+      std::shared_ptr<DataObject> vertexCopy = vertices->deepCopy(getCreatedPath().createChildPath(m_SharedVerticesName));
+      const auto vertexArray = std::dynamic_pointer_cast<Float32Array>(vertexCopy);
 
-      // std::shared_ptr<DataArray<MeshIndexType>> facesArray = faces->deepCopy(getCreatedPath().createChildPath(m_SharedFacesName));
-      const auto facesCopy = faces->deepCopy();
-      dataStructure.insert(std::shared_ptr<DataObject>(facesCopy), getCreatedPath());
-      const auto facesArray = dynamic_cast<DataArray<MeshIndexType>*>(facesCopy);
+      std::shared_ptr<DataObject> facesCopy = faces->deepCopy(getCreatedPath().createChildPath(m_SharedFacesName));
+      const auto facesArray = std::dynamic_pointer_cast<DataArray<MeshIndexType>>(facesCopy);
 
       geometry2d->setFaceList(*facesArray);
       geometry2d->setVertices(*vertexArray);

--- a/src/complex/Filter/Actions/CreateGeometry2DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry2DAction.hpp
@@ -115,7 +115,7 @@ public:
     DataPath trianglesPath = getCreatedPath().createChildPath(m_SharedFacesName);
     // Create the default DataArray that will hold the FaceList and Vertices. We
     // size these to 1 because the Csv parser will resize them to the appropriate number of tuples
-    complex::Result result = complex::CreateArray<MeshIndexType>(dataStructure, faceTupleShape, {Geometry2DType::k_NumFaceVerts}, trianglesPath, mode);
+    complex::Result result = complex::CreateArray<MeshIndexType>(dataStructure, faceTupleShape, {Geometry2DType::k_NumVerts}, trianglesPath, mode);
     if(result.invalid())
     {
       return MakeErrorResult(-226, fmt::format("CreateGeometry2DAction: Could not allocate SharedTriList '{}'", trianglesPath.toString()));

--- a/src/complex/Filter/Actions/CreateGeometry3DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry3DAction.hpp
@@ -30,6 +30,16 @@ public:
 
   CreateGeometry3DAction() = delete;
 
+  /**
+   * @brief Constructor to create the 3D geometry and allocate a default arrays for the shared vertex & shared calls lists
+   * @param geometryPath The path to the created geometry
+   * @param numCells The number of cells in the geometry
+   * @param numVertices The number of vertices in the geometry
+   * @param vertexAttributeMatrixName The name of the vertex AttributeMatrix to be created
+   * @param cellAttributeMatrixName The name of the cell AttributeMatrix to be created
+   * @param sharedVerticesName The name of the shared vertex list array to be created
+   * @param sharedCellsName The name of the shared cell list array to be created
+   */
   CreateGeometry3DAction(const DataPath& geometryPath, size_t numCells, size_t numVertices, const std::string& vertexAttributeMatrixName, const std::string& cellAttributeMatrixName,
                          const std::string& sharedVerticesName, const std::string& sharedCellsName)
   : IDataCreationAction(geometryPath)
@@ -42,7 +52,29 @@ public:
   {
   }
 
-  ~CreateGeometry3DAction() noexcept = default;
+  /**
+   * @brief Constructor to create the 3D geometry using existing vertices & cells arrays by either copying, moving, or referencing them
+   * @param geometryPath The path to the created geometry
+   * @param inputVerticesArrayPath The path to the existing vertices array
+   * @param inputCellsArrayPath The path to the existing cells array
+   * @param vertexAttributeMatrixName The name of the vertex AttributeMatrix to be created
+   * @param cellAttributeMatrixName The name of the cell AttributeMatrix to be created
+   * @param arrayType Tells whether to copy, move, or reference the existing input vertices array
+   */
+  CreateGeometry3DAction(const DataPath& geometryPath, const DataPath& inputVerticesArrayPath, const DataPath& inputCellsArrayPath, const std::string& vertexAttributeMatrixName,
+                         const std::string& cellAttributeMatrixName, const ArrayHandlingType& arrayType)
+  : IDataCreationAction(geometryPath)
+  , m_VertexDataName(vertexAttributeMatrixName)
+  , m_CellDataName(cellAttributeMatrixName)
+  , m_SharedVerticesName(inputVerticesArrayPath.getTargetName())
+  , m_SharedCellsName(inputCellsArrayPath.getTargetName())
+  , m_InputVertices(inputVerticesArrayPath)
+  , m_InputCells(inputCellsArrayPath)
+  , m_ArrayHandlingType(arrayType)
+  {
+  }
+
+  ~CreateGeometry3DAction() noexcept override = default;
 
   CreateGeometry3DAction(const CreateGeometry3DAction&) = delete;
   CreateGeometry3DAction(CreateGeometry3DAction&&) noexcept = delete;
@@ -57,81 +89,155 @@ public:
    */
   Result<> apply(DataStructure& dataStructure, Mode mode) const override
   {
-    DataPath cellDataPath = getCellDataPath();
-    DataPath vertexDataPath = getVertexDataPath();
+    using MeshIndexType = IGeometry::MeshIndexType;
+    using SharedCellList = IGeometry::SharedFaceList;
+    const DataPath cellDataPath = getCellDataPath();
+    const DataPath vertexDataPath = getVertexDataPath();
 
     // Check for empty Geometry DataPath
     if(getCreatedPath().empty())
     {
-      return MakeErrorResult(-220, "CreateGeometry3DAction: Geometry Path cannot be empty");
+      return MakeErrorResult(-320, "CreateGeometry3DAction: Geometry Path cannot be empty");
     }
 
     // Check if the Geometry Path already exists
-    BaseGroup* parentObject = dataStructure.getDataAs<BaseGroup>(getCreatedPath());
+    const BaseGroup* parentObject = dataStructure.getDataAs<BaseGroup>(getCreatedPath());
     if(parentObject != nullptr)
     {
-      return MakeErrorResult(-221, fmt::format("CreateGeometry3DAction: DataObject already exists at path '{}'", getCreatedPath().toString()));
+      return MakeErrorResult(-321, fmt::format("CreateGeometry3DAction: DataObject already exists at path '{}'", getCreatedPath().toString()));
     }
 
-    DataPath parentPath = getCreatedPath().getParent();
+    const DataPath parentPath = getCreatedPath().getParent();
     if(!parentPath.empty())
     {
-      Result<LinkedPath> geomPath = dataStructure.makePath(parentPath);
+      const Result<LinkedPath> geomPath = dataStructure.makePath(parentPath);
       if(geomPath.invalid())
       {
-        return MakeErrorResult(-222, fmt::format("CreateGeometry3DAction: Geometry could not be created at path:'{}'", getCreatedPath().toString()));
+        return MakeErrorResult(-322, fmt::format("CreateGeometry3DAction: Geometry could not be created at path:'{}'", getCreatedPath().toString()));
       }
     }
     // Get the Parent ID
     if(!dataStructure.getId(parentPath).has_value())
     {
-      return MakeErrorResult(-223, fmt::format("CreateGeometry3DAction: Parent Id was not available for path:'{}'", parentPath.toString()));
+      return MakeErrorResult(-323, fmt::format("CreateGeometry3DAction: Parent Id was not available for path:'{}'", parentPath.toString()));
+    }
+
+    // Get the vertices list if we are using an existing array
+    const auto vertices = dataStructure.getDataAs<Float32Array>(m_InputVertices);
+    if(m_ArrayHandlingType != ArrayHandlingType::Create && vertices == nullptr)
+    {
+      return MakeErrorResult(-324, fmt::format("CreateGeometry3DAction: Could not find vertices array at path '{}'", m_InputVertices.toString()));
+    }
+
+    // Get the faces list if we are using an existing array
+    const auto cells = dataStructure.getDataAs<DataArray<MeshIndexType>>(m_InputCells);
+    if(m_ArrayHandlingType != ArrayHandlingType::Create && cells == nullptr)
+    {
+      return MakeErrorResult(-325, fmt::format("CreateGeometry3DAction: Could not find cells array at path '{}'", m_InputCells.toString()));
     }
 
     // Create the Geometry
     auto geometry3d = Geometry3DType::Create(dataStructure, getCreatedPath().getTargetName(), dataStructure.getId(parentPath).value());
+    DimensionType cellTupleShape = {m_NumCells};
+    DimensionType vertexTupleShape = {m_NumVertices}; // We probably don't know how many Vertices there are but take what ever the developer sends us
 
+    if(m_ArrayHandlingType == ArrayHandlingType::Copy)
+    {
+      cellTupleShape = cells->getTupleShape();
+      vertexTupleShape = vertices->getTupleShape();
+
+      // std::shared_ptr<Float32Array> vertexArray = vertices->deepCopy(getCreatedPath().createChildPath(m_SharedVerticesName));
+      const auto vertexCopy = vertices->deepCopy();
+      dataStructure.insert(std::shared_ptr<DataObject>(vertexCopy), getCreatedPath());
+      const auto vertexArray = dynamic_cast<Float32Array*>(vertexCopy);
+
+      // std::shared_ptr<DataArray<MeshIndexType>> cellsArray = cells->deepCopy(getCreatedPath().createChildPath(m_SharedCellsName));
+      const auto cellsCopy = cells->deepCopy();
+      dataStructure.insert(std::shared_ptr<DataObject>(cellsCopy), getCreatedPath());
+      const auto cellsArray = dynamic_cast<DataArray<MeshIndexType>*>(cellsCopy);
+
+      geometry3d->setPolyhedraList(*cellsArray);
+      geometry3d->setVertices(*vertexArray);
+    }
+    else if(m_ArrayHandlingType == ArrayHandlingType::Move)
+    {
+      cellTupleShape = cells->getTupleShape();
+      vertexTupleShape = vertices->getTupleShape();
+      const auto rectGeomId = geometry3d->getId();
+
+      const auto verticesId = vertices->getId();
+      dataStructure.setAdditionalParent(verticesId, rectGeomId);
+      const auto oldVertexParentId = dataStructure.getId(m_InputVertices.getParent());
+      if(!oldVertexParentId.has_value())
+      {
+        return MakeErrorResult(-326, fmt::format("CreateGeometry3DAction: Failed to remove vertices array '{}' from parent at path '{}' while moving array", m_SharedVerticesName,
+                                                 m_InputVertices.getParent().toString()));
+      }
+      dataStructure.removeParent(verticesId, oldVertexParentId.value());
+
+      const auto cellsId = cells->getId();
+      dataStructure.setAdditionalParent(cellsId, rectGeomId);
+      const auto oldCellParentId = dataStructure.getId(m_InputCells.getParent());
+      if(!oldCellParentId.has_value())
+      {
+        return MakeErrorResult(
+            -326, fmt::format("CreateGeometry3DAction: Failed to remove cells array '{}' from parent at path '{}' while moving array", m_SharedCellsName, m_InputCells.getParent().toString()));
+      }
+      dataStructure.removeParent(cellsId, oldCellParentId.value());
+
+      geometry3d->setVertices(*vertices);
+      geometry3d->setPolyhedraList(*cells);
+    }
+    else if(m_ArrayHandlingType == ArrayHandlingType::Reference)
+    {
+      cellTupleShape = cells->getTupleShape();
+      vertexTupleShape = vertices->getTupleShape();
+      const auto geomId = geometry3d->getId();
+      dataStructure.setAdditionalParent(vertices->getId(), geomId);
+      dataStructure.setAdditionalParent(cells->getId(), geomId);
+      geometry3d->setVertices(*vertices);
+      geometry3d->setPolyhedraList(*cells);
+    }
+    else
+    {
+      const DataPath cellsPath = getCreatedPath().createChildPath(m_SharedCellsName);
+      // Create the default DataArray that will hold the CellList and Vertices.
+      complex::Result result = complex::CreateArray<MeshIndexType>(dataStructure, cellTupleShape, {Geometry3DType::k_NumVerts}, cellsPath, mode);
+      if(result.invalid())
+      {
+        return MakeErrorResult(-327, fmt::format("CreateGeometry3DAction: Could not allocate SharedCellList '{}'", cellsPath.toString()));
+      }
+      SharedCellList* polyhedronList = complex::ArrayFromPath<MeshIndexType>(dataStructure, cellsPath);
+      geometry3d->setPolyhedraList(*polyhedronList);
+
+      // Create the Vertex Array with a component size of 3
+      const DataPath vertexPath = getCreatedPath().createChildPath(m_SharedVerticesName);
+
+      result = complex::CreateArray<float>(dataStructure, vertexTupleShape, {3}, vertexPath, mode);
+      if(result.invalid())
+      {
+        return MakeErrorResult(-327, fmt::format("CreateGeometry3DAction: Could not allocate SharedVertList '{}'", vertexPath.toString()));
+      }
+      Float32Array* vertexArray = complex::ArrayFromPath<float>(dataStructure, vertexPath);
+      geometry3d->setVertices(*vertexArray);
+    }
+
+    // Create the vertex and cell AttributeMatrix
     auto* cellAttributeMatrix = AttributeMatrix::Create(dataStructure, m_CellDataName, geometry3d->getId());
     if(cellAttributeMatrix == nullptr)
     {
-      return MakeErrorResult(-224, fmt::format("CreateGeometry3DAction: Failed to create attribute matrix: '{}'", cellDataPath.toString()));
+      return MakeErrorResult(-328, fmt::format("CreateGeometry3DAction: Failed to create attribute matrix: '{}'", cellDataPath.toString()));
     }
-    DimensionType cellTupleShape = {m_NumCells};
     cellAttributeMatrix->setShape(cellTupleShape);
     geometry3d->setPolyhedraAttributeMatrix(*cellAttributeMatrix);
 
     auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, geometry3d->getId());
     if(vertexAttributeMatrix == nullptr)
     {
-      return MakeErrorResult(-225, fmt::format("CreateGeometry3DAction: Failed to create attribute matrix: '{}'", vertexDataPath.toString()));
+      return MakeErrorResult(-329, fmt::format("CreateGeometry3DAction: Failed to create attribute matrix: '{}'", vertexDataPath.toString()));
     }
-    DimensionType vertexTupleShape = {m_NumVertices}; // We probably don't know how many Vertices there are but take what ever the developer sends us
     vertexAttributeMatrix->setShape(vertexTupleShape);
     geometry3d->setVertexAttributeMatrix(*vertexAttributeMatrix);
-
-    using MeshIndexType = IGeometry::MeshIndexType;
-    using SharedCellList = IGeometry::SharedFaceList;
-
-    DataPath cellsPath = getCreatedPath().createChildPath(m_SharedCellsName);
-    // Create the default DataArray that will hold the CellList and Vertices.
-    complex::Result result = complex::CreateArray<MeshIndexType>(dataStructure, cellTupleShape, {Geometry3DType::k_NumVerts}, cellsPath, mode);
-    if(result.invalid())
-    {
-      return MakeErrorResult(-226, fmt::format("CreateGeometry3DAction: Could not allocate SharedCellList '{}'", cellsPath.toString()));
-    }
-    SharedCellList* cells = complex::ArrayFromPath<MeshIndexType>(dataStructure, cellsPath);
-    geometry3d->setPolyhedraList(*cells);
-
-    // Create the Vertex Array with a component size of 3
-    DataPath vertexPath = getCreatedPath().createChildPath(m_SharedVerticesName);
-
-    result = complex::CreateArray<float>(dataStructure, vertexTupleShape, {3}, vertexPath, mode);
-    if(result.invalid())
-    {
-      return MakeErrorResult(-227, fmt::format("CreateGeometry3DAction: Could not allocate SharedVertList '{}'", vertexPath.toString()));
-    }
-    Float32Array* vertexArray = complex::ArrayFromPath<float>(dataStructure, vertexPath);
-    geometry3d->setVertices(*vertexArray);
 
     return {};
   }
@@ -187,17 +293,26 @@ public:
    */
   std::vector<DataPath> getAllCreatedPaths() const override
   {
-    auto topLevelCreatedPath = getCreatedPath();
-    return {topLevelCreatedPath, getCellDataPath(), getVertexDataPath(), topLevelCreatedPath.createChildPath(m_SharedCellsName), topLevelCreatedPath.createChildPath(m_SharedVerticesName)};
+    const auto topLevelCreatedPath = getCreatedPath();
+    std::vector<DataPath> createdPaths = {topLevelCreatedPath, getCellDataPath(), getVertexDataPath()};
+    if(m_ArrayHandlingType == ArrayHandlingType::Create || m_ArrayHandlingType == ArrayHandlingType::Copy)
+    {
+      createdPaths.push_back(topLevelCreatedPath.createChildPath(m_SharedVerticesName));
+      createdPaths.push_back(topLevelCreatedPath.createChildPath(m_SharedCellsName));
+    }
+    return createdPaths;
   }
 
 private:
-  IGeometry::MeshIndexType m_NumCells;
-  IGeometry::MeshIndexType m_NumVertices;
+  IGeometry::MeshIndexType m_NumCells = 1;
+  IGeometry::MeshIndexType m_NumVertices = Geometry3DType::k_NumVerts;
   std::string m_VertexDataName;
   std::string m_CellDataName;
   std::string m_SharedVerticesName;
   std::string m_SharedCellsName;
+  DataPath m_InputVertices;
+  DataPath m_InputCells;
+  ArrayHandlingType m_ArrayHandlingType = ArrayHandlingType::Create;
 };
 
 using CreateTetrahedralGeometryAction = CreateGeometry3DAction<TetrahedralGeom>;

--- a/src/complex/Filter/Actions/CreateGeometry3DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry3DAction.hpp
@@ -146,15 +146,11 @@ public:
       cellTupleShape = cells->getTupleShape();
       vertexTupleShape = vertices->getTupleShape();
 
-      // std::shared_ptr<Float32Array> vertexArray = vertices->deepCopy(getCreatedPath().createChildPath(m_SharedVerticesName));
-      const auto vertexCopy = vertices->deepCopy();
-      dataStructure.insert(std::shared_ptr<DataObject>(vertexCopy), getCreatedPath());
-      const auto vertexArray = dynamic_cast<Float32Array*>(vertexCopy);
+      std::shared_ptr<DataObject> vertexCopy = vertices->deepCopy(getCreatedPath().createChildPath(m_SharedVerticesName));
+      const auto vertexArray = std::dynamic_pointer_cast<Float32Array>(vertexCopy);
 
-      // std::shared_ptr<DataArray<MeshIndexType>> cellsArray = cells->deepCopy(getCreatedPath().createChildPath(m_SharedCellsName));
-      const auto cellsCopy = cells->deepCopy();
-      dataStructure.insert(std::shared_ptr<DataObject>(cellsCopy), getCreatedPath());
-      const auto cellsArray = dynamic_cast<DataArray<MeshIndexType>*>(cellsCopy);
+      std::shared_ptr<DataObject> cellsCopy = cells->deepCopy(getCreatedPath().createChildPath(m_SharedCellsName));
+      const auto cellsArray = std::dynamic_pointer_cast<DataArray<MeshIndexType>>(cellsCopy);
 
       geometry3d->setPolyhedraList(*cellsArray);
       geometry3d->setVertices(*vertexArray);

--- a/src/complex/Filter/Actions/CreateGeometry3DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry3DAction.hpp
@@ -1,0 +1,205 @@
+#pragma once
+
+#include "complex/Common/Array.hpp"
+#include "complex/DataStructure/DataArray.hpp"
+#include "complex/DataStructure/DataGroup.hpp"
+#include "complex/DataStructure/Geometry/HexahedralGeom.hpp"
+#include "complex/DataStructure/Geometry/IGeometry.hpp"
+#include "complex/DataStructure/Geometry/TetrahedralGeom.hpp"
+#include "complex/Filter/Output.hpp"
+#include "complex/Utilities/DataArrayUtilities.hpp"
+#include "complex/complex_export.hpp"
+
+#include <fmt/core.h>
+
+#include <utility>
+
+namespace complex
+{
+/**
+ * @brief Action for creating a Tetrahedral or Hexehedral Geometry in a DataStructure
+ */
+template <typename Geometry3DType>
+class CreateGeometry3DAction : public IDataCreationAction
+{
+public:
+  using DimensionType = std::vector<size_t>;
+
+  static constexpr StringLiteral k_DefaultVerticesName = "SharedVertexList";
+  static constexpr StringLiteral k_DefaultCellsName = "SharedCellList";
+
+  CreateGeometry3DAction() = delete;
+
+  CreateGeometry3DAction(const DataPath& geometryPath, size_t numCells, size_t numVertices, const std::string& vertexAttributeMatrixName, const std::string& cellAttributeMatrixName,
+                         const std::string& sharedVerticesName, const std::string& sharedCellsName)
+  : IDataCreationAction(geometryPath)
+  , m_NumCells(numCells)
+  , m_NumVertices(numVertices)
+  , m_VertexDataName(vertexAttributeMatrixName)
+  , m_CellDataName(cellAttributeMatrixName)
+  , m_SharedVerticesName(sharedVerticesName)
+  , m_SharedCellsName(sharedCellsName)
+  {
+  }
+
+  ~CreateGeometry3DAction() noexcept = default;
+
+  CreateGeometry3DAction(const CreateGeometry3DAction&) = delete;
+  CreateGeometry3DAction(CreateGeometry3DAction&&) noexcept = delete;
+  CreateGeometry3DAction& operator=(const CreateGeometry3DAction&) = delete;
+  CreateGeometry3DAction& operator=(CreateGeometry3DAction&&) noexcept = delete;
+
+  /**
+   * @brief Applies this action's change to the given DataStructure in the given mode.
+   * Returns any warnings/errors. On error, DataStructure is not guaranteed to be consistent.
+   * @param dataStructure
+   * @return
+   */
+  Result<> apply(DataStructure& dataStructure, Mode mode) const override
+  {
+    DataPath cellDataPath = getCellDataPath();
+    DataPath vertexDataPath = getVertexDataPath();
+
+    // Check for empty Geometry DataPath
+    if(getCreatedPath().empty())
+    {
+      return MakeErrorResult(-220, "CreateGeometry3DAction: Geometry Path cannot be empty");
+    }
+
+    // Check if the Geometry Path already exists
+    BaseGroup* parentObject = dataStructure.getDataAs<BaseGroup>(getCreatedPath());
+    if(parentObject != nullptr)
+    {
+      return MakeErrorResult(-221, fmt::format("CreateGeometry3DAction: DataObject already exists at path '{}'", getCreatedPath().toString()));
+    }
+
+    DataPath parentPath = getCreatedPath().getParent();
+    if(!parentPath.empty())
+    {
+      Result<LinkedPath> geomPath = dataStructure.makePath(parentPath);
+      if(geomPath.invalid())
+      {
+        return MakeErrorResult(-222, fmt::format("CreateGeometry3DAction: Geometry could not be created at path:'{}'", getCreatedPath().toString()));
+      }
+    }
+    // Get the Parent ID
+    if(!dataStructure.getId(parentPath).has_value())
+    {
+      return MakeErrorResult(-223, fmt::format("CreateGeometry3DAction: Parent Id was not available for path:'{}'", parentPath.toString()));
+    }
+
+    // Create the Geometry
+    auto geometry3d = Geometry3DType::Create(dataStructure, getCreatedPath().getTargetName(), dataStructure.getId(parentPath).value());
+
+    auto* cellAttributeMatrix = AttributeMatrix::Create(dataStructure, m_CellDataName, geometry3d->getId());
+    if(cellAttributeMatrix == nullptr)
+    {
+      return MakeErrorResult(-224, fmt::format("CreateGeometry3DAction: Failed to create attribute matrix: '{}'", cellDataPath.toString()));
+    }
+    DimensionType cellTupleShape = {m_NumCells};
+    cellAttributeMatrix->setShape(cellTupleShape);
+    geometry3d->setPolyhedraAttributeMatrix(*cellAttributeMatrix);
+
+    auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, geometry3d->getId());
+    if(vertexAttributeMatrix == nullptr)
+    {
+      return MakeErrorResult(-225, fmt::format("CreateGeometry3DAction: Failed to create attribute matrix: '{}'", vertexDataPath.toString()));
+    }
+    DimensionType vertexTupleShape = {m_NumVertices}; // We probably don't know how many Vertices there are but take what ever the developer sends us
+    vertexAttributeMatrix->setShape(vertexTupleShape);
+    geometry3d->setVertexAttributeMatrix(*vertexAttributeMatrix);
+
+    using MeshIndexType = IGeometry::MeshIndexType;
+    using SharedCellList = IGeometry::SharedFaceList;
+
+    DataPath cellsPath = getCreatedPath().createChildPath(m_SharedCellsName);
+    // Create the default DataArray that will hold the CellList and Vertices.
+    complex::Result result = complex::CreateArray<MeshIndexType>(dataStructure, cellTupleShape, {Geometry3DType::k_NumVerts}, cellsPath, mode);
+    if(result.invalid())
+    {
+      return MakeErrorResult(-226, fmt::format("CreateGeometry3DAction: Could not allocate SharedCellList '{}'", cellsPath.toString()));
+    }
+    SharedCellList* cells = complex::ArrayFromPath<MeshIndexType>(dataStructure, cellsPath);
+    geometry3d->setPolyhedraList(*cells);
+
+    // Create the Vertex Array with a component size of 3
+    DataPath vertexPath = getCreatedPath().createChildPath(m_SharedVerticesName);
+
+    result = complex::CreateArray<float>(dataStructure, vertexTupleShape, {3}, vertexPath, mode);
+    if(result.invalid())
+    {
+      return MakeErrorResult(-227, fmt::format("CreateGeometry3DAction: Could not allocate SharedVertList '{}'", vertexPath.toString()));
+    }
+    Float32Array* vertexArray = complex::ArrayFromPath<float>(dataStructure, vertexPath);
+    geometry3d->setVertices(*vertexArray);
+
+    return {};
+  }
+
+  /**
+   * @brief Returns the path of the ImageGeometry to be created.
+   * @return
+   */
+  const DataPath& geometryPath() const
+  {
+    return getCreatedPath();
+  }
+
+  /**
+   * @brief Returns the path of the ImageGeometry to be created.
+   * @return
+   */
+  DataPath getCellDataPath() const
+  {
+    return getCreatedPath().createChildPath(m_CellDataName);
+  }
+
+  /**
+   * @brief Returns the path of the ImageGeometry to be created.
+   * @return
+   */
+  DataPath getVertexDataPath() const
+  {
+    return getCreatedPath().createChildPath(m_VertexDataName);
+  }
+
+  /**
+   * @brief Returns the number of cells
+   * @return
+   */
+  IGeometry::MeshIndexType numCells() const
+  {
+    return m_NumCells;
+  }
+
+  /**
+   * @brief Returns the number of vertices (estimated in some circumstances)
+   * @return
+   */
+  IGeometry::MeshIndexType numVertices() const
+  {
+    return m_NumVertices;
+  }
+
+  /**
+   * @brief Returns all of the DataPaths to be created.
+   * @return std::vector<DataPath>
+   */
+  std::vector<DataPath> getAllCreatedPaths() const override
+  {
+    auto topLevelCreatedPath = getCreatedPath();
+    return {topLevelCreatedPath, getCellDataPath(), getVertexDataPath(), topLevelCreatedPath.createChildPath(m_SharedCellsName), topLevelCreatedPath.createChildPath(m_SharedVerticesName)};
+  }
+
+private:
+  IGeometry::MeshIndexType m_NumCells;
+  IGeometry::MeshIndexType m_NumVertices;
+  std::string m_VertexDataName;
+  std::string m_CellDataName;
+  std::string m_SharedVerticesName;
+  std::string m_SharedCellsName;
+};
+
+using CreateTetrahedralGeometryAction = CreateGeometry3DAction<TetrahedralGeom>;
+using CreateHexahedralGeometryAction = CreateGeometry3DAction<HexahedralGeom>;
+} // namespace complex

--- a/src/complex/Filter/Actions/CreateGeometry3DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry3DAction.hpp
@@ -159,10 +159,10 @@ public:
     {
       cellTupleShape = cells->getTupleShape();
       vertexTupleShape = vertices->getTupleShape();
-      const auto rectGeomId = geometry3d->getId();
+      const auto geomId = geometry3d->getId();
 
       const auto verticesId = vertices->getId();
-      dataStructure.setAdditionalParent(verticesId, rectGeomId);
+      dataStructure.setAdditionalParent(verticesId, geomId);
       const auto oldVertexParentId = dataStructure.getId(m_InputVertices.getParent());
       if(!oldVertexParentId.has_value())
       {
@@ -172,7 +172,7 @@ public:
       dataStructure.removeParent(verticesId, oldVertexParentId.value());
 
       const auto cellsId = cells->getId();
-      dataStructure.setAdditionalParent(cellsId, rectGeomId);
+      dataStructure.setAdditionalParent(cellsId, geomId);
       const auto oldCellParentId = dataStructure.getId(m_InputCells.getParent());
       if(!oldCellParentId.has_value())
       {

--- a/src/complex/Filter/Actions/CreateRectGridGeometryAction.cpp
+++ b/src/complex/Filter/Actions/CreateRectGridGeometryAction.cpp
@@ -5,6 +5,8 @@
 #include "complex/DataStructure/Geometry/RectGridGeom.hpp"
 #include "complex/Utilities/DataArrayUtilities.hpp"
 
+#include <memory>
+
 using namespace complex;
 
 namespace complex
@@ -106,24 +108,13 @@ Result<> CreateRectGridGeometryAction::apply(DataStructure& dataStructure, Mode 
   Result<> results;
   if(m_ArrayHandlingType == ArrayHandlingType::Copy)
   {
-    // std::shared_ptr<Float32Array> xBoundsArray = xBounds->deepCopy(getCreatedPath().createChildPath(m_XBoundsArrayName));
-    // std::shared_ptr<Float32Array> yBoundsArray = yBounds->deepCopy(getCreatedPath().createChildPath(m_YBoundsArrayName));
-    // std::shared_ptr<Float32Array> zBoundsArray = zBounds->deepCopy(getCreatedPath().createChildPath(m_ZBoundsArrayName));
-    // rectGridGeom->setBounds(xBoundsArray.get(), yBoundsArray.get(), zBoundsArray.get());
-
-    const auto xCopy = xBounds->deepCopy();
-    dataStructure.insert(std::shared_ptr<DataObject>(xCopy), getCreatedPath());
-    const auto xBoundsArray = dynamic_cast<Float32Array*>(xCopy);
-
-    const auto yCopy = yBounds->deepCopy();
-    dataStructure.insert(std::shared_ptr<DataObject>(yCopy), getCreatedPath());
-    const auto yBoundsArray = dynamic_cast<Float32Array*>(yCopy);
-
-    const auto zCopy = zBounds->deepCopy();
-    dataStructure.insert(std::shared_ptr<DataObject>(zCopy), getCreatedPath());
-    const auto zBoundsArray = dynamic_cast<Float32Array*>(zCopy);
-
-    rectGridGeom->setBounds(xBoundsArray, yBoundsArray, zBoundsArray);
+    std::shared_ptr<DataObject> xCopy = xBounds->deepCopy(getCreatedPath().createChildPath(m_XBoundsArrayName));
+    std::shared_ptr<DataObject> yCopy = yBounds->deepCopy(getCreatedPath().createChildPath(m_YBoundsArrayName));
+    std::shared_ptr<DataObject> zCopy = zBounds->deepCopy(getCreatedPath().createChildPath(m_ZBoundsArrayName));
+    const auto xBoundsArray = std::dynamic_pointer_cast<Float32Array>(xCopy);
+    const auto yBoundsArray = std::dynamic_pointer_cast<Float32Array>(yCopy);
+    const auto zBoundsArray = std::dynamic_pointer_cast<Float32Array>(zCopy);
+    rectGridGeom->setBounds(xBoundsArray.get(), yBoundsArray.get(), zBoundsArray.get());
   }
   else if(m_ArrayHandlingType == ArrayHandlingType::Move)
   {

--- a/src/complex/Filter/Actions/CreateRectGridGeometryAction.cpp
+++ b/src/complex/Filter/Actions/CreateRectGridGeometryAction.cpp
@@ -1,0 +1,130 @@
+#include "CreateRectGridGeometryAction.hpp"
+
+#include <fmt/core.h>
+
+#include "complex/DataStructure/Geometry/RectGridGeom.hpp"
+#include "complex/Utilities/DataArrayUtilities.hpp"
+
+using namespace complex;
+
+namespace complex
+{
+CreateRectGridGeometryAction::CreateRectGridGeometryAction(const DataPath& path, usize xBoundTuples, usize yBoundTuples, usize zBoundTuples, const std::string& cellAttributeMatrixName,
+                                                           const std::string& xBoundsName, const std::string& yBoundsName, const std::string& zBoundsName)
+: IDataCreationAction(path)
+, m_NumXBoundTuples(xBoundTuples)
+, m_NumYBoundTuples(yBoundTuples)
+, m_NumZBoundTuples(zBoundTuples)
+, m_CellDataName(cellAttributeMatrixName)
+, m_XBoundsArrayName(xBoundsName)
+, m_YBoundsArrayName(yBoundsName)
+, m_ZBoundsArrayName(zBoundsName)
+{
+}
+
+CreateRectGridGeometryAction::~CreateRectGridGeometryAction() noexcept = default;
+
+Result<> CreateRectGridGeometryAction::apply(DataStructure& dataStructure, Mode mode) const
+{
+  // Check for empty Geometry DataPath
+  if(getCreatedPath().empty())
+  {
+    return MakeErrorResult(-220, "CreateRectGridGeometryAction: Geometry Path cannot be empty");
+  }
+  // Check if the Geometry Path already exists
+  BaseGroup* parentObject = dataStructure.getDataAs<BaseGroup>(getCreatedPath());
+  if(parentObject != nullptr)
+  {
+    return MakeErrorResult(-222, fmt::format("CreateRectGridGeometryAction: DataObject already exists at path '{}'", getCreatedPath().toString()));
+  }
+  DataPath parentPath = getCreatedPath().getParent();
+  if(!parentPath.empty())
+  {
+    Result<LinkedPath> geomPath = dataStructure.makePath(parentPath);
+    if(geomPath.invalid())
+    {
+      return MakeErrorResult(-223, fmt::format("CreateRectGridGeometryAction: Geometry could not be created at path:'{}'", getCreatedPath().toString()));
+    }
+  }
+  // Get the Parent ID
+  if(!dataStructure.getId(parentPath).has_value())
+  {
+    return MakeErrorResult(-224, fmt::format("CreateRectGridGeometryAction: Parent Id was not available for path:'{}'", parentPath.toString()));
+  }
+
+  // Create the RectGridGeometry
+  RectGridGeom* rectGridGeom = RectGridGeom::Create(dataStructure, getCreatedPath().getTargetName(), dataStructure.getId(parentPath).value());
+  if(rectGridGeom == nullptr)
+  {
+    return MakeErrorResult(-225, fmt::format("CreateRectGridGeometryAction: Failed to create ImageGeometry:'{}'", getCreatedPath().toString()));
+  }
+  DimensionType dims = {m_NumXBoundTuples - 1, m_NumYBoundTuples - 1, m_NumZBoundTuples - 1};
+  rectGridGeom->setDimensions(dims);
+
+  auto* attributeMatrix = AttributeMatrix::Create(dataStructure, m_CellDataName, rectGridGeom->getId());
+  if(attributeMatrix == nullptr)
+  {
+    return MakeErrorResult(-226, fmt::format("CreateRectGridGeometryAction: Failed to create ImageGeometry: '{}'", getCreatedPath().createChildPath(m_CellDataName).toString()));
+  }
+  attributeMatrix->setShape(std::move(dims));
+
+  rectGridGeom->setCellData(*attributeMatrix);
+
+  // create the bounds arrays
+  DimensionType componentShape = {1};
+  DataPath xBoundsPath = getCreatedPath().createChildPath(m_XBoundsArrayName);
+  Result<> xResult = CreateArray<float32>(dataStructure, {m_NumXBoundTuples}, componentShape, xBoundsPath, mode);
+  if(xResult.invalid())
+  {
+    return xResult;
+  }
+  Float32Array* xBoundsArray = complex::ArrayFromPath<float>(dataStructure, xBoundsPath);
+
+  DataPath yBoundsPath = getCreatedPath().createChildPath(m_YBoundsArrayName);
+  Result<> yResult = CreateArray<float32>(dataStructure, {m_NumYBoundTuples}, componentShape, yBoundsPath, mode);
+  if(yResult.invalid())
+  {
+    return yResult;
+  }
+  Float32Array* yBoundsArray = complex::ArrayFromPath<float>(dataStructure, yBoundsPath);
+
+  DataPath zBoundsPath = getCreatedPath().createChildPath(m_ZBoundsArrayName);
+  Result<> zResult = CreateArray<float32>(dataStructure, {m_NumZBoundTuples}, componentShape, zBoundsPath, mode);
+  if(zResult.invalid())
+  {
+    return zResult;
+  }
+  Float32Array* zBoundsArray = complex::ArrayFromPath<float>(dataStructure, zBoundsPath);
+
+  rectGridGeom->setBounds(xBoundsArray, yBoundsArray, zBoundsArray);
+
+  return {};
+}
+
+DataPath CreateRectGridGeometryAction::path() const
+{
+  return getCreatedPath();
+}
+
+const usize& CreateRectGridGeometryAction::xDims() const
+{
+  return m_NumXBoundTuples;
+}
+
+const usize& CreateRectGridGeometryAction::yDims() const
+{
+  return m_NumYBoundTuples;
+}
+
+const usize& CreateRectGridGeometryAction::zDims() const
+{
+  return m_NumZBoundTuples;
+}
+
+std::vector<DataPath> CreateRectGridGeometryAction::getAllCreatedPaths() const
+{
+  auto topLevelCreatedPath = getCreatedPath();
+  return {topLevelCreatedPath, topLevelCreatedPath.createChildPath(m_CellDataName), topLevelCreatedPath.createChildPath(m_XBoundsArrayName), topLevelCreatedPath.createChildPath(m_YBoundsArrayName),
+          topLevelCreatedPath.createChildPath(m_ZBoundsArrayName)};
+}
+} // namespace complex

--- a/src/complex/Filter/Actions/CreateRectGridGeometryAction.hpp
+++ b/src/complex/Filter/Actions/CreateRectGridGeometryAction.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "complex/Common/Array.hpp"
+#include "complex/DataStructure/Geometry/IGridGeometry.hpp"
+#include "complex/Filter/Output.hpp"
+#include "complex/complex_export.hpp"
+
+namespace complex
+{
+/**
+ * @brief Action for creating an RectGridGeometry in a DataStructure
+ */
+class COMPLEX_EXPORT CreateRectGridGeometryAction : public IDataCreationAction
+{
+public:
+  using DimensionType = std::vector<size_t>;
+  using OriginType = std::vector<float>;
+  using SpacingType = std::vector<float>;
+
+  CreateRectGridGeometryAction() = delete;
+
+  CreateRectGridGeometryAction(const DataPath& path, usize xBoundsDim, usize yBoundsDim, usize zBoundsDim, const std::string& cellAttributeMatrixName, const std::string& xBoundsName,
+                               const std::string& yBoundsName, const std::string& zBoundsName);
+
+  ~CreateRectGridGeometryAction() noexcept override;
+
+  CreateRectGridGeometryAction(const CreateRectGridGeometryAction&) = delete;
+  CreateRectGridGeometryAction(CreateRectGridGeometryAction&&) noexcept = delete;
+  CreateRectGridGeometryAction& operator=(const CreateRectGridGeometryAction&) = delete;
+  CreateRectGridGeometryAction& operator=(CreateRectGridGeometryAction&&) noexcept = delete;
+
+  /**
+   * @brief Applies this action's change to the given DataStructure in the given mode.
+   * Returns any warnings/errors. On error, DataStructure is not guaranteed to be consistent.
+   * @param dataStructure
+   * @return
+   */
+  Result<> apply(DataStructure& dataStructure, Mode mode) const override;
+
+  /**
+   * @brief Returns the path of the RectGridGeometry to be created.
+   * @return DataPath
+   */
+  DataPath path() const;
+
+  /**
+   * @brief Returns the x bounds dimensions of the RectGridGeometry to be created.
+   * @return
+   */
+  const usize& xDims() const;
+
+  /**
+   * @brief Returns the y bounds dimensions of the RectGridGeometry to be created.
+   * @return
+   */
+  const usize& yDims() const;
+
+  /**
+   * @brief Returns the z bounds dimensions of the RectGridGeometry to be created.
+   * @return
+   */
+  const usize& zDims() const;
+
+  /**
+   * @brief Returns all of the DataPaths to be created.
+   * @return std::vector<DataPath>
+   */
+  std::vector<DataPath> getAllCreatedPaths() const override;
+
+private:
+  usize m_NumXBoundTuples;
+  usize m_NumYBoundTuples;
+  usize m_NumZBoundTuples;
+  std::string m_CellDataName;
+  std::string m_XBoundsArrayName;
+  std::string m_YBoundsArrayName;
+  std::string m_ZBoundsArrayName;
+};
+} // namespace complex

--- a/src/complex/Filter/Actions/CreateRectGridGeometryAction.hpp
+++ b/src/complex/Filter/Actions/CreateRectGridGeometryAction.hpp
@@ -19,8 +19,31 @@ public:
 
   CreateRectGridGeometryAction() = delete;
 
+  /**
+   * @brief Constructor to create the geometry and allocate default arrays for the x, y, and z bounds
+   * @param path The path to the created geometry
+   * @param xBoundsDim The dimension of the xBounds array to be created
+   * @param yBoundsDim The dimension of the yBounds array to be created
+   * @param zBoundsDim The dimension of the zBounds array to be created
+   * @param cellAttributeMatrixName The name of the cell AttributeMatrix to be created
+   * @param xBoundsName The name of the xBounds array to be created
+   * @param yBoundsName The name of the yBounds array to be created
+   * @param zBoundsName The name of the zBounds array to be created
+   */
   CreateRectGridGeometryAction(const DataPath& path, usize xBoundsDim, usize yBoundsDim, usize zBoundsDim, const std::string& cellAttributeMatrixName, const std::string& xBoundsName,
                                const std::string& yBoundsName, const std::string& zBoundsName);
+
+  /**
+   * @brief Constructor to create the geometry using existing x, y, and z bounds arrays by either copying, moving, or referencing them
+   * @param path The path to the created geometry
+   * @param inputXBoundsPath The path to the existing input x bounds array to be copied/moved/referenced
+   * @param inputYBoundsPath The path to the existing input y bounds array to be copied/moved/referenced
+   * @param inputZBoundsPath The path to the existing input z bounds array to be copied/moved/referenced
+   * @param cellAttributeMatrixName The name of the cell AttributeMatrix to be created
+   * @param arrayType Tells whether to copy, move, or reference the existing input bounds arrays
+   */
+  CreateRectGridGeometryAction(const DataPath& path, const DataPath& inputXBoundsPath, const DataPath& inputYBoundsPath, const DataPath& inputZBoundsPath, const std::string& cellAttributeMatrixName,
+                               const ArrayHandlingType& arrayType);
 
   ~CreateRectGridGeometryAction() noexcept override;
 
@@ -68,12 +91,18 @@ public:
   std::vector<DataPath> getAllCreatedPaths() const override;
 
 private:
-  usize m_NumXBoundTuples;
-  usize m_NumYBoundTuples;
-  usize m_NumZBoundTuples;
+  usize m_NumXBoundTuples = 2;
+  usize m_NumYBoundTuples = 2;
+  usize m_NumZBoundTuples = 2;
   std::string m_CellDataName;
   std::string m_XBoundsArrayName;
   std::string m_YBoundsArrayName;
   std::string m_ZBoundsArrayName;
+  DataPath m_InputXBounds;
+  DataPath m_InputYBounds;
+  DataPath m_InputZBounds;
+  ArrayHandlingType m_ArrayHandlingType = ArrayHandlingType::Create;
+
+  Float32Array* createBoundArray(DataStructure& dataStructure, Mode mode, const std::string& arrayName, usize numTuples, std::vector<Error>& errors) const;
 };
 } // namespace complex

--- a/src/complex/Filter/Actions/CreateVertexGeometryAction.hpp
+++ b/src/complex/Filter/Actions/CreateVertexGeometryAction.hpp
@@ -26,11 +26,34 @@ public:
 
   CreateVertexGeometryAction() = delete;
 
+  /**
+   * @brief Constructor to create the vertex geometry and allocate a default array for the shared vertex list
+   * @param geometryPath The path to the created geometry
+   * @param numVertices The number of vertices in the geometry
+   * @param vertexAttributeMatrixName The name of the vertex AttributeMatrix to be created
+   * @param sharedVertexListName The name of the shared vertex list array to be created
+   */
   CreateVertexGeometryAction(const DataPath& geometryPath, IGeometry::MeshIndexType numVertices, const std::string& vertexAttributeMatrixName, const std::string& sharedVertexListName)
   : IDataCreationAction(geometryPath)
   , m_NumVertices(numVertices)
   , m_VertexDataName(vertexAttributeMatrixName)
   , m_SharedVertexListName(sharedVertexListName)
+  {
+  }
+
+  /**
+   * @brief Constructor to create the vertex geometry using an existing vertices array by either copying, moving, or referencing it
+   * @param geometryPath The path to the created geometry
+   * @param inputVerticesArrayPath The path to the existing vertices array
+   * @param vertexAttributeMatrixName The name of the vertex AttributeMatrix to be created
+   * @param arrayType Tells whether to copy, move, or reference the existing input vertices array
+   */
+  CreateVertexGeometryAction(const DataPath& geometryPath, const DataPath& inputVerticesArrayPath, const std::string& vertexAttributeMatrixName, const ArrayHandlingType& arrayType)
+  : IDataCreationAction(geometryPath)
+  , m_VertexDataName(vertexAttributeMatrixName)
+  , m_SharedVertexListName(inputVerticesArrayPath.getTargetName())
+  , m_InputVertices(inputVerticesArrayPath)
+  , m_ArrayHandlingType(arrayType)
   {
   }
 
@@ -52,14 +75,14 @@ public:
     // Check for empty Geometry DataPath
     if(getCreatedPath().empty())
     {
-      return MakeErrorResult(-220, "CreateVertexGeometryAction: Geometry Path cannot be empty");
+      return MakeErrorResult(-920, "CreateVertexGeometryAction: Geometry Path cannot be empty");
     }
 
     // Check if the Geometry Path already exists
     BaseGroup* parentObject = dataStructure.getDataAs<BaseGroup>(getCreatedPath());
     if(parentObject != nullptr)
     {
-      return MakeErrorResult(-222, fmt::format("CreateVertexGeometryAction: DataObject already exists at path '{}'", getCreatedPath().toString()));
+      return MakeErrorResult(-921, fmt::format("CreateVertexGeometryAction: DataObject already exists at path '{}'", getCreatedPath().toString()));
     }
 
     DataPath parentPath = getCreatedPath().getParent();
@@ -68,40 +91,83 @@ public:
       Result<LinkedPath> geomPath = dataStructure.makePath(parentPath);
       if(geomPath.invalid())
       {
-        return MakeErrorResult(-223, fmt::format("CreateVertexGeometryAction: Geometry could not be created at path:'{}'", getCreatedPath().toString()));
+        return MakeErrorResult(-922, fmt::format("CreateVertexGeometryAction: Geometry could not be created at path:'{}'", getCreatedPath().toString()));
       }
     }
     // Get the Parent ID
     if(!dataStructure.getId(parentPath).has_value())
     {
-      return MakeErrorResult(-224, fmt::format("CreateVertexGeometryAction: Parent Id was not available for path:'{}'", parentPath.toString()));
+      return MakeErrorResult(-923, fmt::format("CreateVertexGeometryAction: Parent Id was not available for path:'{}'", parentPath.toString()));
+    }
+
+    // Get the vertices list if we are using an existing array
+    const auto vertices = dataStructure.getDataAs<Float32Array>(m_InputVertices);
+    if(m_ArrayHandlingType != ArrayHandlingType::Create && vertices == nullptr)
+    {
+      return MakeErrorResult(-924, fmt::format("CreateVertexGeometryAction: Could not find vertices array at path '{}'", m_InputVertices.toString()));
     }
 
     // Create the VertexGeom
-    VertexGeom* geometry2d = VertexGeom::Create(dataStructure, getCreatedPath().getTargetName(), dataStructure.getId(parentPath).value());
+    VertexGeom* vertexGeom = VertexGeom::Create(dataStructure, getCreatedPath().getTargetName(), dataStructure.getId(parentPath).value());
 
     using MeshIndexType = IGeometry::MeshIndexType;
+    std::vector<usize> tupleShape = {m_NumVertices}; // We don't probably know how many Vertices there are but take what ever the developer sends us
 
     // Create the Vertex Array with a component size of 3
-    DataPath vertexPath = getCreatedPath().createChildPath(m_SharedVertexListName);
-    std::vector<usize> tupleShape = {m_NumVertices}; // We don't probably know how many Vertices there are but take what ever the developer sends us
-    std::vector<usize> componentShape = {3};
-
-    Result<> result = complex::CreateArray<float>(dataStructure, tupleShape, componentShape, vertexPath, mode);
-    if(result.invalid())
+    if(m_ArrayHandlingType == ArrayHandlingType::Copy)
     {
-      return result;
-    }
-    Float32Array* vertexArray = complex::ArrayFromPath<float>(dataStructure, vertexPath);
-    geometry2d->setVertices(*vertexArray);
+      tupleShape = vertices->getTupleShape();
 
-    auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, geometry2d->getId());
+      // std::shared_ptr<Float32Array> vertexArray = vertices->deepCopy(getCreatedPath().createChildPath(m_SharedVertexListName));
+      const auto copy = vertices->deepCopy();
+      dataStructure.insert(std::shared_ptr<DataObject>(copy), getCreatedPath());
+      const auto vertexArray = dynamic_cast<Float32Array*>(copy);
+
+      vertexGeom->setVertices(*vertexArray);
+    }
+    else if(m_ArrayHandlingType == ArrayHandlingType::Move)
+    {
+      tupleShape = vertices->getTupleShape();
+      const auto rectGeomId = vertexGeom->getId();
+      const auto verticesId = vertices->getId();
+      dataStructure.setAdditionalParent(verticesId, rectGeomId);
+      const auto oldParentId = dataStructure.getId(m_InputVertices.getParent());
+      if(!oldParentId.has_value())
+      {
+        return MakeErrorResult(-925, fmt::format("CreateVertexGeometryAction: Failed to remove vertices array '{}' from parent at path '{}' while moving array", m_SharedVertexListName,
+                                                 m_InputVertices.getParent().toString()));
+      }
+      dataStructure.removeParent(verticesId, oldParentId.value());
+      vertexGeom->setVertices(*vertices);
+    }
+    else if(m_ArrayHandlingType == ArrayHandlingType::Reference)
+    {
+      tupleShape = vertices->getTupleShape();
+      dataStructure.setAdditionalParent(vertices->getId(), vertexGeom->getId());
+      vertexGeom->setVertices(*vertices);
+    }
+    else
+    {
+      const DataPath vertexPath = getCreatedPath().createChildPath(m_SharedVertexListName);
+      const std::vector<usize> componentShape = {3};
+
+      Result<> result = complex::CreateArray<float>(dataStructure, tupleShape, componentShape, vertexPath, mode);
+      if(result.invalid())
+      {
+        return result;
+      }
+      const Float32Array* vertexArray = complex::ArrayFromPath<float>(dataStructure, vertexPath);
+      vertexGeom->setVertices(*vertexArray);
+    }
+
+    // Create the Vertex AttributeMatrix
+    auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, vertexGeom->getId());
     if(vertexAttributeMatrix == nullptr)
     {
-      return MakeErrorResult(-225, fmt::format("CreateGeometry2DAction: Failed to create attribute matrix: '{}'", getVertexDataPath().toString()));
+      return MakeErrorResult(-926, fmt::format("CreateVertexGeometryAction: Failed to create attribute matrix: '{}'", getVertexDataPath().toString()));
     }
     vertexAttributeMatrix->setShape(tupleShape);
-    geometry2d->setVertexAttributeMatrix(*vertexAttributeMatrix);
+    vertexGeom->setVertexAttributeMatrix(*vertexAttributeMatrix);
 
     return {};
   }
@@ -148,14 +214,21 @@ public:
    */
   std::vector<DataPath> getAllCreatedPaths() const override
   {
-    auto topLevelCreatedPath = getCreatedPath();
-    return {topLevelCreatedPath, getVertexDataPath(), topLevelCreatedPath.createChildPath(m_SharedVertexListName)};
+    const auto topLevelCreatedPath = getCreatedPath();
+    std::vector<DataPath> createdPaths = {topLevelCreatedPath, getVertexDataPath()};
+    if(m_ArrayHandlingType == ArrayHandlingType::Create || m_ArrayHandlingType == ArrayHandlingType::Copy)
+    {
+      createdPaths.push_back(topLevelCreatedPath.createChildPath(m_SharedVertexListName));
+    }
+    return createdPaths;
   }
 
 private:
-  IGeometry::MeshIndexType m_NumVertices;
+  IGeometry::MeshIndexType m_NumVertices = 1;
   std::string m_VertexDataName;
   std::string m_SharedVertexListName;
+  DataPath m_InputVertices;
+  ArrayHandlingType m_ArrayHandlingType = ArrayHandlingType::Create;
 };
 
 } // namespace complex

--- a/src/complex/Filter/Actions/CreateVertexGeometryAction.hpp
+++ b/src/complex/Filter/Actions/CreateVertexGeometryAction.hpp
@@ -26,10 +26,11 @@ public:
 
   CreateVertexGeometryAction() = delete;
 
-  CreateVertexGeometryAction(const DataPath& geometryPath, IGeometry::MeshIndexType numVertices, const std::string& vertexAttributeMatrixName)
+  CreateVertexGeometryAction(const DataPath& geometryPath, IGeometry::MeshIndexType numVertices, const std::string& vertexAttributeMatrixName, const std::string& sharedVertexListName)
   : IDataCreationAction(geometryPath)
   , m_NumVertices(numVertices)
   , m_VertexDataName(vertexAttributeMatrixName)
+  , m_SharedVertexListName(sharedVertexListName)
   {
   }
 
@@ -82,7 +83,7 @@ public:
     using MeshIndexType = IGeometry::MeshIndexType;
 
     // Create the Vertex Array with a component size of 3
-    DataPath vertexPath = getCreatedPath().createChildPath(k_SharedVertexListName);
+    DataPath vertexPath = getCreatedPath().createChildPath(m_SharedVertexListName);
     std::vector<usize> tupleShape = {m_NumVertices}; // We don't probably know how many Vertices there are but take what ever the developer sends us
     std::vector<usize> componentShape = {3};
 
@@ -133,18 +134,28 @@ public:
   }
 
   /**
+   * @brief Returns the path of the shared vertex list in the created geometry.
+   * @return
+   */
+  DataPath getSharedVertexListDataPath() const
+  {
+    return getCreatedPath().createChildPath(m_SharedVertexListName);
+  }
+
+  /**
    * @brief Returns all of the DataPaths to be created.
    * @return std::vector<DataPath>
    */
   std::vector<DataPath> getAllCreatedPaths() const override
   {
     auto topLevelCreatedPath = getCreatedPath();
-    return {topLevelCreatedPath, getVertexDataPath(), topLevelCreatedPath.createChildPath(k_SharedVertexListName)};
+    return {topLevelCreatedPath, getVertexDataPath(), topLevelCreatedPath.createChildPath(m_SharedVertexListName)};
   }
 
 private:
   IGeometry::MeshIndexType m_NumVertices;
   std::string m_VertexDataName;
+  std::string m_SharedVertexListName;
 };
 
 } // namespace complex

--- a/src/complex/Filter/Actions/CreateVertexGeometryAction.hpp
+++ b/src/complex/Filter/Actions/CreateVertexGeometryAction.hpp
@@ -118,10 +118,8 @@ public:
     {
       tupleShape = vertices->getTupleShape();
 
-      // std::shared_ptr<Float32Array> vertexArray = vertices->deepCopy(getCreatedPath().createChildPath(m_SharedVertexListName));
-      const auto copy = vertices->deepCopy();
-      dataStructure.insert(std::shared_ptr<DataObject>(copy), getCreatedPath());
-      const auto vertexArray = dynamic_cast<Float32Array*>(copy);
+      std::shared_ptr<DataObject> copy = vertices->deepCopy(getCreatedPath().createChildPath(m_SharedVertexListName));
+      const auto vertexArray = std::dynamic_pointer_cast<Float32Array>(copy);
 
       vertexGeom->setVertices(*vertexArray);
     }

--- a/src/complex/Filter/Actions/CreateVertexGeometryAction.hpp
+++ b/src/complex/Filter/Actions/CreateVertexGeometryAction.hpp
@@ -126,9 +126,9 @@ public:
     else if(m_ArrayHandlingType == ArrayHandlingType::Move)
     {
       tupleShape = vertices->getTupleShape();
-      const auto rectGeomId = vertexGeom->getId();
+      const auto geomId = vertexGeom->getId();
       const auto verticesId = vertices->getId();
-      dataStructure.setAdditionalParent(verticesId, rectGeomId);
+      dataStructure.setAdditionalParent(verticesId, geomId);
       const auto oldParentId = dataStructure.getId(m_InputVertices.getParent());
       if(!oldParentId.has_value())
       {

--- a/src/complex/Filter/Output.hpp
+++ b/src/complex/Filter/Output.hpp
@@ -52,6 +52,14 @@ protected:
 class IDataCreationAction : public IDataAction
 {
 public:
+  enum class ArrayHandlingType : uint64
+  {
+    Copy = 0,      // Copy an existing array to the constructed object
+    Move = 1,      // Move an existing array to the constructed object
+    Reference = 2, // Reference an existing array
+    Create = 3     // Allocate a new array
+  };
+
   /**
    * @brief Constructs an IDataCreationAction that takes a DataPath specifying the path to be created.
    * @param createdPath


### PR DESCRIPTION
- Adds CreateRectGridGeometryAction & CreateGeometry3DAction
- Updates the geometry creation actions to allow naming of the arrays as well as the attribute matrices
- Updates the geometry creation actions to have a second constructor for constructing a geometry from already existing arrays 
- Fixes the DataStructure::removeParent fct to handle case when parent is root
- Adds convenience functions for converting IGeometry type to/from string