### PR TITLE
ENH: UUID Backward Compatibility Mapping

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
@@ -2,7 +2,7 @@
 
 #include <map>
 #include <string>
-
+// clang-format off
 namespace complex
 {
   // Regex to grep UUIDs : {\"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\",\s\"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:\s,\s[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})*)\"},\s\/\/\s(\w+)
@@ -122,3 +122,4 @@ namespace complex
   };
 
 } // namespace complex
+// clang-format on

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
@@ -5,7 +5,7 @@
 
 namespace complex
 {
-  // Regex to grep UUIDs : /{\"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\",\s\"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:\s,\s[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})*)\"},\s\/\/\s(\w+)
+  // Regex to grep UUIDs : {\"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\",\s\"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:\s,\s[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})*)\"},\s\/\/\s(\w+)
   static const std::map<std::string, std::string> k_SIMPL_to_ComplexCore
   {
     // syntax std::make_pair {Dream3d UUID , Dream3dnx UUID}, // dream3d-class-name

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace complex
+{
+  // Regex to grep UUIDs : /{\"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\",\s\"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:\s,\s[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})*)\"},\s\/\/\s(\w+)
+  static const std::map<std::string, std::string> k_SIMPL_to_ComplexCore
+  {
+    // syntax std::make_pair {Dream3d UUID , Dream3dnx UUID}, // dream3d-class-name
+    {"ce1ee404-0336-536c-8aad-f9641c9458be", "87fa9e07-6c66-45b0-80a0-cf80cc0def5d"}, // AlignGeometries
+    {"c681caf4-22f2-5885-bbc9-a0476abc72eb", "f5bbc16b-3426-4ae0-b27b-ba7862dc40fe"}, // ApplyTransformationToGeometry
+    {"fab669ad-66c6-5a39-bdb7-fc47b94311ed", "c19203b7-2217-4e52-bff4-7f611695421a"}, // ApproximatePointCloudHull
+    {"656f144c-a120-5c3b-bee5-06deab438588", "c666ee17-ca58-4969-80d0-819986c72485"}, // FindSizes
+    {"a9900cc3-169e-5a1b-bcf4-7569e1950d41", "b149addd-c0c8-4010-a264-596005eaf2a5"}, // TriangleAreaFilter
+    {"f7bc0e1e-0f50-5fe0-a9e7-510b6ed83792", "565e06e2-6fd0-4232-89c4-ee672926d565"}, // ChangeAngleRepresentation
+    {"a6b50fb0-eb7c-5d9b-9691-825d6a4fe772", "2436b614-e96d-47f0-9f6f-41d6fe97acd4"}, // CombineAttributeArrays
+    {"47cafe63-83cc-5826-9521-4fb5bea684ef", "bad9b7bd-1dc9-4f21-a889-6520e7a41881"}, // ConditionalSetValue
+    {"99836b75-144b-5126-b261-b411133b5e8a", "4c8c976a-993d-438b-bd8e-99f71114b9a1"}, // CopyFeatureArrayToElementArray
+    {"93375ef0-7367-5372-addc-baa019b1b341", "a6a28355-ee69-4874-bcac-76ed427423ed"}, // CreateAttributeMatrix
+    {"77f392fb-c1eb-57da-a1b1-e7acf9239fb8", "67041f9b-bdc6-4122-acc6-c9fe9280e90d"}, // CreateDataArray
+    {"816fbe6b-7c38-581b-b149-3f839fb65b93", "e7d2f9b8-4131-4b28-a843-ea3c6950f101"}, // CreateDataContainer
+    {"94438019-21bb-5b61-a7c3-66974b9a34dc", "50e1be47-b027-4f40-8f70-1283682ee3e7"}, // CreateFeatureArrayFromElementArray
+    {"f2132744-3abb-5d66-9cd9-c9a233b5c4aa", "c4320659-1a84-461d-939e-c7c10229a504"}, // CreateImageGeometry
+    {"baa4b7fe-31e5-5e63-a2cb-0bb9d844cfaf", "e6476737-4aa7-48ba-a702-3dfab82c96e2"}, // CropImageGeometry
+    {"f28cbf07-f15a-53ca-8c7f-b41a11dae6cc", "8b16452f-f75e-4918-9460-d3914fdc0d08"}, // CropVertexGeometry
+    {"7b1c8f46-90dd-584a-b3ba-34e16958a7d0", "bf286740-e987-49fe-a7c8-6e566e3a0606"}, // RemoveArrays
+    {"3fcd4c43-9d75-5b86-aad4-4441bc914f37", "b3a95784-2ced-41ec-8d3d-0242ac130003"}, // DataContainerWriter
+    {"52a069b4-6a46-5810-b0ec-e0693c636034", "e020f76f-a77f-4999-8bf1-9b7529f06d0a"}, // ExtractInternalSurfacesFromTriangleGeometry
+    {"bf35f515-294b-55ed-8c69-211b7e69cb56", "645ecae2-cb30-4b53-8165-c9857dfa754f"}, // FindArrayStatistics
+    {"29086169-20ce-52dc-b13e-824694d759aa", "5a0ee5b5-c135-4535-85d0-9c2058943099"}, // FindDifferenceMap
+    {"6334ce16-cea5-5643-83b5-9573805873fa", "da5bb20e-4a8e-49d9-9434-fbab7bc434fc"}, // FindFeaturePhases
+    {"73ee33b6-7622-5004-8b88-4d145514fb6a", "270a824e-414b-455e-bb7e-b38a0848990d"}, // FindNeighborListStatistics
+    {"97cf66f8-7a9b-5ec2-83eb-f8c4c8a17bac", "7177e88c-c3ab-4169-abe9-1fdaff20e598"}, // FindNeighbors
+    {"d2b0ae3d-686a-5dc0-a844-66bc0dc8f3cb", "0893e490-5d24-4c21-95e7-e8372baa8948"}, // FindSurfaceFeatures
+    {"0e8c0818-a3fb-57d4-a5c8-7cb8ae54a40a", "94d47495-5a89-4c7f-a0ee-5ff20e6bd273"}, // IdentifySample
+    {"bdb978bc-96bf-5498-972c-b509c38b8d50", "373be1f8-31cf-49f6-aa5d-e356f4f3f261"}, // ReadASCIIData
+    {"043cbde5-3878-5718-958f-ae75714df0df", "0dbd31c7-19e0-4077-83ef-f4a6459a0e2d"}, // DataContainerReader
+    {"9e98c3b0-5707-5a3b-b8b5-23ef83b02896", "8027f145-c7d5-4589-900e-b909fb3a059c"}, // ImportHDF5Dataset
+    {"a7007472-29e5-5d0a-89a6-1aed11b603f8", "25f7df3e-ca3e-4634-adda-732c0e56efd4"}, // ImportAsciDataArray
+    {"dfab9921-fea3-521c-99ba-48db98e43ff8", "447b8909-661f-446a-8c1f-72e0cb568fcf"}, // InitializeData
+    {"4b551c15-418d-5081-be3f-d3aeb62408e5", "996c4464-08f0-4268-a8a6-f9796c88cf58"}, // InterpolatePointCloudToRegularGrid
+    {"6c8fb24b-5b12-551c-ba6d-ae2fa7724764", "3a206668-fa44-418d-b78e-9fd803b8fb98"}, // IterativeClosestPoint
+    {"601c4885-c218-5da6-9fc7-519d85d241ad", "0dd0916e-9305-4a7b-98cf-a6cfb97cb501"}, // LaplacianSmoothing
+    {"9fe34deb-99e1-5f3a-a9cc-e90c655b47ee", "af53ac60-092f-4e4a-9e13-57f0034ce2c7"}, // MapPointCloudToRegularGrid
+    {"dab5de3c-5f81-5bb5-8490-73521e1183ea", "4ab5153f-6014-4e6d-bbd6-194068620389"}, // MinNeighbors
+    {"fe2cbe09-8ae1-5bea-9397-fd5741091fdb", "651e5894-ab7c-4176-b7f0-ea466c521753"}, // MoveData
+    {"014b7300-cf36-5ede-a751-5faf9b119dae", "4246245e-1011-4add-8436-0af6bed19228"}, // MultiThresholdObjects
+    {"686d5393-2b02-5c86-b887-dd81a8ae80f2", "4246245e-1011-4add-8436-0af6bed19228"}, // MultiThresholdObjects2
+    {"119861c5-e303-537e-b210-2e62936222e9", "ee34ef95-aa04-4ad3-8232-5783a880d279"}, // PointSampleTriangleGeometry
+    {"07b49e30-3900-5c34-862a-f1fb48bad568", "13dd00bd-ad49-4e04-95eb-3267952fd6e5"}, // QuickSurfaceMesh
+    {"0791f556-3d73-5b1e-b275-db3f7bb6850d", "dd159366-5f12-42db-af6d-a33592ae8a89"}, // RawBinaryReader
+    {"379ccc67-16dd-530a-984f-177db2314bac", "46099b4c-ef90-4fb3-b5e9-6c8c543c5be1"}, // RemoveFlaggedVertices
+    {"53ac1638-8934-57b8-b8e5-4b91cdda23ec", "074472d3-ba8d-4a1a-99f2-2d56a0d082a0"}, // MinSize
+    {"53a5f731-2858-5e3e-bd43-8f2cf45d90ec", "911a3aa9-d3c2-4f66-9451-8861c4b726d5"}, // RenameAttributeArray
+    {"ee29e6d6-1f59-551b-9350-a696523261d5", "911a3aa9-d3c2-4f66-9451-8861c4b726d5"}, // RenameAttributeMatrix
+    {"d53c808f-004d-5fac-b125-0fffc8cc78d6", "911a3aa9-d3c2-4f66-9451-8861c4b726d5"}, // RenameDataContainer
+    {"3062fc2c-76b2-5c50-92b7-edbbb424c41d", "ade392e6-f0da-4cf3-bf11-dfe69e200b49"}, // RobustAutomaticThreshold
+    {"2c5edebf-95d8-511f-b787-90ee2adf485c", "e067cd97-9bbf-4c92-89a6-3cb4fdb76c93"}, // ScalarSegmentFeatures
+    {"6d3a3852-6251-5d2e-b749-6257fd0d8951", "057bc7fd-c84a-4902-9397-87e51b1b1fe0"}, // SetOriginResolutionImageGeom
+    {"980c7bfd-20b2-5711-bc3b-0190b9096c34", "2f64bd45-9d28-4254-9e07-6aa7c6d3d015"}, // ReadStlFile
+    {"0541c5eb-1976-5797-9468-be50a93d44e2", "dd42c521-4ae5-485d-ad35-d1276547d2f1"}, // TriangleDihedralAngleFilter
+    {"8133d419-1919-4dbf-a5bf-1c97282ba63f", "928154f6-e4bc-5a10-a9dd-1abb6a6c0f6b"}, // TriangleNormalFilter
+    // {insert DREAM3D UUID here, insert DREAM3DNX UUID here}, // dream3d-class-name
+  };
+
+  static const std::map<std::string, std::string> k_ComplexCore_to_SIMPL
+  {
+    // syntax std::make_pair {Dream3dnx UUID , Dream3d UUID}, // dream3dnx-class-name
+    {"87fa9e07-6c66-45b0-80a0-cf80cc0def5d", "ce1ee404-0336-536c-8aad-f9641c9458be"}, // AlignGeometries
+    {"f5bbc16b-3426-4ae0-b27b-ba7862dc40fe", "c681caf4-22f2-5885-bbc9-a0476abc72eb"}, // ApplyTransformationToGeometryFilter
+    {"c19203b7-2217-4e52-bff4-7f611695421a", "fab669ad-66c6-5a39-bdb7-fc47b94311ed"}, // ApproximatePointCloudHull
+    {"c666ee17-ca58-4969-80d0-819986c72485", "656f144c-a120-5c3b-bee5-06deab438588"}, // CalculateFeatureSizesFilter
+    {"b149addd-c0c8-4010-a264-596005eaf2a5", "a9900cc3-169e-5a1b-bcf4-7569e1950d41"}, // CalculateTriangleAreasFilter
+    {"565e06e2-6fd0-4232-89c4-ee672926d565", "f7bc0e1e-0f50-5fe0-a9e7-510b6ed83792"}, // ChangeAngleRepresentation
+    {"2436b614-e96d-47f0-9f6f-41d6fe97acd4", "a6b50fb0-eb7c-5d9b-9691-825d6a4fe772"}, // CombineAttributeArrays
+    {"bad9b7bd-1dc9-4f21-a889-6520e7a41881", "47cafe63-83cc-5826-9521-4fb5bea684ef"}, // ConditionalSetValue
+    {"4c8c976a-993d-438b-bd8e-99f71114b9a1", "99836b75-144b-5126-b261-b411133b5e8a"}, // CopyFeatureArrayToElementArray
+    {"a6a28355-ee69-4874-bcac-76ed427423ed", "93375ef0-7367-5372-addc-baa019b1b341"}, // CreateAttributeMatrixFilter
+    {"67041f9b-bdc6-4122-acc6-c9fe9280e90d", "77f392fb-c1eb-57da-a1b1-e7acf9239fb8"}, // CreateDataArray
+    {"e7d2f9b8-4131-4b28-a843-ea3c6950f101", "816fbe6b-7c38-581b-b149-3f839fb65b93"}, // CreateDataGroup
+    {"50e1be47-b027-4f40-8f70-1283682ee3e7", "94438019-21bb-5b61-a7c3-66974b9a34dc"}, // CreateFeatureArrayFromElementArray
+    {"c4320659-1a84-461d-939e-c7c10229a504", "f2132744-3abb-5d66-9cd9-c9a233b5c4aa"}, // CreateImageGeometry
+    {"e6476737-4aa7-48ba-a702-3dfab82c96e2", "baa4b7fe-31e5-5e63-a2cb-0bb9d844cfaf"}, // CropImageGeometry
+    {"8b16452f-f75e-4918-9460-d3914fdc0d08", "f28cbf07-f15a-53ca-8c7f-b41a11dae6cc"}, // CropVertexGeometry
+    {"bf286740-e987-49fe-a7c8-6e566e3a0606", "7b1c8f46-90dd-584a-b3ba-34e16958a7d0"}, // DeleteData
+    {"b3a95784-2ced-41ec-8d3d-0242ac130003", "3fcd4c43-9d75-5b86-aad4-4441bc914f37"}, // ExportDREAM3DFilter
+    {"e020f76f-a77f-4999-8bf1-9b7529f06d0a", "52a069b4-6a46-5810-b0ec-e0693c636034"}, // ExtractInternalSurfacesFromTriangleGeometry
+    {"645ecae2-cb30-4b53-8165-c9857dfa754f", "bf35f515-294b-55ed-8c69-211b7e69cb56"}, // FindArrayStatisticsFilter
+    {"5a0ee5b5-c135-4535-85d0-9c2058943099", "29086169-20ce-52dc-b13e-824694d759aa"}, // FindDifferencesMap
+    {"da5bb20e-4a8e-49d9-9434-fbab7bc434fc", "6334ce16-cea5-5643-83b5-9573805873fa"}, // FindFeaturePhasesFilter
+    {"270a824e-414b-455e-bb7e-b38a0848990d", "73ee33b6-7622-5004-8b88-4d145514fb6a"}, // FindNeighborListStatistics
+    {"7177e88c-c3ab-4169-abe9-1fdaff20e598", "97cf66f8-7a9b-5ec2-83eb-f8c4c8a17bac"}, // FindNeighbors
+    {"0893e490-5d24-4c21-95e7-e8372baa8948", "d2b0ae3d-686a-5dc0-a844-66bc0dc8f3cb"}, // FindSurfaceFeatures
+    {"94d47495-5a89-4c7f-a0ee-5ff20e6bd273", "0e8c0818-a3fb-57d4-a5c8-7cb8ae54a40a"}, // IdentifySample
+    {"373be1f8-31cf-49f6-aa5d-e356f4f3f261", "bdb978bc-96bf-5498-972c-b509c38b8d50"}, // ImportCSVDataFilter
+    {"0dbd31c7-19e0-4077-83ef-f4a6459a0e2d", "043cbde5-3878-5718-958f-ae75714df0df"}, // ImportDREAM3DFilter
+    {"8027f145-c7d5-4589-900e-b909fb3a059c", "9e98c3b0-5707-5a3b-b8b5-23ef83b02896"}, // ImportHDF5Dataset
+    {"25f7df3e-ca3e-4634-adda-732c0e56efd4", "a7007472-29e5-5d0a-89a6-1aed11b603f8"}, // ImportTextFilter
+    {"447b8909-661f-446a-8c1f-72e0cb568fcf", "dfab9921-fea3-521c-99ba-48db98e43ff8"}, // InitializeData
+    {"996c4464-08f0-4268-a8a6-f9796c88cf58", "4b551c15-418d-5081-be3f-d3aeb62408e5"}, // InterpolatePointCloudToRegularGridFilter
+    {"3a206668-fa44-418d-b78e-9fd803b8fb98", "6c8fb24b-5b12-551c-ba6d-ae2fa7724764"}, // IterativeClosestPointFilter
+    {"0dd0916e-9305-4a7b-98cf-a6cfb97cb501", "601c4885-c218-5da6-9fc7-519d85d241ad"}, // LaplacianSmoothingFilter
+    {"af53ac60-092f-4e4a-9e13-57f0034ce2c7", "9fe34deb-99e1-5f3a-a9cc-e90c655b47ee"}, // MapPointCloudToRegularGridFilter
+    {"4ab5153f-6014-4e6d-bbd6-194068620389", "dab5de3c-5f81-5bb5-8490-73521e1183ea"}, // MinNeighbors
+    {"651e5894-ab7c-4176-b7f0-ea466c521753", "fe2cbe09-8ae1-5bea-9397-fd5741091fdb"}, // MoveData
+    {"4246245e-1011-4add-8436-0af6bed19228", "686d5393-2b02-5c86-b887-dd81a8ae80f2"}, // MultiThresholdObjects
+    {"ee34ef95-aa04-4ad3-8232-5783a880d279", "014b7300-cf36-5ede-a751-5faf9b119dae , 119861c5-e303-537e-b210-2e62936222e9"}, // PointSampleTriangleGeometryFilter
+    {"13dd00bd-ad49-4e04-95eb-3267952fd6e5", "07b49e30-3900-5c34-862a-f1fb48bad568"}, // QuickSurfaceMeshFilter
+    {"dd159366-5f12-42db-af6d-a33592ae8a89", "0791f556-3d73-5b1e-b275-db3f7bb6850d"}, // RawBinaryReaderFilter
+    {"46099b4c-ef90-4fb3-b5e9-6c8c543c5be1", "379ccc67-16dd-530a-984f-177db2314bac"}, // RemoveFlaggedVertices
+    {"074472d3-ba8d-4a1a-99f2-2d56a0d082a0", "53ac1638-8934-57b8-b8e5-4b91cdda23ec"}, // RemoveMinimumSizeFeaturesFilter
+    {"911a3aa9-d3c2-4f66-9451-8861c4b726d5", "53a5f731-2858-5e3e-bd43-8f2cf45d90ec , ee29e6d6-1f59-551b-9350-a696523261d5 , d53c808f-004d-5fac-b125-0fffc8cc78d6"}, // RenameDataObject
+    {"ade392e6-f0da-4cf3-bf11-dfe69e200b49", "3062fc2c-76b2-5c50-92b7-edbbb424c41d"}, // RobustAutomaticThreshold
+    {"e067cd97-9bbf-4c92-89a6-3cb4fdb76c93", "2c5edebf-95d8-511f-b787-90ee2adf485c"}, // ScalarSegmentFeaturesFilter
+    {"057bc7fd-c84a-4902-9397-87e51b1b1fe0", "6d3a3852-6251-5d2e-b749-6257fd0d8951"}, // SetImageGeomOriginScalingFilter
+    {"2f64bd45-9d28-4254-9e07-6aa7c6d3d015", "980c7bfd-20b2-5711-bc3b-0190b9096c34"}, // StlFileReaderFilter
+    {"dd42c521-4ae5-485d-ad35-d1276547d2f1", "0541c5eb-1976-5797-9468-be50a93d44e2"}, // TriangleDihedralAngleFilter
+    {"928154f6-e4bc-5a10-a9dd-1abb6a6c0f6b", "8133d419-1919-4dbf-a5bf-1c97282ba63f"}, // TriangleNormalFilter
+    // {insert DREAM3DNX UUID here, insert DREAM3D UUID here}, // dream3dnx-class-name
+  };
+
+} // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
@@ -55,7 +55,7 @@
 #include "ComplexCore/Filters/StlFileReaderFilter.hpp"
 #include "ComplexCore/Filters/TriangleDihedralAngleFilter.hpp"
 #include "ComplexCore/Filters/TriangleNormalFilter.hpp"
-// #include "Filters/FilterName.hpp"
+// @@__HEADER__TOKEN__DO__NOT__DELETE__@@
 
 namespace complex
 {
@@ -115,7 +115,7 @@ namespace complex
     {complex::Uuid::FromString("980c7bfd-20b2-5711-bc3b-0190b9096c34").value(), complex::FilterTraits<StlFileReaderFilter>::uuid}, // ReadStlFile
     {complex::Uuid::FromString("0541c5eb-1976-5797-9468-be50a93d44e2").value(), complex::FilterTraits<TriangleDihedralAngleFilter>::uuid}, // TriangleDihedralAngleFilter
     {complex::Uuid::FromString("8133d419-1919-4dbf-a5bf-1c97282ba63f").value(), complex::FilterTraits<TriangleNormalFilter>::uuid}, // TriangleNormalFilter
-    // {complex::Uuid::FromString(insert DREAM3D UUID string here).value(), complex::FilterTraits<insert DREAM3DNX filter name here>::uuid}, // dream3d-class-name
+    // @@__MAP__UPDATE__TOKEN__DO__NOT__DELETE__@@
   };
 
 } // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
@@ -2,66 +2,120 @@
 
 #include <map>
 #include <string>
+
 // clang-format off
+#include "ComplexCore/Filters/AlignGeometries.hpp"
+#include "ComplexCore/Filters/ApplyTransformationToGeometryFilter.hpp"
+#include "ComplexCore/Filters/ApproximatePointCloudHull.hpp"
+#include "ComplexCore/Filters/CalculateFeatureSizesFilter.hpp"
+#include "ComplexCore/Filters/CalculateTriangleAreasFilter.hpp"
+#include "ComplexCore/Filters/ChangeAngleRepresentation.hpp"
+#include "ComplexCore/Filters/CombineAttributeArraysFilter.hpp"
+#include "ComplexCore/Filters/ConditionalSetValue.hpp"
+#include "ComplexCore/Filters/CopyDataGroup.hpp"
+#include "ComplexCore/Filters/CopyFeatureArrayToElementArray.hpp"
+#include "ComplexCore/Filters/CreateAttributeMatrixFilter.hpp"
+#include "ComplexCore/Filters/CreateDataArray.hpp"
+#include "ComplexCore/Filters/CreateDataGroup.hpp"
+#include "ComplexCore/Filters/CreateFeatureArrayFromElementArray.hpp"
+#include "ComplexCore/Filters/CreateImageGeometry.hpp"
+#include "ComplexCore/Filters/CropImageGeometry.hpp"
+#include "ComplexCore/Filters/CropVertexGeometry.hpp"
+#include "ComplexCore/Filters/DeleteData.hpp"
+#include "ComplexCore/Filters/ExportDREAM3DFilter.hpp"
+#include "ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.hpp"
+#include "ComplexCore/Filters/FindArrayStatisticsFilter.hpp"
+#include "ComplexCore/Filters/FindDifferencesMap.hpp"
+#include "ComplexCore/Filters/FindFeaturePhasesFilter.hpp"
+#include "ComplexCore/Filters/FindNeighborListStatistics.hpp"
+#include "ComplexCore/Filters/FindNeighbors.hpp"
+#include "ComplexCore/Filters/FindSurfaceFeatures.hpp"
+#include "ComplexCore/Filters/IdentifySample.hpp"
+#include "ComplexCore/Filters/ImportCSVDataFilter.hpp"
+#include "ComplexCore/Filters/ImportDREAM3DFilter.hpp"
+#include "ComplexCore/Filters/ImportHDF5Dataset.hpp"
+#include "ComplexCore/Filters/ImportTextFilter.hpp"
+#include "ComplexCore/Filters/InitializeData.hpp"
+#include "ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp"
+#include "ComplexCore/Filters/IterativeClosestPointFilter.hpp"
+#include "ComplexCore/Filters/LaplacianSmoothingFilter.hpp"
+#include "ComplexCore/Filters/MapPointCloudToRegularGridFilter.hpp"
+#include "ComplexCore/Filters/MinNeighbors.hpp"
+#include "ComplexCore/Filters/MoveData.hpp"
+#include "ComplexCore/Filters/MultiThresholdObjects.hpp"
+#include "ComplexCore/Filters/PointSampleTriangleGeometryFilter.hpp"
+#include "ComplexCore/Filters/QuickSurfaceMeshFilter.hpp"
+#include "ComplexCore/Filters/RawBinaryReaderFilter.hpp"
+#include "ComplexCore/Filters/RemoveFlaggedVertices.hpp"
+#include "ComplexCore/Filters/RemoveMinimumSizeFeaturesFilter.hpp"
+#include "ComplexCore/Filters/RenameDataObject.hpp"
+#include "ComplexCore/Filters/RobustAutomaticThreshold.hpp"
+#include "ComplexCore/Filters/ScalarSegmentFeaturesFilter.hpp"
+#include "ComplexCore/Filters/SetImageGeomOriginScalingFilter.hpp"
+#include "ComplexCore/Filters/StlFileReaderFilter.hpp"
+#include "ComplexCore/Filters/TriangleDihedralAngleFilter.hpp"
+#include "ComplexCore/Filters/TriangleNormalFilter.hpp"
+// #include "Filters/FilterName.hpp"
+
 namespace complex
 {
   static const std::map<complex::Uuid, complex::Uuid> k_SIMPL_to_ComplexCore
   {
     // syntax std::make_pair {Dream3d UUID , Dream3dnx UUID}, // dream3d-class-name
-    {complex::Uuid::FromString("ce1ee404-0336-536c-8aad-f9641c9458be").value(), complex::Uuid::FromString("87fa9e07-6c66-45b0-80a0-cf80cc0def5d").value()}, // AlignGeometries
-    {complex::Uuid::FromString("c681caf4-22f2-5885-bbc9-a0476abc72eb").value(), complex::Uuid::FromString("f5bbc16b-3426-4ae0-b27b-ba7862dc40fe").value()}, // ApplyTransformationToGeometry
-    {complex::Uuid::FromString("fab669ad-66c6-5a39-bdb7-fc47b94311ed").value(), complex::Uuid::FromString("c19203b7-2217-4e52-bff4-7f611695421a").value()}, // ApproximatePointCloudHull
-    {complex::Uuid::FromString("656f144c-a120-5c3b-bee5-06deab438588").value(), complex::Uuid::FromString("c666ee17-ca58-4969-80d0-819986c72485").value()}, // FindSizes
-    {complex::Uuid::FromString("a9900cc3-169e-5a1b-bcf4-7569e1950d41").value(), complex::Uuid::FromString("b149addd-c0c8-4010-a264-596005eaf2a5").value()}, // TriangleAreaFilter
-    {complex::Uuid::FromString("f7bc0e1e-0f50-5fe0-a9e7-510b6ed83792").value(), complex::Uuid::FromString("565e06e2-6fd0-4232-89c4-ee672926d565").value()}, // ChangeAngleRepresentation
-    {complex::Uuid::FromString("a6b50fb0-eb7c-5d9b-9691-825d6a4fe772").value(), complex::Uuid::FromString("2436b614-e96d-47f0-9f6f-41d6fe97acd4").value()}, // CombineAttributeArrays
-    {complex::Uuid::FromString("47cafe63-83cc-5826-9521-4fb5bea684ef").value(), complex::Uuid::FromString("bad9b7bd-1dc9-4f21-a889-6520e7a41881").value()}, // ConditionalSetValue
-    {complex::Uuid::FromString("99836b75-144b-5126-b261-b411133b5e8a").value(), complex::Uuid::FromString("4c8c976a-993d-438b-bd8e-99f71114b9a1").value()}, // CopyFeatureArrayToElementArray
-    {complex::Uuid::FromString("93375ef0-7367-5372-addc-baa019b1b341").value(), complex::Uuid::FromString("a6a28355-ee69-4874-bcac-76ed427423ed").value()}, // CreateAttributeMatrix
-    {complex::Uuid::FromString("77f392fb-c1eb-57da-a1b1-e7acf9239fb8").value(), complex::Uuid::FromString("67041f9b-bdc6-4122-acc6-c9fe9280e90d").value()}, // CreateDataArray
-    {complex::Uuid::FromString("816fbe6b-7c38-581b-b149-3f839fb65b93").value(), complex::Uuid::FromString("e7d2f9b8-4131-4b28-a843-ea3c6950f101").value()}, // CreateDataContainer
-    {complex::Uuid::FromString("94438019-21bb-5b61-a7c3-66974b9a34dc").value(), complex::Uuid::FromString("50e1be47-b027-4f40-8f70-1283682ee3e7").value()}, // CreateFeatureArrayFromElementArray
-    {complex::Uuid::FromString("f2132744-3abb-5d66-9cd9-c9a233b5c4aa").value(), complex::Uuid::FromString("c4320659-1a84-461d-939e-c7c10229a504").value()}, // CreateImageGeometry
-    {complex::Uuid::FromString("baa4b7fe-31e5-5e63-a2cb-0bb9d844cfaf").value(), complex::Uuid::FromString("e6476737-4aa7-48ba-a702-3dfab82c96e2").value()}, // CropImageGeometry
-    {complex::Uuid::FromString("f28cbf07-f15a-53ca-8c7f-b41a11dae6cc").value(), complex::Uuid::FromString("8b16452f-f75e-4918-9460-d3914fdc0d08").value()}, // CropVertexGeometry
-    {complex::Uuid::FromString("7b1c8f46-90dd-584a-b3ba-34e16958a7d0").value(), complex::Uuid::FromString("bf286740-e987-49fe-a7c8-6e566e3a0606").value()}, // RemoveArrays
-    {complex::Uuid::FromString("3fcd4c43-9d75-5b86-aad4-4441bc914f37").value(), complex::Uuid::FromString("b3a95784-2ced-41ec-8d3d-0242ac130003").value()}, // DataContainerWriter
-    {complex::Uuid::FromString("52a069b4-6a46-5810-b0ec-e0693c636034").value(), complex::Uuid::FromString("e020f76f-a77f-4999-8bf1-9b7529f06d0a").value()}, // ExtractInternalSurfacesFromTriangleGeometry
-    {complex::Uuid::FromString("bf35f515-294b-55ed-8c69-211b7e69cb56").value(), complex::Uuid::FromString("645ecae2-cb30-4b53-8165-c9857dfa754f").value()}, // FindArrayStatistics
-    {complex::Uuid::FromString("29086169-20ce-52dc-b13e-824694d759aa").value(), complex::Uuid::FromString("5a0ee5b5-c135-4535-85d0-9c2058943099").value()}, // FindDifferenceMap
-    {complex::Uuid::FromString("6334ce16-cea5-5643-83b5-9573805873fa").value(), complex::Uuid::FromString("da5bb20e-4a8e-49d9-9434-fbab7bc434fc").value()}, // FindFeaturePhases
-    {complex::Uuid::FromString("73ee33b6-7622-5004-8b88-4d145514fb6a").value(), complex::Uuid::FromString("270a824e-414b-455e-bb7e-b38a0848990d").value()}, // FindNeighborListStatistics
-    {complex::Uuid::FromString("97cf66f8-7a9b-5ec2-83eb-f8c4c8a17bac").value(), complex::Uuid::FromString("7177e88c-c3ab-4169-abe9-1fdaff20e598").value()}, // FindNeighbors
-    {complex::Uuid::FromString("d2b0ae3d-686a-5dc0-a844-66bc0dc8f3cb").value(), complex::Uuid::FromString("0893e490-5d24-4c21-95e7-e8372baa8948").value()}, // FindSurfaceFeatures
-    {complex::Uuid::FromString("0e8c0818-a3fb-57d4-a5c8-7cb8ae54a40a").value(), complex::Uuid::FromString("94d47495-5a89-4c7f-a0ee-5ff20e6bd273").value()}, // IdentifySample
-    {complex::Uuid::FromString("bdb978bc-96bf-5498-972c-b509c38b8d50").value(), complex::Uuid::FromString("373be1f8-31cf-49f6-aa5d-e356f4f3f261").value()}, // ReadASCIIData
-    {complex::Uuid::FromString("043cbde5-3878-5718-958f-ae75714df0df").value(), complex::Uuid::FromString("0dbd31c7-19e0-4077-83ef-f4a6459a0e2d").value()}, // DataContainerReader
-    {complex::Uuid::FromString("9e98c3b0-5707-5a3b-b8b5-23ef83b02896").value(), complex::Uuid::FromString("8027f145-c7d5-4589-900e-b909fb3a059c").value()}, // ImportHDF5Dataset
-    {complex::Uuid::FromString("a7007472-29e5-5d0a-89a6-1aed11b603f8").value(), complex::Uuid::FromString("25f7df3e-ca3e-4634-adda-732c0e56efd4").value()}, // ImportAsciDataArray
-    {complex::Uuid::FromString("dfab9921-fea3-521c-99ba-48db98e43ff8").value(), complex::Uuid::FromString("447b8909-661f-446a-8c1f-72e0cb568fcf").value()}, // InitializeData
-    {complex::Uuid::FromString("4b551c15-418d-5081-be3f-d3aeb62408e5").value(), complex::Uuid::FromString("996c4464-08f0-4268-a8a6-f9796c88cf58").value()}, // InterpolatePointCloudToRegularGrid
-    {complex::Uuid::FromString("6c8fb24b-5b12-551c-ba6d-ae2fa7724764").value(), complex::Uuid::FromString("3a206668-fa44-418d-b78e-9fd803b8fb98").value()}, // IterativeClosestPoint
-    {complex::Uuid::FromString("601c4885-c218-5da6-9fc7-519d85d241ad").value(), complex::Uuid::FromString("0dd0916e-9305-4a7b-98cf-a6cfb97cb501").value()}, // LaplacianSmoothing
-    {complex::Uuid::FromString("9fe34deb-99e1-5f3a-a9cc-e90c655b47ee").value(), complex::Uuid::FromString("af53ac60-092f-4e4a-9e13-57f0034ce2c7").value()}, // MapPointCloudToRegularGrid
-    {complex::Uuid::FromString("dab5de3c-5f81-5bb5-8490-73521e1183ea").value(), complex::Uuid::FromString("4ab5153f-6014-4e6d-bbd6-194068620389").value()}, // MinNeighbors
-    {complex::Uuid::FromString("fe2cbe09-8ae1-5bea-9397-fd5741091fdb").value(), complex::Uuid::FromString("651e5894-ab7c-4176-b7f0-ea466c521753").value()}, // MoveData
-    {complex::Uuid::FromString("014b7300-cf36-5ede-a751-5faf9b119dae").value(), complex::Uuid::FromString("4246245e-1011-4add-8436-0af6bed19228").value()}, // MultiThresholdObjects
-    {complex::Uuid::FromString("686d5393-2b02-5c86-b887-dd81a8ae80f2").value(), complex::Uuid::FromString("4246245e-1011-4add-8436-0af6bed19228").value()}, // MultiThresholdObjects2
-    {complex::Uuid::FromString("119861c5-e303-537e-b210-2e62936222e9").value(), complex::Uuid::FromString("ee34ef95-aa04-4ad3-8232-5783a880d279").value()}, // PointSampleTriangleGeometry
-    {complex::Uuid::FromString("07b49e30-3900-5c34-862a-f1fb48bad568").value(), complex::Uuid::FromString("13dd00bd-ad49-4e04-95eb-3267952fd6e5").value()}, // QuickSurfaceMesh
-    {complex::Uuid::FromString("0791f556-3d73-5b1e-b275-db3f7bb6850d").value(), complex::Uuid::FromString("dd159366-5f12-42db-af6d-a33592ae8a89").value()}, // RawBinaryReader
-    {complex::Uuid::FromString("379ccc67-16dd-530a-984f-177db2314bac").value(), complex::Uuid::FromString("46099b4c-ef90-4fb3-b5e9-6c8c543c5be1").value()}, // RemoveFlaggedVertices
-    {complex::Uuid::FromString("53ac1638-8934-57b8-b8e5-4b91cdda23ec").value(), complex::Uuid::FromString("074472d3-ba8d-4a1a-99f2-2d56a0d082a0").value()}, // MinSize
-    {complex::Uuid::FromString("53a5f731-2858-5e3e-bd43-8f2cf45d90ec").value(), complex::Uuid::FromString("911a3aa9-d3c2-4f66-9451-8861c4b726d5").value()}, // RenameAttributeArray
-    {complex::Uuid::FromString("ee29e6d6-1f59-551b-9350-a696523261d5").value(), complex::Uuid::FromString("911a3aa9-d3c2-4f66-9451-8861c4b726d5").value()}, // RenameAttributeMatrix
-    {complex::Uuid::FromString("d53c808f-004d-5fac-b125-0fffc8cc78d6").value(), complex::Uuid::FromString("911a3aa9-d3c2-4f66-9451-8861c4b726d5").value()}, // RenameDataContainer
-    {complex::Uuid::FromString("3062fc2c-76b2-5c50-92b7-edbbb424c41d").value(), complex::Uuid::FromString("ade392e6-f0da-4cf3-bf11-dfe69e200b49").value()}, // RobustAutomaticThreshold
-    {complex::Uuid::FromString("2c5edebf-95d8-511f-b787-90ee2adf485c").value(), complex::Uuid::FromString("e067cd97-9bbf-4c92-89a6-3cb4fdb76c93").value()}, // ScalarSegmentFeatures
-    {complex::Uuid::FromString("6d3a3852-6251-5d2e-b749-6257fd0d8951").value(), complex::Uuid::FromString("057bc7fd-c84a-4902-9397-87e51b1b1fe0").value()}, // SetOriginResolutionImageGeom
-    {complex::Uuid::FromString("980c7bfd-20b2-5711-bc3b-0190b9096c34").value(), complex::Uuid::FromString("2f64bd45-9d28-4254-9e07-6aa7c6d3d015").value()}, // ReadStlFile
-    {complex::Uuid::FromString("0541c5eb-1976-5797-9468-be50a93d44e2").value(), complex::Uuid::FromString("dd42c521-4ae5-485d-ad35-d1276547d2f1").value()}, // TriangleDihedralAngleFilter
-    {complex::Uuid::FromString("8133d419-1919-4dbf-a5bf-1c97282ba63f").value(), complex::Uuid::FromString("928154f6-e4bc-5a10-a9dd-1abb6a6c0f6b").value()}, // TriangleNormalFilter
-    // {complex::Uuid::FromString(insert DREAM3D UUID string here).value(), complex::Uuid::FromString(insert DREAM3DNX UUID string here).value()}, // dream3d-class-name
+    {complex::Uuid::FromString("ce1ee404-0336-536c-8aad-f9641c9458be").value(), complex::FilterTraits<AlignGeometries>::uuid}, // AlignGeometries
+    {complex::Uuid::FromString("c681caf4-22f2-5885-bbc9-a0476abc72eb").value(), complex::FilterTraits<ApplyTransformationToGeometryFilter>::uuid}, // ApplyTransformationToGeometry
+    {complex::Uuid::FromString("fab669ad-66c6-5a39-bdb7-fc47b94311ed").value(), complex::FilterTraits<ApproximatePointCloudHull>::uuid}, // ApproximatePointCloudHull
+    {complex::Uuid::FromString("656f144c-a120-5c3b-bee5-06deab438588").value(), complex::FilterTraits<CalculateFeatureSizesFilter>::uuid}, // FindSizes
+    {complex::Uuid::FromString("a9900cc3-169e-5a1b-bcf4-7569e1950d41").value(), complex::FilterTraits<CalculateTriangleAreasFilter>::uuid}, // TriangleAreaFilter
+    {complex::Uuid::FromString("f7bc0e1e-0f50-5fe0-a9e7-510b6ed83792").value(), complex::FilterTraits<ChangeAngleRepresentation>::uuid}, // ChangeAngleRepresentation
+    {complex::Uuid::FromString("a6b50fb0-eb7c-5d9b-9691-825d6a4fe772").value(), complex::FilterTraits<CombineAttributeArraysFilter>::uuid}, // CombineAttributeArrays
+    {complex::Uuid::FromString("47cafe63-83cc-5826-9521-4fb5bea684ef").value(), complex::FilterTraits<ConditionalSetValue>::uuid}, // ConditionalSetValue
+    {complex::Uuid::FromString("99836b75-144b-5126-b261-b411133b5e8a").value(), complex::FilterTraits<CopyFeatureArrayToElementArray>::uuid}, // CopyFeatureArrayToElementArray
+    {complex::Uuid::FromString("93375ef0-7367-5372-addc-baa019b1b341").value(), complex::FilterTraits<CreateAttributeMatrixFilter>::uuid}, // CreateAttributeMatrix
+    {complex::Uuid::FromString("77f392fb-c1eb-57da-a1b1-e7acf9239fb8").value(), complex::FilterTraits<CreateDataArray>::uuid}, // CreateDataArray
+    {complex::Uuid::FromString("816fbe6b-7c38-581b-b149-3f839fb65b93").value(), complex::FilterTraits<CreateDataGroup>::uuid}, // CreateDataContainer
+    {complex::Uuid::FromString("94438019-21bb-5b61-a7c3-66974b9a34dc").value(), complex::FilterTraits<CreateFeatureArrayFromElementArray>::uuid}, // CreateFeatureArrayFromElementArray
+    {complex::Uuid::FromString("f2132744-3abb-5d66-9cd9-c9a233b5c4aa").value(), complex::FilterTraits<CreateImageGeometry>::uuid}, // CreateImageGeometry
+    {complex::Uuid::FromString("baa4b7fe-31e5-5e63-a2cb-0bb9d844cfaf").value(), complex::FilterTraits<CropImageGeometry>::uuid}, // CropImageGeometry
+    {complex::Uuid::FromString("f28cbf07-f15a-53ca-8c7f-b41a11dae6cc").value(), complex::FilterTraits<CropVertexGeometry>::uuid}, // CropVertexGeometry
+    {complex::Uuid::FromString("7b1c8f46-90dd-584a-b3ba-34e16958a7d0").value(), complex::FilterTraits<DeleteData>::uuid}, // RemoveArrays
+    {complex::Uuid::FromString("3fcd4c43-9d75-5b86-aad4-4441bc914f37").value(), complex::FilterTraits<ExportDREAM3DFilter>::uuid}, // DataContainerWriter
+    {complex::Uuid::FromString("52a069b4-6a46-5810-b0ec-e0693c636034").value(), complex::FilterTraits<ExtractInternalSurfacesFromTriangleGeometry>::uuid}, // ExtractInternalSurfacesFromTriangleGeometry
+    {complex::Uuid::FromString("bf35f515-294b-55ed-8c69-211b7e69cb56").value(), complex::FilterTraits<FindArrayStatisticsFilter>::uuid}, // FindArrayStatistics
+    {complex::Uuid::FromString("29086169-20ce-52dc-b13e-824694d759aa").value(), complex::FilterTraits<FindDifferencesMap>::uuid}, // FindDifferenceMap
+    {complex::Uuid::FromString("6334ce16-cea5-5643-83b5-9573805873fa").value(), complex::FilterTraits<FindFeaturePhasesFilter>::uuid}, // FindFeaturePhases
+    {complex::Uuid::FromString("73ee33b6-7622-5004-8b88-4d145514fb6a").value(), complex::FilterTraits<FindNeighborListStatistics>::uuid}, // FindNeighborListStatistics
+    {complex::Uuid::FromString("97cf66f8-7a9b-5ec2-83eb-f8c4c8a17bac").value(), complex::FilterTraits<FindNeighbors>::uuid}, // FindNeighbors
+    {complex::Uuid::FromString("d2b0ae3d-686a-5dc0-a844-66bc0dc8f3cb").value(), complex::FilterTraits<FindSurfaceFeatures>::uuid}, // FindSurfaceFeatures
+    {complex::Uuid::FromString("0e8c0818-a3fb-57d4-a5c8-7cb8ae54a40a").value(), complex::FilterTraits<IdentifySample>::uuid}, // IdentifySample
+    {complex::Uuid::FromString("bdb978bc-96bf-5498-972c-b509c38b8d50").value(), complex::FilterTraits<ImportCSVDataFilter>::uuid}, // ReadASCIIData
+    {complex::Uuid::FromString("043cbde5-3878-5718-958f-ae75714df0df").value(), complex::FilterTraits<ImportDREAM3DFilter>::uuid}, // DataContainerReader
+    {complex::Uuid::FromString("9e98c3b0-5707-5a3b-b8b5-23ef83b02896").value(), complex::FilterTraits<ImportHDF5Dataset>::uuid}, // ImportHDF5Dataset
+    {complex::Uuid::FromString("a7007472-29e5-5d0a-89a6-1aed11b603f8").value(), complex::FilterTraits<ImportTextFilter>::uuid}, // ImportAsciDataArray
+    {complex::Uuid::FromString("dfab9921-fea3-521c-99ba-48db98e43ff8").value(), complex::FilterTraits<InitializeData>::uuid}, // InitializeData
+    {complex::Uuid::FromString("4b551c15-418d-5081-be3f-d3aeb62408e5").value(), complex::FilterTraits<InterpolatePointCloudToRegularGridFilter>::uuid}, // InterpolatePointCloudToRegularGrid
+    {complex::Uuid::FromString("6c8fb24b-5b12-551c-ba6d-ae2fa7724764").value(), complex::FilterTraits<IterativeClosestPointFilter>::uuid}, // IterativeClosestPoint
+    {complex::Uuid::FromString("601c4885-c218-5da6-9fc7-519d85d241ad").value(), complex::FilterTraits<LaplacianSmoothingFilter>::uuid}, // LaplacianSmoothing
+    {complex::Uuid::FromString("9fe34deb-99e1-5f3a-a9cc-e90c655b47ee").value(), complex::FilterTraits<MapPointCloudToRegularGridFilter>::uuid}, // MapPointCloudToRegularGrid
+    {complex::Uuid::FromString("dab5de3c-5f81-5bb5-8490-73521e1183ea").value(), complex::FilterTraits<MinNeighbors>::uuid}, // MinNeighbors
+    {complex::Uuid::FromString("fe2cbe09-8ae1-5bea-9397-fd5741091fdb").value(), complex::FilterTraits<MoveData>::uuid}, // MoveData
+    {complex::Uuid::FromString("014b7300-cf36-5ede-a751-5faf9b119dae").value(), complex::FilterTraits<MultiThresholdObjects>::uuid}, // MultiThresholdObjects
+    {complex::Uuid::FromString("686d5393-2b02-5c86-b887-dd81a8ae80f2").value(), complex::FilterTraits<MultiThresholdObjects>::uuid}, // MultiThresholdObjects2
+    {complex::Uuid::FromString("119861c5-e303-537e-b210-2e62936222e9").value(), complex::FilterTraits<PointSampleTriangleGeometryFilter>::uuid}, // PointSampleTriangleGeometry
+    {complex::Uuid::FromString("07b49e30-3900-5c34-862a-f1fb48bad568").value(), complex::FilterTraits<QuickSurfaceMeshFilter>::uuid}, // QuickSurfaceMesh
+    {complex::Uuid::FromString("0791f556-3d73-5b1e-b275-db3f7bb6850d").value(), complex::FilterTraits<RawBinaryReaderFilter>::uuid}, // RawBinaryReader
+    {complex::Uuid::FromString("379ccc67-16dd-530a-984f-177db2314bac").value(), complex::FilterTraits<RemoveFlaggedVertices>::uuid}, // RemoveFlaggedVertices
+    {complex::Uuid::FromString("53ac1638-8934-57b8-b8e5-4b91cdda23ec").value(), complex::FilterTraits<RemoveMinimumSizeFeaturesFilter>::uuid}, // MinSize
+    {complex::Uuid::FromString("53a5f731-2858-5e3e-bd43-8f2cf45d90ec").value(), complex::FilterTraits<RenameDataObject>::uuid}, // RenameAttributeArray
+    {complex::Uuid::FromString("ee29e6d6-1f59-551b-9350-a696523261d5").value(), complex::FilterTraits<RenameDataObject>::uuid}, // RenameAttributeMatrix
+    {complex::Uuid::FromString("d53c808f-004d-5fac-b125-0fffc8cc78d6").value(), complex::FilterTraits<RenameDataObject>::uuid}, // RenameDataContainer
+    {complex::Uuid::FromString("3062fc2c-76b2-5c50-92b7-edbbb424c41d").value(), complex::FilterTraits<RobustAutomaticThreshold>::uuid}, // RobustAutomaticThreshold
+    {complex::Uuid::FromString("2c5edebf-95d8-511f-b787-90ee2adf485c").value(), complex::FilterTraits<ScalarSegmentFeaturesFilter>::uuid}, // ScalarSegmentFeatures
+    {complex::Uuid::FromString("6d3a3852-6251-5d2e-b749-6257fd0d8951").value(), complex::FilterTraits<SetImageGeomOriginScalingFilter>::uuid}, // SetOriginResolutionImageGeom
+    {complex::Uuid::FromString("980c7bfd-20b2-5711-bc3b-0190b9096c34").value(), complex::FilterTraits<StlFileReaderFilter>::uuid}, // ReadStlFile
+    {complex::Uuid::FromString("0541c5eb-1976-5797-9468-be50a93d44e2").value(), complex::FilterTraits<TriangleDihedralAngleFilter>::uuid}, // TriangleDihedralAngleFilter
+    {complex::Uuid::FromString("8133d419-1919-4dbf-a5bf-1c97282ba63f").value(), complex::FilterTraits<TriangleNormalFilter>::uuid}, // TriangleNormalFilter
+    // {complex::Uuid::FromString(insert DREAM3D UUID string here).value(), complex::FilterTraits<insert DREAM3DNX filter name here>::uuid}, // dream3d-class-name
   };
 
 } // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
@@ -5,120 +5,63 @@
 // clang-format off
 namespace complex
 {
-  // Regex to grep UUIDs : {\"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\",\s\"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:\s,\s[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})*)\"},\s\/\/\s(\w+)
-  static const std::map<std::string, std::string> k_SIMPL_to_ComplexCore
+  static const std::map<complex::Uuid, complex::Uuid> k_SIMPL_to_ComplexCore
   {
     // syntax std::make_pair {Dream3d UUID , Dream3dnx UUID}, // dream3d-class-name
-    {"ce1ee404-0336-536c-8aad-f9641c9458be", "87fa9e07-6c66-45b0-80a0-cf80cc0def5d"}, // AlignGeometries
-    {"c681caf4-22f2-5885-bbc9-a0476abc72eb", "f5bbc16b-3426-4ae0-b27b-ba7862dc40fe"}, // ApplyTransformationToGeometry
-    {"fab669ad-66c6-5a39-bdb7-fc47b94311ed", "c19203b7-2217-4e52-bff4-7f611695421a"}, // ApproximatePointCloudHull
-    {"656f144c-a120-5c3b-bee5-06deab438588", "c666ee17-ca58-4969-80d0-819986c72485"}, // FindSizes
-    {"a9900cc3-169e-5a1b-bcf4-7569e1950d41", "b149addd-c0c8-4010-a264-596005eaf2a5"}, // TriangleAreaFilter
-    {"f7bc0e1e-0f50-5fe0-a9e7-510b6ed83792", "565e06e2-6fd0-4232-89c4-ee672926d565"}, // ChangeAngleRepresentation
-    {"a6b50fb0-eb7c-5d9b-9691-825d6a4fe772", "2436b614-e96d-47f0-9f6f-41d6fe97acd4"}, // CombineAttributeArrays
-    {"47cafe63-83cc-5826-9521-4fb5bea684ef", "bad9b7bd-1dc9-4f21-a889-6520e7a41881"}, // ConditionalSetValue
-    {"99836b75-144b-5126-b261-b411133b5e8a", "4c8c976a-993d-438b-bd8e-99f71114b9a1"}, // CopyFeatureArrayToElementArray
-    {"93375ef0-7367-5372-addc-baa019b1b341", "a6a28355-ee69-4874-bcac-76ed427423ed"}, // CreateAttributeMatrix
-    {"77f392fb-c1eb-57da-a1b1-e7acf9239fb8", "67041f9b-bdc6-4122-acc6-c9fe9280e90d"}, // CreateDataArray
-    {"816fbe6b-7c38-581b-b149-3f839fb65b93", "e7d2f9b8-4131-4b28-a843-ea3c6950f101"}, // CreateDataContainer
-    {"94438019-21bb-5b61-a7c3-66974b9a34dc", "50e1be47-b027-4f40-8f70-1283682ee3e7"}, // CreateFeatureArrayFromElementArray
-    {"f2132744-3abb-5d66-9cd9-c9a233b5c4aa", "c4320659-1a84-461d-939e-c7c10229a504"}, // CreateImageGeometry
-    {"baa4b7fe-31e5-5e63-a2cb-0bb9d844cfaf", "e6476737-4aa7-48ba-a702-3dfab82c96e2"}, // CropImageGeometry
-    {"f28cbf07-f15a-53ca-8c7f-b41a11dae6cc", "8b16452f-f75e-4918-9460-d3914fdc0d08"}, // CropVertexGeometry
-    {"7b1c8f46-90dd-584a-b3ba-34e16958a7d0", "bf286740-e987-49fe-a7c8-6e566e3a0606"}, // RemoveArrays
-    {"3fcd4c43-9d75-5b86-aad4-4441bc914f37", "b3a95784-2ced-41ec-8d3d-0242ac130003"}, // DataContainerWriter
-    {"52a069b4-6a46-5810-b0ec-e0693c636034", "e020f76f-a77f-4999-8bf1-9b7529f06d0a"}, // ExtractInternalSurfacesFromTriangleGeometry
-    {"bf35f515-294b-55ed-8c69-211b7e69cb56", "645ecae2-cb30-4b53-8165-c9857dfa754f"}, // FindArrayStatistics
-    {"29086169-20ce-52dc-b13e-824694d759aa", "5a0ee5b5-c135-4535-85d0-9c2058943099"}, // FindDifferenceMap
-    {"6334ce16-cea5-5643-83b5-9573805873fa", "da5bb20e-4a8e-49d9-9434-fbab7bc434fc"}, // FindFeaturePhases
-    {"73ee33b6-7622-5004-8b88-4d145514fb6a", "270a824e-414b-455e-bb7e-b38a0848990d"}, // FindNeighborListStatistics
-    {"97cf66f8-7a9b-5ec2-83eb-f8c4c8a17bac", "7177e88c-c3ab-4169-abe9-1fdaff20e598"}, // FindNeighbors
-    {"d2b0ae3d-686a-5dc0-a844-66bc0dc8f3cb", "0893e490-5d24-4c21-95e7-e8372baa8948"}, // FindSurfaceFeatures
-    {"0e8c0818-a3fb-57d4-a5c8-7cb8ae54a40a", "94d47495-5a89-4c7f-a0ee-5ff20e6bd273"}, // IdentifySample
-    {"bdb978bc-96bf-5498-972c-b509c38b8d50", "373be1f8-31cf-49f6-aa5d-e356f4f3f261"}, // ReadASCIIData
-    {"043cbde5-3878-5718-958f-ae75714df0df", "0dbd31c7-19e0-4077-83ef-f4a6459a0e2d"}, // DataContainerReader
-    {"9e98c3b0-5707-5a3b-b8b5-23ef83b02896", "8027f145-c7d5-4589-900e-b909fb3a059c"}, // ImportHDF5Dataset
-    {"a7007472-29e5-5d0a-89a6-1aed11b603f8", "25f7df3e-ca3e-4634-adda-732c0e56efd4"}, // ImportAsciDataArray
-    {"dfab9921-fea3-521c-99ba-48db98e43ff8", "447b8909-661f-446a-8c1f-72e0cb568fcf"}, // InitializeData
-    {"4b551c15-418d-5081-be3f-d3aeb62408e5", "996c4464-08f0-4268-a8a6-f9796c88cf58"}, // InterpolatePointCloudToRegularGrid
-    {"6c8fb24b-5b12-551c-ba6d-ae2fa7724764", "3a206668-fa44-418d-b78e-9fd803b8fb98"}, // IterativeClosestPoint
-    {"601c4885-c218-5da6-9fc7-519d85d241ad", "0dd0916e-9305-4a7b-98cf-a6cfb97cb501"}, // LaplacianSmoothing
-    {"9fe34deb-99e1-5f3a-a9cc-e90c655b47ee", "af53ac60-092f-4e4a-9e13-57f0034ce2c7"}, // MapPointCloudToRegularGrid
-    {"dab5de3c-5f81-5bb5-8490-73521e1183ea", "4ab5153f-6014-4e6d-bbd6-194068620389"}, // MinNeighbors
-    {"fe2cbe09-8ae1-5bea-9397-fd5741091fdb", "651e5894-ab7c-4176-b7f0-ea466c521753"}, // MoveData
-    {"014b7300-cf36-5ede-a751-5faf9b119dae", "4246245e-1011-4add-8436-0af6bed19228"}, // MultiThresholdObjects
-    {"686d5393-2b02-5c86-b887-dd81a8ae80f2", "4246245e-1011-4add-8436-0af6bed19228"}, // MultiThresholdObjects2
-    {"119861c5-e303-537e-b210-2e62936222e9", "ee34ef95-aa04-4ad3-8232-5783a880d279"}, // PointSampleTriangleGeometry
-    {"07b49e30-3900-5c34-862a-f1fb48bad568", "13dd00bd-ad49-4e04-95eb-3267952fd6e5"}, // QuickSurfaceMesh
-    {"0791f556-3d73-5b1e-b275-db3f7bb6850d", "dd159366-5f12-42db-af6d-a33592ae8a89"}, // RawBinaryReader
-    {"379ccc67-16dd-530a-984f-177db2314bac", "46099b4c-ef90-4fb3-b5e9-6c8c543c5be1"}, // RemoveFlaggedVertices
-    {"53ac1638-8934-57b8-b8e5-4b91cdda23ec", "074472d3-ba8d-4a1a-99f2-2d56a0d082a0"}, // MinSize
-    {"53a5f731-2858-5e3e-bd43-8f2cf45d90ec", "911a3aa9-d3c2-4f66-9451-8861c4b726d5"}, // RenameAttributeArray
-    {"ee29e6d6-1f59-551b-9350-a696523261d5", "911a3aa9-d3c2-4f66-9451-8861c4b726d5"}, // RenameAttributeMatrix
-    {"d53c808f-004d-5fac-b125-0fffc8cc78d6", "911a3aa9-d3c2-4f66-9451-8861c4b726d5"}, // RenameDataContainer
-    {"3062fc2c-76b2-5c50-92b7-edbbb424c41d", "ade392e6-f0da-4cf3-bf11-dfe69e200b49"}, // RobustAutomaticThreshold
-    {"2c5edebf-95d8-511f-b787-90ee2adf485c", "e067cd97-9bbf-4c92-89a6-3cb4fdb76c93"}, // ScalarSegmentFeatures
-    {"6d3a3852-6251-5d2e-b749-6257fd0d8951", "057bc7fd-c84a-4902-9397-87e51b1b1fe0"}, // SetOriginResolutionImageGeom
-    {"980c7bfd-20b2-5711-bc3b-0190b9096c34", "2f64bd45-9d28-4254-9e07-6aa7c6d3d015"}, // ReadStlFile
-    {"0541c5eb-1976-5797-9468-be50a93d44e2", "dd42c521-4ae5-485d-ad35-d1276547d2f1"}, // TriangleDihedralAngleFilter
-    {"8133d419-1919-4dbf-a5bf-1c97282ba63f", "928154f6-e4bc-5a10-a9dd-1abb6a6c0f6b"}, // TriangleNormalFilter
-    // {insert DREAM3D UUID here, insert DREAM3DNX UUID here}, // dream3d-class-name
-  };
-
-  static const std::map<std::string, std::string> k_ComplexCore_to_SIMPL
-  {
-    // syntax std::make_pair {Dream3dnx UUID , Dream3d UUID}, // dream3dnx-class-name
-    {"87fa9e07-6c66-45b0-80a0-cf80cc0def5d", "ce1ee404-0336-536c-8aad-f9641c9458be"}, // AlignGeometries
-    {"f5bbc16b-3426-4ae0-b27b-ba7862dc40fe", "c681caf4-22f2-5885-bbc9-a0476abc72eb"}, // ApplyTransformationToGeometryFilter
-    {"c19203b7-2217-4e52-bff4-7f611695421a", "fab669ad-66c6-5a39-bdb7-fc47b94311ed"}, // ApproximatePointCloudHull
-    {"c666ee17-ca58-4969-80d0-819986c72485", "656f144c-a120-5c3b-bee5-06deab438588"}, // CalculateFeatureSizesFilter
-    {"b149addd-c0c8-4010-a264-596005eaf2a5", "a9900cc3-169e-5a1b-bcf4-7569e1950d41"}, // CalculateTriangleAreasFilter
-    {"565e06e2-6fd0-4232-89c4-ee672926d565", "f7bc0e1e-0f50-5fe0-a9e7-510b6ed83792"}, // ChangeAngleRepresentation
-    {"2436b614-e96d-47f0-9f6f-41d6fe97acd4", "a6b50fb0-eb7c-5d9b-9691-825d6a4fe772"}, // CombineAttributeArrays
-    {"bad9b7bd-1dc9-4f21-a889-6520e7a41881", "47cafe63-83cc-5826-9521-4fb5bea684ef"}, // ConditionalSetValue
-    {"4c8c976a-993d-438b-bd8e-99f71114b9a1", "99836b75-144b-5126-b261-b411133b5e8a"}, // CopyFeatureArrayToElementArray
-    {"a6a28355-ee69-4874-bcac-76ed427423ed", "93375ef0-7367-5372-addc-baa019b1b341"}, // CreateAttributeMatrixFilter
-    {"67041f9b-bdc6-4122-acc6-c9fe9280e90d", "77f392fb-c1eb-57da-a1b1-e7acf9239fb8"}, // CreateDataArray
-    {"e7d2f9b8-4131-4b28-a843-ea3c6950f101", "816fbe6b-7c38-581b-b149-3f839fb65b93"}, // CreateDataGroup
-    {"50e1be47-b027-4f40-8f70-1283682ee3e7", "94438019-21bb-5b61-a7c3-66974b9a34dc"}, // CreateFeatureArrayFromElementArray
-    {"c4320659-1a84-461d-939e-c7c10229a504", "f2132744-3abb-5d66-9cd9-c9a233b5c4aa"}, // CreateImageGeometry
-    {"e6476737-4aa7-48ba-a702-3dfab82c96e2", "baa4b7fe-31e5-5e63-a2cb-0bb9d844cfaf"}, // CropImageGeometry
-    {"8b16452f-f75e-4918-9460-d3914fdc0d08", "f28cbf07-f15a-53ca-8c7f-b41a11dae6cc"}, // CropVertexGeometry
-    {"bf286740-e987-49fe-a7c8-6e566e3a0606", "7b1c8f46-90dd-584a-b3ba-34e16958a7d0"}, // DeleteData
-    {"b3a95784-2ced-41ec-8d3d-0242ac130003", "3fcd4c43-9d75-5b86-aad4-4441bc914f37"}, // ExportDREAM3DFilter
-    {"e020f76f-a77f-4999-8bf1-9b7529f06d0a", "52a069b4-6a46-5810-b0ec-e0693c636034"}, // ExtractInternalSurfacesFromTriangleGeometry
-    {"645ecae2-cb30-4b53-8165-c9857dfa754f", "bf35f515-294b-55ed-8c69-211b7e69cb56"}, // FindArrayStatisticsFilter
-    {"5a0ee5b5-c135-4535-85d0-9c2058943099", "29086169-20ce-52dc-b13e-824694d759aa"}, // FindDifferencesMap
-    {"da5bb20e-4a8e-49d9-9434-fbab7bc434fc", "6334ce16-cea5-5643-83b5-9573805873fa"}, // FindFeaturePhasesFilter
-    {"270a824e-414b-455e-bb7e-b38a0848990d", "73ee33b6-7622-5004-8b88-4d145514fb6a"}, // FindNeighborListStatistics
-    {"7177e88c-c3ab-4169-abe9-1fdaff20e598", "97cf66f8-7a9b-5ec2-83eb-f8c4c8a17bac"}, // FindNeighbors
-    {"0893e490-5d24-4c21-95e7-e8372baa8948", "d2b0ae3d-686a-5dc0-a844-66bc0dc8f3cb"}, // FindSurfaceFeatures
-    {"94d47495-5a89-4c7f-a0ee-5ff20e6bd273", "0e8c0818-a3fb-57d4-a5c8-7cb8ae54a40a"}, // IdentifySample
-    {"373be1f8-31cf-49f6-aa5d-e356f4f3f261", "bdb978bc-96bf-5498-972c-b509c38b8d50"}, // ImportCSVDataFilter
-    {"0dbd31c7-19e0-4077-83ef-f4a6459a0e2d", "043cbde5-3878-5718-958f-ae75714df0df"}, // ImportDREAM3DFilter
-    {"8027f145-c7d5-4589-900e-b909fb3a059c", "9e98c3b0-5707-5a3b-b8b5-23ef83b02896"}, // ImportHDF5Dataset
-    {"25f7df3e-ca3e-4634-adda-732c0e56efd4", "a7007472-29e5-5d0a-89a6-1aed11b603f8"}, // ImportTextFilter
-    {"447b8909-661f-446a-8c1f-72e0cb568fcf", "dfab9921-fea3-521c-99ba-48db98e43ff8"}, // InitializeData
-    {"996c4464-08f0-4268-a8a6-f9796c88cf58", "4b551c15-418d-5081-be3f-d3aeb62408e5"}, // InterpolatePointCloudToRegularGridFilter
-    {"3a206668-fa44-418d-b78e-9fd803b8fb98", "6c8fb24b-5b12-551c-ba6d-ae2fa7724764"}, // IterativeClosestPointFilter
-    {"0dd0916e-9305-4a7b-98cf-a6cfb97cb501", "601c4885-c218-5da6-9fc7-519d85d241ad"}, // LaplacianSmoothingFilter
-    {"af53ac60-092f-4e4a-9e13-57f0034ce2c7", "9fe34deb-99e1-5f3a-a9cc-e90c655b47ee"}, // MapPointCloudToRegularGridFilter
-    {"4ab5153f-6014-4e6d-bbd6-194068620389", "dab5de3c-5f81-5bb5-8490-73521e1183ea"}, // MinNeighbors
-    {"651e5894-ab7c-4176-b7f0-ea466c521753", "fe2cbe09-8ae1-5bea-9397-fd5741091fdb"}, // MoveData
-    {"4246245e-1011-4add-8436-0af6bed19228", "686d5393-2b02-5c86-b887-dd81a8ae80f2"}, // MultiThresholdObjects
-    {"ee34ef95-aa04-4ad3-8232-5783a880d279", "014b7300-cf36-5ede-a751-5faf9b119dae , 119861c5-e303-537e-b210-2e62936222e9"}, // PointSampleTriangleGeometryFilter
-    {"13dd00bd-ad49-4e04-95eb-3267952fd6e5", "07b49e30-3900-5c34-862a-f1fb48bad568"}, // QuickSurfaceMeshFilter
-    {"dd159366-5f12-42db-af6d-a33592ae8a89", "0791f556-3d73-5b1e-b275-db3f7bb6850d"}, // RawBinaryReaderFilter
-    {"46099b4c-ef90-4fb3-b5e9-6c8c543c5be1", "379ccc67-16dd-530a-984f-177db2314bac"}, // RemoveFlaggedVertices
-    {"074472d3-ba8d-4a1a-99f2-2d56a0d082a0", "53ac1638-8934-57b8-b8e5-4b91cdda23ec"}, // RemoveMinimumSizeFeaturesFilter
-    {"911a3aa9-d3c2-4f66-9451-8861c4b726d5", "53a5f731-2858-5e3e-bd43-8f2cf45d90ec , ee29e6d6-1f59-551b-9350-a696523261d5 , d53c808f-004d-5fac-b125-0fffc8cc78d6"}, // RenameDataObject
-    {"ade392e6-f0da-4cf3-bf11-dfe69e200b49", "3062fc2c-76b2-5c50-92b7-edbbb424c41d"}, // RobustAutomaticThreshold
-    {"e067cd97-9bbf-4c92-89a6-3cb4fdb76c93", "2c5edebf-95d8-511f-b787-90ee2adf485c"}, // ScalarSegmentFeaturesFilter
-    {"057bc7fd-c84a-4902-9397-87e51b1b1fe0", "6d3a3852-6251-5d2e-b749-6257fd0d8951"}, // SetImageGeomOriginScalingFilter
-    {"2f64bd45-9d28-4254-9e07-6aa7c6d3d015", "980c7bfd-20b2-5711-bc3b-0190b9096c34"}, // StlFileReaderFilter
-    {"dd42c521-4ae5-485d-ad35-d1276547d2f1", "0541c5eb-1976-5797-9468-be50a93d44e2"}, // TriangleDihedralAngleFilter
-    {"928154f6-e4bc-5a10-a9dd-1abb6a6c0f6b", "8133d419-1919-4dbf-a5bf-1c97282ba63f"}, // TriangleNormalFilter
-    // {insert DREAM3DNX UUID here, insert DREAM3D UUID here}, // dream3dnx-class-name
+    {complex::Uuid::FromString("ce1ee404-0336-536c-8aad-f9641c9458be").value(), complex::Uuid::FromString("87fa9e07-6c66-45b0-80a0-cf80cc0def5d").value()}, // AlignGeometries
+    {complex::Uuid::FromString("c681caf4-22f2-5885-bbc9-a0476abc72eb").value(), complex::Uuid::FromString("f5bbc16b-3426-4ae0-b27b-ba7862dc40fe").value()}, // ApplyTransformationToGeometry
+    {complex::Uuid::FromString("fab669ad-66c6-5a39-bdb7-fc47b94311ed").value(), complex::Uuid::FromString("c19203b7-2217-4e52-bff4-7f611695421a").value()}, // ApproximatePointCloudHull
+    {complex::Uuid::FromString("656f144c-a120-5c3b-bee5-06deab438588").value(), complex::Uuid::FromString("c666ee17-ca58-4969-80d0-819986c72485").value()}, // FindSizes
+    {complex::Uuid::FromString("a9900cc3-169e-5a1b-bcf4-7569e1950d41").value(), complex::Uuid::FromString("b149addd-c0c8-4010-a264-596005eaf2a5").value()}, // TriangleAreaFilter
+    {complex::Uuid::FromString("f7bc0e1e-0f50-5fe0-a9e7-510b6ed83792").value(), complex::Uuid::FromString("565e06e2-6fd0-4232-89c4-ee672926d565").value()}, // ChangeAngleRepresentation
+    {complex::Uuid::FromString("a6b50fb0-eb7c-5d9b-9691-825d6a4fe772").value(), complex::Uuid::FromString("2436b614-e96d-47f0-9f6f-41d6fe97acd4").value()}, // CombineAttributeArrays
+    {complex::Uuid::FromString("47cafe63-83cc-5826-9521-4fb5bea684ef").value(), complex::Uuid::FromString("bad9b7bd-1dc9-4f21-a889-6520e7a41881").value()}, // ConditionalSetValue
+    {complex::Uuid::FromString("99836b75-144b-5126-b261-b411133b5e8a").value(), complex::Uuid::FromString("4c8c976a-993d-438b-bd8e-99f71114b9a1").value()}, // CopyFeatureArrayToElementArray
+    {complex::Uuid::FromString("93375ef0-7367-5372-addc-baa019b1b341").value(), complex::Uuid::FromString("a6a28355-ee69-4874-bcac-76ed427423ed").value()}, // CreateAttributeMatrix
+    {complex::Uuid::FromString("77f392fb-c1eb-57da-a1b1-e7acf9239fb8").value(), complex::Uuid::FromString("67041f9b-bdc6-4122-acc6-c9fe9280e90d").value()}, // CreateDataArray
+    {complex::Uuid::FromString("816fbe6b-7c38-581b-b149-3f839fb65b93").value(), complex::Uuid::FromString("e7d2f9b8-4131-4b28-a843-ea3c6950f101").value()}, // CreateDataContainer
+    {complex::Uuid::FromString("94438019-21bb-5b61-a7c3-66974b9a34dc").value(), complex::Uuid::FromString("50e1be47-b027-4f40-8f70-1283682ee3e7").value()}, // CreateFeatureArrayFromElementArray
+    {complex::Uuid::FromString("f2132744-3abb-5d66-9cd9-c9a233b5c4aa").value(), complex::Uuid::FromString("c4320659-1a84-461d-939e-c7c10229a504").value()}, // CreateImageGeometry
+    {complex::Uuid::FromString("baa4b7fe-31e5-5e63-a2cb-0bb9d844cfaf").value(), complex::Uuid::FromString("e6476737-4aa7-48ba-a702-3dfab82c96e2").value()}, // CropImageGeometry
+    {complex::Uuid::FromString("f28cbf07-f15a-53ca-8c7f-b41a11dae6cc").value(), complex::Uuid::FromString("8b16452f-f75e-4918-9460-d3914fdc0d08").value()}, // CropVertexGeometry
+    {complex::Uuid::FromString("7b1c8f46-90dd-584a-b3ba-34e16958a7d0").value(), complex::Uuid::FromString("bf286740-e987-49fe-a7c8-6e566e3a0606").value()}, // RemoveArrays
+    {complex::Uuid::FromString("3fcd4c43-9d75-5b86-aad4-4441bc914f37").value(), complex::Uuid::FromString("b3a95784-2ced-41ec-8d3d-0242ac130003").value()}, // DataContainerWriter
+    {complex::Uuid::FromString("52a069b4-6a46-5810-b0ec-e0693c636034").value(), complex::Uuid::FromString("e020f76f-a77f-4999-8bf1-9b7529f06d0a").value()}, // ExtractInternalSurfacesFromTriangleGeometry
+    {complex::Uuid::FromString("bf35f515-294b-55ed-8c69-211b7e69cb56").value(), complex::Uuid::FromString("645ecae2-cb30-4b53-8165-c9857dfa754f").value()}, // FindArrayStatistics
+    {complex::Uuid::FromString("29086169-20ce-52dc-b13e-824694d759aa").value(), complex::Uuid::FromString("5a0ee5b5-c135-4535-85d0-9c2058943099").value()}, // FindDifferenceMap
+    {complex::Uuid::FromString("6334ce16-cea5-5643-83b5-9573805873fa").value(), complex::Uuid::FromString("da5bb20e-4a8e-49d9-9434-fbab7bc434fc").value()}, // FindFeaturePhases
+    {complex::Uuid::FromString("73ee33b6-7622-5004-8b88-4d145514fb6a").value(), complex::Uuid::FromString("270a824e-414b-455e-bb7e-b38a0848990d").value()}, // FindNeighborListStatistics
+    {complex::Uuid::FromString("97cf66f8-7a9b-5ec2-83eb-f8c4c8a17bac").value(), complex::Uuid::FromString("7177e88c-c3ab-4169-abe9-1fdaff20e598").value()}, // FindNeighbors
+    {complex::Uuid::FromString("d2b0ae3d-686a-5dc0-a844-66bc0dc8f3cb").value(), complex::Uuid::FromString("0893e490-5d24-4c21-95e7-e8372baa8948").value()}, // FindSurfaceFeatures
+    {complex::Uuid::FromString("0e8c0818-a3fb-57d4-a5c8-7cb8ae54a40a").value(), complex::Uuid::FromString("94d47495-5a89-4c7f-a0ee-5ff20e6bd273").value()}, // IdentifySample
+    {complex::Uuid::FromString("bdb978bc-96bf-5498-972c-b509c38b8d50").value(), complex::Uuid::FromString("373be1f8-31cf-49f6-aa5d-e356f4f3f261").value()}, // ReadASCIIData
+    {complex::Uuid::FromString("043cbde5-3878-5718-958f-ae75714df0df").value(), complex::Uuid::FromString("0dbd31c7-19e0-4077-83ef-f4a6459a0e2d").value()}, // DataContainerReader
+    {complex::Uuid::FromString("9e98c3b0-5707-5a3b-b8b5-23ef83b02896").value(), complex::Uuid::FromString("8027f145-c7d5-4589-900e-b909fb3a059c").value()}, // ImportHDF5Dataset
+    {complex::Uuid::FromString("a7007472-29e5-5d0a-89a6-1aed11b603f8").value(), complex::Uuid::FromString("25f7df3e-ca3e-4634-adda-732c0e56efd4").value()}, // ImportAsciDataArray
+    {complex::Uuid::FromString("dfab9921-fea3-521c-99ba-48db98e43ff8").value(), complex::Uuid::FromString("447b8909-661f-446a-8c1f-72e0cb568fcf").value()}, // InitializeData
+    {complex::Uuid::FromString("4b551c15-418d-5081-be3f-d3aeb62408e5").value(), complex::Uuid::FromString("996c4464-08f0-4268-a8a6-f9796c88cf58").value()}, // InterpolatePointCloudToRegularGrid
+    {complex::Uuid::FromString("6c8fb24b-5b12-551c-ba6d-ae2fa7724764").value(), complex::Uuid::FromString("3a206668-fa44-418d-b78e-9fd803b8fb98").value()}, // IterativeClosestPoint
+    {complex::Uuid::FromString("601c4885-c218-5da6-9fc7-519d85d241ad").value(), complex::Uuid::FromString("0dd0916e-9305-4a7b-98cf-a6cfb97cb501").value()}, // LaplacianSmoothing
+    {complex::Uuid::FromString("9fe34deb-99e1-5f3a-a9cc-e90c655b47ee").value(), complex::Uuid::FromString("af53ac60-092f-4e4a-9e13-57f0034ce2c7").value()}, // MapPointCloudToRegularGrid
+    {complex::Uuid::FromString("dab5de3c-5f81-5bb5-8490-73521e1183ea").value(), complex::Uuid::FromString("4ab5153f-6014-4e6d-bbd6-194068620389").value()}, // MinNeighbors
+    {complex::Uuid::FromString("fe2cbe09-8ae1-5bea-9397-fd5741091fdb").value(), complex::Uuid::FromString("651e5894-ab7c-4176-b7f0-ea466c521753").value()}, // MoveData
+    {complex::Uuid::FromString("014b7300-cf36-5ede-a751-5faf9b119dae").value(), complex::Uuid::FromString("4246245e-1011-4add-8436-0af6bed19228").value()}, // MultiThresholdObjects
+    {complex::Uuid::FromString("686d5393-2b02-5c86-b887-dd81a8ae80f2").value(), complex::Uuid::FromString("4246245e-1011-4add-8436-0af6bed19228").value()}, // MultiThresholdObjects2
+    {complex::Uuid::FromString("119861c5-e303-537e-b210-2e62936222e9").value(), complex::Uuid::FromString("ee34ef95-aa04-4ad3-8232-5783a880d279").value()}, // PointSampleTriangleGeometry
+    {complex::Uuid::FromString("07b49e30-3900-5c34-862a-f1fb48bad568").value(), complex::Uuid::FromString("13dd00bd-ad49-4e04-95eb-3267952fd6e5").value()}, // QuickSurfaceMesh
+    {complex::Uuid::FromString("0791f556-3d73-5b1e-b275-db3f7bb6850d").value(), complex::Uuid::FromString("dd159366-5f12-42db-af6d-a33592ae8a89").value()}, // RawBinaryReader
+    {complex::Uuid::FromString("379ccc67-16dd-530a-984f-177db2314bac").value(), complex::Uuid::FromString("46099b4c-ef90-4fb3-b5e9-6c8c543c5be1").value()}, // RemoveFlaggedVertices
+    {complex::Uuid::FromString("53ac1638-8934-57b8-b8e5-4b91cdda23ec").value(), complex::Uuid::FromString("074472d3-ba8d-4a1a-99f2-2d56a0d082a0").value()}, // MinSize
+    {complex::Uuid::FromString("53a5f731-2858-5e3e-bd43-8f2cf45d90ec").value(), complex::Uuid::FromString("911a3aa9-d3c2-4f66-9451-8861c4b726d5").value()}, // RenameAttributeArray
+    {complex::Uuid::FromString("ee29e6d6-1f59-551b-9350-a696523261d5").value(), complex::Uuid::FromString("911a3aa9-d3c2-4f66-9451-8861c4b726d5").value()}, // RenameAttributeMatrix
+    {complex::Uuid::FromString("d53c808f-004d-5fac-b125-0fffc8cc78d6").value(), complex::Uuid::FromString("911a3aa9-d3c2-4f66-9451-8861c4b726d5").value()}, // RenameDataContainer
+    {complex::Uuid::FromString("3062fc2c-76b2-5c50-92b7-edbbb424c41d").value(), complex::Uuid::FromString("ade392e6-f0da-4cf3-bf11-dfe69e200b49").value()}, // RobustAutomaticThreshold
+    {complex::Uuid::FromString("2c5edebf-95d8-511f-b787-90ee2adf485c").value(), complex::Uuid::FromString("e067cd97-9bbf-4c92-89a6-3cb4fdb76c93").value()}, // ScalarSegmentFeatures
+    {complex::Uuid::FromString("6d3a3852-6251-5d2e-b749-6257fd0d8951").value(), complex::Uuid::FromString("057bc7fd-c84a-4902-9397-87e51b1b1fe0").value()}, // SetOriginResolutionImageGeom
+    {complex::Uuid::FromString("980c7bfd-20b2-5711-bc3b-0190b9096c34").value(), complex::Uuid::FromString("2f64bd45-9d28-4254-9e07-6aa7c6d3d015").value()}, // ReadStlFile
+    {complex::Uuid::FromString("0541c5eb-1976-5797-9468-be50a93d44e2").value(), complex::Uuid::FromString("dd42c521-4ae5-485d-ad35-d1276547d2f1").value()}, // TriangleDihedralAngleFilter
+    {complex::Uuid::FromString("8133d419-1919-4dbf-a5bf-1c97282ba63f").value(), complex::Uuid::FromString("928154f6-e4bc-5a10-a9dd-1abb6a6c0f6b").value()}, // TriangleNormalFilter
+    // {complex::Uuid::FromString(insert DREAM3D UUID string here).value(), complex::Uuid::FromString(insert DREAM3DNX UUID string here).value()}, // dream3d-class-name
   };
 
 } // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCorePlugin.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCorePlugin.cpp
@@ -31,4 +31,14 @@ std::vector<complex::H5::IDataFactory*> ComplexCorePlugin::getDataFactories() co
   return {};
 }
 
