### PR TITLE
ENH: OStreamUtilites API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,7 @@ set(COMPLEX_HDRS
   ${COMPLEX_SOURCE_DIR}/Utilities/SamplingUtils.hpp
   ${COMPLEX_SOURCE_DIR}/Utilities/SegmentFeatures.hpp
   ${COMPLEX_SOURCE_DIR}/Utilities/AlignSections.hpp
+  ${COMPLEX_SOURCE_DIR}/Utilities/OStreamUtilities.hpp
 
   ${COMPLEX_SOURCE_DIR}/Utilities/Math/GeometryMath.hpp
   ${COMPLEX_SOURCE_DIR}/Utilities/Math/MatrixMath.hpp
@@ -486,6 +487,7 @@ set(COMPLEX_SRCS
   ${COMPLEX_SOURCE_DIR}/Utilities/ParallelTaskAlgorithm.cpp
   ${COMPLEX_SOURCE_DIR}/Utilities/SegmentFeatures.cpp
   ${COMPLEX_SOURCE_DIR}/Utilities/AlignSections.cpp
+  ${COMPLEX_SOURCE_DIR}/Utilities/OStreamUtilities.cpp
 
   ${COMPLEX_SOURCE_DIR}/Utilities/Math/GeometryMath.cpp
   ${COMPLEX_SOURCE_DIR}/Utilities/Math/MatrixMath.cpp

--- a/src/complex/DataStructure/DataStore.hpp
+++ b/src/complex/DataStructure/DataStore.hpp
@@ -11,13 +11,13 @@
 #include <nonstd/span.hpp>
 
 #include <algorithm>
+#include <cstring>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <optional>
 #include <stdexcept>
 #include <vector>
-
-#include <cstring>
 
 namespace complex
 {
@@ -377,6 +377,25 @@ public:
     }
 
     return dataStore;
+  }
+
+  std::pair<int32, std::string> writeBinaryFile(const std::string& absoluteFilePath) const override
+  {
+    FILE* file = fopen(absoluteFilePath.c_str(), "wb");
+    if(nullptr == file)
+    {
+      return {-10170, fmt::format("File could not be opened for writing:\n  '{}'", absoluteFilePath)};
+    }
+
+    usize totalElements = getNumberOfComponents() * getNumberOfTuples();
+    usize elementsWritten = fwrite(m_Data.get(), sizeof(T), totalElements, file);
+    fclose(file);
+    if(totalElements != elementsWritten)
+    {
+      return {-10175, fmt::format("Error writing binary file:\n  Total Elements:'{}'\n  Elements Written:'{}'", absoluteFilePath, totalElements, elementsWritten)};
+    }
+
+    return {0, ""};
   }
 
 private:

--- a/src/complex/DataStructure/EmptyDataStore.hpp
+++ b/src/complex/DataStructure/EmptyDataStore.hpp
@@ -225,6 +225,11 @@ public:
     return dataStore;
   }
 
+  std::pair<int32, std::string> writeBinaryFile(const std::string& absoluteFilePath) const override
+  {
+    return {-10175, fmt::format("EmptyDataStore cannot read or write files", absoluteFilePath)};
+  }
+
 private:
   ShapeType m_ComponentShape;
   ShapeType m_TupleShape;

--- a/src/complex/DataStructure/IDataStore.hpp
+++ b/src/complex/DataStructure/IDataStore.hpp
@@ -114,6 +114,8 @@ public:
    */
   virtual H5::ErrorType writeHdf5(H5::DatasetWriter& datasetWriter) const = 0;
 
+  virtual std::pair<int32, std::string> writeBinaryFile(const std::string& absoluteFilePath) const = 0;
+
   static ShapeType ReadTupleShape(const H5::DatasetReader& datasetReader)
   {
     H5::AttributeReader tupleShapeAttribute = datasetReader.getAttribute(complex::H5::k_TupleShapeTag);

--- a/src/complex/DataStructure/NeighborList.hpp
+++ b/src/complex/DataStructure/NeighborList.hpp
@@ -365,6 +365,10 @@ DataType COMPLEX_EXPORT NeighborList<float32>::getDataType() const;
 template <>
 DataType COMPLEX_EXPORT NeighborList<float64>::getDataType() const;
 
+/**
+ * Boolean NeighborLists are uncompilable
+ */
+
 // -----------------------------------------------------------------------------
 // Declare our extern templates
 extern template class NeighborList<int8>;
@@ -396,8 +400,6 @@ using USizeNeighborList = NeighborList<usize>;
 
 using Float32NeighborList = NeighborList<float32>;
 using Float64NeighborList = NeighborList<float64>;
-
-using BoolNeighborList = NeighborList<bool>;
 
 using VectorOfFloat32NeighborList = std::vector<std::shared_ptr<Float32NeighborList>>;
 } // namespace complex

