### PR TITLE
MultiArraySelectionParameterUpdates

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CombineAttributeArraysFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CombineAttributeArraysFilter.cpp
@@ -61,7 +61,8 @@ Parameters CombineAttributeArraysFilter::parameters() const
 
   params.insertSeparator(Parameters::Separator{"Required Input Data Objects"});
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_SelectedDataArrayPaths_Key, "Attribute Arrays to Combine", "The complete path to each of the Attribute Arrays to combine",
-                                                               MultiArraySelectionParameter::ValueType{}, MultiArraySelectionParameter::AllowedTypes{}));
+                                                               MultiArraySelectionParameter::ValueType{}, MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray},
+                                                               MultiArraySelectionParameter::AllowedDataTypes{}));
 
   params.insertSeparator(Parameters::Separator{"Created Output Data Objects"});
   params.insert(std::make_unique<ArrayCreationParameter>(k_StackedDataArrayName_Key, "Created Data Array", "This is the DataPath to the created output array of the combined attribute arrays.",

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
@@ -74,7 +74,7 @@ Parameters CropVertexGeometry::parameters() const
   params.insert(std::make_unique<VectorFloat32Parameter>(k_MinPos_Key, "Min Pos", "Minimum vertex position", std::vector<float32>{0, 0, 0}, std::vector<std::string>{"X", "Y", "Z"}));
   params.insert(std::make_unique<VectorFloat32Parameter>(k_MaxPos_Key, "Max Pos", "Maximum vertex position", std::vector<float32>{0, 0, 0}, std::vector<std::string>{"X", "Y", "Z"}));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_TargetArrayPaths_Key, "Vertex Data Arrays to crop", "The complete path to all the vertex data arrays to crop", std::vector<DataPath>(),
-                                                               complex::GetAllDataTypes()));
+                                                               MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray}, complex::GetAllDataTypes()));
   return params;
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -129,9 +129,9 @@ Parameters ExtractInternalSurfacesFromTriangleGeometry::parameters() const
 
   params.insertSeparator(Parameters::Separator{"Optional Transferred Data"});
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_CopyVertexPaths_Key, "Copy Vertex Arrays", "Paths to vertex-related DataArrays that should be copied to the new geometry",
-                                                               std::vector<DataPath>{}, GetAllDataTypes()));
+                                                               std::vector<DataPath>{}, MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray}, GetAllDataTypes()));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_CopyTrianglePaths_Key, "Copy Face Arrays", "Paths to face-related DataArrays that should be copied to the new geometry",
-                                                               std::vector<DataPath>{}, GetAllDataTypes()));
+                                                               std::vector<DataPath>{}, MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray}, GetAllDataTypes()));
   return params;
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
@@ -183,7 +183,7 @@ Parameters InitializeData::parameters() const
   params.insertSeparator(Parameters::Separator{"Required Data Objects"});
 
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_CellArrayPaths_Key, "Cell Arrays", "The cell data arrays in which to initialize a subvolume to zeros", std::vector<DataPath>{},
-                                                               complex::GetAllDataTypes()));
+                                                               MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray}, complex::GetAllDataTypes()));
   params.insert(std::make_unique<GeometrySelectionParameter>(k_ImageGeometryPath_Key, "Image Geometry", "The geometry containing the cell data for which to initialize", DataPath{},
                                                              GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image}));
   return params;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
@@ -223,9 +223,10 @@ Parameters InterpolatePointCloudToRegularGridFilter::parameters() const
                                                           ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_Mask_Key, "Mask", "DataPath to mask array", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::boolean},
                                                           ArraySelectionParameter::AllowedComponentShapes{{1}}));
-  params.insert(
-      std::make_unique<MultiArraySelectionParameter>(k_InterpolateArrays_Key, "Attribute Arrays to Interpolate", "DataPaths to interpolate", std::vector<DataPath>(), complex::GetAllNumericTypes()));
-  params.insert(std::make_unique<MultiArraySelectionParameter>(k_CopyArrays_Key, "Attribute Arrays to Copy", "DataPaths to copy", std::vector<DataPath>(), complex::GetAllDataTypes()));
+  params.insert(std::make_unique<MultiArraySelectionParameter>(k_InterpolateArrays_Key, "Attribute Arrays to Interpolate", "DataPaths to interpolate", std::vector<DataPath>(),
+                                                               MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray}, complex::GetAllNumericTypes()));
+  params.insert(std::make_unique<MultiArraySelectionParameter>(k_CopyArrays_Key, "Attribute Arrays to Copy", "DataPaths to copy", std::vector<DataPath>(),
+                                                               MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray}, complex::GetAllDataTypes()));
 
   params.insertSeparator(Parameters::Separator{"Created Data Objects"});
   params.insert(std::make_unique<DataGroupCreationParameter>(k_InterpolatedGroup_Key, "Interpolated Group", "DataPath to created DataGroup for interpolated data", DataPath()));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.cpp