+std::map<std::string, std::string> ComplexCorePlugin::getSimplToComplexMap() const
+{
+  return complex::k_SIMPL_to_ComplexCore;
+}
+
+std::map<std::string, std::string> ComplexCorePlugin::getComplexToSimplMap() const
+{
+  return complex::k_ComplexCore_to_SIMPL;
+}
+
 COMPLEX_DEF_PLUGIN(ComplexCorePlugin)

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCorePlugin.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCorePlugin.cpp
@@ -1,5 +1,7 @@
 #include "ComplexCorePlugin.hpp"
+
 #include "ComplexCore/ComplexCore_filter_registration.hpp"
+#include "ComplexCoreLegacyUUIDMapping.hpp"
 
 using namespace complex;
 
@@ -31,14 +33,9 @@ std::vector<complex::H5::IDataFactory*> ComplexCorePlugin::getDataFactories() co
   return {};
 }
 
-std::map<std::string, std::string> ComplexCorePlugin::getSimplToComplexMap() const
+std::map<complex::Uuid, complex::Uuid> ComplexCorePlugin::getSimplToComplexMap() const
 {
   return complex::k_SIMPL_to_ComplexCore;
-}
-
-std::map<std::string, std::string> ComplexCorePlugin::getComplexToSimplMap() const
-{
-  return complex::k_ComplexCore_to_SIMPL;
 }
 
 COMPLEX_DEF_PLUGIN(ComplexCorePlugin)

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCorePlugin.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCorePlugin.hpp
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "ComplexCoreLegacyUUIDMapping.hpp"
 #include "complex/Plugin/AbstractPlugin.hpp"
 #include "complex/Utilities/Parsing/HDF5/H5IDataFactory.hpp"
 
