### PR TITLE
Specifying [Array/DataGroup]CreationParameter parent group type

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.cpp
@@ -52,7 +52,8 @@ Parameters ApproximatePointCloudHull::parameters() const
   params.insert(std::make_unique<VectorFloat32Parameter>(k_GridResolution_Key, "Grid Resolution", "Geometry resolution", std::vector<float32>{0, 0, 0}, std::vector<std::string>{"X", "Y", "Z"}));
   params.insert(std::make_unique<UInt64Parameter>(k_MinEmptyNeighbors_Key, "Minimum Number of Empty Neighbors", "Minimum number of empty neighbors", 0));
   params.insert(std::make_unique<DataPathSelectionParameter>(k_VertexGeomPath_Key, "Vertex Geometry", "Path to the target Vertex geometry", DataPath()));
-  params.insert(std::make_unique<DataGroupCreationParameter>(k_HullVertexGeomPath_Key, "Hull Vertex Geometry", "Path to create the hull Vertex geometry", DataPath{}));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_HullVertexGeomPath_Key, "Hull Vertex Geometry", "Path to create the hull Vertex geometry", DataPath{},
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   return params;
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ArrayCalculatorFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ArrayCalculatorFilter.cpp
@@ -54,7 +54,8 @@ Parameters ArrayCalculatorFilter::parameters() const
   params.insert(std::make_unique<CalculatorParameter>(k_InfixEquation_Key, "Infix Expression", "The mathematical expression used to calculate the output array", CalculatorParameter::ValueType{}));
   params.insertSeparator(Parameters::Separator{"Created Cell Data"});
   params.insert(std::make_unique<NumericTypeParameter>(k_ScalarType_Key, "Output Scalar Type", "The data type of the calculated array", NumericType::float64));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_CalculatedArray_Key, "Output Calculated Array", "The path to the calculated array", DataPath{}));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_CalculatedArray_Key, "Output Calculated Array", "The path to the calculated array", DataPath{},
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CombineAttributeArraysFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CombineAttributeArraysFilter.cpp
@@ -65,7 +65,7 @@ Parameters CombineAttributeArraysFilter::parameters() const
 
   params.insertSeparator(Parameters::Separator{"Created Output Data Objects"});
   params.insert(std::make_unique<ArrayCreationParameter>(k_StackedDataArrayName_Key, "Created Data Array", "This is the DataPath to the created output array of the combined attribute arrays.",
-                                                         DataPath({"Combined DataArray"})));
+                                                         DataPath({"Combined DataArray"}), ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyDataGroup.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyDataGroup.cpp
@@ -40,7 +40,8 @@ Parameters CopyDataGroup::parameters() const
   params.insert(std::make_unique<DataGroupSelectionParameter>(k_DataPath_Key, "Group to copy", "DataPath to BaseGroup", DataPath{}, BaseGroup::GetAllGroupTypes()));
 
   params.insertSeparator(Parameters::Separator{"Created Output Data Objects"});
-  params.insert(std::make_unique<DataGroupCreationParameter>(k_NewPath_Key, "Copied Group", "DataPath to new BaseGroup", DataPath{}));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_NewPath_Key, "Copied Group", "DataPath to new BaseGroup", DataPath{},
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   return params;
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateAttributeMatrixFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateAttributeMatrixFilter.cpp
@@ -39,7 +39,8 @@ Parameters CreateAttributeMatrixFilter::parameters() const
   Parameters params;
 
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
-  params.insert(std::make_unique<DataGroupCreationParameter>(k_DataObjectPath, "DataObject Path", "The complete path to the Attribute Matrix being created", DataPath{}));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_DataObjectPath, "DataObject Path", "The complete path to the Attribute Matrix being created", DataPath{},
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   DynamicTableInfo tableInfo;
   tableInfo.setRowsInfo(DynamicTableInfo::StaticVectorInfo(1));
   tableInfo.setColsInfo(DynamicTableInfo::DynamicVectorInfo(1, "DIM {}"));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.cpp
@@ -66,7 +66,8 @@ Parameters CreateDataArray::parameters() const
   tableInfo.setColsInfo(DynamicTableInfo::DynamicVectorInfo(1, "DIM {}"));
 
   params.insert(std::make_unique<DynamicTableParameter>(k_TupleDims_Key, "Data Array Dimensions (Slowest to Fastest Dimensions)", "Slowest to Fastest Dimensions", tableInfo));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_DataPath_Key, "Created Array", "Array storing the data", DataPath{}));
