### PR TITLE
BUG: CropImageGeometry: Fix runtime geometry and array tuple shape bugs

### DIFF
--- a/src/Plugins/ComplexCore/data/6_5_test_data_1.xdmf
+++ b/src/Plugins/ComplexCore/data/6_5_test_data_1.xdmf
@@ -8,9 +8,14 @@
     <Geometry Type="ORIGIN_DXDYDZ">
       <!-- Origin  Z, Y, X -->
       <DataItem Format="XML" Dimensions="3">0 0 0</DataItem>
-      <!-- DxDyDz (Spacing/Spacing) Z, Y, X -->
+      <!-- DxDyDz (Spacing/Resolution) Z, Y, X -->
       <DataItem Format="XML" Dimensions="3">1 1 1</DataItem>
     </Geometry>
+    <Attribute Name="BoundaryCells" AttributeType="Scalar" Center="Cell">
+      <DataItem Format="HDF" Dimensions="100 100 100 1" NumberType="Char" Precision="1" >
+        6_5_test_data_1.dream3d:/DataContainers/DataContainer/CellData/BoundaryCells
+      </DataItem>
+    </Attribute>
     <Attribute Name="ConfidenceIndex" AttributeType="Scalar" Center="Cell">
       <DataItem Format="HDF" Dimensions="100 100 100 1" NumberType="Float" Precision="4" >
         6_5_test_data_1.dream3d:/DataContainers/DataContainer/CellData/ConfidenceIndex
@@ -36,12 +41,48 @@
         6_5_test_data_1.dream3d:/DataContainers/DataContainer/CellData/Phases
       </DataItem>
     </Attribute>
+  </Grid>
+  <!-- *************** END OF DataContainer *************** -->
+  <!-- *************** START OF 6_5_Cropped_ImageGeom *************** -->
+  <Grid Name="6_5_Cropped_ImageGeom" GridType="Uniform">
+    <Topology TopologyType="3DCoRectMesh" Dimensions="52 27 52 "></Topology>
+    <Geometry Type="ORIGIN_DXDYDZ">
+      <!-- Origin  Z, Y, X -->
+      <DataItem Format="XML" Dimensions="3">0 15 10</DataItem>
+      <!-- DxDyDz (Spacing/Resolution) Z, Y, X -->
+      <DataItem Format="XML" Dimensions="3">1 1 1</DataItem>
+    </Geometry>
     <Attribute Name="BoundaryCells" AttributeType="Scalar" Center="Cell">
-      <DataItem Format="HDF" Dimensions="100 100 100 1" NumberType="Char" Precision="1" >
-        6_5_test_data_1.dream3d:/DataContainers/DataContainer/CellData/BoundaryCells
+      <DataItem Format="HDF" Dimensions="51 26 51 1" NumberType="Char" Precision="1" >
+        6_5_test_data_1.dream3d:/DataContainers/6_5_Cropped_ImageGeom/CellData/BoundaryCells
+      </DataItem>
+    </Attribute>
+    <Attribute Name="ConfidenceIndex" AttributeType="Scalar" Center="Cell">
+      <DataItem Format="HDF" Dimensions="51 26 51 1" NumberType="Float" Precision="4" >
+        6_5_test_data_1.dream3d:/DataContainers/6_5_Cropped_ImageGeom/CellData/ConfidenceIndex
+      </DataItem>
+    </Attribute>
+    <Attribute Name="FeatureIds" AttributeType="Scalar" Center="Cell">
+      <DataItem Format="HDF" Dimensions="51 26 51 1" NumberType="Int" Precision="4" >
+        6_5_test_data_1.dream3d:/DataContainers/6_5_Cropped_ImageGeom/CellData/FeatureIds
+      </DataItem>
+    </Attribute>
+    <Attribute Name="IPFColors" AttributeType="Vector" Center="Cell">
+      <DataItem Format="HDF" Dimensions="51 26 51 3" NumberType="UChar" Precision="1" >
+        6_5_test_data_1.dream3d:/DataContainers/6_5_Cropped_ImageGeom/CellData/IPFColors
+      </DataItem>
+    </Attribute>
+    <Attribute Name="ImageQuality" AttributeType="Scalar" Center="Cell">
+      <DataItem Format="HDF" Dimensions="51 26 51 1" NumberType="Float" Precision="4" >
+        6_5_test_data_1.dream3d:/DataContainers/6_5_Cropped_ImageGeom/CellData/ImageQuality
+      </DataItem>
+    </Attribute>
+    <Attribute Name="Phases" AttributeType="Scalar" Center="Cell">
+      <DataItem Format="HDF" Dimensions="51 26 51 1" NumberType="Int" Precision="4" >
+        6_5_test_data_1.dream3d:/DataContainers/6_5_Cropped_ImageGeom/CellData/Phases
       </DataItem>
     </Attribute>
   </Grid>