@@ -25,4 +26,24 @@ public:
    * @return std::vector<complex::H5::IDataFactory*>
    */
   std::vector<complex::H5::IDataFactory*> getDataFactories() const override;
+
+  /**
+   * @brief Returns a map of UUIDs as strings, where SIMPL UUIDs are keys to
+   * their complex counterpart
+   * @return std::map<std::string, std::string>
+   */
+  std::map<std::string, std::string> getSimplToComplexMap() const override
+  {
+    return complex::k_SIMPL_to_ComplexCore;
+  }
+
+  /**
+   * @brief Returns a map of UUIDs as strings, where Complex UUIDs are keys to
+   * their SIMPL counterpart(s)
+   * @return std::map<std::string, std::string>
+   */
+  std::map<std::string, std::string> getComplexToSimplMap() const override
+  {
+    return complex::k_ComplexCore_to_SIMPL;
+  }
 };

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCorePlugin.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCorePlugin.hpp
@@ -2,7 +2,6 @@
 
 #include <vector>
 
-#include "ComplexCoreLegacyUUIDMapping.hpp"
 #include "complex/Plugin/AbstractPlugin.hpp"
 #include "complex/Utilities/Parsing/HDF5/H5IDataFactory.hpp"
 
@@ -30,14 +29,8 @@ public:
   /**
    * @brief Returns a map of UUIDs as strings, where SIMPL UUIDs are keys to
    * their complex counterpart
-   * @return std::map<std::string, std::string>
+   * @return std::map<complex::Uuid, complex::Uuid>
    */