+  params.insert(
+      std::make_unique<ArrayCreationParameter>(k_DataPath_Key, "Created Array", "Array storing the data", DataPath{}, ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   params.insert(std::make_unique<StringParameter>(k_InitilizationValue_Key, "Initialization Value", "This value will be used to fill the new array", "0"));
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataGroup.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataGroup.cpp
@@ -38,7 +38,8 @@ Parameters CreateDataGroup::parameters() const
   Parameters params;
 
   params.insertSeparator(Parameters::Separator{"Created Data Objects"});
-  params.insert(std::make_unique<DataGroupCreationParameter>(k_DataObjectPath, "DataObject Path", "The complete path to the DataObject being created", DataPath{}));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_DataObjectPath, "DataObject Path", "The complete path to the DataObject being created", DataPath{},
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   return params;
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateFeatureArrayFromElementArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateFeatureArrayFromElementArray.cpp
@@ -110,7 +110,8 @@ Parameters CreateFeatureArrayFromElementArray::parameters() const
   params.insert(std::make_unique<ArraySelectionParameter>(k_CellFeatureIdsArrayPath_Key, "Feature Ids", "Specifies to which Feature each Element belongs", DataPath{},
                                                           ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insertSeparator(Parameters::Separator{"Feature Data"});
-  params.insert(std::make_unique<ArrayCreationParameter>(k_CreatedArrayName_Key, "Copied Attribute Array", "The path to the copied AttributeArray", DataPath{}));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_CreatedArrayName_Key, "Copied Attribute Array", "The path to the copied AttributeArray", DataPath{},
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateImageGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateImageGeometry.cpp
@@ -57,7 +57,8 @@ Parameters CreateImageGeometry::parameters() const
 
   // Create the parameter descriptors that are needed for this filter
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
-  params.insert(std::make_unique<DataGroupCreationParameter>(k_GeometryDataPath_Key, "Geometry Name [Data Group]", "The complete path to the Geometry being created", DataPath({"[Image Geometry]"})));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_GeometryDataPath_Key, "Geometry Name [Data Group]", "The complete path to the Geometry being created", DataPath({"[Image Geometry]"}),
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   params.insert(std::make_unique<VectorUInt64Parameter>(k_Dimensions_Key, "Dimensions", "The number of cells in each of the X, Y, Z directions", std::vector<uint64_t>{20ULL, 60ULL, 200ULL},
                                                         std::vector<std::string>{"X"s, "Y"s, "Z"s}));
   params.insert(

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropImageGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropImageGeometry.cpp
@@ -249,7 +249,8 @@ Parameters CropImageGeometry::parameters() const
 
   params.insertSeparator(Parameters::Separator{"Input Data"});
   params.insert(std::make_unique<GeometrySelectionParameter>(k_ImageGeom_Key, "Image Geom", "DataPath to the target ImageGeom", DataPath(), std::set{IGeometry::Type::Image}));
-  params.insert(std::make_unique<DataGroupCreationParameter>(k_NewImageGeom_Key, "New Image Geom", "DataPath to create the new ImageGeom at", DataPath()));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_NewImageGeom_Key, "New Image Geom", "DataPath to create the new ImageGeom at", DataPath(),
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_RemoveOriginalGeometry_Key, "Remove Original Image Geometry Group", "Remove the original geometry after cropping", true));
 
   params.insertSeparator(Parameters::Separator{"Input Parameters"});

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
@@ -69,7 +69,8 @@ Parameters CropVertexGeometry::parameters() const
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
   params.insert(std::make_unique<GeometrySelectionParameter>(k_VertexGeom_Key, "Vertex Geometry to Crop", "DataPath to target VertexGeom", DataPath{},
                                                              GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Vertex}));
-  params.insert(std::make_unique<DataGroupCreationParameter>(k_CroppedGeom_Key, "Cropped Vertex Geometry", "Created VertexGeom path", DataPath{}));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_CroppedGeom_Key, "Cropped Vertex Geometry", "Created VertexGeom path", DataPath{},
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   params.insert(std::make_unique<DataObjectNameParameter>(k_VertexDataName_Key, "Vertex Data Name", "Name of the vertex data AttributeMatrix", INodeGeometry0D::k_VertexDataName));
   params.insert(std::make_unique<VectorFloat32Parameter>(k_MinPos_Key, "Min Pos", "Minimum vertex position", std::vector<float32>{0, 0, 0}, std::vector<std::string>{"X", "Y", "Z"}));
   params.insert(std::make_unique<VectorFloat32Parameter>(k_MaxPos_Key, "Max Pos", "Maximum vertex position", std::vector<float32>{0, 0, 0}, std::vector<std::string>{"X", "Y", "Z"}));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -123,7 +123,8 @@ Parameters ExtractInternalSurfacesFromTriangleGeometry::parameters() const
                                                           ArraySelectionParameter::AllowedComponentShapes{{1}}));
 
   params.insertSeparator(Parameters::Separator{"Create Data Objects"});
-  params.insert(std::make_unique<DataGroupCreationParameter>(k_InternalTriangleGeom_Key, "Created Triangle Geometry Path", "Path to create the new Triangle Geometry", DataPath()));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_InternalTriangleGeom_Key, "Created Triangle Geometry Path", "Path to create the new Triangle Geometry", DataPath(),
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   params.insert(std::make_unique<DataObjectNameParameter>(k_VertexDataName_Key, "Vertex Data Attribute Matrix", "Created vertex data AttributeMatrix name", INodeGeometry0D::k_VertexDataName));
   params.insert(std::make_unique<DataObjectNameParameter>(k_FaceDataName_Key, "Face Data Attribute Matrix", "Created face data AttributeMatrix name", INodeGeometry2D::k_FaceDataName));
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindArrayStatisticsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindArrayStatisticsFilter.cpp
@@ -143,8 +143,8 @@ Parameters FindArrayStatisticsFilter::parameters() const
   params.insertSeparator(Parameters::Separator{"Required Input Data"});
   params.insert(std::make_unique<ArraySelectionParameter>(k_SelectedArrayPath_Key, "Attribute Array to Compute Statistics", "Input Attribute Array for which to compute statistics", DataPath{},
                                                           complex::GetAllDataTypes(), ArraySelectionParameter::AllowedComponentShapes{{1}}));