--- a/src/complex/Utilities/DataArrayUtilities.hpp
+++ b/src/complex/Utilities/DataArrayUtilities.hpp
@@ -569,6 +569,13 @@ COMPLEX_EXPORT bool CheckArraysHaveSameTupleCount(const DataStructure& dataStruc
 
 COMPLEX_EXPORT void ResizeAttributeMatrix(AttributeMatrix& attributeMatrix, const std::vector<usize>& newShape);
 
+/**
+ * @brief Validates that
+ * @param dataStructure
+ * @param arrayPath
+ * @param featureIds
+ * @return
+ */
 COMPLEX_EXPORT Result<> ValidateNumFeaturesInArray(const DataStructure& dataStructure, const DataPath& arrayPath, const Int32Array& featureIds);
 
 /**

--- a/src/complex/Utilities/DataArrayUtilities.hpp
+++ b/src/complex/Utilities/DataArrayUtilities.hpp
@@ -570,11 +570,11 @@ COMPLEX_EXPORT bool CheckArraysHaveSameTupleCount(const DataStructure& dataStruc
 COMPLEX_EXPORT void ResizeAttributeMatrix(AttributeMatrix& attributeMatrix, const std::vector<usize>& newShape);
 
 /**
- * @brief Validates that
- * @param dataStructure
- * @param arrayPath
- * @param featureIds
- * @return
+ * @brief Validates that the number of features in the array are equivalent
+ * @param dataStructure the DataStructure containing the array
+ * @param arrayPath the DataPath to the array in the dataStructure
+ * @param featureIds the ids for the array
+ * @return void
  */
 COMPLEX_EXPORT Result<> ValidateNumFeaturesInArray(const DataStructure& dataStructure, const DataPath& arrayPath, const Int32Array& featureIds);
 

--- a/src/complex/Utilities/FilterUtilities.hpp
+++ b/src/complex/Utilities/FilterUtilities.hpp
@@ -49,4 +49,48 @@ auto ExecuteDataFunction(FuncT&& func, DataType dataType, ArgsT&&... args)
   }
   }
 }