-  std::map<std::string, std::string> getSimplToComplexMap() const override;
+  std::map<complex::Uuid, complex::Uuid> getSimplToComplexMap() const override;
 
-  /**
-   * @brief Returns a map of UUIDs as strings, where Complex UUIDs are keys to
-   * their SIMPL counterpart(s)
-   * @return std::map<std::string, std::string>
-   */
-  std::map<std::string, std::string> getComplexToSimplMap() const override;
 };

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCorePlugin.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCorePlugin.hpp
@@ -32,18 +32,12 @@ public:
    * their complex counterpart
    * @return std::map<std::string, std::string>
    */
-  std::map<std::string, std::string> getSimplToComplexMap() const override
-  {
-    return complex::k_SIMPL_to_ComplexCore;
-  }
+  std::map<std::string, std::string> getSimplToComplexMap() const override;
 
   /**
    * @brief Returns a map of UUIDs as strings, where Complex UUIDs are keys to
    * their SIMPL counterpart(s)
    * @return std::map<std::string, std::string>
    */
-  std::map<std::string, std::string> getComplexToSimplMap() const override
-  {
-    return complex::k_ComplexCore_to_SIMPL;
-  }
+  std::map<std::string, std::string> getComplexToSimplMap() const override;
 };

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCorePlugin.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCorePlugin.hpp
@@ -32,5 +32,4 @@ public:
    * @return std::map<complex::Uuid, complex::Uuid>
    */
   std::map<complex::Uuid, complex::Uuid> getSimplToComplexMap() const override;