-  params.insert(
-      std::make_unique<DataGroupCreationParameter>(k_DestinationAttributeMatrix_Key, "Destination Attribute Matrix", "Attribute Matrix in which to store the computed statistics", DataPath{}));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_DestinationAttributeMatrix_Key, "Destination Attribute Matrix", "Attribute Matrix in which to store the computed statistics", DataPath{},
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   params.insertSeparator(Parameters::Separator{"Histogram Options"});
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_FindHistogram_Key, "Find Histogram", "Whether to compute the histogram of the input array", false));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindDifferencesMap.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindDifferencesMap.cpp
@@ -156,7 +156,8 @@ Parameters FindDifferencesMap::parameters() const
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
   params.insert(std::make_unique<DataPathSelectionParameter>(k_FirstInputArrayPath_Key, "First Input Array", "DataPath to the first input DataArray", DataPath{}));
   params.insert(std::make_unique<DataPathSelectionParameter>(k_SecondInputArrayPath_Key, "Second Input Array", "DataPath to the second input DataArray", DataPath{}));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_DifferenceMapArrayPath_Key, "Difference Map", "DataPath for created Difference Map DataArray", DataPath{}));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_DifferenceMapArrayPath_Key, "Difference Map", "DataPath for created Difference Map DataArray", DataPath{},
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   return params;
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighborListStatistics.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighborListStatistics.cpp
@@ -304,14 +304,20 @@ Parameters FindNeighborListStatistics::parameters() const
       std::make_unique<NeighborListSelectionParameter>(k_InputArray_Key, "NeighborList to Compute Statistics", "Input Data Array to compute statistics", DataPath(), complex::GetAllDataTypes()));
 
   params.insertSeparator(Parameters::Separator{"Created Data Objects"});
-  params.insert(std::make_unique<ArrayCreationParameter>(k_Length_Key, "Length", "Path to create the Length array during calculations", DataPath({"Length"})));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_Minimum_Key, "Minimum", "Path to create the Minimum array during calculations", DataPath({"Minimum"})));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_Maximum_Key, "Maximum", "Path to create the Maximum array during calculations", DataPath({"Maximum"})));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_Mean_Key, "Mean", "Path to create the Mean array during calculations", DataPath({"Mean"})));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_Median_Key, "Median", "Path to create the Median array during calculations", DataPath({"Median"})));
-  params.insert(
-      std::make_unique<ArrayCreationParameter>(k_StandardDeviation_Key, "Standard Deviation", "Path to create the Standard Deviation array during calculations", DataPath({"StandardDeviation"})));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_Summation_Key, "Summation", "Path to create the Summation array during calculations", DataPath({"Summation"})));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_Length_Key, "Length", "Path to create the Length array during calculations", DataPath({"Length"}),
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_Minimum_Key, "Minimum", "Path to create the Minimum array during calculations", DataPath({"Minimum"}),
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_Maximum_Key, "Maximum", "Path to create the Maximum array during calculations", DataPath({"Maximum"}),
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_Mean_Key, "Mean", "Path to create the Mean array during calculations", DataPath({"Mean"}),
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_Median_Key, "Median", "Path to create the Median array during calculations", DataPath({"Median"}),
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_StandardDeviation_Key, "Standard Deviation", "Path to create the Standard Deviation array during calculations",
+                                                         DataPath({"StandardDeviation"}), ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_Summation_Key, "Summation", "Path to create the Summation array during calculations", DataPath({"Summation"}),
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   return params;
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNumFeaturesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNumFeaturesFilter.cpp
@@ -53,7 +53,8 @@ Parameters FindNumFeaturesFilter::parameters() const
                                                           DataPath({"DataContainer", "FeatureData", "Phases"}), complex::GetAllDataTypes()));
 
   params.insertSeparator(Parameters::Separator{"Created Objects: Ensemble Data"});
-  params.insert(std::make_unique<ArrayCreationParameter>(k_NumFeaturesArrayPath_Key, "Number of Features", "The number of Features that belong to each Ensemble", DataPath({"Number of Features"})));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_NumFeaturesArrayPath_Key, "Number of Features", "The number of Features that belong to each Ensemble", DataPath({"Number of Features"}),
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindSurfaceFeatures.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindSurfaceFeatures.cpp
@@ -236,7 +236,7 @@ Parameters FindSurfaceFeatures::parameters() const
   params.insertSeparator(Parameters::Separator{"Created  Feature Data"});
   params.insert(std::make_unique<ArrayCreationParameter>(k_SurfaceFeaturesArrayPath_Key, "Surface Features",
                                                          "The path to the created surface features array. Flag of 1 if Feature touches an outer surface or of 0 if it does not",
-                                                         DataPath({"CellFeatureData", "SurfaceFeatures"})));
+                                                         DataPath({"CellFeatureData", "SurfaceFeatures"}), ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindVolFractionsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindVolFractionsFilter.cpp
@@ -54,7 +54,8 @@ Parameters FindVolFractionsFilter::parameters() const
                                                           DataPath({"DataContainer", "CellData", "Phases"}), ArraySelectionParameter::AllowedTypes{DataType::int32},
                                                           ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insertSeparator(Parameters::Separator{"Created Objects: Ensemble Data"});