@@ -226,7 +226,8 @@ Parameters MapPointCloudToRegularGridFilter::parameters() const
   params.insert(std::make_unique<DataPathSelectionParameter>(k_VertexGeometry_Key, "Vertex Geometry", "Path to the target Vertex Geometry", DataPath()));
   params.insert(std::make_unique<DataGroupCreationParameter>(k_NewImageGeometry_Key, "Image Geometry", "Path to create the Image Geometry", DataPath()));
 
-  params.insert(std::make_unique<MultiArraySelectionParameter>(k_ArraysToMap_Key, "Arrays to Map", "Paths to map to the grid geometry", std::vector<DataPath>(), complex::GetAllDataTypes()));
+  params.insert(std::make_unique<MultiArraySelectionParameter>(k_ArraysToMap_Key, "Arrays to Map", "Paths to map to the grid geometry", std::vector<DataPath>(),
+                                                               MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray}, complex::GetAllDataTypes()));
 
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_UseMask_Key, "Use Mask", "Specifies if a mask array should be used", false));
   params.insert(std::make_unique<ArraySelectionParameter>(k_MaskPath_Key, "Mask", "Path to the target mask array", DataPath(), ArraySelectionParameter::AllowedTypes{DataType::boolean},

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
@@ -322,7 +322,8 @@ Parameters MinNeighbors::parameters() const
       DataPath({"Data Container", "Feature Data", "Phases"}), ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
   // Attribute Arrays to Ignore
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_IgnoredVoxelArrays_Key, "Cell Arrays to Ignore", "The arrays to ignore when applying the minimum neighbors algorithm",
-                                                               std::vector<DataPath>{}, MultiArraySelectionParameter::AllowedTypes{}));
+                                                               std::vector<DataPath>{}, MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray},
+                                                               MultiArraySelectionParameter::AllowedDataTypes{}));
 
   params.linkParameters(k_ApplyToSinglePhase_Key, k_PhaseNumber_Key, std::make_any<bool>(true));
   params.linkParameters(k_ApplyToSinglePhase_Key, k_FeaturePhases_Key, std::make_any<bool>(true));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.cpp
@@ -70,7 +70,8 @@ Parameters PointSampleTriangleGeometryFilter::parameters() const
                                                           ArraySelectionParameter::AllowedTypes{DataType::boolean}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_SelectedDataArrayPaths_Key, "Face Attribute Arrays to Transfer",
                                                                "The paths to the Face Attribute Arrays to transfer to the created Vertex Geometry where the mask is false, if Use Mask is checked",
-                                                               MultiArraySelectionParameter::ValueType{}, complex::GetAllDataTypes()));
+                                                               MultiArraySelectionParameter::ValueType{}, MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray},
+                                                               complex::GetAllDataTypes()));
 
   params.insertSeparator(Parameters::Separator{"Created Objects"});
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
@@ -66,9 +66,9 @@ Parameters QuickSurfaceMeshFilter::parameters() const
       std::make_unique<DataPathSelectionParameter>(k_GridGeometryDataPath_Key, "Grid Geometry", "The complete path to the Grid Geometry from which to create a Triangle Geometry", DataPath{}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_CellFeatureIdsArrayPath_Key, "Feature Ids", "The complete path to the Array specifying which Feature each Cell belongs to", DataPath{},
                                                           ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
-  params.insert(std::make_unique<MultiArraySelectionParameter>(k_SelectedDataArrayPaths_Key, "Attribute Arrays to Transfer",
-                                                               "The paths to the Arrays specifying which Cell Attribute Arrays to transfer to the created Triangle Geometry",
-                                                               MultiArraySelectionParameter::ValueType{}, complex::GetAllDataTypes()));
+  params.insert(std::make_unique<MultiArraySelectionParameter>(
+      k_SelectedDataArrayPaths_Key, "Attribute Arrays to Transfer", "The paths to the Arrays specifying which Cell Attribute Arrays to transfer to the created Triangle Geometry",
+      MultiArraySelectionParameter::ValueType{}, MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray}, complex::GetAllDataTypes()));
 
   params.insertSeparator(Parameters::Separator{"Created Triangle Geometry"});
   params.insert(

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
@@ -85,7 +85,7 @@ Parameters RemoveFlaggedVertices::parameters() const
   params.insert(std::make_unique<GeometrySelectionParameter>(k_VertexGeomPath_Key, "Vertex Geometry", "Path to the target Vertex Geometry", DataPath(),
                                                              GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Vertex}));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_ArraySelection_Key, "Vertex Data Arrays", "Paths to the target Vertex DataArrays to also reduce.", std::vector<DataPath>(),