-
 };

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateFeatureSizesFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateFeatureSizesFilter.hpp
@@ -124,4 +124,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, CalculateFeatureSizesFilter, "656f144c-a120-5c3b-bee5-06deab438588");
+COMPLEX_DEF_FILTER_TRAITS(complex, CalculateFeatureSizesFilter, "c666ee17-ca58-4969-80d0-819986c72485");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateTriangleAreasFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateTriangleAreasFilter.hpp
@@ -93,4 +93,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, CalculateTriangleAreasFilter, "a9900cc3-169e-5a1b-bcf4-7569e1950d41");
+COMPLEX_DEF_FILTER_TRAITS(complex, CalculateTriangleAreasFilter, "b149addd-c0c8-4010-a264-596005eaf2a5");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.hpp
@@ -97,4 +97,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, ConditionalSetValue, "bad9b7bd-1dc9-5f21-a889-6520e7a41881");
+COMPLEX_DEF_FILTER_TRAITS(complex, ConditionalSetValue, "bad9b7bd-1dc9-4f21-a889-6520e7a41881");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateImageGeometry.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateImageGeometry.hpp
@@ -96,4 +96,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, CreateImageGeometry, "c4320659-1a84-561d-939e-c7c10229a504");
+COMPLEX_DEF_FILTER_TRAITS(complex, CreateImageGeometry, "c4320659-1a84-461d-939e-c7c10229a504");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExportDREAM3DFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExportDREAM3DFilter.hpp
@@ -91,4 +91,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, ExportDREAM3DFilter, "b3a95784-2ced-11ec-8d3d-0242ac130003");
+COMPLEX_DEF_FILTER_TRAITS(complex, ExportDREAM3DFilter, "b3a95784-2ced-41ec-8d3d-0242ac130003");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportCSVDataFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportCSVDataFilter.hpp
@@ -107,4 +107,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, ImportCSVDataFilter, "bdb978bc-96bf-5498-972c-b509c38b8d50");
+COMPLEX_DEF_FILTER_TRAITS(complex, ImportCSVDataFilter, "373be1f8-31cf-49f6-aa5d-e356f4f3f261");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.hpp
@@ -102,4 +102,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, PointSampleTriangleGeometryFilter, "ee34ef95-aa04-5ad3-8232-5783a880d279");
+COMPLEX_DEF_FILTER_TRAITS(complex, PointSampleTriangleGeometryFilter, "ee34ef95-aa04-4ad3-8232-5783a880d279");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveMinimumSizeFeaturesFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveMinimumSizeFeaturesFilter.hpp
@@ -96,4 +96,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, RemoveMinimumSizeFeaturesFilter, "53ac1638-8934-57b8-b8e5-4b91cdda23ec");
+COMPLEX_DEF_FILTER_TRAITS(complex, RemoveMinimumSizeFeaturesFilter, "074472d3-ba8d-4a1a-99f2-2d56a0d082a0");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RenameDataObject.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RenameDataObject.hpp
@@ -89,4 +89,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, RenameDataObject, "d53c808f-004d-5fac-b125-0fffc8cc78d6");
+COMPLEX_DEF_FILTER_TRAITS(complex, RenameDataObject, "911a3aa9-d3c2-4f66-9451-8861c4b726d5");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/SetImageGeomOriginScalingFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/SetImageGeomOriginScalingFilter.hpp
@@ -86,4 +86,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, SetImageGeomOriginScalingFilter, "6d3a3852-6251-5d2e-b749-6257fd0d8951");
+COMPLEX_DEF_FILTER_TRAITS(complex, SetImageGeomOriginScalingFilter, "057bc7fd-c84a-4902-9397-87e51b1b1fe0");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.hpp
@@ -100,4 +100,4 @@ protected:
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, StlFileReaderFilter, "980c7bfd-20b2-5711-bc3b-0190b9096c34");
+COMPLEX_DEF_FILTER_TRAITS(complex, StlFileReaderFilter, "2f64bd45-9d28-4254-9e07-6aa7c6d3d015");