-  params.insert(std::make_unique<ArrayCreationParameter>(k_VolFractionsArrayPath_Key, "Volume Fractions", "Fraction of volume that belongs to each Ensemble", DataPath({"Volume Fractions"})));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_VolFractionsArrayPath_Key, "Volume Fractions", "Fraction of volume that belongs to each Ensemble", DataPath({"Volume Fractions"}),
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportCSVDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportCSVDataFilter.cpp
@@ -329,7 +329,8 @@ Parameters ImportCSVDataFilter::parameters() const
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_UseExistingGroup_Key, "Use Existing Group", "Store the imported CSV data arrays in an existing group.", false));
   params.insert(std::make_unique<DataGroupSelectionParameter>(k_SelectedDataGroup_Key, "Existing Data Group", "Store the imported CSV data arrays in this existing group.", DataPath{},
                                                               BaseGroup::GetAllGroupTypes()));
-  params.insert(std::make_unique<DataGroupCreationParameter>(k_CreatedDataGroup_Key, "New Data Group", "Store the imported CSV data arrays in a newly created group.", DataPath{}));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_CreatedDataGroup_Key, "New Data Group", "Store the imported CSV data arrays in a newly created group.", DataPath{},
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   // Associate the Linkable Parameter(s) to the children parameters that they control
   params.linkParameters(k_UseExistingGroup_Key, k_SelectedDataGroup_Key, true);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
@@ -58,7 +58,8 @@ Parameters ImportTextFilter::parameters() const
   params.insert(std::make_unique<UInt64Parameter>(k_NSkipLinesKey, "Skip Header Lines", "Number of lines at the start of the file to skip", 0));
   params.insert(std::make_unique<ChoicesParameter>(k_DelimiterChoiceKey, "Delimiter", "Delimiter for values on a line", 0,
                                                    ChoicesParameter::Choices{", (comma)", "; (semicolon)", "  (space)", ": (colon)", "\\t (Tab)"}));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_DataArrayKey, "Created Array Path", "DataPath or Name for the underlying Data Array", DataPath{}));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_DataArrayKey, "Created Array Path", "DataPath or Name for the underlying Data Array", DataPath{},
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   return params;
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
@@ -228,8 +228,10 @@ Parameters InterpolatePointCloudToRegularGridFilter::parameters() const
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_CopyArrays_Key, "Attribute Arrays to Copy", "DataPaths to copy", std::vector<DataPath>(), complex::GetAllDataTypes()));
 
   params.insertSeparator(Parameters::Separator{"Created Data Objects"});
-  params.insert(std::make_unique<DataGroupCreationParameter>(k_InterpolatedGroup_Key, "Interpolated Group", "DataPath to created DataGroup for interpolated data", DataPath()));
-  params.insert(std::make_unique<DataGroupCreationParameter>(k_KernelDistancesGroup_Key, "Kernel Distances Group", "DataPath to created DataGroup for kernel distances data", DataPath()));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_InterpolatedGroup_Key, "Interpolated Group", "DataPath to created DataGroup for interpolated data", DataPath(),
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_KernelDistancesGroup_Key, "Kernel Distances Group", "DataPath to created DataGroup for kernel distances data", DataPath(),
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   params.linkParameters(k_UseMask_Key, k_Mask_Key, std::make_any<bool>(true));
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/IterativeClosestPointFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/IterativeClosestPointFilter.cpp
@@ -97,7 +97,8 @@ Parameters IterativeClosestPointFilter::parameters() const
   params.insert(std::make_unique<DataPathSelectionParameter>(k_TargetVertexPath_Key, "Target Vertex Geometry", "Number of components", DataPath()));
 
   params.insertSeparator(Parameters::Separator{"Created Data Objects"});
-  params.insert(std::make_unique<ArrayCreationParameter>(k_TransformArrayPath_Key, "Output Transform Array", "Number of tuples", DataPath()));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_TransformArrayPath_Key, "Output Transform Array", "Number of tuples", DataPath(),
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   return params;
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.cpp
@@ -224,7 +224,8 @@ Parameters MapPointCloudToRegularGridFilter::parameters() const
   params.insert(std::make_unique<DataPathSelectionParameter>(k_ExistingImageGeometry_Key, "Image Geometry", "Path to the target Image Geometry", DataPath()));
 
   params.insert(std::make_unique<DataPathSelectionParameter>(k_VertexGeometry_Key, "Vertex Geometry", "Path to the target Vertex Geometry", DataPath()));