-                                                               complex::GetAllDataTypes()));
+                                                               MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray}, complex::GetAllDataTypes()));
   params.insert(std::make_unique<ArraySelectionParameter>(k_MaskPath_Key, "Mask Array", "DataPath to the conditional array that will be used to decide which vertices are removed.", DataPath(),
                                                           ArraySelectionParameter::AllowedTypes{DataType::boolean}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insert(

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
@@ -78,7 +78,7 @@ Parameters ExampleFilter2::parameters() const
   params.insert(std::make_unique<ArraySelectionParameter>(k_Param6, "Array Selection", "Example array selection help text", ArraySelectionParameter::ValueType{}, complex::GetAllDataTypes()));
   params.insert(std::make_unique<GeometrySelectionParameter>(k_Param11, "GeometrySelectionParameter", "Example geometry selection help text", DataPath{}, GeometrySelectionParameter::AllowedTypes{}));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_Param12, "MultiArraySelectionParameter", "Example multiarray selection help text", MultiArraySelectionParameter::ValueType{},
-                                                               complex::GetAllDataTypes()));
+                                                               MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray}, complex::GetAllDataTypes()));
 
   params.linkParameters(k_Param7, k_Param9, std::make_any<BoolParameter::ValueType>(true));
 

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
@@ -78,7 +78,7 @@ Parameters ExampleFilter2::parameters() const
   params.insert(std::make_unique<ArraySelectionParameter>(k_Param6, "Array Selection", "Example array selection help text", ArraySelectionParameter::ValueType{}, complex::GetAllDataTypes()));
   params.insert(std::make_unique<GeometrySelectionParameter>(k_Param11, "GeometrySelectionParameter", "Example geometry selection help text", DataPath{}, GeometrySelectionParameter::AllowedTypes{}));
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_Param12, "MultiArraySelectionParameter", "Example multiarray selection help text", MultiArraySelectionParameter::ValueType{},
-                                                               MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray}, complex::GetAllDataTypes()));
+                                                               MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::Any}, complex::GetAllDataTypes()));
 
   params.linkParameters(k_Param7, k_Param9, std::make_any<BoolParameter::ValueType>(true));
 

--- a/src/complex/Common/TypesUtility.hpp
+++ b/src/complex/Common/TypesUtility.hpp
@@ -608,4 +608,61 @@ inline constexpr StringLiteral DataObjectTypeToString(DataObject::Type dataObjTy
   }
   }
 }
+
+/**
+ * @brief Converts IArray::ArrayType to DataObject::Type. ArrayType is a subset of DataObject::Type so this function cannot fail.
+ * @param arrayType
+ * @return
+ */
+inline constexpr DataObject::Type ConvertArrayTypeToDataObjectType(IArray::ArrayType arrayType)
+{
+  switch(arrayType)
+  {
+  case IArray::ArrayType::DataArray: {
+    return DataObject::Type::DataArray;
+  }
+  case IArray::ArrayType::NeighborListArray: {
+    return DataObject::Type::NeighborList;
+  }
+  case IArray::ArrayType::StringArray: {
+    return DataObject::Type::StringArray;
+  }
+  case IArray::ArrayType::Any: {
+    return DataObject::Type::Any;
+  }
+  default: {
+    throw std::runtime_error("complex::ConvertArrayTypeToDataObjectType: Invalid ArrayType");
+  }
+  }
+}
+
+/**
+ * @brief Converts DataObject::Type to IArray::ArrayType.
+ * @param dataObjectType
+ * @return
+ */
+inline constexpr std::optional<IArray::ArrayType> ConvertDataObjectTypeToArrayType(DataObject::Type dataObjectType) noexcept
+{
+  switch(dataObjectType)
+  {
+  case DataObject::Type::IDataArray:
+  case DataObject::Type::DataArray: {
+    return IArray::ArrayType::DataArray;
+  }
+  case DataObject::Type::INeighborList:
+  case DataObject::Type::NeighborList: {
+    return IArray::ArrayType::NeighborListArray;
+  }
+  case DataObject::Type::StringArray: {
+    return IArray::ArrayType::StringArray;
+  }
+  case DataObject::Type::Any: {
+    return IArray::ArrayType::Any;
+  }
+  default: {
+    return {};
+  }
+  }
+}
+
 } // namespace complex