--- a/src/Plugins/TestOne/src/TestOne/TestOnePlugin.cpp
+++ b/src/Plugins/TestOne/src/TestOne/TestOnePlugin.cpp
@@ -25,4 +25,9 @@ std::vector<complex::H5::IDataFactory*> TestOnePlugin::getDataFactories() const
   return {};
 }
 
+std::map<complex::Uuid, complex::Uuid> TestOnePlugin::getSimplToComplexMap() const
+{
+  return {};
+}
+
 COMPLEX_DEF_PLUGIN(TestOnePlugin)

--- a/src/Plugins/TestOne/src/TestOne/TestOnePlugin.hpp
+++ b/src/Plugins/TestOne/src/TestOne/TestOnePlugin.hpp
@@ -25,4 +25,24 @@ public:
    * @return std::vector<complex::H5::IDataFactory*>
    */
   std::vector<complex::H5::IDataFactory*> getDataFactories() const override;
+
+  /**
+   * @brief Returns a map of UUIDs as strings, where SIMPL UUIDs are keys to
+   * their complex counterpart
+   * @return std::map<std::string, std::string>
+   */
+  std::map<std::string, std::string> getSimplToComplexMap() const override
+  {
+    return {};
+  }
+
+  /**
+   * @brief Returns a map of UUIDs as strings, where Complex UUIDs are keys to
+   * their SIMPL counterpart(s)
+   * @return std::map<std::string, std::string>
+   */
+  std::map<std::string, std::string> getComplexToSimplMap() const override
+  {
+    return {};
+  }
 };