-  params.insert(std::make_unique<DataGroupCreationParameter>(k_NewImageGeometry_Key, "Image Geometry", "Path to create the Image Geometry", DataPath()));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_NewImageGeometry_Key, "Image Geometry", "Path to create the Image Geometry", DataPath(),
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_ArraysToMap_Key, "Arrays to Map", "Paths to map to the grid geometry", std::vector<DataPath>(), complex::GetAllDataTypes()));
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MultiThresholdObjects.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MultiThresholdObjects.cpp
@@ -357,7 +357,8 @@ Parameters MultiThresholdObjects::parameters() const
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
   params.insert(
       std::make_unique<ArrayThresholdsParameter>(k_ArrayThresholds_Key, "Data Thresholds", "DataArray thresholds to mask", ArrayThresholdSet{}, ArrayThresholdsParameter::AllowedComponentShapes{{1}}));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_CreatedDataPath_Key, "Mask Array", "DataPath to the created Mask Array", DataPath{}));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_CreatedDataPath_Key, "Mask Array", "DataPath to the created Mask Array", DataPath{},
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   return params;
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.cpp
@@ -77,7 +77,8 @@ Parameters PointSampleTriangleGeometryFilter::parameters() const
   // params.insert(std::make_unique<DataGroupSelectionParameter>(k_VertexParentGroup_Key, "Created Vertex Geometry Parent [Data Group]", "", DataPath{},
   // DataGroupSelectionParameter::AllowedTypes{BaseGroup::GroupType::DataGroup}));
   params.insert(std::make_unique<DataGroupCreationParameter>(k_VertexGeometryPath_Key, "Vertex Geometry Name",
-                                                             "The complete path to the DataGroup holding the Vertex Geometry that represents the sampling points", DataPath({"[Vertex Geometry]"})));
+                                                             "The complete path to the DataGroup holding the Vertex Geometry that represents the sampling points", DataPath({"[Vertex Geometry]"}),
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   params.insert(
       std::make_unique<DataObjectNameParameter>(k_VertexDataGroupPath_Key, "Vertex Data", "The complete path to the vertex data arrays for the Vertex Geometry", INodeGeometry0D::k_VertexDataName));
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
@@ -78,14 +78,15 @@ Parameters QuickSurfaceMeshFilter::parameters() const
   params.insert(std::make_unique<DataObjectNameParameter>(k_VertexDataGroupName_Key, "Vertex Data [AttributeMatrix]",
                                                           "The complete path to the DataGroup where the Vertex Data of the Triangle Geometry will be created", INodeGeometry0D::k_VertexDataName));
   params.insert(std::make_unique<ArrayCreationParameter>(k_NodeTypesArrayName_Key, "NodeType", "The complete path to the Array specifying the type of node in the Triangle Geometry",
-                                                         DataPath({"TriangleDataContainer", "VertexData", "NodeTypes"})));
+                                                         DataPath({"TriangleDataContainer", "VertexData", "NodeTypes"}),
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   params.insertSeparator(Parameters::Separator{"Created Face Data"});
   params.insert(std::make_unique<DataObjectNameParameter>(k_FaceDataGroupName_Key, "Face Data [AttributeMatrix]",
                                                           "The complete path to the DataGroup where the Face Data of the Triangle Geometry will be created", INodeGeometry2D::k_FaceDataName));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_FaceLabelsArrayName_Key, "Face Labels",
-                                                         "The complete path to the Array specifying which Features are on either side of each Face in the Triangle Geometry",
-                                                         DataPath({"TriangleDataContainer", "FaceData", "FaceLabels"})));
+  params.insert(std::make_unique<ArrayCreationParameter>(
+      k_FaceLabelsArrayName_Key, "Face Labels", "The complete path to the Array specifying which Features are on either side of each Face in the Triangle Geometry",
+      DataPath({"TriangleDataContainer", "FaceData", "FaceLabels"}), ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   params.insertSeparator(Parameters::Separator{"Created Face Feature Data"});
   params.insert(std::make_unique<DataObjectNameParameter>(k_FaceFeatureAttributeMatrixName_Key, "Face Feature Data [AttributeMatrix]",
                                                           "The complete path to the DataGroup where the Feature Data will be stored.", INodeGeometry1D::k_FaceFeatureAttributeMatrix));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
@@ -71,8 +71,8 @@ Parameters QuickSurfaceMeshFilter::parameters() const
                                                                MultiArraySelectionParameter::ValueType{}, complex::GetAllDataTypes()));
 
   params.insertSeparator(Parameters::Separator{"Created Triangle Geometry"});