+
+template <class FuncT, class... ArgsT>
+auto ExecuteNeighborFunction(FuncT&& func, DataType dataType, ArgsT&&... args)
+{
+  switch(dataType)
+  {
+  case DataType::int8: {
+    return func.template operator()<int8>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::int16: {
+    return func.template operator()<int16>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::int32: {
+    return func.template operator()<int32>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::int64: {
+    return func.template operator()<int64>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::uint8: {
+    return func.template operator()<uint8>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::uint16: {
+    return func.template operator()<uint16>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::uint32: {
+    return func.template operator()<uint32>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::uint64: {
+    return func.template operator()<uint64>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::float32: {
+    return func.template operator()<float32>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::float64: {
+    return func.template operator()<float64>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::boolean: {
+    return MakeErrorResult(-89850, "Cannot create a NeighborList of booleans.");
+  }
+  default: {
+    throw std::runtime_error("complex::ExecuteDataFunction<...>(FuncT&& func, DataType dataType, ArgsT&&... args). Error: Invalid DataType");
+  }
+  }
+}
 } // namespace complex

--- a/src/complex/Utilities/OStreamUtilities.cpp
+++ b/src/complex/Utilities/OStreamUtilities.cpp
@@ -3,6 +3,7 @@
 
 #include <chrono>
 #include <fstream>
+#include <iomanip>
 #include <ostream>
 #include <string>
 
@@ -40,7 +41,8 @@ struct PrintNeighborList
       {
         outputStrm << "Feature_IDs" << delimiter;
       }
-      outputStrm << "Element Count" << delimiter << "NeighborList" << delimiter << "\n";
+      outputStrm << "Element Count" << delimiter << "NeighborList"
+                 << "\n";
     }
     if(hasIndex)
     {
@@ -58,12 +60,16 @@ struct PrintNeighborList
           }
         }
         const auto& grain = neighborList.getListReference(list);
-        outputStrm << list << grain.size() << delimiter;
+        outputStrm << list << delimiter << grain.size() << delimiter;
         for(size_t index = 0; index < grain.size(); index++)
         {
           if constexpr(std::is_same_v<ScalarType, int8> || std::is_same_v<ScalarType, uint8>)
           {
             outputStrm << static_cast<int32>(grain[index]);
+          }
+          else if constexpr(std::is_same_v<ScalarType, float32> || std::is_same_v<ScalarType, float64>)
+          {
+            outputStrm << fmt::format("{}", grain[index]);
           }
           else
           {
@@ -99,6 +105,10 @@ struct PrintNeighborList
           if constexpr(std::is_same_v<ScalarType, int8> || std::is_same_v<ScalarType, uint8>)
           {
             outputStrm << static_cast<int32>(grain[index]);
+          }
+          else if constexpr(std::is_same_v<ScalarType, float32> || std::is_same_v<ScalarType, float64>)
+          {
+            outputStrm << fmt::format("{}", grain[index]);
           }
           else
           {
@@ -159,6 +169,10 @@ struct PrintDataArray
         if constexpr(std::is_same_v<ScalarType, int8> || std::is_same_v<ScalarType, uint8>)
         {
           outputStrm << static_cast<int32>(dataArray[index]);
+        }
+        else if constexpr(std::is_same_v<ScalarType, float32> || std::is_same_v<ScalarType, float64>)
+        {
+          outputStrm << fmt::format("{}", dataArray[index]);
         }
         else
         {
@@ -259,6 +273,10 @@ public:
       if constexpr(std::is_same_v<ScalarType, int8> || std::is_same_v<ScalarType, uint8>)
       {
         outputStrm << static_cast<int32>(m_DataArray[tupleIndex * m_NumComps + comp]);
+      }
+      else if constexpr(std::is_same_v<ScalarType, float32> || std::is_same_v<ScalarType, float64>)
+      {
+        outputStrm << fmt::format("{}", m_DataArray[tupleIndex * m_NumComps + comp]);
       }
       else
       {
@@ -510,7 +528,7 @@ void PrintDataSetsToSingleFile(std::ostream& outputStrm, const std::vector<DataP
 
   if(neighborLists.size() != 0)
   {
-    for(const auto& dataPath : objectPaths)
+    for(const auto& dataPath : neighborLists)
     {
       auto* neighborList = dataStructure.getDataAs<INeighborList>(dataPath);
       if(neighborList != nullptr)

--- a/src/complex/Utilities/OStreamUtilities.cpp
+++ b/src/complex/Utilities/OStreamUtilities.cpp
@@ -1,0 +1,528 @@
+#include "OStreamUtilities.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
+
+#include <chrono>
+#include <fstream>
+#include <ostream>
+#include <string>
+
+namespace fs = std::filesystem;
+using namespace complex;
+
+namespace // for nonmember functions
+{
+const std::array<std::string, 5> k_DelimiterStrings = {" ", ";", ",", ":", "\t"}; // Don't reorder
+
+/**
+ * @brief implicit writing of **NeighborList**'s elements to outputStrm
+ * @tparam ScalarType The primitive type attacthed to **NeighborList**
+ * @param outputStrm the ostream to write to
+ * @param inputNeighborList The **NeighborList** that will have its values translated into strings
+ * @param mesgHandler The message handler to dump progress updates to
+ * // default parameters
+ * @param delimiter The delimiter to insert between values
+ * @param hasIndex bool to determine if index must be printed
+ * @param hasHeaders bool to determine if headers must be printed
+ */
+struct PrintNeighborList
+{
+  template <typename ScalarType>
+  Result<> operator()(std::ostream& outputStrm, INeighborList* inputNeighborList, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, const std::string& delimiter = ",",
+                      bool hasIndex = false, bool hasHeader = false)
+  {
+    auto& neighborList = *dynamic_cast<NeighborList<ScalarType>*>(inputNeighborList);
+    auto start = std::chrono::steady_clock::now();
+    auto numLists = neighborList.getNumberOfLists();
+
+    if(hasHeader)
+    {
+      if(hasIndex)
+      {
+        outputStrm << "Feature_IDs" << delimiter;
+      }
+      outputStrm << "Element Count" << delimiter << "NeighborList" << delimiter << "\n";
+    }
+    if(hasIndex)
+    {
+      for(size_t list = 0; list < numLists; list++)
+      {
+        auto now = std::chrono::steady_clock::now();
+        if(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count() > 1000)
+        {
+          auto string = fmt::format("Processing {}: {}% completed", neighborList.getName(), static_cast<int32>(100 * static_cast<float>(list) / static_cast<float>(numLists)));
+          mesgHandler(IFilter::Message::Type::Info, string);
+          start = now;
+          if(shouldCancel)
+          {
+            return {};
+          }
+        }
+        const auto& grain = neighborList.getListReference(list);
+        outputStrm << list << grain.size() << delimiter;
+        for(size_t index = 0; index < grain.size(); index++)
+        {
+          if constexpr(std::is_same_v<ScalarType, int8> || std::is_same_v<ScalarType, uint8>)
+          {
+            outputStrm << static_cast<int32>(grain[index]);
+          }
+          else
+          {
+            outputStrm << grain[index];
+          }
+          if(index != grain.size() - 1)
+          {
+            outputStrm << delimiter;
+          }
+        }
+        outputStrm << "\n";
+      }
+    }
+    else // no index
+    {
+      for(size_t list = 0; list < neighborList.getNumberOfLists(); list++)
+      {
+        auto now = std::chrono::steady_clock::now();
+        if(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count() > 1000)
+        {
+          auto string = fmt::format("Processing {}: {}% completed", neighborList.getName(), static_cast<int32>(static_cast<float>(list) / static_cast<float>(numLists)));
+          mesgHandler(IFilter::Message::Type::Info, string);
+          start = now;
+          if(shouldCancel)
+          {
+            return {};
+          }
+        }
+        const auto& grain = neighborList.getListReference(list);
+        outputStrm << grain.size() << delimiter;
+        for(size_t index = 0; index < grain.size(); index++)
+        {
+          if constexpr(std::is_same_v<ScalarType, int8> || std::is_same_v<ScalarType, uint8>)
+          {
+            outputStrm << static_cast<int32>(grain[index]);
+          }
+          else
+          {
+            outputStrm << grain[index];
+          }
+          if(index != grain.size() - 1)
+          {
+            outputStrm << delimiter;
+          }
+        }
+        outputStrm << "\n";
+      }
+    }
+    return {};
+  }
+};
+
+/**
+ * @brief implicit writing of **DataArray**'s elements to outputStrm
+ * @tparam ScalarType The primitive type attacthed to **DataArray**
+ * @param outputStrm the ostream to write to
+ * @param inputDataArray The **DataArray** that will have its values translated into strings
+ * @param mesgHandler The message handler to dump progress updates to
+ * // default parameters
+ * @param delimiter The delimiter to insert between values
+ * @param componentsPerLine The number of components per line
+ */
+struct PrintDataArray
+{
+  template <typename ScalarType>
+  Result<> operator()(std::ostream& outputStrm, IDataArray* inputDataArray, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, const std::string& delimiter = ",",
+                      int32 componentsPerLine = 0)
+  {
+    auto& dataArray = *dynamic_cast<DataArray<ScalarType>*>(inputDataArray);
+    auto start = std::chrono::steady_clock::now();
+    auto numTuples = dataArray.getNumberOfTuples();
+    auto maxLine = static_cast<size_t>(componentsPerLine);
+    if(componentsPerLine == 0)
+    {
+      maxLine = static_cast<size_t>(dataArray.getNumberOfComponents());
+    }
+
+    for(size_t tuple = 0; tuple < numTuples; tuple++)
+    {
+      auto now = std::chrono::steady_clock::now();
+      if(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count() > 1000)
+      {
+        auto string = fmt::format("Processing {}: {}% completed", dataArray.getName(), static_cast<int32>(100 * static_cast<float>(tuple) / static_cast<float>(numTuples)));
+        mesgHandler(IFilter::Message::Type::Info, string);
+        start = now;
+        if(shouldCancel)
+        {
+          return {};
+        }
+      }
+      for(size_t index = 0; index < dataArray.getNumberOfComponents(); index++)
+      {
+        if constexpr(std::is_same_v<ScalarType, int8> || std::is_same_v<ScalarType, uint8>)
+        {
+          outputStrm << static_cast<int32>(dataArray[index]);
+        }
+        else
+        {
+          outputStrm << dataArray[index];
+        }
+        if(index != maxLine - 1)
+        {
+          outputStrm << delimiter;
+        }
+        else
+        {
+          outputStrm << "\n";
+        }
+      }
+    }
+    return {};
+  }
+};
+
+/**
+ * @brief writing of **StringArray**'s elements to outputStrm
+ * @param absoluteFilePath The output path to write to
+ * @param inputStringArray The **StringArray** that will have its values translated into strings
+ * @param mesgHandler The message handler to dump progress updates to
+ * // default parameters
+ * @param delimiter The delimiter to insert between values
+ * @param componentsPerLine The number of components per line
+ */
+Result<> PrintStringArray(std::ostream& outputStrm, const StringArray& inputStringArray, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel,
+                          const std::string& delimiter = ",", int32 componentsPerLine = 0)
+{
+  auto start = std::chrono::steady_clock::now();
+  auto numTuples = inputStringArray.getNumberOfTuples();
+  auto maxLine = static_cast<size_t>(componentsPerLine);
+  if(componentsPerLine == 0)
+  {
+    maxLine = static_cast<size_t>(inputStringArray.getNumberOfComponents());
+  }
+
+  for(size_t tuple = 0; tuple < numTuples; tuple++)
+  {
+    auto now = std::chrono::steady_clock::now();
+    if(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count() > 1000)
+    {
+      auto string = fmt::format("Processing {}: {}% completed", inputStringArray.getName(), static_cast<int32>(100 * static_cast<float>(tuple) / static_cast<float>(numTuples)));
+      mesgHandler(IFilter::Message::Type::Info, string);
+      start = now;
+      if(shouldCancel)
+      {
+        return {};
+      }
+    }
+
+    for(size_t index = 0; index < inputStringArray.getNumberOfComponents(); index++)
+    {
+      outputStrm << inputStringArray[index];
+      if(index != maxLine - 1)
+      {
+        outputStrm << delimiter;
+      }
+      else
+      {
+        outputStrm << "\n";
+      }
+    }
+  }
+
+  return {};
+}
+
+class ITupleWriter
+{
+public:
+  ITupleWriter() = default;
+  virtual ~ITupleWriter() = default;
+  virtual void write(std::ostream& outputStrm, usize tupleIndex) const = 0;
+  virtual void writeHeader(std::ostream& outputStrm) const = 0;
+};
+
+template <typename ScalarType>
+class TupleWriter : public ITupleWriter
+{
+  using DataArrayType = DataArray<ScalarType>;
+
+public:
+  TupleWriter(const IDataArray& iDataArray, const std::string& delimiter)
+  : m_DataArray(dynamic_cast<const DataArray<ScalarType>&>(iDataArray))
+  , m_Delimiter(delimiter)
+  {
+    m_NumComps = m_DataArray.getNumberOfComponents();
+  }
+  ~TupleWriter() override = default;
+
+  void write(std::ostream& outputStrm, usize tupleIndex) const override
+  {
+    for(usize comp = 0; comp < m_NumComps; comp++)
+    {
+      if constexpr(std::is_same_v<ScalarType, int8> || std::is_same_v<ScalarType, uint8>)
+      {
+        outputStrm << static_cast<int32>(m_DataArray[tupleIndex * m_NumComps + comp]);
+      }
+      else
+      {
+        outputStrm << m_DataArray[tupleIndex * m_NumComps + comp];
+      }
+      if(comp < m_NumComps - 1)
+      {
+        outputStrm << m_Delimiter;
+      }
+    }
+  }
+
+  void writeHeader(std::ostream& outputStrm) const override
+  {
+    for(size_t index = 0; index < m_NumComps; index++)
+    {
+      outputStrm << m_DataArray.getName() << "_" << index;
+      if(index < m_NumComps - 1)
+      {
+        outputStrm << m_Delimiter;
+      }
+    }
+  }
+
+private:
+  const DataArrayType& m_DataArray;
+  const std::string& m_Delimiter = ",";
+  usize m_NumComps = 1;
+};
+
+struct AddTupleWriter
+{
+  template <typename ScalarType>
+  Result<> operator()(std::vector<std::shared_ptr<ITupleWriter>>& writers, const IDataArray& iDataArray, const std::string& delimiter)
+  {
+    writers.push_back(std::make_shared<TupleWriter<ScalarType>>(iDataArray, delimiter));
+    return {};
+  }
+};
+} // namespace
+
+namespace complex
+{
+namespace OStreamUtilities
+{
+/**
+ * @brief turns the enum in this API to respective character as a string
+ * @param delim the underlying value of the enum type
+ */
+std::string DelimiterToString(uint64 delim)
+{
+  return k_DelimiterStrings[delim];
+};
+
+/**
+ * @brief [BINARY CAPABLE, unless neighborlist][Multiple File Output] | Writes out to multiple files | !!!!endianess must be addressed in calling class!!!!
+ * @param objectPaths The vector of datapaths for respective dataObjects to be written out
+ * @param dataStructure The complex datastructure where *objectPaths* datacontainers are stored
+ * @param directoryPath The path to the directory to write files to | used to create outputStrm paths for ofstream
+ * @param mesgHandler The handler to send progress updates to
+ * @param shouldCancel The atomic boolean that determines cancel
+ * //params with defaults
+ * @param fileExtension The extension to create and write to files with
+ * @param exportToBinary The boolean that determines if it writes out binary
+ * @param delimiter The delimiter to be inserted into string | leave blank if binary is end output
+ * @param includeIndex The boolean that determines if "Feature_IDs" are printed | leave blank if binary is end output
+ * @param includeHeaders The boolean that determines if headers are printed | leave blank if binary is end output
+ * @param componentsPerLine The amount of elements to be inserted before newline character | leave blank if binary is end output
+ */
+void PrintDataSetsToMultipleFiles(const std::vector<DataPath>& objectPaths, DataStructure& dataStructure, const std::string& directoryPath, const IFilter::MessageHandler& mesgHandler,
+                                  const std::atomic_bool& shouldCancel, std::string fileExtension, bool exportToBinary, const std::string& delimiter, bool includeIndex, bool includeHeaders,
+                                  size_t componentsPerLine)
+{
+  fs::path dirPath(directoryPath);
+  if(!fs::is_directory(dirPath))
+  {
+    throw std::runtime_error(fmt::format("{}({}): Function {}: Error. OutputPath must be a directory. '{}'", "PrintDataSetsToMultipleFiles", __FILE__, __LINE__, directoryPath));
+  }
+
+  for(const auto& dataPath : objectPaths)
+  {
+    auto outputFilePath = fmt::format("{}/{}{}", directoryPath, dataPath.getTargetName(), fileExtension);
+    mesgHandler(IFilter::Message::Type::Info, fmt::format("Writing IArray ({}) to output file {}", dataPath.getTargetName(), outputFilePath));
+
+    std::ofstream outStrm(outputFilePath, std::ios_base::out);
+
+    std::pair<int32, std::string> result = {0, "PrintDataSetsToMultipleFiles default failure. If you are seeing this error something bad has happened."};
+    auto* dataArray = dataStructure.getDataAs<IDataArray>(dataPath);
+    if(dataArray != nullptr)
+    {
+      if(exportToBinary)
+      {
+        result = dataArray->getIDataStore()->writeBinaryFile(outputFilePath);
+      }
+      else
+      {
+        ExecuteDataFunction(PrintDataArray{}, dataArray->getDataType(), outStrm, dataArray, mesgHandler, shouldCancel, delimiter, componentsPerLine);
+      }
+    }
+    auto* stringArray = dataStructure.getDataAs<StringArray>(dataPath);
+    if(stringArray != nullptr)
+    {
+      if(exportToBinary)
+      {
+        throw std::runtime_error(fmt::format("{}({}): Function {}: Error. Cannot print a StringArray to binary: '{}'", "PrintDataSetsToMultipleFiles", __FILE__, __LINE__, dataPath.getTargetName()));
+      }
+      PrintStringArray(outStrm, *stringArray, mesgHandler, shouldCancel, delimiter, componentsPerLine);
+    }
+    auto* neighborList = dataStructure.getDataAs<INeighborList>(dataPath);
+    if(neighborList != nullptr)
+    {
+      if(exportToBinary)
+      {
+        throw std::runtime_error(fmt::format("{}({}): Function {}: Error. Cannot print a NeighborList to binary: '{}'", "PrintDataSetsToMultipleFiles", __FILE__, __LINE__, dataPath.getTargetName()));
+      }
+      ExecuteNeighborFunction(PrintNeighborList{}, neighborList->getDataType(), outStrm, neighborList, mesgHandler, shouldCancel, delimiter, includeIndex, includeHeaders);
+    }
+    if(result.first < 0)
+    {
+      mesgHandler(IFilter::Message::Type::Error, result.second);
+    }
+    if(shouldCancel)
+    {
+      return;
+    }
+  }
+};
+
+/**
+ * @brief [Single Output][Custom OStream] | Writes one IArray child to some OStream
+ * @param outputStrm The already opened output string to write to
+ * @param objectPath The datapath for respective dataObject to be written out
+ * @param dataStructure The complex datastructure where *objectPath* datacontainer is stored
+ * //params with defaults
+ * @param delimiter The delimiter to be inserted into string
+ * @param includeIndex The boolean that determines if "Feature_IDs" are printed
+ * @param includeHeaders The boolean that determines if headers are printed
+ * @param componentsPerLine The amount of elements to be inserted before newline character
+ */
+void PrintSingleDataObject(std::ostream& outputStrm, const DataPath& objectPath, DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel,
+                           const std::string& delimiter, bool includeIndex, bool includeHeaders, size_t componentsPerLine)
+{
+  mesgHandler(IFilter::Message::Type::Info, fmt::format("Writing IArray ({}) to output stream", objectPath.getTargetName()));
+
+  auto* dataArray = dataStructure.getDataAs<IDataArray>(objectPath);
+  if(dataArray != nullptr)
+  {
+    ExecuteDataFunction(PrintDataArray{}, dataArray->getDataType(), outputStrm, dataArray, mesgHandler, shouldCancel, delimiter, componentsPerLine);
+  }
+  auto* stringArray = dataStructure.getDataAs<StringArray>(objectPath);
+  if(stringArray != nullptr)
+  {
+    PrintStringArray(outputStrm, *stringArray, mesgHandler, shouldCancel, delimiter, componentsPerLine);
+  }
+  auto* neighborList = dataStructure.getDataAs<INeighborList>(objectPath);
+  if(neighborList != nullptr)
+  {
+    ExecuteNeighborFunction(PrintNeighborList{}, neighborList->getDataType(), outputStrm, neighborList, mesgHandler, shouldCancel, delimiter, includeIndex, includeHeaders);
+  }
+};
+
+/**
+ * @brief [Single Output][Custom OStream] | writes out multiple arrays to ostream
+ * @param outputStrm The already opened output string to write to
+ * @param objectPaths The vector of datapaths for respective dataObjects to be written out
+ * @param dataStructure The complex datastructure where *objectPaths* datacontainers are stored
+ * @param mesgHandler The handler to send progress updates to
+ * @param shouldCancel The atomic boolean that determines cancel
+ * //params with defaults
+ * @param delimiter The delimiter to be inserted into string
+ * @param includeIndex The boolean that determines if "Feature_IDs" are printed
+ * @param includeHeaders The boolean that determines if headers are printed
+ * @param componentsPerLine The amount of elements to be inserted before newline character
+ * @param neighborLists The list of dataPaths of neighborlists to include
+ */
+void PrintDataSetsToSingleFile(std::ostream& outputStrm, const std::vector<DataPath>& objectPaths, DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler,
+                               const std::atomic_bool& shouldCancel, const std::string& delimiter, bool includeIndex, bool includeHeaders, size_t componentsPerLine,
+                               const std::vector<DataPath>& neighborLists)
+{
+  const auto& firstDataArray = dataStructure.getDataRefAs<IDataArray>(objectPaths[0]);
+  usize numTuples = firstDataArray.getNumberOfTuples();
+  auto start = std::chrono::steady_clock::now();
+
+  // Create our wrapper classes for each DataArray
+  std::vector<std::shared_ptr<ITupleWriter>> writers;
+  for(const auto& selectedArrayPath : objectPaths)
+  {
+    const auto& iDataArray = dataStructure.getDataRefAs<IDataArray>(selectedArrayPath);
+    ExecuteDataFunction(AddTupleWriter{}, iDataArray.getDataType(), writers, iDataArray, delimiter);
+  }
+  size_t writersCount = writers.size();
+
+  if(shouldCancel)
+  {
+    return;
+  }
+
+  // Write out the header line
+  if(includeHeaders)
+  {
+    if(includeIndex)
+    {
+      outputStrm << "Feature_IDs" << delimiter;
+    }
+    for(size_t writerIndex = 0; writerIndex < writersCount; writerIndex++)
+    {
+      writers[writerIndex]->writeHeader(outputStrm);
+      if(writerIndex != writersCount - 1)
+      {
+        outputStrm << delimiter;
+      }
+    }
+    outputStrm << '\n';
+  }
+
+  if(shouldCancel)
+  {
+    return;
+  }
+
+  // Loop on ever tuple using our predefined writer for each data array
+  for(usize tupleIndex = 0; tupleIndex < numTuples; tupleIndex++)
+  {
+    auto now = std::chrono::steady_clock::now();
+    if(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count() > 1000)
+    {
+      auto string = fmt::format("Printing tuples: {}% completed", static_cast<int32>(100 * static_cast<float>(tupleIndex) / static_cast<float>(numTuples)));
+      mesgHandler(IFilter::Message::Type::Info, string);
+      start = now;
+      if(shouldCancel)
+      {
+        return;
+      }
+    }
+    if(includeIndex)
+    {
+      outputStrm << tupleIndex << delimiter;
+    }
+    for(size_t writerIndex = 0; writerIndex < writersCount; writerIndex++)
+    {
+      writers[writerIndex]->write(outputStrm, tupleIndex);
+      if(writerIndex != writersCount - 1)
+      {
+        outputStrm << delimiter;
+      }
+    }
+    outputStrm << '\n';
+  }
+
+  if(neighborLists.size() != 0)
+  {
+    for(const auto& dataPath : objectPaths)
+    {
+      auto* neighborList = dataStructure.getDataAs<INeighborList>(dataPath);
+      if(neighborList != nullptr)
+      {
+        ExecuteNeighborFunction(PrintNeighborList{}, neighborList->getDataType(), outputStrm, neighborList, mesgHandler, shouldCancel, delimiter, includeIndex, includeHeaders);
+      }
+      if(shouldCancel)
+      {
+        return;
+      }
+    }
+  }
+};
+} // namespace OStreamUtilities
+} // namespace complex

--- a/src/complex/Utilities/OStreamUtilities.cpp
+++ b/src/complex/Utilities/OStreamUtilities.cpp
@@ -290,16 +290,17 @@ public:
 
   void writeHeader(std::ostream& outputStrm) const override
   {
+    // If there is only 1 component then write the name of the array and return
+    if(m_NumComps == 1)
+    {
+      outputStrm << m_DataArray.getName();
+      return;
+    }
+
     for(size_t index = 0; index < m_NumComps; index++)
     {
-      if(index == 0)
-      {
-        outputStrm << m_DataArray.getName();
-      }
-      else
-      {
-        outputStrm << m_DataArray.getName() << "_" << index;
-      }
+      outputStrm << m_DataArray.getName() << "_" << index;
+
       if(index < m_NumComps - 1)
       {
         outputStrm << m_Delimiter;

--- a/src/complex/Utilities/OStreamUtilities.hpp
+++ b/src/complex/Utilities/OStreamUtilities.hpp
@@ -48,7 +48,7 @@ COMPLEX_EXPORT std::string DelimiterToString(uint64 delim);
  * @param componentsPerLine The amount of elements to be inserted before newline character | leave blank if binary is end output
  */
 COMPLEX_EXPORT void PrintDataSetsToMultipleFiles(const std::vector<DataPath>& objectPaths, DataStructure& dataStructure, const std::string& directoryPath, const IFilter::MessageHandler& mesgHandler,
-                                                 const std::atomic_bool& shouldCancel, std::string fileExtension = ".txt", bool exportToBinary = false, const std::string& delimiter = "",
+                                                 const std::atomic_bool& shouldCancel, const std::string& fileExtension = ".txt", bool exportToBinary = false, const std::string& delimiter = "",
                                                  bool includeIndex = false, bool includeHeaders = false, size_t componentsPerLine = 0);
 
 /**
@@ -77,12 +77,12 @@ COMPLEX_EXPORT void PrintSingleDataObject(std::ostream& outputStrm, const DataPa
  * @param delimiter The delimiter to be inserted into string
  * @param includeIndex The boolean that determines if "Feature_IDs" are printed
  * @param includeHeaders The boolean that determines if headers are printed
- * @param componentsPerLine The amount of elements to be inserted before newline character
  * @param neighborLists The list of dataPaths of neighborlists to include
+ * @param writeNumOfFeatures The amount of elements per tuple printed at top
  */
 COMPLEX_EXPORT void PrintDataSetsToSingleFile(std::ostream& outputStrm, const std::vector<DataPath>& objectPaths, DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler,
                                               const std::atomic_bool& shouldCancel, const std::string& delimiter = "", bool includeIndex = false, bool includeHeaders = false,
-                                              size_t componentsPerLine = 0, const std::vector<DataPath>& neighborLists = {});
+                                              const std::vector<DataPath>& neighborLists = {}, bool writeNumOfFeatures = false);
 } // namespace OStreamUtilities
 
 } // namespace complex

--- a/src/complex/Utilities/OStreamUtilities.hpp
+++ b/src/complex/Utilities/OStreamUtilities.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "complex/DataStructure/DataArray.hpp"
+#include "complex/DataStructure/DataObject.hpp"
+#include "complex/DataStructure/DataPath.hpp"
+#include "complex/DataStructure/DataStructure.hpp"
+#include "complex/DataStructure/IDataArray.hpp"
+#include "complex/DataStructure/INeighborList.hpp"
+#include "complex/DataStructure/NeighborList.hpp"
+#include "complex/DataStructure/StringArray.hpp"
+#include "complex/Filter/IFilter.hpp"
+
+namespace complex
+{
+namespace OStreamUtilities
+{
+/**
+ * @brief enum for accepted output delimiters in DREAM3D
+ */
+enum class Delimiter : uint64
+{
+  Space = 0,
+  Semicolon = 1,
+  Comma = 2,
+  Colon = 3,
+  Tab = 4
+}; // Don't reorder
+
+/**
+ * @brief turns the enum in this API to respective character as a string
+ * @param delim the underlying value of the enum type
+ */
+COMPLEX_EXPORT std::string DelimiterToString(uint64 delim);
+
+/**
+ * @brief [BINARY CAPABLE, unless neighborlist][Multiple File Output] | Writes out to multiple files | !!!!endianess must be addressed in calling class!!!!
+ * @param objectPaths The vector of datapaths for respective dataObjects to be written out
+ * @param dataStructure The complex datastructure where *objectPaths* datacontainers are stored
+ * @param directoryPath The path to the directory to write files to | used to create outputStrm paths for ofstream
+ * @param mesgHandler The handler to send progress updates to
+ * @param shouldCancel The atomic boolean that determines cancel
+ * //params with defaults
+ * @param fileExtension The extension to create and write to files with
+ * @param exportToBinary The boolean that determines if it writes out binary
+ * @param delimiter The delimiter to be inserted into string | leave blank if binary is end output
+ * @param includeIndex The boolean that determines if "Feature_IDs" are printed | leave blank if binary is end output
+ * @param includeHeaders The boolean that determines if headers are printed | leave blank if binary is end output
+ * @param componentsPerLine The amount of elements to be inserted before newline character | leave blank if binary is end output
+ */
+COMPLEX_EXPORT void PrintDataSetsToMultipleFiles(const std::vector<DataPath>& objectPaths, DataStructure& dataStructure, const std::string& directoryPath, const IFilter::MessageHandler& mesgHandler,
+                                                 const std::atomic_bool& shouldCancel, std::string fileExtension = ".txt", bool exportToBinary = false, const std::string& delimiter = "",
+                                                 bool includeIndex = false, bool includeHeaders = false, size_t componentsPerLine = 0);
+
+/**
+ * @brief [Single Output][Custom OStream] | Writes one IArray child to some OStream
+ * @param outputStrm The already opened output string to write to
+ * @param objectPath The datapath for respective dataObject to be written out
+ * @param dataStructure The complex datastructure where *objectPath* datacontainer is stored
+ * //params with defaults
+ * @param delimiter The delimiter to be inserted into string
+ * @param includeIndex The boolean that determines if "Feature_IDs" are printed
+ * @param includeHeaders The boolean that determines if headers are printed
+ * @param componentsPerLine The amount of elements to be inserted before newline character
+ */
+COMPLEX_EXPORT void PrintSingleDataObject(std::ostream& outputStrm, const DataPath& objectPath, DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler,
+                                          const std::atomic_bool& shouldCancel, const std::string& delimiter = "", bool includeIndex = false, bool includeHeaders = false,
+                                          size_t componentsPerLine = 0);
+
+/**
+ * @brief [Single Output][Custom OStream] | writes out multiple arrays to ostream
+ * @param outputStrm The already opened output string to write to
+ * @param objectPaths The vector of datapaths for respective dataObjects to be written out
+ * @param dataStructure The complex datastructure where *objectPaths* datacontainers are stored
+ * @param mesgHandler The handler to send progress updates to
+ * @param shouldCancel The atomic boolean that determines cancel
+ * //params with defaults
+ * @param delimiter The delimiter to be inserted into string
+ * @param includeIndex The boolean that determines if "Feature_IDs" are printed
+ * @param includeHeaders The boolean that determines if headers are printed
+ * @param componentsPerLine The amount of elements to be inserted before newline character
+ * @param neighborLists The list of dataPaths of neighborlists to include
+ */
+COMPLEX_EXPORT void PrintDataSetsToSingleFile(std::ostream& outputStrm, const std::vector<DataPath>& objectPaths, DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler,
+                                              const std::atomic_bool& shouldCancel, const std::string& delimiter = "", bool includeIndex = false, bool includeHeaders = false,
+                                              size_t componentsPerLine = 0, const std::vector<DataPath>& neighborLists = {});
+} // namespace OStreamUtilities
+
+} // namespace complex

--- a/src/complex/Utilities/StringUtilities.hpp
+++ b/src/complex/Utilities/StringUtilities.hpp
@@ -212,6 +212,10 @@ template <typename T>
 inline std::string number(T arg)
 {
   std::stringstream ss;
+  if constexpr(std::is_floating_point_v<T>)
+  {
+    ss.precision(std::numeric_limits<T>::digits10);
+  }
   ss << arg;
   return ss.str();
 }


### PR DESCRIPTION
The API for all primary std::ostream child classes. It has capability for printing every child of IArray. Ready for code review.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files.

- [x] Class and Structs are `UpperCamelCase`
- [x] Class private member variables are `m_UpperCamelCase`
- [x] Class methods are `lowerCamelCase`
- [x] Method arguments are `lowerCamelCase`
- [x] Normal variables are `lowerCamelCase`
- [x] Constants are `k_UpperCamelCase`
- [x] Global statics are `s_UpperCamelCase`
- [x] Free Functions are `UpperCamelCase`
- [x] Macros are `ALL_UPPER_SNAKE_CASE`
- [x] Unit test will test data output from the filter.
- [x] Reused strings should be constants in an anonymous namespace
- [x] If parallelization is used, proper use of the abstracted complex classes are used. Using TBB specifically in a filter should be frowned upon unless for a really good reason.

## Filter Checklist

- [x] Parameters should be generally broken down into "Input Parameters", "Required Data Objects", "Created Data Objects". There can be exceptions to this.
- [x] ChoicesParameter selections should be an enumeration defined in the filer header
- [x] Documentation copied from SIMPL Repo and updated (if necessary)
- [x] Parameter argument variables are k_CamelCase_Key
- [x] Parameter argument strings are lower_snake_case
```
static inline constexpr StringLiteral k_AlignmentType_Key = "alignment_type";
```

## Unit Testing
- [x] 1 Unit test to instantiate the filter with the default arguments.
- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] Filters should have both the Filter class and Algorithm class for anything beyond trivial needs
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added Python wrapping to new files (if any) as necessary
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented.


<!-- **Thanks for contributing to complex!** -->