--- a/src/Plugins/TestOne/src/TestOne/TestOnePlugin.hpp
+++ b/src/Plugins/TestOne/src/TestOne/TestOnePlugin.hpp
@@ -29,20 +29,7 @@ public:
   /**
    * @brief Returns a map of UUIDs as strings, where SIMPL UUIDs are keys to
    * their complex counterpart
-   * @return std::map<std::string, std::string>
+   * @return std::map<complex::Uuid, complex::Uuid>
    */
-  std::map<std::string, std::string> getSimplToComplexMap() const override
-  {
-    return {};
-  }
-
-  /**
-   * @brief Returns a map of UUIDs as strings, where Complex UUIDs are keys to
-   * their SIMPL counterpart(s)
-   * @return std::map<std::string, std::string>
-   */
-  std::map<std::string, std::string> getComplexToSimplMap() const override
-  {
-    return {};
-  }
+  std::map<complex::Uuid, complex::Uuid> getSimplToComplexMap() const override;
 };

--- a/src/Plugins/TestTwo/src/TestTwo/TestTwoPlugin.cpp
+++ b/src/Plugins/TestTwo/src/TestTwo/TestTwoPlugin.cpp
@@ -25,4 +25,9 @@ std::vector<complex::H5::IDataFactory*> TestTwoPlugin::getDataFactories() const
   return {};
 }
 