--- a/src/complex/DataStructure/DataArray.hpp
+++ b/src/complex/DataStructure/DataArray.hpp
@@ -181,6 +181,15 @@ public:
   }
 
   /**
+   * @brief Returns an enumeration of the class or subclass. Used for quick comparison or type deduction
+   * @return
+   */
+  ArrayType getArrayType() const
+  {
+    return ArrayType::DataArray;
+  }
+
+  /**
    * @brief Returns a shallow copy of the DataArray without copying data. THE CALLING CODE
    * MUST DISPOSE OF THE RETURNED OBJECT.
    * @return DataObject*

--- a/src/complex/DataStructure/DataArray.hpp
+++ b/src/complex/DataStructure/DataArray.hpp
@@ -184,7 +184,7 @@ public:
    * @brief Returns an enumeration of the class or subclass. Used for quick comparison or type deduction
    * @return
    */
-  ArrayType getArrayType() const
+  ArrayType getArrayType() const override
   {
     return ArrayType::DataArray;
   }

--- a/src/complex/DataStructure/IArray.hpp
+++ b/src/complex/DataStructure/IArray.hpp
@@ -11,7 +11,21 @@ public:
 
   static inline constexpr StringLiteral k_TypeName = "IArray";
 
+  enum class ArrayType : EnumType
+  {
+    StringArray,
+    DataArray,
+    NeighborListArray,
+    Any
+  };
+
   ~IArray() override = default;
+
+  /**
+   * @brief Returns an enumeration of the class or subclass. Used for quick comparison or type deduction
+   * @return
+   */
+  virtual ArrayType getArrayType() const = 0;
 
   /**
    * @brief Returns the number of elements.
@@ -47,6 +61,19 @@ public:
    * @brief Resizes the internal array to accomondate
    */
   virtual void reshapeTuples(const std::vector<usize>& tupleShape) = 0;
+
+  static std::set<std::string> StringListFromArrayType(const std::set<ArrayType>& arrayTypes)
+  {
+    static const std::map<ArrayType, std::string> k_TypeToStringMap = {
+        {ArrayType::StringArray, "StringArray"}, {ArrayType::DataArray, "DataArray"}, {ArrayType::NeighborListArray, "NeighborListArray"}, {ArrayType::Any, "Any"}};
+
+    std::set<std::string> stringValues;
+    for(auto arrayType : arrayTypes)
+    {
+      stringValues.insert(k_TypeToStringMap.at(arrayType));
+    }
+    return stringValues;
+  }
 
 protected:
   IArray() = delete;

--- a/src/complex/DataStructure/NeighborList.hpp
+++ b/src/complex/DataStructure/NeighborList.hpp
@@ -260,7 +260,7 @@ public:
    * @brief Returns an enumeration of the class or subclass. Used for quick comparison or type deduction
    * @return
    */
-  ArrayType getArrayType() const
+  ArrayType getArrayType() const override
   {
     return ArrayType::NeighborListArray;
   }

--- a/src/complex/DataStructure/NeighborList.hpp
+++ b/src/complex/DataStructure/NeighborList.hpp
@@ -257,6 +257,15 @@ public:
   }
 
   /**
+   * @brief Returns an enumeration of the class or subclass. Used for quick comparison or type deduction
+   * @return
+   */
+  ArrayType getArrayType() const
+  {
+    return ArrayType::NeighborListArray;
+  }
+
+  /**
    * @brief copyOfList
    * @param grainId
    * @return VectorType

--- a/src/complex/DataStructure/StringArray.cpp
+++ b/src/complex/DataStructure/StringArray.cpp
@@ -78,6 +78,11 @@ std::string StringArray::getTypeName() const
   return GetTypeName();
 }
 
+IArray::ArrayType StringArray::getArrayType() const
+{
+  return ArrayType::StringArray;
+}
+
 DataObject* StringArray::shallowCopy()
 {
   return new StringArray(*this);

--- a/src/complex/DataStructure/StringArray.hpp
+++ b/src/complex/DataStructure/StringArray.hpp
@@ -40,7 +40,7 @@ public:
    * @brief Returns an enumeration of the class or subclass. Used for quick comparison or type deduction
    * @return
    */
-  ArrayType getArrayType() const;
+  ArrayType getArrayType() const override;
 
   DataObject* shallowCopy() override;
   std::shared_ptr<DataObject> deepCopy(const DataPath& copyPath) override;

--- a/src/complex/DataStructure/StringArray.hpp
+++ b/src/complex/DataStructure/StringArray.hpp
@@ -36,6 +36,12 @@ public:
   DataObject::Type getDataObjectType() const override;
   std::string getTypeName() const override;
 