-  <!-- *************** END OF DataContainer *************** -->
+  <!-- *************** END OF 6_5_Cropped_ImageGeom *************** -->
  </Domain>
 </Xdmf>

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropImageGeometry.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropImageGeometry.hpp
@@ -86,14 +86,15 @@ protected:
 
   /**
    * @brief
-   * @param data
+   * @param dataStructure
    * @param args
    * @param pipelineNode
    * @param messageHandler
    * @param shouldCancel
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                       const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace complex
 

--- a/src/Plugins/ComplexCore/test/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/test/CMakeLists.txt
@@ -21,7 +21,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   CropVertexGeometryTest.cpp
   CopyFeatureArrayToElementArrayTest.cpp
   CreateImageGeometryTest.cpp
-  CropImageGeomTest.cpp
+  CropImageGeometryTest.cpp
   ExtractInternalSurfacesFromTriangleGeometryTest.cpp
   FindDifferencesMapTest.cpp
   FindFeaturePhasesFilterTest.cpp

--- a/src/complex/DataStructure/Geometry/ImageGeom.hpp
+++ b/src/complex/DataStructure/Geometry/ImageGeom.hpp
@@ -193,13 +193,14 @@ public:
   usize getDimensionality() const;
 
   /**
-   * @brief
+   * @brief Returns the dimensions of the image geometry in the order of X, Y, Z
    * @return SizeVec3
    */
   SizeVec3 getDimensions() const override;
 
   /**
-   * @brief
+   * @brief Sets the dimensions of the Image Geometry. Ordering is X (Fastest), then Y, then Z (Slowest). These values
+   * become important when calculating things like an index based off of the Dimension values.
    * @param dims
    */
   void setDimensions(const SizeVec3& dims) override;

--- a/src/complex/Filter/Actions/CreateImageGeometryAction.hpp
+++ b/src/complex/Filter/Actions/CreateImageGeometryAction.hpp
@@ -18,7 +18,14 @@ public:
   using SpacingType = std::vector<float>;
 
   CreateImageGeometryAction() = delete;
-
+  /**
+   * @brief
+   * @param path
+   * @param dims The dimensions of the newly created Image Geometry: ORDERED: X, Y, Z.
+   * @param origin
+   * @param spacing
+   * @param cellAttributeMatrixName
+   */
   CreateImageGeometryAction(const DataPath& path, const DimensionType& dims, const OriginType& origin, const SpacingType& spacing, const std::string& cellAttributeMatrixName);
 
   ~CreateImageGeometryAction() noexcept override;

--- a/src/complex/Utilities/DataArrayUtilities.hpp
+++ b/src/complex/Utilities/DataArrayUtilities.hpp
@@ -151,7 +151,13 @@ Result<> CheckValuesUnsignedInt(const std::string& valueAsStr, const std::string
   return ConvertResult(std::move(conversionResult));
 }
 
