### PR TITLE
STYLE: Patch Overwritten UUIDs and Snake Case Variables

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignGeometries.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignGeometries.hpp
@@ -83,4 +83,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, AlignGeometries, "ce1ee404-0336-536c-8aad-f9641c9458be");
+COMPLEX_DEF_FILTER_TRAITS(complex, AlignGeometries, "87fa9e07-6c66-45b0-80a0-cf80cc0def5d");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.hpp
@@ -88,4 +88,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, ApproximatePointCloudHull, "fab669ad-66c6-5a39-bdb7-fc47b94311ed");
+COMPLEX_DEF_FILTER_TRAITS(complex, ApproximatePointCloudHull, "c19203b7-2217-4e52-bff4-7f611695421a");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CombineAttributeArraysFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CombineAttributeArraysFilter.hpp
@@ -24,10 +24,10 @@ public:
   CombineAttributeArraysFilter& operator=(CombineAttributeArraysFilter&&) noexcept = delete;
 
   // Parameter Keys
-  static inline constexpr StringLiteral k_NormalizeData_Key = "NormalizeData";
-  static inline constexpr StringLiteral k_MoveValues_Key = "MoveValues";
-  static inline constexpr StringLiteral k_SelectedDataArrayPaths_Key = "SelectedDataArrayPaths";
-  static inline constexpr StringLiteral k_StackedDataArrayName_Key = "StackedDataArrayName";
+  static inline constexpr StringLiteral k_NormalizeData_Key = "normalize_data";
+  static inline constexpr StringLiteral k_MoveValues_Key = "move_values";
+  static inline constexpr StringLiteral k_SelectedDataArrayPaths_Key = "selected_data_array_paths";
+  static inline constexpr StringLiteral k_StackedDataArrayName_Key = "stacked_data_array_name";
 
   /**
    * @brief Returns the name of the filter.

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyFeatureArrayToElementArray.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyFeatureArrayToElementArray.hpp
@@ -97,4 +97,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, CopyFeatureArrayToElementArray, "99836b75-144b-5126-b261-b411133b5e8a");
+COMPLEX_DEF_FILTER_TRAITS(complex, CopyFeatureArrayToElementArray, "4c8c976a-993d-438b-bd8e-99f71114b9a1");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateFeatureArrayFromElementArray.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateFeatureArrayFromElementArray.hpp
@@ -95,4 +95,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, CreateFeatureArrayFromElementArray, "94438019-21bb-5b61-a7c3-66974b9a34dc");
+COMPLEX_DEF_FILTER_TRAITS(complex, CreateFeatureArrayFromElementArray, "50e1be47-b027-4f40-8f70-1283682ee3e7");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropImageGeometry.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropImageGeometry.hpp
@@ -29,7 +29,7 @@ public:
   static inline constexpr StringLiteral k_RenumberFeatures_Key = "renumber_features";
   static inline constexpr StringLiteral k_FeatureIds_Key = "feature_ids";
   static inline constexpr StringLiteral k_CellFeatureAttributeMatrix_Key = "cell_feature_attribute_matrix";
-  static inline constexpr StringLiteral k_RemoveOriginalGeometry_Key = "RemoveOriginalGeometry";
+  static inline constexpr StringLiteral k_RemoveOriginalGeometry_Key = "remove_original_geometry";
 
   /**
    * @brief

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighbors.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighbors.hpp
@@ -90,4 +90,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, FindNeighbors, "97cf66f8-7a9b-5ec2-83eb-f8c4c8a17bac");
+COMPLEX_DEF_FILTER_TRAITS(complex, FindNeighbors, "7177e88c-c3ab-4169-abe9-1fdaff20e598");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindSurfaceFeatures.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindSurfaceFeatures.hpp
@@ -110,4 +110,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, FindSurfaceFeatures, "d2b0ae3d-686a-5dc0-a844-66bc0dc8f3cb");
+COMPLEX_DEF_FILTER_TRAITS(complex, FindSurfaceFeatures, "0893e490-5d24-4c21-95e7-e8372baa8948");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindSurfaceFeatures.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindSurfaceFeatures.hpp
@@ -39,7 +39,7 @@ public:
   FindSurfaceFeatures& operator=(FindSurfaceFeatures&&) noexcept = delete;
 
   // Parameter Keys
-  static inline constexpr StringLiteral k_MarkFeature0Neighbors = "MarkFeature0Neighbors";
+  static inline constexpr StringLiteral k_MarkFeature0Neighbors = "mark_feature_0_neighbors";
   static inline constexpr StringLiteral k_FeatureGeometryPath_Key = "feature_geometry_path";
   static inline constexpr StringLiteral k_CellFeatureIdsArrayPath_Key = "feature_ids_path";
   static inline constexpr StringLiteral k_SurfaceFeaturesArrayPath_Key = "surface_features_array_path";

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportCSVDataFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportCSVDataFilter.hpp
@@ -34,11 +34,11 @@ public:
   ImportCSVDataFilter& operator=(ImportCSVDataFilter&&) noexcept = delete;
 
   // Parameter Keys
-  static inline constexpr StringLiteral k_WizardData_Key = "Wizard Data";
-  static inline constexpr StringLiteral k_TupleDims_Key = "Tuple Dimensions";
-  static inline constexpr StringLiteral k_UseExistingGroup_Key = "Use Existing Group";
-  static inline constexpr StringLiteral k_SelectedDataGroup_Key = "Selected Data Group";
-  static inline constexpr StringLiteral k_CreatedDataGroup_Key = "Created Data Group";
+  static inline constexpr StringLiteral k_WizardData_Key = "wizard_data";
+  static inline constexpr StringLiteral k_TupleDims_Key = "tuple_dimensions";
+  static inline constexpr StringLiteral k_UseExistingGroup_Key = "use_existing_group";
+  static inline constexpr StringLiteral k_SelectedDataGroup_Key = "selected_data_group";
+  static inline constexpr StringLiteral k_CreatedDataGroup_Key = "created_data_group";
 
   /**
    * @brief Returns the name of the filter.

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.hpp
@@ -89,4 +89,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, MinNeighbors, "dab5de3c-5f81-5bb5-8490-73521e1183ea");
+COMPLEX_DEF_FILTER_TRAITS(complex, MinNeighbors, "4ab5153f-6014-4e6d-bbd6-194068620389");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.hpp
@@ -96,4 +96,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, RemoveFlaggedVertices, "379ccc67-16dd-530a-984f-177db2314bac");
+COMPLEX_DEF_FILTER_TRAITS(complex, RemoveFlaggedVertices, "46099b4c-ef90-4fb3-b5e9-6c8c543c5be1");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ScalarSegmentFeaturesFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ScalarSegmentFeaturesFilter.hpp
@@ -29,14 +29,14 @@ public:
 
   // Parameter Keys
   static inline constexpr StringLiteral k_GridGeomPath_Key = "grid_geometry_path";
-  static inline constexpr StringLiteral k_ScalarToleranceKey = "scalar tolerance";
-  static inline constexpr StringLiteral k_InputArrayPathKey = "input array path";
-  static inline constexpr StringLiteral k_UseGoodVoxelsKey = "use mask";
-  static inline constexpr StringLiteral k_GoodVoxelsPath_Key = "mask path";
-  static inline constexpr StringLiteral k_FeatureIdsPathKey = "feature ids path";
-  static inline constexpr StringLiteral k_CellFeaturePathKey = "cell feature group path";
-  static inline constexpr StringLiteral k_ActiveArrayPathKey = "active array path";
-  static inline constexpr StringLiteral k_RandomizeFeatures_Key = "randomize features";
+  static inline constexpr StringLiteral k_ScalarToleranceKey = "scalar_tolerance";
+  static inline constexpr StringLiteral k_InputArrayPathKey = "input_array_path";
+  static inline constexpr StringLiteral k_UseGoodVoxelsKey = "use_mask";
+  static inline constexpr StringLiteral k_GoodVoxelsPath_Key = "mask_path";
+  static inline constexpr StringLiteral k_FeatureIdsPathKey = "feature_ids_path";
+  static inline constexpr StringLiteral k_CellFeaturePathKey = "cell_feature_group_path";
+  static inline constexpr StringLiteral k_ActiveArrayPathKey = "active_array_path";
+  static inline constexpr StringLiteral k_RandomizeFeatures_Key = "randomize_features";
 
   /**
    * @brief Returns the filter's name.

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.hpp
@@ -31,8 +31,8 @@ public:
 
   static inline constexpr StringLiteral k_FaceGroupDataPath_Key = "face_data_path";
   static inline constexpr StringLiteral k_FaceNormalsDataPath_Key = "face_normals_data_path";
-  static inline constexpr StringLiteral k_ScaleOutput = "ScaleOutput";
-  static inline constexpr StringLiteral k_ScaleFactor = "ScaleFactor";
+  static inline constexpr StringLiteral k_ScaleOutput = "scale_output";
+  static inline constexpr StringLiteral k_ScaleFactor = "scale_factor";
 
   /**
    * @brief Returns the name of the filter.

--- a/src/complex/Parameters/Dream3dImportParameter.cpp
+++ b/src/complex/Parameters/Dream3dImportParameter.cpp
@@ -15,8 +15,8 @@ using namespace complex;
 
 namespace
 {
-constexpr StringLiteral k_FilePathKey = "filepath";
-constexpr StringLiteral k_DataPathsKey = "datapaths";
+constexpr StringLiteral k_FilePathKey = "file_path";
+constexpr StringLiteral k_DataPathsKey = "data_paths";
 } // namespace
 
 namespace complex

--- a/src/complex/Parameters/GeneratedFileListParameter.cpp
+++ b/src/complex/Parameters/GeneratedFileListParameter.cpp
@@ -20,15 +20,15 @@ namespace
 {
 using OrderingUnderlyingT = std::underlying_type_t<GeneratedFileListParameter::Ordering>;
 
-constexpr StringLiteral k_StartIndex = "startIndex";
-constexpr StringLiteral k_EndIndex = "endIndex";
-constexpr StringLiteral k_PaddingDigits = "paddingDigits";
+constexpr StringLiteral k_StartIndex = "start_index";
+constexpr StringLiteral k_EndIndex = "end_index";
+constexpr StringLiteral k_PaddingDigits = "padding_digits";
 constexpr StringLiteral k_Ordering = "ordering";
-constexpr StringLiteral k_IncrementIndex = "incrementIndex";
-constexpr StringLiteral k_InputPath = "inputPath";
-constexpr StringLiteral k_FilePrefix = "filePrefix";
-constexpr StringLiteral k_FileSuffix = "fileSuffix";
-constexpr StringLiteral k_FileExtension = "fileExtension";
+constexpr StringLiteral k_IncrementIndex = "increment_index";
+constexpr StringLiteral k_InputPath = "input_path";
+constexpr StringLiteral k_FilePrefix = "file_prefix";
+constexpr StringLiteral k_FileSuffix = "file_suffix";
+constexpr StringLiteral k_FileExtension = "file_extension";
 } // namespace
 
 //-----------------------------------------------------------------------------

--- a/src/complex/Parameters/ImportHDF5DatasetParameter.cpp
+++ b/src/complex/Parameters/ImportHDF5DatasetParameter.cpp
@@ -33,9 +33,9 @@
 using namespace complex;
 namespace
 {
-constexpr StringLiteral k_DataPathsKey = "datapaths";
-constexpr StringLiteral k_InputFileKey = "inputfile";
-constexpr StringLiteral k_ParentGroupKey = "parentgroup";
+constexpr StringLiteral k_DataPathsKey = "data_paths";
+constexpr StringLiteral k_InputFileKey = "input_file";
+constexpr StringLiteral k_ParentGroupKey = "parent_group";
 } // namespace
 
 namespace complex

--- a/src/complex/Parameters/ImportHDF5DatasetParameter.hpp
+++ b/src/complex/Parameters/ImportHDF5DatasetParameter.hpp
@@ -52,9 +52,9 @@ public:
     std::string componentDimensions;
     std::string tupleDimensions;
 
-    static inline constexpr StringLiteral k_DatasetPath_Key = "Dataset Path";
-    static inline constexpr StringLiteral k_ComponentDimensions_Key = "Component Dimensions";
-    static inline constexpr StringLiteral k_TupleDimensions_Key = "Tuple Dimensions";
+    static inline constexpr StringLiteral k_DatasetPath_Key = "dataset_path";
+    static inline constexpr StringLiteral k_ComponentDimensions_Key = "component_dimensions";
+    static inline constexpr StringLiteral k_TupleDimensions_Key = "tuple_dimensions";
 
     static Result<DatasetImportInfo> ReadJson(const nlohmann::json& json)
     {


### PR DESCRIPTION
I went through and fixed the UUIDs that were reverted in merges as well as patched snake parameter argument strings.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files.

- [x] Class and Structs are `UpperCamelCase`
- [x] Class private member variables are `m_UpperCamelCase`
- [x] Class methods are `lowerCamelCase`
- [x] Method arguments are `lowerCamelCase`
- [x] Normal variables are `lowerCamelCase`
- [x] Constants are `k_UpperCamelCase`
- [x] Global statics are `s_UpperCamelCase`
- [x] Free Functions are `UpperCamelCase`
- [x] Macros are `ALL_UPPER_SNAKE_CASE`
- [x] Unit test will test data output from the filter.
- [x] Reused strings should be constants in an anonymous namespace
- [x] If parallelization is used, proper use of the abstracted complex classes are used. Using TBB specifically in a filter should be frowned upon unless for a really good reason.

## Filter Checklist

- [x] Parameters should be generally broken down into "Input Parameters", "Required Data Objects", "Created Data Objects". There can be exceptions to this.
- [x] ChoicesParameter selections should be an enumeration defined in the filer header
- [x] Documentation copied from SIMPL Repo and updated (if necessary)
- [x] Parameter argument variables are k_CamelCase_Key
- [x] Parameter argument strings are lower_snake_case
```
static inline constexpr StringLiteral k_AlignmentType_Key = "alignment_type";
```

## Unit Testing
- [x] 1 Unit test to instantiate the filter with the default arguments.
- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] Filters should have both the Filter class and Algorithm class for anything beyond trivial needs
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added Python wrapping to new files (if any) as necessary
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented.


<!-- **Thanks for contributing to complex!** -->