+std::map<complex::Uuid, complex::Uuid> TestTwoPlugin::getSimplToComplexMap() const
+{
+  return {};
+}
+
 COMPLEX_DEF_PLUGIN(TestTwoPlugin)

--- a/src/Plugins/TestTwo/src/TestTwo/TestTwoPlugin.hpp
+++ b/src/Plugins/TestTwo/src/TestTwo/TestTwoPlugin.hpp
@@ -25,4 +25,24 @@ public:
    * @return std::vector<complex::H5::IDataFactory*>
    */
   std::vector<complex::H5::IDataFactory*> getDataFactories() const override;
+
+  /**
+   * @brief Returns a map of UUIDs as strings, where SIMPL UUIDs are keys to
+   * their complex counterpart
+   * @return std::map<std::string, std::string>
+   */
+  std::map<std::string, std::string> getSimplToComplexMap() const override
+  {
+    return {};
+  }
+
+  /**
+   * @brief Returns a map of UUIDs as strings, where Complex UUIDs are keys to
+   * their SIMPL counterpart(s)
+   * @return std::map<std::string, std::string>
+   */
+  std::map<std::string, std::string> getComplexToSimplMap() const override
+  {
+    return {};
+  }
 };

--- a/src/Plugins/TestTwo/src/TestTwo/TestTwoPlugin.hpp
+++ b/src/Plugins/TestTwo/src/TestTwo/TestTwoPlugin.hpp
@@ -29,20 +29,7 @@ public:
   /**
    * @brief Returns a map of UUIDs as strings, where SIMPL UUIDs are keys to
    * their complex counterpart
-   * @return std::map<std::string, std::string>
+   * @return std::map<complex::Uuid, complex::Uuid>
    */
-  std::map<std::string, std::string> getSimplToComplexMap() const override
-  {
-    return {};
-  }
-
-  /**
-   * @brief Returns a map of UUIDs as strings, where Complex UUIDs are keys to
-   * their SIMPL counterpart(s)
-   * @return std::map<std::string, std::string>
-   */
-  std::map<std::string, std::string> getComplexToSimplMap() const override
-  {
-    return {};
-  }
+  std::map<complex::Uuid, complex::Uuid> getSimplToComplexMap() const override;
 };

--- a/src/complex/Core/Application.cpp
+++ b/src/complex/Core/Application.cpp
@@ -115,40 +115,40 @@ std::filesystem::path Application::getCurrentDir() const
 std::optional<Uuid> Application::getComplexUuid(const Uuid& simplUuid)
 {
   std::string searchUuid = simplUuid.str();
-  if(m_SIMPL_To_Complex.count(searchUuid) == 1)
+  if(m_SIMPL_To_Complex.count(searchUuid) == 0)
   {
-    return Uuid::FromString(m_SIMPL_To_Complex[searchUuid]);
+    return {};
   }
-  return std::nullopt;
+  return Uuid::FromString(m_SIMPL_To_Complex[searchUuid]);
 }
 
 std::optional<std::vector<Uuid>> Application::getSimplUuid(const Uuid& complexUuid)
 {
   std::string searchUuid = complexUuid.str();
-  std::vector<Uuid> uuidList;
-  if(m_Complex_To_SIMPL.count(searchUuid) == 1)
+  if(m_Complex_To_SIMPL.count(searchUuid) == 0)
   {
-    std::string uuidString = m_Complex_To_SIMPL[searchUuid];
-    std::string delimiter = " , ";
-    size_t pos = 0;
-    while((pos = uuidString.find(delimiter)) != std::string::npos)
-    {
-      std::string token = uuidString.substr(0, pos);
-      std::optional<Uuid> uuid = Uuid::FromString(token);
-      if(uuid != std::nullopt)
-      {
-        uuidList.emplace_back(Uuid::FromString(token).value());
-      }
-      uuidString.erase(0, pos + delimiter.length());
-    }
-    std::optional<Uuid> uuid = Uuid::FromString(uuidString);
+    return {};
+  }
+  std::vector<Uuid> uuidList;
+  std::string uuidString = m_Complex_To_SIMPL[searchUuid];
+  std::string delimiter = " , ";
+  size_t pos = 0;
+  while((pos = uuidString.find(delimiter)) != std::string::npos)
+  {
+    std::string token = uuidString.substr(0, pos);
+    std::optional<Uuid> uuid = Uuid::FromString(token);
     if(uuid != std::nullopt)
     {
-      uuidList.emplace_back(Uuid::FromString(uuidString).value());
+      uuidList.emplace_back(Uuid::FromString(token).value());
     }
-    return uuidList;
+    uuidString.erase(0, pos + delimiter.length());
   }
-  return std::nullopt;
+  std::optional<Uuid> uuid = Uuid::FromString(uuidString);
+  if(uuid != std::nullopt)
+  {
+    uuidList.emplace_back(Uuid::FromString(uuidString).value());
+  }
+  return uuidList;
 }
 
 void Application::loadPlugins(const std::filesystem::path& pluginDir, bool verbose)

--- a/src/complex/Core/Application.hpp
+++ b/src/complex/Core/Application.hpp
@@ -118,6 +118,18 @@ public:
    */
   std::filesystem::path getCurrentDir() const;
 
+  /**
+   * @brief Returns the Complex filter UUID [v4] from the SIMPL filter UUID [v5]
+   * @return std::optional<Uuid>
+   */
+  std::optional<Uuid> getComplexUuid(const Uuid& simplUuid);
+
+  /**
+   * @brief Returns the SIMPL filter UUID(s) [v5] from the Complex filter UUID [v4]
+   * @return std::optional<std::vector<Uuid>>
+   */
+  std::optional<std::vector<Uuid>> getSimplUuid(const Uuid& complexUuid);
+
 private:
   /**
    * @brief Assigns Application as the current instance and sets the current
@@ -141,5 +153,7 @@ private:
   std::unique_ptr<complex::FilterList> m_FilterList;
   std::filesystem::path m_CurrentPath = "";
   std::unique_ptr<H5::DataFactoryManager> m_DataReader;
+  std::map<std::string, std::string> m_SIMPL_To_Complex; // syntax std::make_pair {Dream3d UUID , Dream3dnx UUID}, // dream3d-class-name
+  std::map<std::string, std::string> m_Complex_To_SIMPL; // syntax std::make_pair {Dream3dnx UUID , Dream3d UUID}, // dream3dnx-class-name
 };
 } // namespace complex

--- a/src/complex/Core/Application.hpp
+++ b/src/complex/Core/Application.hpp
@@ -128,7 +128,7 @@ public:
    * @brief Returns the SIMPL filter UUID(s) [v5] from the Complex filter UUID [v4]
    * @return std::optional<std::vector<Uuid>>
    */
-  std::optional<std::vector<Uuid>> getSimplUuid(const Uuid& complexUuid);
+  std::vector<Uuid> getSimplUuid(const Uuid& complexUuid);
 
 private:
   /**
@@ -153,7 +153,7 @@ private:
   std::unique_ptr<complex::FilterList> m_FilterList;
   std::filesystem::path m_CurrentPath = "";
   std::unique_ptr<H5::DataFactoryManager> m_DataReader;
-  std::map<std::string, std::string> m_SIMPL_To_Complex; // syntax std::make_pair {Dream3d UUID , Dream3dnx UUID}, // dream3d-class-name
-  std::map<std::string, std::string> m_Complex_To_SIMPL; // syntax std::make_pair {Dream3dnx UUID , Dream3d UUID}, // dream3dnx-class-name
+  std::vector<Uuid> m_Simpl_Uuids;   // no duplicates; index must match m_Complex_Uuids
+  std::vector<Uuid> m_Complex_Uuids; // duplicate allowed conditionally; index must match m_Simpl_Uuids
 };
 } // namespace complex

--- a/src/complex/Plugin/AbstractPlugin.hpp
+++ b/src/complex/Plugin/AbstractPlugin.hpp
@@ -93,6 +93,20 @@ public:
    */
   virtual std::vector<H5::IDataFactory*> getDataFactories() const = 0;
 
+  /**
+   * @brief Returns a map of UUIDs as strings, where SIMPL UUIDs are keys to
+   * their complex counterpart
+   * @return std::map<std::string, std::string>
+   */
+  virtual std::map<std::string, std::string> getSimplToComplexMap() const = 0;
+
+  /**
+   * @brief Returns a map of UUIDs as strings, where Complex UUIDs are keys to
+   * their SIMPL counterpart(s)
+   * @return std::map<std::string, std::string>
+   */
+  virtual std::map<std::string, std::string> getComplexToSimplMap() const = 0;
+
 protected:
   /**
    * @brief Constructs a new AbstractPlugin. Takes an ID, name, description,

--- a/src/complex/Plugin/AbstractPlugin.hpp
+++ b/src/complex/Plugin/AbstractPlugin.hpp
@@ -96,16 +96,9 @@ public:
   /**
    * @brief Returns a map of UUIDs as strings, where SIMPL UUIDs are keys to
    * their complex counterpart
-   * @return std::map<std::string, std::string>
+   * @return std::map<complex::Uuid, complex::Uuid>
    */
-  virtual std::map<std::string, std::string> getSimplToComplexMap() const = 0;
-
-  /**
-   * @brief Returns a map of UUIDs as strings, where Complex UUIDs are keys to
-   * their SIMPL counterpart(s)
-   * @return std::map<std::string, std::string>
-   */
-  virtual std::map<std::string, std::string> getComplexToSimplMap() const = 0;
+  virtual std::map<complex::Uuid, complex::Uuid> getSimplToComplexMap() const = 0;
 
 protected:
   /**

--- a/test/DREAM3DFileTest.cpp
+++ b/test/DREAM3DFileTest.cpp
@@ -55,7 +55,7 @@ constexpr StringLiteral k_ExportD3DFilterName = "Write DREAM3D NX File (V8)";
 
 const FilterHandle k_CreateDataGroupHandle(Uuid::FromString("e7d2f9b8-4131-4b28-a843-ea3c6950f101").value(), Uuid::FromString("05cc618b-781f-4ac0-b9ac-43f26ce1854f").value());
 const FilterHandle k_CreateDataArrayHandle(Uuid::FromString("67041f9b-bdc6-4122-acc6-c9fe9280e90d").value(), Uuid::FromString("05cc618b-781f-4ac0-b9ac-43f26ce1854f").value());
-const FilterHandle k_ExportD3DHandle(Uuid::FromString("b3a95784-2ced-11ec-8d3d-0242ac130003").value(), Uuid::FromString("05cc618b-781f-4ac0-b9ac-43f26ce1854f").value());
+const FilterHandle k_ExportD3DHandle(Uuid::FromString("b3a95784-2ced-41ec-8d3d-0242ac130003").value(), Uuid::FromString("05cc618b-781f-4ac0-b9ac-43f26ce1854f").value());
 const FilterHandle k_ImportD3DHandle(Uuid::FromString("0dbd31c7-19e0-4077-83ef-f4a6459a0e2d").value(), Uuid::FromString("05cc618b-781f-4ac0-b9ac-43f26ce1854f").value());
 
 fs::path GetDataDir(const Application& app)

--- a/test/UnitTestCommon/include/complex/UnitTest/UnitTestCommon.hpp
+++ b/test/UnitTestCommon/include/complex/UnitTest/UnitTestCommon.hpp
@@ -51,6 +51,7 @@ namespace Constants
 inline constexpr StringLiteral k_DataContainer("DataContainer");
 inline constexpr StringLiteral k_CellData("CellData");
 inline constexpr StringLiteral k_CellFeatureData("CellFeatureData");
+inline constexpr StringLiteral k_CellEnsembleData("CellEnsembleData");
 
 inline constexpr StringLiteral k_SmallIN1002("Small IN1002");
 inline constexpr StringLiteral k_SmallIN100("Small IN100");


### PR DESCRIPTION
API and UUID updates in order to prep NX for backwards pipeline compatibility

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files.

- [x] Class and Structs are `UpperCamelCase`
- [x] Class private member variables are `m_UpperCamelCase`
- [x] Class methods are `lowerCamelCase`
- [x] Method arguments are `lowerCamelCase`
- [x] Normal variables are `lowerCamelCase`
- [x] Constants are `k_UpperCamelCase`
- [x] Global statics are `s_UpperCamelCase`
- [x] Free Functions are `UpperCamelCase`
- [x] Macros are `ALL_UPPER_SNAKE_CASE`
- [x] Unit test will test data output from the filter.
- [x] Reused strings should be constants in an anonymous namespace
- [x] If parallelization is used, proper use of the abstracted complex classes are used. Using TBB specifically in a filter should be frowned upon unless for a really good reason.

## Filter Checklist

- [x] Parameters should be generally broken down into "Input Parameters", "Required Data Objects", "Created Data Objects". There can be exceptions to this.
- [x] ChoicesParameter selections should be an enumeration defined in the filer header
- [x] Documentation copied from SIMPL Repo and updated (if necessary)
- [x] Parameter argument variables are k_CamelCase_Key
- [x] Parameter argument strings are lower_snake_case
```
static inline constexpr StringLiteral k_AlignmentType_Key = "alignment_type";
```

## Unit Testing
- [x] 1 Unit test to instantiate the filter with the default arguments.
- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] Filters should have both the Filter class and Algorithm class for anything beyond trivial needs
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added Python wrapping to new files (if any) as necessary
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented.


<!-- **Thanks for contributing to complex!** -->
