### PR TITLE
ENH: Fully Implement FindVolFractionsFilter and FindNumFeaturesFilter

### DIFF
--- a/src/Plugins/ComplexCore/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/CMakeLists.txt
@@ -58,6 +58,8 @@ set(FilterList
   StlFileReaderFilter
   TriangleDihedralAngleFilter
   TriangleNormalFilter
+  FindNumFeaturesFilter
+  FindVolFractionsFilter
 )
 
 set(ActionList

--- a/src/Plugins/ComplexCore/docs/FindNumFeatures.md
+++ b/src/Plugins/ComplexCore/docs/FindNumFeatures.md
@@ -1,0 +1,44 @@
+# Find Number of Features  #
+
+
+## Group (Subgroup) ##
+
+Statistics (Morphological)
+
+## Description ##
+
+This **Filter** determines the number of **Features** in each **Ensemble**.
+
+## Parameters ##
+
+None 
+
+## Required Geometry ##
+
+Not Applicable
+
+## Required Objects ##
+
+| Kind | Default Name | Type | Component Dimensions | Description |
+|------|--------------|------|----------------------|-------------|
+| **Feature Attribute Array** | Phases | int32 | (1) | Specifies to which **Ensemble** each **Feature** belongs |
+
+## Created Objects ##
+
+| Kind | Default Name | Type | Component Dimensions | Description |
+|------|--------------|------|----------------------|-------------|
+| **Ensemble Attribute Array** | NumFeatures | int32 | (1) | Number of **Features** that belong each **Ensemble** |
+
+## Example Pipelines ##
+
++ INL Export
+
+## License & Copyright ##
+
+Please see the description file distributed with this **Plugin**
+
+## DREAM.3D Mailing Lists ##
+
+If you need more help with a **Filter**, please consider asking your question on the [DREAM.3D Users Google group!](https://groups.google.com/forum/?hl=en#!forum/dream3d-users)
+
+

--- a/src/Plugins/ComplexCore/docs/FindVolFractions.md
+++ b/src/Plugins/ComplexCore/docs/FindVolFractions.md
@@ -1,0 +1,44 @@
+# Find Volume Fractions of Ensembles  #
+
+
+## Group (Subgroup) ##
+
+Statistics (Morphological)
+
+## Description ##
+
+This **Filter** determines the volume fraction of each **Ensemble**. The **Filter** counts the number of **Cells** belonging to each **Ensemble** and stores the number fraction.
+
+## Parameters ##
+
+None 
+
+## Required Geometry ##
+
+None
+
+## Required Objects ##
+
+| Kind | Default Name | Type | Component Dimensions | Description |
+|------|--------------|------|----------------------|-------------|
+| **Cell Attribute Array** | Phases | int32 | (1) | Specifies to which **Ensemble** each **Cell** belongs |
+
+## Created Objects ##
+
+| Kind | Default Name | Type | Component Dimensions | Description |
+|------|--------------|------|----------------------|-------------|
+| **Ensemble Attribute Array** | VolFractions | float | (1) | Fraction of volume that belongs to each **Ensemble** |
+
+## Example Pipelines ##
+
+
+
+## License & Copyright ##
+
+Please see the description file distributed with this **Plugin**
+
+## DREAM.3D Mailing Lists ##
+
+If you need more help with a **Filter**, please consider asking your question on the [DREAM.3D Users Google group!](https://groups.google.com/forum/?hl=en#!forum/dream3d-users)
+
+

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
@@ -29,7 +29,9 @@
 #include "ComplexCore/Filters/FindFeaturePhasesFilter.hpp"
 #include "ComplexCore/Filters/FindNeighborListStatistics.hpp"
 #include "ComplexCore/Filters/FindNeighbors.hpp"
+#include "ComplexCore/Filters/FindNumFeaturesFilter.hpp"
 #include "ComplexCore/Filters/FindSurfaceFeatures.hpp"
+#include "ComplexCore/Filters/FindVolFractionsFilter.hpp"
 #include "ComplexCore/Filters/IdentifySample.hpp"
 #include "ComplexCore/Filters/ImportCSVDataFilter.hpp"
 #include "ComplexCore/Filters/ImportDREAM3DFilter.hpp"
@@ -86,7 +88,9 @@ namespace complex
     {complex::Uuid::FromString("6334ce16-cea5-5643-83b5-9573805873fa").value(), complex::FilterTraits<FindFeaturePhasesFilter>::uuid}, // FindFeaturePhases
     {complex::Uuid::FromString("73ee33b6-7622-5004-8b88-4d145514fb6a").value(), complex::FilterTraits<FindNeighborListStatistics>::uuid}, // FindNeighborListStatistics
     {complex::Uuid::FromString("97cf66f8-7a9b-5ec2-83eb-f8c4c8a17bac").value(), complex::FilterTraits<FindNeighbors>::uuid}, // FindNeighbors
+    {complex::Uuid::FromString("529743cf-d5d5-5d5a-a79f-95c84a5ddbb5").value(), complex::FilterTraits<FindNumFeaturesFilter>::uuid}, // FindNumFeatures
     {complex::Uuid::FromString("d2b0ae3d-686a-5dc0-a844-66bc0dc8f3cb").value(), complex::FilterTraits<FindSurfaceFeatures>::uuid}, // FindSurfaceFeatures
+    {complex::Uuid::FromString("68246a67-7f32-5c80-815a-bec82008d7bc").value(), complex::FilterTraits<FindVolFractionsFilter>::uuid}, // FindVolFractions
     {complex::Uuid::FromString("0e8c0818-a3fb-57d4-a5c8-7cb8ae54a40a").value(), complex::FilterTraits<IdentifySample>::uuid}, // IdentifySample
     {complex::Uuid::FromString("bdb978bc-96bf-5498-972c-b509c38b8d50").value(), complex::FilterTraits<ImportCSVDataFilter>::uuid}, // ReadASCIIData
     {complex::Uuid::FromString("043cbde5-3878-5718-958f-ae75714df0df").value(), complex::FilterTraits<ImportDREAM3DFilter>::uuid}, // DataContainerReader

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNumFeaturesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNumFeaturesFilter.cpp
@@ -1,0 +1,102 @@
+#include "FindNumFeaturesFilter.hpp"
+
+#include "complex/DataStructure/AttributeMatrix.hpp"
+#include "complex/DataStructure/DataArray.hpp"
+#include "complex/DataStructure/DataPath.hpp"
+#include "complex/Filter/Actions/CreateArrayAction.hpp"
+#include "complex/Filter/Actions/EmptyAction.hpp"
+#include "complex/Parameters/ArrayCreationParameter.hpp"
+#include "complex/Parameters/ArraySelectionParameter.hpp"
+#include "complex/Parameters/AttributeMatrixSelectionParameter.hpp"
+
+using namespace complex;
+
+namespace complex
+{
+//------------------------------------------------------------------------------
+std::string FindNumFeaturesFilter::name() const
+{
+  return FilterTraits<FindNumFeaturesFilter>::name.str();
+}
+
+//------------------------------------------------------------------------------
+std::string FindNumFeaturesFilter::className() const
+{
+  return FilterTraits<FindNumFeaturesFilter>::className;
+}
+
+//------------------------------------------------------------------------------
+Uuid FindNumFeaturesFilter::uuid() const
+{
+  return FilterTraits<FindNumFeaturesFilter>::uuid;
+}
+
+//------------------------------------------------------------------------------
+std::string FindNumFeaturesFilter::humanName() const
+{
+  return "Find Number of Features";
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> FindNumFeaturesFilter::defaultTags() const
+{
+  return {"#Statistics", "#Morphological"};
+}
+
+//------------------------------------------------------------------------------
+Parameters FindNumFeaturesFilter::parameters() const
+{
+  Parameters params;
+
+  params.insertSeparator(Parameters::Separator{"Required Objects: Feature Data"});
+  params.insert(std::make_unique<ArraySelectionParameter>(k_FeaturePhasesArrayPath_Key, "Feature Phases", "", DataPath({"DataContainer", "FeatureData", "Phases"}), complex::GetAllDataTypes()));
+
+  params.insertSeparator(Parameters::Separator{"Created Objects: Ensemble Data"});
+  params.insert(std::make_unique<ArrayCreationParameter>(k_NumFeaturesArrayPath_Key, "Number of Features", "", DataPath({"Number of Features"})));
+
+  return params;
+}
+
+//------------------------------------------------------------------------------
+IFilter::UniquePointer FindNumFeaturesFilter::clone() const
+{
+  return std::make_unique<FindNumFeaturesFilter>();
+}
+
+//------------------------------------------------------------------------------
+IFilter::PreflightResult FindNumFeaturesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
+                                                              const std::atomic_bool& shouldCancel) const
+{
+  auto pFeaturePhasesArrayPathValue = filterArgs.value<DataPath>(k_FeaturePhasesArrayPath_Key);
+  auto pNumFeaturesArrayPathValue = filterArgs.value<DataPath>(k_NumFeaturesArrayPath_Key);
+
+  PreflightResult preflightResult;
+  complex::Result<OutputActions> resultOutputActions;
+  std::vector<PreflightValue> preflightUpdatedValues;
+
+  const auto* featureData = dataStructure.getDataAs<AttributeMatrix>(pNumFeaturesArrayPathValue.getParent());
+  if(featureData == nullptr)
+  {
+    return {MakeErrorResult<OutputActions>(-47630, fmt::format("Could not find selected feature Attribute Matrix at path '{}'", pNumFeaturesArrayPathValue.getParent().toString()))};
+  }
+
+  auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::int32, featureData->getShape(), std::vector<usize>{1}, pNumFeaturesArrayPathValue);
+  resultOutputActions.value().actions.push_back(std::move(createArrayAction));
+
+  return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
+}
+
+//------------------------------------------------------------------------------
+Result<> FindNumFeaturesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                                            const std::atomic_bool& shouldCancel) const
+{
+  const auto& featurePhasesArrayRef = dataStructure.getDataRefAs<Int32Array>(filterArgs.value<DataPath>(k_FeaturePhasesArrayPath_Key));
+  auto& numFeaturesArrayRef = dataStructure.getDataRefAs<Int32Array>(filterArgs.value<DataPath>(k_NumFeaturesArrayPath_Key));
+
+  for(usize index = 1; index < featurePhasesArrayRef.getNumberOfTuples(); index++)
+  {
+    numFeaturesArrayRef[featurePhasesArrayRef[index]]++;
+  }
+  return {};
+}
+} // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNumFeaturesFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNumFeaturesFilter.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "ComplexCore/ComplexCore_export.hpp"
+
+#include "complex/Filter/FilterTraits.hpp"
+#include "complex/Filter/IFilter.hpp"
+
+namespace complex
+{
+/**
+ * @class FindNumFeaturesFilter
+ * @brief This filter will create a new array containing the number of features
+ */
+class COMPLEXCORE_EXPORT FindNumFeaturesFilter : public IFilter
+{
+public:
+  FindNumFeaturesFilter() = default;
+  ~FindNumFeaturesFilter() noexcept override = default;
+
+  FindNumFeaturesFilter(const FindNumFeaturesFilter&) = delete;
+  FindNumFeaturesFilter(FindNumFeaturesFilter&&) noexcept = delete;
+
+  FindNumFeaturesFilter& operator=(const FindNumFeaturesFilter&) = delete;
+  FindNumFeaturesFilter& operator=(FindNumFeaturesFilter&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_FeaturePhasesArrayPath_Key = "feature_phases_array_path";
+  static inline constexpr StringLiteral k_NumFeaturesArrayPath_Key = "num_features_array_path";
+
+  /**
+   * @brief Returns the name of the filter.
+   * @return
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the C++ classname of this filter.
+   * @return
+   */
+  std::string className() const override;
+
+  /**
+   * @brief Returns the uuid of the filter.
+   * @return
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief Returns the human readable name of the filter.
+   * @return
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
+   * @brief Returns the parameters of the filter (i.e. its inputs)
+   * @return
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief Returns a copy of the filter.
+   * @return
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param ds The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  PreflightResult preflightImpl(const DataStructure& ds, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+
+  /**
+   * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
+   * On failure, there is no guarantee that the DataStructure is in a correct state.
+   * @param ds The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  Result<> executeImpl(DataStructure& data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+};
+} // namespace complex
+
+COMPLEX_DEF_FILTER_TRAITS(complex, FindNumFeaturesFilter, "ec3388de-d7a7-4cf6-94f4-81061b0863c8");
+/* LEGACY UUID FOR THIS FILTER 529743cf-d5d5-5d5a-a79f-95c84a5ddbb5 */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindVolFractionsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindVolFractionsFilter.cpp
@@ -1,0 +1,116 @@
+#include "FindVolFractionsFilter.hpp"
+
+#include "complex/DataStructure/DataArray.hpp"
+#include "complex/DataStructure/DataPath.hpp"
+#include "complex/DataStructure/Geometry/ImageGeom.hpp"
+#include "complex/Filter/Actions/CreateArrayAction.hpp"
+#include "complex/Filter/Actions/EmptyAction.hpp"
+#include "complex/Parameters/ArrayCreationParameter.hpp"
+#include "complex/Parameters/ArraySelectionParameter.hpp"
+#include "complex/Parameters/GeometrySelectionParameter.hpp"
+
+using namespace complex;
+
+namespace complex
+{
+//------------------------------------------------------------------------------
+std::string FindVolFractionsFilter::name() const
+{
+  return FilterTraits<FindVolFractionsFilter>::name.str();
+}
+
+//------------------------------------------------------------------------------
+std::string FindVolFractionsFilter::className() const
+{
+  return FilterTraits<FindVolFractionsFilter>::className;
+}
+
+//------------------------------------------------------------------------------
+Uuid FindVolFractionsFilter::uuid() const
+{
+  return FilterTraits<FindVolFractionsFilter>::uuid;
+}
+
+//------------------------------------------------------------------------------
+std::string FindVolFractionsFilter::humanName() const
+{
+  return "Find Volume Fractions of Ensembles";
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> FindVolFractionsFilter::defaultTags() const
+{
+  return {"#Statistics", "#Morphological"};
+}
+
+//------------------------------------------------------------------------------
+Parameters FindVolFractionsFilter::parameters() const
+{
+  Parameters params;
+
+  // Create the parameter descriptors that are needed for this filter
+  params.insertSeparator(Parameters::Separator{"Required Objects: Cell Data"});
+  params.insert(std::make_unique<ArraySelectionParameter>(k_CellPhasesArrayPath_Key, "Cell Phases", "", DataPath({"DataContainer", "CellData", "Phases"}),
+                                                          ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
+  params.insertSeparator(Parameters::Separator{"Created Objects: Ensemble Data"});
+  params.insert(std::make_unique<ArrayCreationParameter>(k_VolFractionsArrayPath_Key, "Volume Fractions", "", DataPath({"Volume Fractions"})));
+
+  return params;
+}
+
+//------------------------------------------------------------------------------
+IFilter::UniquePointer FindVolFractionsFilter::clone() const
+{
+  return std::make_unique<FindVolFractionsFilter>();
+}
+
+//------------------------------------------------------------------------------
+IFilter::PreflightResult FindVolFractionsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
+                                                               const std::atomic_bool& shouldCancel) const
+{
+  auto pCellPhasesArrayPathValue = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
+  auto pVolFractionsArrayPathValue = filterArgs.value<DataPath>(k_VolFractionsArrayPath_Key);
+
+  const auto& cellPhasesArray = dataStructure.getDataRefAs<IDataArray>(pCellPhasesArrayPathValue);
+
+  PreflightResult preflightResult;
+  complex::Result<OutputActions> resultOutputActions;
+  std::vector<PreflightValue> preflightUpdatedValues;
+
+  const auto* cellEnsembleData = dataStructure.getDataAs<AttributeMatrix>(pVolFractionsArrayPathValue.getParent());
+  if(cellEnsembleData == nullptr)
+  {
+    return {MakeErrorResult<OutputActions>(-47630, fmt::format("Could not find selected feature Attribute Matrix at path '{}'", pVolFractionsArrayPathValue.getParent().toString()))};
+  }
+
+  auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::float32, cellEnsembleData->getShape(), std::vector<usize>{1}, pVolFractionsArrayPathValue);
+  resultOutputActions.value().actions.push_back(std::move(createArrayAction));
+
+  return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
+}
+
+//------------------------------------------------------------------------------
+Result<> FindVolFractionsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                                             const std::atomic_bool& shouldCancel) const
+{
+  auto& cellPhasesArrayRef = dataStructure.getDataRefAs<Int32Array>(filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key));
+  auto& volFractionsArrayRef = dataStructure.getDataRefAs<Float32Array>(filterArgs.value<DataPath>(k_VolFractionsArrayPath_Key));
+
+  usize totalPoints = cellPhasesArrayRef.getNumberOfTuples();
+  usize totalEnsembles = volFractionsArrayRef.getNumberOfTuples();
+
+  std::vector<usize> ensembleElements(totalEnsembles, 0);
+  // Calculate the total number of elements in each Ensemble
+  for(usize index = 0; index < totalPoints; index++)
+  {
+    ensembleElements[cellPhasesArrayRef[index]]++;
+  }
+  // Calculate the Volume Fraction
+  for(usize index = 0; index < totalEnsembles; index++)
+  {
+    volFractionsArrayRef[index] = static_cast<float32>(ensembleElements[index]) / static_cast<float32>(totalPoints);
+  }
+
+  return {};
+}
+} // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindVolFractionsFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindVolFractionsFilter.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "ComplexCore/ComplexCore_export.hpp"
+
+#include "complex/Filter/FilterTraits.hpp"
+#include "complex/Filter/IFilter.hpp"
+
+namespace complex
+{
+/**
+ * @class FindVolFractionsFilter
+ * @brief This filter will calculate the volume fraction for each Ensemble
+ */
+class COMPLEXCORE_EXPORT FindVolFractionsFilter : public IFilter
+{
+public:
+  FindVolFractionsFilter() = default;
+  ~FindVolFractionsFilter() noexcept override = default;
+
+  FindVolFractionsFilter(const FindVolFractionsFilter&) = delete;
+  FindVolFractionsFilter(FindVolFractionsFilter&&) noexcept = delete;
+
+  FindVolFractionsFilter& operator=(const FindVolFractionsFilter&) = delete;
+  FindVolFractionsFilter& operator=(FindVolFractionsFilter&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_CellPhasesArrayPath_Key = "cell_phases_array_path";
+  static inline constexpr StringLiteral k_VolFractionsArrayPath_Key = "vol_fractions_array_path";
+
+  /**
+   * @brief Returns the name of the filter.
+   * @return
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the C++ classname of this filter.
+   * @return
+   */
+  std::string className() const override;
+
+  /**
+   * @brief Returns the uuid of the filter.
+   * @return
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief Returns the human readable name of the filter.
+   * @return
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
+   * @brief Returns the parameters of the filter (i.e. its inputs)
+   * @return
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief Returns a copy of the filter.
+   * @return
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param ds The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  PreflightResult preflightImpl(const DataStructure& ds, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+
+  /**
+   * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
+   * On failure, there is no guarantee that the DataStructure is in a correct state.
+   * @param ds The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  Result<> executeImpl(DataStructure& data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+};
+} // namespace complex
+
+COMPLEX_DEF_FILTER_TRAITS(complex, FindVolFractionsFilter, "340b3433-193a-4287-a7d2-794e1bce061b");
+/* LEGACY UUID FOR THIS FILTER 68246a67-7f32-5c80-815a-bec82008d7bc */

--- a/src/Plugins/ComplexCore/test/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/test/CMakeLists.txt
@@ -52,6 +52,8 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   FindArrayStatisticsTest.cpp
   TriangleNormalFilterTest.cpp
   TriangleDihedralAngleFilterTest.cpp
+  FindNumFeaturesTest.cpp
+  FindVolFractionsTest.cpp
 )
 
 create_complex_plugin_unit_test(PLUGIN_NAME ${PLUGIN_NAME}

--- a/src/Plugins/ComplexCore/test/FindNumFeaturesTest.cpp
+++ b/src/Plugins/ComplexCore/test/FindNumFeaturesTest.cpp
@@ -27,8 +27,6 @@ const fs::path k_BaseDataFilePath = fs::path(fmt::format("{}/TestFiles/6_6_volum
 
 TEST_CASE("ComplexCore::FindNumFeaturesFilter: Instantiation and Parameter Check", "[ComplexCore][FindNumFeaturesFilter]")
 {
-  std::shared_ptr<UnitTest::make_shared_enabler> app = std::make_shared<UnitTest::make_shared_enabler>();
-
   // Instantiate the filter, a DataStructure object and an Arguments Object
   FindNumFeaturesFilter filter;
   Arguments args;
@@ -50,8 +48,6 @@ TEST_CASE("ComplexCore::FindNumFeaturesFilter: Instantiation and Parameter Check
 
 TEST_CASE("ComplexCore::FindNumFeaturesFilter: Valid filter execution", "[ComplexCore][FindNumFeaturesFilter]")
 {
-  std::shared_ptr<UnitTest::make_shared_enabler> app = std::make_shared<UnitTest::make_shared_enabler>();
-
   // Instantiate the filter, a DataStructure object and an Arguments Object
   FindNumFeaturesFilter filter;
   Arguments args;
@@ -81,8 +77,6 @@ TEST_CASE("ComplexCore::FindNumFeaturesFilter: Valid filter execution", "[Comple
 
 TEST_CASE("ComplexCore::FindNumFeaturesFilter: InValid filter execution", "[ComplexCore][FindNumFeaturesFilter]")
 {
-  std::shared_ptr<UnitTest::make_shared_enabler> app = std::make_shared<UnitTest::make_shared_enabler>();
-
   // Instantiate the filter, a DataStructure object and an Arguments Object
   FindNumFeaturesFilter filter;
   Arguments args;

--- a/src/Plugins/ComplexCore/test/FindNumFeaturesTest.cpp
+++ b/src/Plugins/ComplexCore/test/FindNumFeaturesTest.cpp
@@ -1,0 +1,111 @@
+#include <catch2/catch.hpp>
+
+#include "complex/Core/Application.hpp"
+#include "complex/Parameters/ArrayCreationParameter.hpp"
+#include "complex/Parameters/ArraySelectionParameter.hpp"
+#include "complex/UnitTest/UnitTestCommon.hpp"
+
+#include "ComplexCore/ComplexCore_test_dirs.hpp"
+#include "ComplexCore/Filters/FindNumFeaturesFilter.hpp"
+
+namespace fs = std::filesystem;
+using namespace complex;
+
+namespace
+{
+const std::string k_FeatureCounts("Feature Count");
+const std::string k_FeatureCountsNX("Feature Count NX");
+
+const DataPath k_FeaturePhasesPath({Constants::k_DataContainer, Constants::k_FeatureData, Constants::k_Phases});
+const DataPath k_IncorrectFeaturePhasesPath({Constants::k_DataContainer, Constants::k_CellData, Constants::k_Phases});
+
+const DataPath k_FeatureCountsPath({Constants::k_DataContainer, Constants::k_CellEnsembleData, k_FeatureCounts});
+const DataPath k_FeatureCountsPathNX({Constants::k_DataContainer, Constants::k_CellEnsembleData, k_FeatureCountsNX});
+
+const fs::path k_BaseDataFilePath = fs::path(fmt::format("{}/TestFiles/6_6_volume_fraction_feature_count.dream3d", unit_test::k_DREAM3DDataDir));
+} // namespace
+
+TEST_CASE("ComplexCore::FindNumFeaturesFilter: Instantiation and Parameter Check", "[ComplexCore][FindNumFeaturesFilter]")
+{
+  std::shared_ptr<UnitTest::make_shared_enabler> app = std::make_shared<UnitTest::make_shared_enabler>();
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  FindNumFeaturesFilter filter;
+  Arguments args;
+
+  DataStructure ds = UnitTest::LoadDataStructure(k_BaseDataFilePath);
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(FindNumFeaturesFilter::k_FeaturePhasesArrayPath_Key, std::make_any<DataPath>(k_FeaturePhasesPath));
+  args.insertOrAssign(FindNumFeaturesFilter::k_NumFeaturesArrayPath_Key, std::make_any<DataPath>(k_FeatureCountsPathNX));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(ds, args);
+  REQUIRE(executeResult.result.valid());
+}
+
+TEST_CASE("ComplexCore::FindNumFeaturesFilter: Valid filter execution", "[ComplexCore][FindNumFeaturesFilter]")
+{
+  std::shared_ptr<UnitTest::make_shared_enabler> app = std::make_shared<UnitTest::make_shared_enabler>();
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  FindNumFeaturesFilter filter;
+  Arguments args;
+
+  DataStructure ds = UnitTest::LoadDataStructure(k_BaseDataFilePath);
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(FindNumFeaturesFilter::k_FeaturePhasesArrayPath_Key, std::make_any<DataPath>(k_FeaturePhasesPath));
+  args.insertOrAssign(FindNumFeaturesFilter::k_NumFeaturesArrayPath_Key, std::make_any<DataPath>(k_FeatureCountsPathNX));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(ds, args);
+  REQUIRE(executeResult.result.valid());
+
+  auto& d3dFeatureCountsArrayRef = ds.getDataRefAs<Int32Array>(k_FeatureCountsPath);
+  auto& nxFeatureCountsArrayRef = ds.getDataRefAs<Int32Array>(k_FeatureCountsPathNX);
+
+  for(usize index = 0; index < d3dFeatureCountsArrayRef.getSize(); index++)
+  {
+    REQUIRE(d3dFeatureCountsArrayRef[index] == nxFeatureCountsArrayRef[index]);
+  }
+}
+
+TEST_CASE("ComplexCore::FindNumFeaturesFilter: InValid filter execution", "[ComplexCore][FindNumFeaturesFilter]")
+{
+  std::shared_ptr<UnitTest::make_shared_enabler> app = std::make_shared<UnitTest::make_shared_enabler>();
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  FindNumFeaturesFilter filter;
+  Arguments args;
+
+  DataStructure ds = UnitTest::LoadDataStructure(k_BaseDataFilePath);
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(FindNumFeaturesFilter::k_FeaturePhasesArrayPath_Key, std::make_any<DataPath>(k_IncorrectFeaturePhasesPath));
+  args.insertOrAssign(FindNumFeaturesFilter::k_NumFeaturesArrayPath_Key, std::make_any<DataPath>(k_FeatureCountsPathNX));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(ds, args);
+  REQUIRE(executeResult.result.valid());
+
+  auto& d3dFeatureCountsArrayRef = ds.getDataRefAs<Int32Array>(k_FeatureCountsPath);
+  auto& nxFeatureCountsArrayRef = ds.getDataRefAs<Int32Array>(k_FeatureCountsPathNX);
+
+  for(usize index = 1; index < d3dFeatureCountsArrayRef.getSize(); index++)
+  {
+    REQUIRE(d3dFeatureCountsArrayRef[index] != nxFeatureCountsArrayRef[index]);
+  }
+}

--- a/src/Plugins/ComplexCore/test/FindVolFractionsTest.cpp
+++ b/src/Plugins/ComplexCore/test/FindVolFractionsTest.cpp
@@ -71,7 +71,7 @@ TEST_CASE("ComplexCore::FindVolFractionsFilter: Valid filter execution", "[Compl
 
   for(usize index = 0; index < d3dVolumeFractionsArrayRef.getSize(); index++)
   {
-    float32 result = std::fabsf(d3dVolumeFractionsArrayRef[index] - nxVolumeFractionsArrayRef[index]);
+    float32 result = fabsf(d3dVolumeFractionsArrayRef[index] - nxVolumeFractionsArrayRef[index]);
     REQUIRE(result < UnitTest::EPSILON);
   }
 }
@@ -102,7 +102,7 @@ TEST_CASE("ComplexCore::FindVolFractionsFilter: InValid filter execution", "[Com
 
   for(usize index = 0; index < d3dVolumeFractionsArrayRef.getSize(); index++)
   {
-    float32 result = std::fabsf(d3dVolumeFractionsArrayRef[index] - nxVolumeFractionsArrayRef[index]);
+    float32 result = fabsf(d3dVolumeFractionsArrayRef[index] - nxVolumeFractionsArrayRef[index]);
     REQUIRE(result > UnitTest::EPSILON);
   }
 }

--- a/src/Plugins/ComplexCore/test/FindVolFractionsTest.cpp
+++ b/src/Plugins/ComplexCore/test/FindVolFractionsTest.cpp
@@ -27,8 +27,6 @@ const fs::path k_BaseDataFilePath = fs::path(fmt::format("{}/TestFiles/6_6_volum
 
 TEST_CASE("ComplexCore::FindVolFractionsFilter: Instantiation and Parameter Check", "[ComplexCore]")
 {
-  std::shared_ptr<UnitTest::make_shared_enabler> app = std::make_shared<UnitTest::make_shared_enabler>();
-
   // Instantiate the filter, a DataStructure object and an Arguments Object
   FindVolFractionsFilter filter;
   Arguments args;
@@ -50,8 +48,6 @@ TEST_CASE("ComplexCore::FindVolFractionsFilter: Instantiation and Parameter Chec
 
 TEST_CASE("ComplexCore::FindVolFractionsFilter: Valid filter execution", "[ComplexCore]")
 {
-  std::shared_ptr<UnitTest::make_shared_enabler> app = std::make_shared<UnitTest::make_shared_enabler>();
-
   // Instantiate the filter, a DataStructure object and an Arguments Object
   FindVolFractionsFilter filter;
   Arguments args;
@@ -82,8 +78,6 @@ TEST_CASE("ComplexCore::FindVolFractionsFilter: Valid filter execution", "[Compl
 
 TEST_CASE("ComplexCore::FindVolFractionsFilter: InValid filter execution", "[ComplexCore]")
 {
-  std::shared_ptr<UnitTest::make_shared_enabler> app = std::make_shared<UnitTest::make_shared_enabler>();
-
   // Instantiate the filter, a DataStructure object and an Arguments Object
   FindVolFractionsFilter filter;
   Arguments args;

--- a/src/Plugins/ComplexCore/test/FindVolFractionsTest.cpp
+++ b/src/Plugins/ComplexCore/test/FindVolFractionsTest.cpp
@@ -1,0 +1,114 @@
+#include <catch2/catch.hpp>
+
+#include "complex/Core/Application.hpp"
+#include "complex/Parameters/ArrayCreationParameter.hpp"
+#include "complex/Parameters/ArraySelectionParameter.hpp"
+#include "complex/UnitTest/UnitTestCommon.hpp"
+
+#include "ComplexCore/ComplexCore_test_dirs.hpp"
+#include "ComplexCore/Filters/FindVolFractionsFilter.hpp"
+
+namespace fs = std::filesystem;
+using namespace complex;
+
+namespace
+{
+const std::string k_VolumeFractions("Volume Fractions");
+const std::string k_VolumeFractionsNX("Volume Fractions NX");
+
+const DataPath k_CellPhasesPath({Constants::k_DataContainer, Constants::k_CellData, Constants::k_Phases});
+const DataPath k_IncorrectCellPhasesPath({Constants::k_DataContainer, Constants::k_FeatureData, Constants::k_Phases});
+
+const DataPath k_VolumeFractionsPath({Constants::k_DataContainer, Constants::k_CellEnsembleData, k_VolumeFractions});
+const DataPath k_VolumeFractionsPathNX({Constants::k_DataContainer, Constants::k_CellEnsembleData, k_VolumeFractionsNX});
+
+const fs::path k_BaseDataFilePath = fs::path(fmt::format("{}/TestFiles/6_6_volume_fraction_feature_count.dream3d", unit_test::k_DREAM3DDataDir));
+} // namespace
+
+TEST_CASE("ComplexCore::FindVolFractionsFilter: Instantiation and Parameter Check", "[ComplexCore]")
+{
+  std::shared_ptr<UnitTest::make_shared_enabler> app = std::make_shared<UnitTest::make_shared_enabler>();
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  FindVolFractionsFilter filter;
+  Arguments args;
+
+  DataStructure ds = UnitTest::LoadDataStructure(k_BaseDataFilePath);
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(FindVolFractionsFilter::k_CellPhasesArrayPath_Key, std::make_any<DataPath>(k_CellPhasesPath));
+  args.insertOrAssign(FindVolFractionsFilter::k_VolFractionsArrayPath_Key, std::make_any<DataPath>(k_VolumeFractionsPathNX));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(ds, args);
+  REQUIRE(executeResult.result.valid());
+}
+
+TEST_CASE("ComplexCore::FindVolFractionsFilter: Valid filter execution", "[ComplexCore]")
+{
+  std::shared_ptr<UnitTest::make_shared_enabler> app = std::make_shared<UnitTest::make_shared_enabler>();
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  FindVolFractionsFilter filter;
+  Arguments args;
+
+  DataStructure ds = UnitTest::LoadDataStructure(k_BaseDataFilePath);
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(FindVolFractionsFilter::k_CellPhasesArrayPath_Key, std::make_any<DataPath>(k_CellPhasesPath));
+  args.insertOrAssign(FindVolFractionsFilter::k_VolFractionsArrayPath_Key, std::make_any<DataPath>(k_VolumeFractionsPathNX));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(ds, args);
+  REQUIRE(executeResult.result.valid());
+
+  auto& d3dVolumeFractionsArrayRef = ds.getDataRefAs<Float32Array>(k_VolumeFractionsPath);
+  auto& nxVolumeFractionsArrayRef = ds.getDataRefAs<Float32Array>(k_VolumeFractionsPathNX);
+
+  for(usize index = 0; index < d3dVolumeFractionsArrayRef.getSize(); index++)
+  {
+    float32 result = std::fabsf(d3dVolumeFractionsArrayRef[index] - nxVolumeFractionsArrayRef[index]);
+    REQUIRE(result < UnitTest::EPSILON);
+  }
+}
+
+TEST_CASE("ComplexCore::FindVolFractionsFilter: InValid filter execution", "[ComplexCore]")
+{
+  std::shared_ptr<UnitTest::make_shared_enabler> app = std::make_shared<UnitTest::make_shared_enabler>();
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  FindVolFractionsFilter filter;
+  Arguments args;
+
+  auto baseDataFilePath = fs::path(fmt::format("{}/TestFiles/6_6_volFractions_and_numFeatures_test.dream3d", unit_test::k_DREAM3DDataDir));
+  DataStructure ds = UnitTest::LoadDataStructure(k_BaseDataFilePath);
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(FindVolFractionsFilter::k_CellPhasesArrayPath_Key, std::make_any<DataPath>(k_IncorrectCellPhasesPath));
+  args.insertOrAssign(FindVolFractionsFilter::k_VolFractionsArrayPath_Key, std::make_any<DataPath>(k_VolumeFractionsPathNX));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(ds, args);
+  REQUIRE(executeResult.result.valid());
+
+  auto& d3dVolumeFractionsArrayRef = ds.getDataRefAs<Float32Array>(k_VolumeFractionsPath);
+  auto& nxVolumeFractionsArrayRef = ds.getDataRefAs<Float32Array>(k_VolumeFractionsPathNX);
+
+  for(usize index = 0; index < d3dVolumeFractionsArrayRef.getSize(); index++)
+  {
+    float32 result = std::fabsf(d3dVolumeFractionsArrayRef[index] - nxVolumeFractionsArrayRef[index]);
+    REQUIRE(result > UnitTest::EPSILON);
+  }
+}

--- a/test/UnitTestCommon/include/complex/UnitTest/UnitTestCommon.hpp
+++ b/test/UnitTestCommon/include/complex/UnitTest/UnitTestCommon.hpp
@@ -117,10 +117,6 @@ namespace UnitTest
 
 inline constexpr float EPSILON = 0.0001;
 
-struct make_shared_enabler : public complex::Application
-{
-};
-
 /**
  * @brief Loads a .dream3d file into a DataStructure. Checks are made to ensure the filepath does exist
  * @param filepath

--- a/test/UnitTestCommon/include/complex/UnitTest/UnitTestCommon.hpp
+++ b/test/UnitTestCommon/include/complex/UnitTest/UnitTestCommon.hpp
@@ -2,6 +2,7 @@
 
 #include "complex/Common/Result.hpp"
 #include "complex/Common/StringLiteral.hpp"
+#include "complex/Core/Application.hpp"
 #include "complex/DataStructure/DataGroup.hpp"
 #include "complex/DataStructure/DataObject.hpp"
 #include "complex/DataStructure/DataStore.hpp"
@@ -47,9 +48,10 @@ namespace complex
 {
 namespace Constants
 {
-
 inline constexpr StringLiteral k_DataContainer("DataContainer");
 inline constexpr StringLiteral k_CellData("CellData");
+inline constexpr StringLiteral k_GrainData("GrainData");
+inline constexpr StringLiteral k_FeatureData("FeatureData");
 inline constexpr StringLiteral k_CellFeatureData("CellFeatureData");
 inline constexpr StringLiteral k_CellEnsembleData("CellEnsembleData");
 
@@ -114,6 +116,10 @@ namespace UnitTest
 {
 
 inline constexpr float EPSILON = 0.0001;
+
+struct make_shared_enabler : public complex::Application
+{
+};
 
 /**
  * @brief Loads a .dream3d file into a DataStructure. Checks are made to ensure the filepath does exist


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files.

- [x] Class and Structs are `UpperCamelCase`
- [x] Class private member variables are `m_UpperCamelCase`
- [x] Class methods are `lowerCamelCase`
- [x] Method arguments are `lowerCamelCase`
- [x] Normal variables are `lowerCamelCase`
- [x] Constants are `k_UpperCamelCase`
- [x] Global statics are `s_UpperCamelCase`
- [x] Free Functions are `UpperCamelCase`
- [x] Macros are `ALL_UPPER_SNAKE_CASE`
- [x] Unit test will test data output from the filter.
- [x] Reused strings should be constants in an anonymous namespace
- [x] If parallelization is used, proper use of the abstracted complex classes are used. Using TBB specifically in a filter should be frowned upon unless for a really good reason.

## Filter Checklist

- [x] Parameters should be generally broken down into "Input Parameters", "Required Data Objects", "Created Data Objects". There can be exceptions to this.
- [x] ChoicesParameter selections should be an enumeration defined in the filer header
- [x] Documentation copied from SIMPL Repo and updated (if necessary)
- [x] Parameter argument variables are k_CamelCase_Key
- [x] Parameter argument strings are lower_snake_case
```
static inline constexpr StringLiteral k_AlignmentType_Key = "alignment_type";
```

## Unit Testing
- [x] 1 Unit test to instantiate the filter with the default arguments.
- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] Filters should have both the Filter class and Algorithm class for anything beyond trivial needs
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added Python wrapping to new files (if any) as necessary
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented.


<!-- **Thanks for contributing to complex!** -->