-// -----------------------------------------------------------------------------
+/**
+ * @brief
+ * @tparam T
+ * @param valueAsStr
+ * @param strType
+ * @return
+ */
 template <class T>
 Result<> CheckValuesSignedInt(const std::string& valueAsStr, const std::string& strType)
 {
@@ -170,7 +176,13 @@ Result<> CheckValuesSignedInt(const std::string& valueAsStr, const std::string& 
   return ConvertResult(std::move(conversionResult));
 }
 
-// -----------------------------------------------------------------------------
+/**
+ * @brief
+ * @tparam T
+ * @param valueAsStr
+ * @param strType
+ * @return
+ */
 template <class T>
 Result<> CheckValuesFloatDouble(const std::string& valueAsStr, const std::string& strType)
 {
@@ -332,11 +344,6 @@ Result<> CreateArray(DataStructure& dataStructure, const std::vector<usize>& tup
   {
     return MakeErrorResult(-261, fmt::format("CreateArray: Tuple Shape was empty. Please set the number of tuples."));
   }
-  //  size_t numTuples = std::accumulate(tupleShape.cbegin(), tupleShape.cend(), static_cast<size_t>(1), std::multiplies<>());
-  //  if(numTuples == 0 && mode == IDataAction::Mode::Execute)
-  //  {
-  //    return MakeErrorResult(-263, fmt::format("CreateArrayAction: Number of tuples is ZERO. Please set the number of tuples."));
-  //  }
 
   // Validate Number of Components
   if(compShape.empty())
@@ -444,6 +451,13 @@ DataArray<T>* ArrayFromPath(DataStructure& dataStructure, const DataPath& path)
   return dataArray;
 }
 
+/**
+ * @brief
+ * @tparam T
+ * @param data
+ * @param path
+ * @return
+ */
 template <class T>
 DataArray<T>& ArrayRefFromPath(DataStructure& data, const DataPath& path)
 {
@@ -522,6 +536,32 @@ DataArray<T>* ImportFromBinaryFile(const std::string& filename, const std::strin
   fclose(inputFile);
 
   return dataArray;
+}
+
+/**
+ * @brief Creates a deep copy of an array into another location in the DataStructure.
+ *
+ * WARNING: If there is a DataObject already at the destination path then that data object
+ * is removed from the DataStructure and replaced with the new copy
+ * @tparam ArrayType The Type of DataArray to copy. IDataArray and StringArray are supported
+ * @param dataStructure The DataStructure object
+ * @param sourceDataPath The source path to copy from.
+ * @param destDataPath The destination path to copy into.
+ * @return Result<> object.
+ */
+template <typename ArrayType>
+Result<> DeepCopy(DataStructure& dataStructure, const DataPath& sourceDataPath, const DataPath& destDataPath)
+{
+  ArrayType& iDataArray = dataStructure.getDataRefAs<ArrayType>(sourceDataPath);
+  if(dataStructure.removeData(destDataPath))
+  {
+    iDataArray.deepCopy(destDataPath);
+  }
+  else
+  {
+    return MakeErrorResult(-34600, fmt::format("Could not remove data array at path '{}' which would be replaced through a deep copy.", destDataPath.toString()));
+  }
+  return {};
 }
 
 /**

--- a/src/complex/Utilities/ParallelTaskAlgorithm.cpp
+++ b/src/complex/Utilities/ParallelTaskAlgorithm.cpp
@@ -7,8 +7,7 @@ using namespace complex;
 
 // -----------------------------------------------------------------------------
 ParallelTaskAlgorithm::ParallelTaskAlgorithm()
-: m_Parallelization(true)
-, m_MaxThreads(std::thread::hardware_concurrency())
+: m_MaxThreads(std::thread::hardware_concurrency())
 #ifdef COMPLEX_ENABLE_MULTICORE
 , m_TaskGroup(new tbb::task_group)
 #endif
@@ -26,13 +25,13 @@ ParallelTaskAlgorithm::~ParallelTaskAlgorithm()
 // -----------------------------------------------------------------------------
 bool ParallelTaskAlgorithm::getParallelizationEnabled() const
 {
-  return m_Parallelization;
+  return m_RunParallel;
 }
 
 // -----------------------------------------------------------------------------
 void ParallelTaskAlgorithm::setParallelizationEnabled(bool doParallel)
 {
-  m_Parallelization = doParallel;
+  m_RunParallel = doParallel;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/complex/Utilities/ParallelTaskAlgorithm.hpp
+++ b/src/complex/Utilities/ParallelTaskAlgorithm.hpp
@@ -61,9 +61,7 @@ public:
   void execute(const Body& body)
   {
 #ifdef COMPLEX_ENABLE_MULTICORE
-    bool doParallel = false;
-    doParallel = m_Parallelization;
-    if(doParallel)
+    if(m_RunParallel)
     {
       m_TaskGroup->run(body);
       m_CurThreads++;
@@ -72,9 +70,11 @@ public:
         wait();
       }
     }
-#else
-    body();
 #endif
+    // Run non-parallel operation
+    {
+      body();
+    }
   }
 
   /**
@@ -83,11 +83,13 @@ public:
   void wait();
 
 private:
-  bool m_Parallelization = false;
-  uint32_t m_MaxThreads = 1;
 #ifdef COMPLEX_ENABLE_MULTICORE
+  bool m_RunParallel = true;
   uint32_t m_CurThreads = 0;
   std::shared_ptr<tbb::task_group> m_TaskGroup;
+#else
+  bool m_RunParallel = false;
 #endif
+  uint32_t m_MaxThreads = 1;
 };
 } // namespace complex


### PR DESCRIPTION
The root of the problem was the flipping of the X and Z values when creating DataArrays and Creating the Image Geometry.
Refactored many sections to be more efficient in performance and less code to maintain

Also fixed in this commit:
Fix issue in ParallelTaskAlgorithm if the developer set the parallelization to (false) nothing would be executed. Add in some documentation to a few places to help developers understand the ordering of the axis. Updated the test data file to include the exemplar data as SIMPL would produce it.
Updated Resample Image Geometry and RotateSampleRefFrame to use the same kinds and types of functions as CropImageGeometry since they are doing close to the same operations.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>


Start complex commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result

## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files.

- [x] Class and Structs are `UpperCamelCase`
- [x] Class private member variables are `m_UpperCamelCase`
- [x] Class methods are `lowerCamelCase`
- [x] Method arguments are `lowerCamelCase`
- [x] Normal variables are `lowerCamelCase`
- [x] Constants are `k_UpperCamelCase`
- [x] Global statics are `s_UpperCamelCase`
- [x] Free Functions are `UpperCamelCase`
- [x] Macros are `ALL_UPPER_SNAKE_CASE`
- [x] Unit test will test data output from the filter.
- [x] Reused strings should be constants in an anonymous namespace
- [x] If parallelization is used, proper use of the abstracted complex classes are used. Using TBB specifically in a filter should be frowned upon unless for a really good reason.

## Unit Testing
- [x] 1 Unit test to instantiate the filter with the default arguments.
- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] Filters should have both the Filter class and Algorithm class for anything beyond trivial needs
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added Python wrapping to new files (if any) as necessary
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented.


<!-- **Thanks for contributing to complex!** -->