-  params.insert(
-      std::make_unique<DataGroupCreationParameter>(k_TriangleGeometryName_Key, "Created Triangle Geometry", "The name of the created Triangle Geometry", DataPath({"TriangleDataContainer"})));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_TriangleGeometryName_Key, "Created Triangle Geometry", "The name of the created Triangle Geometry", DataPath({"TriangleDataContainer"}),
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   params.insertSeparator(Parameters::Separator{"Created Vertex Data"});
   params.insert(std::make_unique<DataObjectNameParameter>(k_VertexDataGroupName_Key, "Vertex Data [AttributeMatrix]",

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
@@ -77,7 +77,7 @@ Parameters RawBinaryReaderFilter::parameters() const
   params.insert(std::make_unique<ChoicesParameter>(k_Endian_Key, "Endian", "The endianness of the data", 0, ChoicesParameter::Choices{"Little", "Big"}));
   params.insert(std::make_unique<UInt64Parameter>(k_SkipHeaderBytes_Key, "Skip Header Bytes", "Number of bytes to skip before reading data", 0));
   params.insert(std::make_unique<ArrayCreationParameter>(k_CreatedAttributeArrayPath_Key, "Output Attribute Array", "The complete path to the created Attribute Array",
-                                                         DataPath(std::vector<std::string>{"Imported Array"})));
+                                                         DataPath(std::vector<std::string>{"Imported Array"}), ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
@@ -88,8 +88,8 @@ Parameters RemoveFlaggedVertices::parameters() const
                                                                complex::GetAllDataTypes()));
   params.insert(std::make_unique<ArraySelectionParameter>(k_MaskPath_Key, "Mask Array", "DataPath to the conditional array that will be used to decide which vertices are removed.", DataPath(),
                                                           ArraySelectionParameter::AllowedTypes{DataType::boolean}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
-  params.insert(
-      std::make_unique<DataGroupCreationParameter>(k_ReducedVertexPath_Key, "Reduced Vertex Geometry", "Created Vertex Geometry DataPath. This will be created during the filter.", DataPath()));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_ReducedVertexPath_Key, "Reduced Vertex Geometry", "Created Vertex Geometry DataPath. This will be created during the filter.",
+                                                             DataPath(), DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
   params.insert(std::make_unique<DataObjectNameParameter>(k_VertexDataName_Key, "Vertex Data Name", "Name of the vertex data AttributeMatrix", INodeGeometry0D::k_VertexDataName));
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RobustAutomaticThreshold.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RobustAutomaticThreshold.cpp
@@ -141,7 +141,8 @@ Parameters RobustAutomaticThreshold::parameters() const
                                                           ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_GradientMagnitudePath, "Gradient Magnitude Data", "The complete path to the Array specifying the gradient magnitude of the Input Array",
                                                           DataPath(), ArraySelectionParameter::AllowedTypes{DataType::float32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_ArrayCreationPath, "Mask", "Created mask based on Input Array and Gradient Magnitude", DataPath()));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_ArrayCreationPath, "Mask", "Created mask based on Input Array and Gradient Magnitude", DataPath(),
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
@@ -76,7 +76,7 @@ Parameters StlFileReaderFilter::parameters() const
   params.insertSeparator(Parameters::Separator{"Created Objects"});
 
   params.insert(std::make_unique<DataGroupCreationParameter>(k_GeometryDataPath_Key, "Geometry Name [Data Group]", "The complete path to the DataGroup containing the created Geometry data",
-                                                             DataPath({"[Triangle Geometry]"})));
+                                                             DataPath({"[Triangle Geometry]"}), DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::BaseGroup}));
 
   return params;
 }

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
@@ -87,7 +87,8 @@ Parameters ExampleFilter2::parameters() const
   params.linkParameters(k_Param3, k_Param11, std::make_any<ChoicesParameter::ValueType>(2));
 
   // These should show up under the "Created Objects" section in the GUI
-  params.insert(std::make_unique<DataGroupCreationParameter>(k_Param8, "DataGroupCreationParameter", "Example data group creation help text", DataPath{}));
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_Param8, "DataGroupCreationParameter", "Example data group creation help text", DataPath{},
+                                                             DataGroupCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::DataGroup}));
   params.insert(std::make_unique<ArrayCreationParameter>(k_Param5, "Array Creation", "Example array creation help text", ArrayCreationParameter::ValueType{},
                                                          ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::AttributeMatrix}));
 

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
@@ -88,7 +88,8 @@ Parameters ExampleFilter2::parameters() const
 
   // These should show up under the "Created Objects" section in the GUI
   params.insert(std::make_unique<DataGroupCreationParameter>(k_Param8, "DataGroupCreationParameter", "Example data group creation help text", DataPath{}));
-  params.insert(std::make_unique<ArrayCreationParameter>(k_Param5, "Array Creation", "Example array creation help text", ArrayCreationParameter::ValueType{}));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_Param5, "Array Creation", "Example array creation help text", ArrayCreationParameter::ValueType{},
+                                                         ArrayCreationParameter::AllowedParentGroupType{BaseGroup::GroupType::AttributeMatrix}));
 
   return params;
 }

--- a/src/complex/Parameters/ArrayCreationParameter.cpp
+++ b/src/complex/Parameters/ArrayCreationParameter.cpp
@@ -1,6 +1,7 @@
 #include "ArrayCreationParameter.hpp"
 
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 
 #include <nlohmann/json.hpp>
 
@@ -8,9 +9,11 @@
 
 namespace complex
 {
-ArrayCreationParameter::ArrayCreationParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue)
+ArrayCreationParameter::ArrayCreationParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue,
+                                               const AllowedParentGroupType& allowedParentGroup)
 : MutableDataParameter(name, humanName, helpText, Category::Created)
 , m_DefaultValue(defaultValue)
+, m_AllowedParentGroupType(allowedParentGroup)
 {
 }
 
@@ -50,7 +53,7 @@ Result<std::any> ArrayCreationParameter::fromJson(const nlohmann::json& json) co
 
 IParameter::UniquePointer ArrayCreationParameter::clone() const
 {
-  return std::make_unique<ArrayCreationParameter>(name(), humanName(), helpText(), m_DefaultValue);
+  return std::make_unique<ArrayCreationParameter>(name(), humanName(), helpText(), m_DefaultValue, m_AllowedParentGroupType);
 }
 
 std::any ArrayCreationParameter::defaultValue() const
@@ -61,6 +64,11 @@ std::any ArrayCreationParameter::defaultValue() const
 typename ArrayCreationParameter::ValueType ArrayCreationParameter::defaultPath() const
 {
   return m_DefaultValue;
+}
+
+ArrayCreationParameter::AllowedParentGroupType ArrayCreationParameter::allowedParentGroupType() const
+{
+  return m_AllowedParentGroupType;
 }
 
 Result<> ArrayCreationParameter::validate(const DataStructure& dataStructure, const std::any& value) const
