### PR TITLE
Removing unnecessary call to read Verts array for legacy D3D files.

### DIFF
--- a/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -1088,7 +1088,6 @@ DataObject* readLegacyVertexGeom(DataStructure& ds, const H5::GroupReader& geomG
   auto* geom = VertexGeom::Create(ds, name);
   readGenericGeomDims(geom, geomGroup);
   auto* sharedVertexList = readLegacyGeomArrayAs<Float32Array>(ds, geom, geomGroup, Legacy::VertexListName);
-  auto* verts = readLegacyGeomArray(ds, geom, geomGroup, Legacy::VerticesName);
 
   geom->setVertices(*sharedVertexList);
   return geom;


### PR DESCRIPTION
Signed-off-by: Joey Kleingers <joey.kleingers@bluequartz.net>