+  /**
+   * @brief Returns an enumeration of the class or subclass. Used for quick comparison or type deduction
+   * @return
+   */
+  ArrayType getArrayType() const;
+
   DataObject* shallowCopy() override;
   std::shared_ptr<DataObject> deepCopy(const DataPath& copyPath) override;
 

--- a/src/complex/Parameters/MultiArraySelectionParameter.cpp
+++ b/src/complex/Parameters/MultiArraySelectionParameter.cpp
@@ -80,7 +80,7 @@ Result<std::any> MultiArraySelectionParameter::fromJson(const nlohmann::json& js
 
 IParameter::UniquePointer MultiArraySelectionParameter::clone() const
 {
-  return std::make_unique<MultiArraySelectionParameter>(name(), humanName(), helpText(), m_DefaultValue, m_AllowedTypes);
+  return std::make_unique<MultiArraySelectionParameter>(name(), humanName(), helpText(), m_DefaultValue, m_AllowedTypes, m_AllowedDataTypes, m_RequiredComponentShapes);
 }
 
 std::any MultiArraySelectionParameter::defaultValue() const

--- a/src/complex/Parameters/MultiArraySelectionParameter.hpp
+++ b/src/complex/Parameters/MultiArraySelectionParameter.hpp
@@ -13,12 +13,13 @@ class COMPLEX_EXPORT MultiArraySelectionParameter : public MutableDataParameter
 {
 public:
   using ValueType = std::vector<DataPath>;
-  using AllowedTypes = std::set<DataType>;
+  using AllowedTypes = std::set<IArray::ArrayType>;
+  using AllowedDataTypes = std::set<DataType>;
   using AllowedComponentShapes = std::vector<IArray::ShapeType>;
 
   MultiArraySelectionParameter() = delete;
   MultiArraySelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, const AllowedTypes& allowedTypes,
-                               AllowedComponentShapes requiredComps = {});
+                               const AllowedDataTypes& allowedDataTypes, AllowedComponentShapes requiredComps = {});
   ~MultiArraySelectionParameter() override = default;
 
   MultiArraySelectionParameter(const MultiArraySelectionParameter&) = delete;
@@ -72,10 +73,16 @@ public:
   ValueType defaultPath() const;
 
   /**
-   * @brief Returns the set of allowed DataArray types. An empty set means all are allowed.
+   * @brief Returns the set of allowed IArray types. An empty set means all are allowed.
    * @return
    */
   AllowedTypes allowedTypes() const;
+
+  /**
+   * @brief Returns the set of allowed DataTypes. An empty set means all are allowed.
+   * @return
+   */
+  AllowedDataTypes allowedDataTypes() const;
 
   /**
    * @brief Returns the required number of components. If return value is empty, then no component requirements.
@@ -111,6 +118,7 @@ public:
 private:
   ValueType m_DefaultValue = {};
   AllowedTypes m_AllowedTypes = {};
+  AllowedDataTypes m_AllowedDataTypes = {};
   AllowedComponentShapes m_RequiredComponentShapes = {};
 };
 } // namespace complex


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files.

- [x] Class and Structs are `UpperCamelCase`
- [x] Class private member variables are `m_UpperCamelCase`
- [x] Class methods are `lowerCamelCase`
- [x] Method arguments are `lowerCamelCase`
- [x] Normal variables are `lowerCamelCase`
- [x] Constants are `k_UpperCamelCase`
- [x] Global statics are `s_UpperCamelCase`
- [x] Free Functions are `UpperCamelCase`
- [x] Macros are `ALL_UPPER_SNAKE_CASE`
- [x] Unit test will test data output from the filter.
- [x] Reused strings should be constants in an anonymous namespace
- [x] If parallelization is used, proper use of the abstracted complex classes are used. Using TBB specifically in a filter should be frowned upon unless for a really good reason.

## Filter Checklist

- [x] Parameters should be generally broken down into "Input Parameters", "Required Data Objects", "Created Data Objects". There can be exceptions to this.
- [x] ChoicesParameter selections should be an enumeration defined in the filer header
- [x] Documentation copied from SIMPL Repo and updated (if necessary)
- [x] Parameter argument variables are k_CamelCase_Key
- [x] Parameter argument strings are lower_snake_case
```
static inline constexpr StringLiteral k_AlignmentType_Key = "alignment_type";
```

## Unit Testing
- [x] 1 Unit test to instantiate the filter with the default arguments.
- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] Filters should have both the Filter class and Algorithm class for anything beyond trivial needs
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added Python wrapping to new files (if any) as necessary
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented.


<!-- **Thanks for contributing to complex!** -->