@@ -82,6 +90,25 @@ Result<> ArrayCreationParameter::validatePath(const DataStructure& dataStructure
   if(object != nullptr)
   {
     return complex::MakeErrorResult(complex::FilterParameter::Constants::k_Validate_ExistingValue, fmt::format("{}Object exists at path '{}'", prefix, value.toString()));
+  }
+
+  DataPath parentPath = value.getParent();
+  const auto* parentGroup = dataStructure.getDataAs<BaseGroup>(parentPath);
+  if(parentGroup == nullptr)
+  {
+    return complex::MakeErrorResult(complex::FilterParameter::Constants::k_Validate_ExistingValue, fmt::format("{}Parent path '{}' is not a BaseGroup type", prefix, parentPath.toString()));
+  }
+
+  if(m_AllowedParentGroupType.empty() || m_AllowedParentGroupType.find(BaseGroup::GroupType::BaseGroup) != m_AllowedParentGroupType.end())
+  {
+    return {};
+  }
+
+  if(m_AllowedParentGroupType.find(parentGroup->getGroupType()) == m_AllowedParentGroupType.end())
+  {
+    return complex::MakeErrorResult(complex::FilterParameter::Constants::k_Validate_ExistingValue,
+                                    fmt::format("{}Parent path '{}' is of type {} but only {} types are allowed", prefix, parentPath.toString(),
+                                                BaseGroup::StringListFromGroupType(AllowedParentGroupType{parentGroup->getGroupType()}), BaseGroup::StringListFromGroupType(m_AllowedParentGroupType)));
   }
 
   return {};

--- a/src/complex/Parameters/ArrayCreationParameter.cpp
+++ b/src/complex/Parameters/ArrayCreationParameter.cpp
@@ -93,6 +93,11 @@ Result<> ArrayCreationParameter::validatePath(const DataStructure& dataStructure
   }
 
   DataPath parentPath = value.getParent();
+  if(parentPath.empty())
+  {
+    return {};
+  }
+
   const auto* parentGroup = dataStructure.getDataAs<BaseGroup>(parentPath);
   if(parentGroup == nullptr)
   {

--- a/src/complex/Parameters/ArrayCreationParameter.hpp
+++ b/src/complex/Parameters/ArrayCreationParameter.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "complex/DataStructure/BaseGroup.hpp"
 #include "complex/Filter/MutableDataParameter.hpp"
 #include "complex/Filter/ParameterTraits.hpp"
 #include "complex/complex_export.hpp"
@@ -12,9 +13,10 @@ class COMPLEX_EXPORT ArrayCreationParameter : public MutableDataParameter
 {
 public:
   using ValueType = DataPath;
+  using AllowedParentGroupType = std::set<BaseGroup::GroupType>;
 
   ArrayCreationParameter() = delete;
-  ArrayCreationParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue);
+  ArrayCreationParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, const AllowedParentGroupType& allowedParentGroup);
   ~ArrayCreationParameter() override = default;
 
   ArrayCreationParameter(const ArrayCreationParameter&) = delete;
@@ -67,6 +69,12 @@ public:
 
   /**
    * @brief
+   * @return
+   */
+  AllowedParentGroupType allowedParentGroupType() const;
+
+  /**
+   * @brief
    * @param value
    * @return
    */
@@ -89,6 +97,7 @@ public:
 
 private:
   ValueType m_DefaultValue = {};
+  AllowedParentGroupType m_AllowedParentGroupType = {};
 };
 } // namespace complex
 

--- a/src/complex/Parameters/ArrayCreationParameter.hpp
+++ b/src/complex/Parameters/ArrayCreationParameter.hpp
@@ -68,8 +68,8 @@ public:
   ValueType defaultPath() const;
 
   /**
-   * @brief
-   * @return
+   * @brief Returns to the user the allowed group types of the parent group
+   * @return std::set<BaseGroup::GroupType>
    */
   AllowedParentGroupType allowedParentGroupType() const;
 

--- a/src/complex/Parameters/DataGroupCreationParameter.cpp
+++ b/src/complex/Parameters/DataGroupCreationParameter.cpp
@@ -1,6 +1,7 @@
 #include "DataGroupCreationParameter.hpp"
 
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 
 #include <nlohmann/json.hpp>
 
@@ -8,9 +9,11 @@
 
 namespace complex
 {
-DataGroupCreationParameter::DataGroupCreationParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue)
+DataGroupCreationParameter::DataGroupCreationParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue,
+                                                       const AllowedParentGroupType& allowedParentGroup)
 : MutableDataParameter(name, humanName, helpText, Category::Created)
 , m_DefaultValue(defaultValue)
+, m_AllowedParentGroupType(allowedParentGroup)
 {
 }
 
@@ -51,7 +54,7 @@ Result<std::any> DataGroupCreationParameter::fromJson(const nlohmann::json& json
 
 IParameter::UniquePointer DataGroupCreationParameter::clone() const
 {
-  return std::make_unique<DataGroupCreationParameter>(name(), humanName(), helpText(), m_DefaultValue);
+  return std::make_unique<DataGroupCreationParameter>(name(), humanName(), helpText(), m_DefaultValue, m_AllowedParentGroupType);
 }
 
 std::any DataGroupCreationParameter::defaultValue() const
@@ -62,6 +65,11 @@ std::any DataGroupCreationParameter::defaultValue() const
 typename DataGroupCreationParameter::ValueType DataGroupCreationParameter::defaultPath() const
 {
   return m_DefaultValue;
+}
+
+DataGroupCreationParameter::AllowedParentGroupType DataGroupCreationParameter::allowedParentGroupType() const
+{
+  return m_AllowedParentGroupType;
 }
 
 Result<> DataGroupCreationParameter::validate(const DataStructure& dataStructure, const std::any& value) const
@@ -83,6 +91,30 @@ Result<> DataGroupCreationParameter::validatePath(const DataStructure& dataStruc
   if(object != nullptr)
   {
     return complex::MakeErrorResult(complex::FilterParameter::Constants::k_Validate_ExistingValue, fmt::format("{}Object exists at path '{}'", prefix, value.toString()));
+  }
+
+  DataPath parentPath = value.getParent();
+  if(parentPath.empty())
+  {
+    return {};
+  }
+
+  const auto* parentGroup = dataStructure.getDataAs<BaseGroup>(parentPath);
+  if(parentGroup == nullptr)
+  {
+    return complex::MakeErrorResult(complex::FilterParameter::Constants::k_Validate_ExistingValue, fmt::format("{}Parent path '{}' is not a BaseGroup type", prefix, parentPath.toString()));
+  }
+
+  if(m_AllowedParentGroupType.empty() || m_AllowedParentGroupType.find(BaseGroup::GroupType::BaseGroup) != m_AllowedParentGroupType.end())
+  {
+    return {};
+  }
+
+  if(m_AllowedParentGroupType.find(parentGroup->getGroupType()) == m_AllowedParentGroupType.end())
+  {
+    return complex::MakeErrorResult(complex::FilterParameter::Constants::k_Validate_ExistingValue,
+                                    fmt::format("{}Parent path '{}' is of type {} but only {} types are allowed", prefix, parentPath.toString(),
+                                                BaseGroup::StringListFromGroupType(AllowedParentGroupType{parentGroup->getGroupType()}), BaseGroup::StringListFromGroupType(m_AllowedParentGroupType)));
   }
 
   return {};

--- a/src/complex/Parameters/DataGroupCreationParameter.hpp
+++ b/src/complex/Parameters/DataGroupCreationParameter.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "complex/DataStructure/BaseGroup.hpp"
 #include "complex/DataStructure/DataPath.hpp"
 #include "complex/Filter/MutableDataParameter.hpp"
 #include "complex/Filter/ParameterTraits.hpp"
@@ -13,9 +14,10 @@ class COMPLEX_EXPORT DataGroupCreationParameter : public MutableDataParameter
 {
 public:
   using ValueType = DataPath;
+  using AllowedParentGroupType = std::set<BaseGroup::GroupType>;
 
   DataGroupCreationParameter() = delete;
-  DataGroupCreationParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue);
+  DataGroupCreationParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, const AllowedParentGroupType& allowedParentGroup);
   ~DataGroupCreationParameter() override = default;
 
   DataGroupCreationParameter(const DataGroupCreationParameter&) = delete;
@@ -69,6 +71,12 @@ public:
   ValueType defaultPath() const;
 
   /**
+   * @brief Returns to the user the allowed group types of the parent group
+   * @return std::set<BaseGroup::GroupType>
+   */
+  AllowedParentGroupType allowedParentGroupType() const;
+
+  /**
    * @brief Validates the given value against the given DataStructure. Returns warnings/errors.
    * @param dataStructure The active DataStructure to use during validation
    * @param value The value to validate
@@ -95,6 +103,7 @@ public:
 
 private:
   ValueType m_DefaultValue = {};
+  AllowedParentGroupType m_AllowedParentGroupType = {};
 };
 } // namespace complex
 


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files.

- [x] Class and Structs are `UpperCamelCase`
- [x] Class private member variables are `m_UpperCamelCase`
- [x] Class methods are `lowerCamelCase`
- [x] Method arguments are `lowerCamelCase`
- [x] Normal variables are `lowerCamelCase`
- [x] Constants are `k_UpperCamelCase`
- [x] Global statics are `s_UpperCamelCase`
- [x] Free Functions are `UpperCamelCase`
- [x] Macros are `ALL_UPPER_SNAKE_CASE`
- [x] Unit test will test data output from the filter.
- [x] Reused strings should be constants in an anonymous namespace
- [x] If parallelization is used, proper use of the abstracted complex classes are used. Using TBB specifically in a filter should be frowned upon unless for a really good reason.

## Filter Checklist

- [x] Parameters should be generally broken down into "Input Parameters", "Required Data Objects", "Created Data Objects". There can be exceptions to this.
- [x] ChoicesParameter selections should be an enumeration defined in the filer header
- [x] Documentation copied from SIMPL Repo and updated (if necessary)
- [x] Parameter argument variables are k_CamelCase_Key
- [x] Parameter argument strings are lower_snake_case
```
static inline constexpr StringLiteral k_AlignmentType_Key = "alignment_type";
```

## Unit Testing
- [x] 1 Unit test to instantiate the filter with the default arguments.
- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] Filters should have both the Filter class and Algorithm class for anything beyond trivial needs
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added Python wrapping to new files (if any) as necessary
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented.


<!-- **Thanks for contributing to complex!** -->
