### PR TITLE
FILTER: Implement Multiple Filters

### DIFF
--- a/src/Plugins/ComplexCore/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/CMakeLists.txt
@@ -61,6 +61,7 @@ set(FilterList
   TriangleNormalFilter
   FindNumFeaturesFilter
   FindVolFractionsFilter
+  ExtractComponentAsArrayFilter
 )
 
 set(ActionList
@@ -78,6 +79,7 @@ set(AlgorithmList
   ScalarSegmentFeatures
   FindArrayStatistics
   CombineAttributeArrays
+  ExtractComponentAsArray
   )
 
 create_complex_plugin(NAME ${PLUGIN_NAME}

--- a/src/Plugins/ComplexCore/docs/ConditionalSetValue.md
+++ b/src/Plugins/ComplexCore/docs/ConditionalSetValue.md
@@ -7,7 +7,7 @@ Core (Misc)
 
 ## Description ##
 
-This **Filter** replaces values in a user specified **Attribute Array** with a user specified value, but only when a second boolean **Attribute Array** specifies. For example, if the user entered a *Replace Value* of *5.5*, then for every occurence of *true* in the conditional boolean array, the selected **Attribute Array** would be changed to 5.5. Below are the ranges for the values that can be entered for the different primitive types of arrays (for user reference). The selected **Attribute Array** must be a scalar array.
+This **Filter** replaces values in a user specified **Attribute Array** with a user specified value a second boolean **Attribute Array** specifies, but only when **Use Conditional Mask** is *true*. For example, if the user entered a *Replace Value* of *5.5*, then for every occurence of *true* in the conditional boolean array, the selected **Attribute Array** would be changed to 5.5. If **Use Conditional Mask** is *false*, then **Value to Replace** will be searched for in the provided **Attribute Array** and all instances will be replaced. Below are the ranges for the values that can be entered for the different primitive types of arrays (for user reference). The selected **Attribute Array** must be a scalar array.
     
 ### Primitive Data Types ##
 
@@ -29,9 +29,14 @@ This **Filter** replaces values in a user specified **Attribute Array** with a u
 
 | Name             | Type | Description |
 |------------------|------|-------------|
-| Use Conditional | bool | The bool that determines whether a conditional mask will be used or just a value |
-| Value to Replace | std::string | The numeric value to replace in the array [will be typecasted to appropriate value later] |
 | New Value | std::string | Value to replace the removed values in the array [will be typecasted to appropriate value later] |
+
+## Optional Data Mask ##
+| Name             | Type | Description |
+|------------------|------|-------------|
+| Use Conditional Mask | bool | Whether to use a boolean mask array to replace values marked true |
+| Any **Attribute Array** | None | Bool | (1) | The complete path to the conditional array that will determine which values/entries will be replaced if index is true|
+| Value to Replace | std::string | The numerical value that will be replaced in the array [will be typecasted to appropriate value later] |
 
 ## Required Geometry ##
 
@@ -41,7 +46,6 @@ Not Applicable
 
 | Kind | Default Name | Type | Component Dimensions | Description |
 |------|--------------|-------------|---------|----------------|
-| Any **Attribute Array** | None | Bool | (1) | Path to conditional **Attribute Array** that will determine which values/entries will be replaced |
 | Any **Attribute Array** | None | Any | (1) | Path to **Attribute Array** that will have values replaced |
 
 ## Created Objects ##

--- a/src/Plugins/ComplexCore/docs/ConditionalSetValue.md
+++ b/src/Plugins/ComplexCore/docs/ConditionalSetValue.md
@@ -1,4 +1,4 @@
-# Replace Value in Array (Conditional) 
+# Replace Value in Array (Conditional) #
 
 
 ## Group (Subgroup) ##
@@ -29,7 +29,9 @@ This **Filter** replaces values in a user specified **Attribute Array** with a u
 
 | Name             | Type | Description |
 |------------------|------|-------------|
-| New Value | double | Value to replace the removed values in the array |
+| Use Conditional | bool | The bool that determines whether a conditional mask will be used or just a value |
+| Value to Replace | std::string | The numeric value to replace in the array [will be typecasted to appropriate value later] |
+| New Value | std::string | Value to replace the removed values in the array [will be typecasted to appropriate value later] |
 
 ## Required Geometry ##
 
@@ -45,10 +47,6 @@ Not Applicable
 ## Created Objects ##
 
 None
-
-## Example Pipelines ##
-
-
 
 ## License & Copyright ##
 

--- a/src/Plugins/ComplexCore/docs/ExtractComponentAsArray.md
+++ b/src/Plugins/ComplexCore/docs/ExtractComponentAsArray.md
@@ -7,12 +7,17 @@ Core (Memory/Management)
 
 ## Description ##
 
-This **Filter** will create an **Attribute Array** from a single component of a user chosen array multicomponent array.
+This **Filter** will do one of the following to one component of a multicomponent **Attribute Array**:
+- Remove 1 component from multicomponent **Attribute Array** completely [This is done implicitly so long as **Move Extracted Components To New Array** is false]
+- Extract 1 component from multicomponent **Attribute Array** and store it in a new **DataArray** without removing from original
+- Extract 1 component from multicomponent **Attribute Array** and store it in a new **DataArray** and remove that component from the original
 
 ## Parameters ##
 
 | Name | Type | Description |
 |------|------| ----------- |
+| Move Extracted Components To New Array | bool | The bool that determines if extracted components will be stored in new array |
+| Remove Extracted Components from Old Array | bool | The bool that determines if extracted components will be deleted from original array |
 | Component Number to Extract | int32_t | The index of which component to extract |
 
 

--- a/src/Plugins/ComplexCore/docs/ExtractComponentAsArray.md
+++ b/src/Plugins/ComplexCore/docs/ExtractComponentAsArray.md
@@ -1,0 +1,48 @@
+# Extract Component as Attribute Array  #
+
+
+## Group (Subgroup) ##
+
+Core (Memory/Management)
+
+## Description ##
+
+This **Filter** will create an **Attribute Array** from a single component of a user chosen array multicomponent array.
+
+## Parameters ##
+
+| Name | Type | Description |
+|------|------| ----------- |
+| Component Number to Extract | int32_t | The index of which component to extract |
+
+
+## Required Geometry ##
+
+Not Applicable
+
+## Required Objects ##
+
+| Kind | Default Name | Type | Component Dimensions | Description |
+|------|--------------|------|----------------------|-------------|
+| Any **Attribute Array** | None | Any | >1 | Multicomponent **Attribute Array** to use as input |
+
+
+## Created Objects ##
+
+| Kind | Default Name | Type | Component Dimensions | Description |
+|------|--------------|------|----------------------|-------------|
+| Any **Attribute Array** | None | Any | (1) | Scalar **Attribute Array** name |
+
+## Example Pipelines ##
+
+
+
+## License & Copyright ##
+
+Please see the description file distributed with this **Plugin**
+
+## DREAM.3D Mailing Lists ##
+
+If you need more help with a **Filter**, please consider asking your question on the [DREAM.3D Users Google group!](https://groups.google.com/forum/?hl=en#!forum/dream3d-users)
+
+

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
@@ -58,6 +58,7 @@
 #include "ComplexCore/Filters/StlFileReaderFilter.hpp"
 #include "ComplexCore/Filters/TriangleDihedralAngleFilter.hpp"
 #include "ComplexCore/Filters/TriangleNormalFilter.hpp"
+#include "ComplexCore/Filters/ExtractComponentAsArrayFilter.hpp"
 // @@__HEADER__TOKEN__DO__NOT__DELETE__@@
 
 namespace complex
@@ -74,6 +75,7 @@ namespace complex
     {complex::Uuid::FromString("f7bc0e1e-0f50-5fe0-a9e7-510b6ed83792").value(), complex::FilterTraits<ChangeAngleRepresentation>::uuid}, // ChangeAngleRepresentation
     {complex::Uuid::FromString("a6b50fb0-eb7c-5d9b-9691-825d6a4fe772").value(), complex::FilterTraits<CombineAttributeArraysFilter>::uuid}, // CombineAttributeArrays
     {complex::Uuid::FromString("47cafe63-83cc-5826-9521-4fb5bea684ef").value(), complex::FilterTraits<ConditionalSetValue>::uuid}, // ConditionalSetValue
+    {complex::Uuid::FromString("a37f2e24-7400-5005-b9a7-b2224570cbe9").value(), complex::FilterTraits<ConditionalSetValue>::uuid}, // ReplaceValueInArray
     {complex::Uuid::FromString("99836b75-144b-5126-b261-b411133b5e8a").value(), complex::FilterTraits<CopyFeatureArrayToElementArray>::uuid}, // CopyFeatureArrayToElementArray
     {complex::Uuid::FromString("93375ef0-7367-5372-addc-baa019b1b341").value(), complex::FilterTraits<CreateAttributeMatrixFilter>::uuid}, // CreateAttributeMatrix
     {complex::Uuid::FromString("77f392fb-c1eb-57da-a1b1-e7acf9239fb8").value(), complex::FilterTraits<CreateDataArray>::uuid}, // CreateDataArray
@@ -121,6 +123,8 @@ namespace complex
     {complex::Uuid::FromString("980c7bfd-20b2-5711-bc3b-0190b9096c34").value(), complex::FilterTraits<StlFileReaderFilter>::uuid}, // ReadStlFile
     {complex::Uuid::FromString("0541c5eb-1976-5797-9468-be50a93d44e2").value(), complex::FilterTraits<TriangleDihedralAngleFilter>::uuid}, // TriangleDihedralAngleFilter
     {complex::Uuid::FromString("8133d419-1919-4dbf-a5bf-1c97282ba63f").value(), complex::FilterTraits<TriangleNormalFilter>::uuid}, // TriangleNormalFilter
+    {complex::Uuid::FromString("79d59b85-01e8-5c4a-a6e1-3fd3e2ceffb4").value(), complex::FilterTraits<ExtractComponentAsArrayFilter>::uuid}, // ExtractComponentAsArray
+    {complex::Uuid::FromString("1b4b9941-62e4-52f2-9918-15d48147ab88").value(), complex::FilterTraits<ExtractComponentAsArrayFilter>::uuid}, // RemoveComponentFromArray
     // @@__MAP__UPDATE__TOKEN__DO__NOT__DELETE__@@
   };
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ExtractComponentAsArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ExtractComponentAsArray.cpp
@@ -7,17 +7,61 @@
 using namespace complex;
 namespace
 {
-//struct ExtractComponentsFunctor
-//{
-//  template <class T>
-//  void operator()(IDataArray& inputDataRef, IDataArray& extractedCompRef, int32 componentsToExtract, bool insertInNew)
-//  {
-//    auto& inputDataRef = dynamic_cast<DataArray<T>&>(inputDataPtr);
-//    auto& maskedData = dynamic_cast<DataArray<T>&>(maskedDataPtr);
-//
-//    inputDataRef.getIDataStore()->
-//  }
-//};
+struct RemoveComponentsFunctor
+{
+  template <class ScalarType>
+  void operator()(IDataArray& originalArray, IDataArray& resizedArray, usize componentIndexToRemove) // Due to logic structure originalArray cannot be const
+  {
+    const auto& originalArrayRef = dynamic_cast<const DataArray<ScalarType>&>(originalArray);
+    auto& resizedArrayRef = dynamic_cast<DataArray<ScalarType>&>(resizedArray);
+
+    usize originalTupleCount = originalArrayRef.getNumberOfTuples();
+    usize originalCompCount = originalArrayRef.getNumberOfComponents();
+
+    usize distanceToShuffle = 0;
+    for(usize tuple = 0; tuple < originalTupleCount; tuple++)
+    {
+      for(usize comp = 0; comp < originalCompCount; comp++)
+      {
+        if(comp == componentIndexToRemove)
+        {
+          distanceToShuffle++;
+          continue;
+        }
+        usize index = tuple * originalCompCount + comp;
+        resizedArrayRef[index - distanceToShuffle] = originalArrayRef[index];
+      }
+    }
+
+    // inputArrayRef
+  }
+};
+
+struct ExtractComponentsFunctor
+{
+  template <class ScalarType>
+  void operator()(IDataArray& inputArray, IDataArray& extractedCompArray, usize componentIndexToExtract) // Due to logic structure inputArray cannot be const
+  {
+    const auto& inputArrayRef = dynamic_cast<const DataArray<ScalarType>&>(inputArray);
+    auto& extractedArrayRef = dynamic_cast<DataArray<ScalarType>&>(extractedCompArray);
+
+    usize inputTupleCount = inputArrayRef.getNumberOfTuples();
+    usize inputCompCount = inputArrayRef.getNumberOfComponents();
+
+    usize extractedCompCount = extractedArrayRef.getNumberOfComponents();
+
+    for(usize tuple = 0; tuple < inputTupleCount; tuple++)
+    {
+      for(usize comp = 0; comp < inputCompCount; comp++)
+      {
+        if(comp == componentIndexToExtract)
+        {
+          extractedArrayRef[tuple] = inputArrayRef[tuple * inputCompCount + comp]; // extracted array will always have comp count of 1
+        }
+      }
+    }
+  }
+};
 } // namespace
 
 // -----------------------------------------------------------------------------
@@ -42,17 +86,29 @@ const std::atomic_bool& ExtractComponentAsArray::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ExtractComponentAsArray::operator()()
 {
-  /*
-   * Assumptions:
-   * Both paths from the inputValues exist (provided you arent deleting the data)
-   * Component count is less than than the number of components in the array
-   */
-  const bool moveToNewArrayBool = m_InputValues->MoveToNewArray;
-  const int32 compToRemoveNum = m_InputValues->CompNumber;
-  const auto& selectedArrayRef = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->SelectedArrayPath);
-  const auto& extractedCompArrayRef = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->NewArrayPath);
+  /* baseArrayRef CANNOT be const because it can either be the original array [can be const] OR the resized array [can't be const]*/
+  /* tempArrayRef CANNOT be const because the functor has to be capable of handling both cases of remove components*/
+  const bool moveComponentsToNewArrayBool = m_InputValues->MoveComponentsToNewArray;
+  const bool removeComponentsFromArrayBool = m_InputValues->RemoveComponentsFromArray;
+  const usize compToRemoveNum = static_cast<usize>(abs(m_InputValues->CompNumber));
+  // this will be the original array if components are not being removed, else it is resized array
+  IDataArray& baseArrayRef = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->BaseArrayPath);
+  if((!removeComponentsFromArrayBool) && moveComponentsToNewArrayBool)
+  {
+    ExecuteDataFunction(ExtractComponentsFunctor{}, baseArrayRef.getDataType(), baseArrayRef, m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->NewArrayPath), compToRemoveNum);
+    return {};
+  }
+  // will not exist if remove components isnt occuring, hence the early bailout ^
+  IDataArray& tempArrayRef = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->TempArrayPath); // will not exist if remove components isnt true, hence the early bailout ^
 
-  //ExecuteDataFunction(ExtractComponentsFunctor{}, selectedArrayRef.getDataType(), selectedArrayRef, extractedCompArrayRef, compToRemoveNum, moveToNewArrayBool);
+  if(moveComponentsToNewArrayBool)
+  {
+    auto& extractedCompArrayRef = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->NewArrayPath);
+    ExecuteDataFunction(ExtractComponentsFunctor{}, tempArrayRef.getDataType(), tempArrayRef, extractedCompArrayRef, compToRemoveNum);
+  }
+
+  // remove by default, because the only case where they weren't removed was covered at start
+  ExecuteDataFunction(RemoveComponentsFunctor{}, tempArrayRef.getDataType(), tempArrayRef, baseArrayRef, compToRemoveNum);
 
   return {};
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ExtractComponentAsArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ExtractComponentAsArray.cpp
@@ -1,0 +1,58 @@
+#include "ExtractComponentAsArray.hpp"
+
+#include "complex/DataStructure/DataArray.hpp"
+#include "complex/DataStructure/DataGroup.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
+
+using namespace complex;
+namespace
+{
+//struct ExtractComponentsFunctor
+//{
+//  template <class T>
+//  void operator()(IDataArray& inputDataRef, IDataArray& extractedCompRef, int32 componentsToExtract, bool insertInNew)
+//  {
+//    auto& inputDataRef = dynamic_cast<DataArray<T>&>(inputDataPtr);
+//    auto& maskedData = dynamic_cast<DataArray<T>&>(maskedDataPtr);
+//
+//    inputDataRef.getIDataStore()->
+//  }
+//};
+} // namespace
+
+// -----------------------------------------------------------------------------
+ExtractComponentAsArray::ExtractComponentAsArray(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel,
+                                                 ExtractComponentAsArrayInputValues* inputValues)
+: m_DataStructure(dataStructure)
+, m_InputValues(inputValues)
+, m_ShouldCancel(shouldCancel)
+, m_MessageHandler(mesgHandler)
+{
+}
+
+// -----------------------------------------------------------------------------
+ExtractComponentAsArray::~ExtractComponentAsArray() noexcept = default;
+
+// -----------------------------------------------------------------------------
+const std::atomic_bool& ExtractComponentAsArray::getCancel()
+{
+  return m_ShouldCancel;
+}
+
+// -----------------------------------------------------------------------------
+Result<> ExtractComponentAsArray::operator()()
+{
+  /*
+   * Assumptions:
+   * Both paths from the inputValues exist (provided you arent deleting the data)
+   * Component count is less than than the number of components in the array
+   */
+  const bool moveToNewArrayBool = m_InputValues->MoveToNewArray;
+  const int32 compToRemoveNum = m_InputValues->CompNumber;
+  const auto& selectedArrayRef = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->SelectedArrayPath);
+  const auto& extractedCompArrayRef = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->NewArrayPath);
+
+  //ExecuteDataFunction(ExtractComponentsFunctor{}, selectedArrayRef.getDataType(), selectedArrayRef, extractedCompArrayRef, compToRemoveNum, moveToNewArrayBool);
+
+  return {};
+}

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ExtractComponentAsArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ExtractComponentAsArray.cpp
@@ -15,8 +15,8 @@ struct RemoveComponentsFunctor
     const auto& originalArrayRef = dynamic_cast<const DataArray<ScalarType>&>(originalArray);
     auto& resizedArrayRef = dynamic_cast<DataArray<ScalarType>&>(resizedArray);
 
-    usize originalTupleCount = originalArrayRef.getNumberOfTuples();
-    usize originalCompCount = originalArrayRef.getNumberOfComponents();
+    const usize originalTupleCount = originalArrayRef.getNumberOfTuples();
+    const usize originalCompCount = originalArrayRef.getNumberOfComponents();
 
     usize distanceToShuffle = 0;
     for(usize tuple = 0; tuple < originalTupleCount; tuple++)
@@ -28,7 +28,7 @@ struct RemoveComponentsFunctor
           distanceToShuffle++;
           continue;
         }
-        usize index = tuple * originalCompCount + comp;
+        const usize index = tuple * originalCompCount + comp;
         resizedArrayRef[index - distanceToShuffle] = originalArrayRef[index];
       }
     }
@@ -45,10 +45,10 @@ struct ExtractComponentsFunctor
     const auto& inputArrayRef = dynamic_cast<const DataArray<ScalarType>&>(inputArray);
     auto& extractedArrayRef = dynamic_cast<DataArray<ScalarType>&>(extractedCompArray);
 
-    usize inputTupleCount = inputArrayRef.getNumberOfTuples();
-    usize inputCompCount = inputArrayRef.getNumberOfComponents();
+    const usize inputTupleCount = inputArrayRef.getNumberOfTuples();
+    const usize inputCompCount = inputArrayRef.getNumberOfComponents();
 
-    usize extractedCompCount = extractedArrayRef.getNumberOfComponents();
+    const usize extractedCompCount = extractedArrayRef.getNumberOfComponents();
 
     for(usize tuple = 0; tuple < inputTupleCount; tuple++)
     {
@@ -90,16 +90,16 @@ Result<> ExtractComponentAsArray::operator()()
   /* tempArrayRef CANNOT be const because the functor has to be capable of handling both cases of remove components*/
   const bool moveComponentsToNewArrayBool = m_InputValues->MoveComponentsToNewArray;
   const bool removeComponentsFromArrayBool = m_InputValues->RemoveComponentsFromArray;
-  const usize compToRemoveNum = static_cast<usize>(abs(m_InputValues->CompNumber));
+  const auto compToRemoveNum = static_cast<usize>(abs(m_InputValues->CompNumber));
   // this will be the original array if components are not being removed, else it is resized array
-  IDataArray& baseArrayRef = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->BaseArrayPath);
+  auto& baseArrayRef = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->BaseArrayPath);
   if((!removeComponentsFromArrayBool) && moveComponentsToNewArrayBool)
   {
     ExecuteDataFunction(ExtractComponentsFunctor{}, baseArrayRef.getDataType(), baseArrayRef, m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->NewArrayPath), compToRemoveNum);
     return {};
   }
-  // will not exist if remove components isnt occuring, hence the early bailout ^
-  IDataArray& tempArrayRef = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->TempArrayPath); // will not exist if remove components isnt true, hence the early bailout ^
+  // will not exist if remove components is not occurring, hence the early bailout ^
+  auto& tempArrayRef = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->TempArrayPath); // will not exist if remove components is not true, hence the early bailout ^
 
   if(moveComponentsToNewArrayBool)
   {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ExtractComponentAsArray.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ExtractComponentAsArray.hpp
@@ -14,9 +14,11 @@ namespace complex
 
 struct COMPLEXCORE_EXPORT ExtractComponentAsArrayInputValues
 {
-  bool MoveToNewArray;
+  bool MoveComponentsToNewArray;
+  bool RemoveComponentsFromArray;
   int32 CompNumber;
-  DataPath SelectedArrayPath;
+  DataPath TempArrayPath;
+  DataPath BaseArrayPath;
   DataPath NewArrayPath;
 };
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ExtractComponentAsArray.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ExtractComponentAsArray.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "ComplexCore/ComplexCore_export.hpp"
+
+#include "complex/DataStructure/DataPath.hpp"
+#include "complex/DataStructure/DataStructure.hpp"
+#include "complex/Filter/IFilter.hpp"
+#include "complex/Parameters/ArrayCreationParameter.hpp"
+#include "complex/Parameters/ArraySelectionParameter.hpp"
+#include "complex/Parameters/NumberParameter.hpp"
+
+namespace complex
+{
+
+struct COMPLEXCORE_EXPORT ExtractComponentAsArrayInputValues
+{
+  bool MoveToNewArray;
+  int32 CompNumber;
+  DataPath SelectedArrayPath;
+  DataPath NewArrayPath;
+};
+
+/**
+ * @class ConditionalSetValue
+ * @brief This filter replaces values in the target array with a user specified value
+ * where a bool mask array specifies.
+ */
+
+class COMPLEXCORE_EXPORT ExtractComponentAsArray
+{
+public:
+  ExtractComponentAsArray(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ExtractComponentAsArrayInputValues* inputValues);
+  ~ExtractComponentAsArray() noexcept;
+
+  ExtractComponentAsArray(const ExtractComponentAsArray&) = delete;
+  ExtractComponentAsArray(ExtractComponentAsArray&&) noexcept = delete;
+  ExtractComponentAsArray& operator=(const ExtractComponentAsArray&) = delete;
+  ExtractComponentAsArray& operator=(ExtractComponentAsArray&&) noexcept = delete;
+
+  Result<> operator()();
+
+  const std::atomic_bool& getCancel();
+
+private:
+  DataStructure& m_DataStructure;
+  const ExtractComponentAsArrayInputValues* m_InputValues = nullptr;
+  const std::atomic_bool& m_ShouldCancel;
+  const IFilter::MessageHandler& m_MessageHandler;
+};
+
+} // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
@@ -162,7 +162,6 @@ Result<> ConditionalSetValue::executeImpl(DataStructure& dataStructure, const Ar
                                           const std::atomic_bool& shouldCancel) const
 {
   auto useConditionalValue = filterArgs.value<bool>(k_ConditionalArrayPath_Key);
-  auto removeValueString = filterArgs.value<std::string>(k_RemoveValue_Key);
   auto replaceValueString = filterArgs.value<std::string>(k_ReplaceValue_Key);
   auto conditionalArrayPath = filterArgs.value<DataPath>(k_ConditionalArrayPath_Key);
   auto selectedArrayPath = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
@@ -180,6 +179,7 @@ Result<> ConditionalSetValue::executeImpl(DataStructure& dataStructure, const Ar
   else
   {
     auto& inputDataArray = dataStructure.getDataRefAs<IDataArray>(selectedArrayPath);
+    auto removeValueString = filterArgs.value<std::string>(k_RemoveValue_Key);
     ExecuteDataFunction(ReplaceValueInArrayFunctor{}, inputDataArray.getDataType(), inputDataArray, removeValueString, replaceValueString);
   }
   return {};

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
@@ -109,7 +109,7 @@ IFilter::UniquePointer ConditionalSetValue::clone() const
 IFilter::PreflightResult ConditionalSetValue::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                             const std::atomic_bool& shouldCancel) const
 {
-  auto useConditionalValue = filterArgs.value<bool>(k_ConditionalArrayPath_Key);
+  auto useConditionalValue = filterArgs.value<bool>(k_UseConditional_Key);
   auto removeValueString = filterArgs.value<std::string>(k_RemoveValue_Key);
   auto replaceValueString = filterArgs.value<std::string>(k_ReplaceValue_Key);
   auto selectedArrayPath = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
@@ -161,7 +161,7 @@ IFilter::PreflightResult ConditionalSetValue::preflightImpl(const DataStructure&
 Result<> ConditionalSetValue::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                           const std::atomic_bool& shouldCancel) const
 {
-  auto useConditionalValue = filterArgs.value<bool>(k_ConditionalArrayPath_Key);
+  auto useConditionalValue = filterArgs.value<bool>(k_UseConditional_Key);
   auto replaceValueString = filterArgs.value<std::string>(k_ReplaceValue_Key);
   auto conditionalArrayPath = filterArgs.value<DataPath>(k_ConditionalArrayPath_Key);
   auto selectedArrayPath = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
@@ -86,13 +86,16 @@ Parameters ConditionalSetValue::parameters() const
   Parameters params;
 
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
-  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_UseConditional_Key, "Use Conditional", "Determines whether a conditional array should be used.", false));
-  params.insert(std::make_unique<StringParameter>(k_RemoveValue_Key, "Value To Replace", "The value that will be replaced", "0"));
   params.insert(std::make_unique<StringParameter>(k_ReplaceValue_Key, "New Value", "The value that will be used as the replacement value", "0"));
-  params.insertSeparator(Parameters::Separator{"Required Objects"});
+
+  params.insertSeparator(Parameters::Separator{"Optional Data Mask"});
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_UseConditional_Key, "Use Conditional Mask", "Whether to use a boolean mask array to replace values marked true", false));
   params.insert(std::make_unique<ArraySelectionParameter>(
-      k_ConditionalArrayPath_Key, "Conditional Array", "The complete path to the conditional array that will determine which values/entries will be replaced", DataPath{},
+      k_ConditionalArrayPath_Key, "Conditional Array", "The complete path to the conditional array that will determine which values/entries will be replaced if index is true", DataPath{},
       ArraySelectionParameter::AllowedTypes{DataType::boolean, DataType::uint8, DataType::int8}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
+  params.insert(std::make_unique<StringParameter>(k_RemoveValue_Key, "Value To Replace", "The numerical value that will be replaced in the array", "0"));
+
+  params.insertSeparator(Parameters::Separator{"Required Input Data"});
   params.insert(
       std::make_unique<ArraySelectionParameter>(k_SelectedArrayPath_Key, "Attribute Array", "The complete path to array that will have values replaced", DataPath{}, complex::GetAllDataTypes()));
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
@@ -4,8 +4,10 @@
 #include "complex/DataStructure/DataArray.hpp"
 #include "complex/DataStructure/DataPath.hpp"
 #include "complex/Parameters/ArraySelectionParameter.hpp"
+#include "complex/Parameters/BoolParameter.hpp"
 #include "complex/Parameters/StringParameter.hpp"
 #include "complex/Utilities/DataArrayUtilities.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 using namespace complex;
 
@@ -13,6 +15,42 @@ namespace
 {
 constexpr int32 k_EmptyParameterValue = -123;
 constexpr int32 k_IncorrectInputArrayType = -124;
+constexpr int32 k_ConvertReplaceValueTypeError = -125;
+
+template <typename ScalarType>
+ScalarType convertFromStringToType(const std::string& convertValue)
+{
+  Result<ScalarType> convertResult = ConvertTo<ScalarType>::convert(convertValue);
+
+  if(convertResult.invalid())
+  {
+    throw std::runtime_error(fmt::format("{}({}): Function {}: Error. Cannot convert {} to the type {}.", "ReplaceValueInArrayFunctor", __FILE__, __LINE__, convertValue, ScalarType));
+  }
+
+  return static_cast<ScalarType>(convertResult.value());
+}
+
+struct ReplaceValueInArrayFunctor
+{
+  template <typename ScalarType>
+  void replaceValue(IDataArray& workingArray, const std::string& removeValue, const std::string& replaceValue)
+  {
+    DataArray<ScalarType>& dataArray = dynamic_cast<DataArray<ScalarType>&>(workingArray);
+
+    auto removeVal = convertFromStringToType<ScalarType>(removeValue);
+    auto replaceVal = convertFromStringToType<ScalarType>(replaceValue);
+
+    const size = dataArray.getNumberOfTuples() * dataArray.getNumberOfComponents();
+
+    for(usize index = 0; index < size; index++)
+    {
+      if(dataArray[index] == removeVal)
+      {
+        dataArray[index] = replaceVal;
+      }
+    }
+  }
+};
 } // namespace
 
 namespace complex
@@ -48,12 +86,18 @@ Parameters ConditionalSetValue::parameters() const
   Parameters params;
 
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
-  params.insert(std::make_unique<StringParameter>(k_ReplaceValue_Key, "New Value", "The value that will be used as the replacement value", ""));
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_UseConditional_Key, "Use Conditional", "Determines whether a conditional array should be used.", false));
+  params.insert(std::make_unique<StringParameter>(k_RemoveValue_Key, "Value To Replace", "The value that will be replaced", "0"));
+  params.insert(std::make_unique<StringParameter>(k_ReplaceValue_Key, "New Value", "The value that will be used as the replacement value", "0"));
+  params.insertSeparator(Parameters::Separator{"Required Objects"});
   params.insert(std::make_unique<ArraySelectionParameter>(
       k_ConditionalArrayPath_Key, "Conditional Array", "The complete path to the conditional array that will determine which values/entries will be replaced", DataPath{},
       ArraySelectionParameter::AllowedTypes{DataType::boolean, DataType::uint8, DataType::int8}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insert(
       std::make_unique<ArraySelectionParameter>(k_SelectedArrayPath_Key, "Attribute Array", "The complete path to array that will have values replaced", DataPath{}, complex::GetAllDataTypes()));
+
+  params.linkParameters(k_UseConditional_Key, k_RemoveValue_Key, false);
+  params.linkParameters(k_UseConditional_Key, k_ConditionalArrayPath_Key, true);
   return params;
 }
 
@@ -65,31 +109,48 @@ IFilter::UniquePointer ConditionalSetValue::clone() const
 IFilter::PreflightResult ConditionalSetValue::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                             const std::atomic_bool& shouldCancel) const
 {
+  auto useConditionalValue = filterArgs.value<bool>(k_ConditionalArrayPath_Key);
+  auto removeValueString = filterArgs.value<std::string>(k_RemoveValue_Key);
   auto replaceValueString = filterArgs.value<std::string>(k_ReplaceValue_Key);
   auto selectedArrayPath = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
   auto pConditionalPath = filterArgs.value<DataPath>(k_ConditionalArrayPath_Key);
+
+  const DataObject& inputDataObject = dataStructure.getDataRef(selectedArrayPath);
 
   if(replaceValueString.empty())
   {
     return {MakeErrorResult<OutputActions>(::k_EmptyParameterValue, fmt::format("{}: Replacement parameter cannot be empty.{}({})", humanName(), __FILE__, __LINE__)), {}};
   }
-
-  // Validate that the Conditional Array is of the correct type
-  const IDataArray* dataObject = dataStructure.getDataAs<IDataArray>(pConditionalPath);
-
-  if(dataObject->getDataType() != complex::DataType::boolean && dataObject->getDataType() != complex::DataType::uint8 && dataObject->getDataType() != complex::DataType::int8)
+  if(removeValueString.empty())
   {
-    return {MakeErrorResult<OutputActions>(
-        ::k_IncorrectInputArrayType, fmt::format("Conditional Array must be of type [Bool|UInt8|Int8]. The object at path '{}' is '{}'", pConditionalPath.toString(), dataObject->getTypeName()))};
+    return {MakeErrorResult<OutputActions>(::k_EmptyParameterValue, fmt::format("{}: Remove parameter cannot be empty.{}({})", humanName(), __FILE__, __LINE__)), {}};
   }
 
-  const DataObject& inputDataObject = dataStructure.getDataRef(selectedArrayPath);
+  if(useConditionalValue)
+  {
+    // Validate that the Conditional Array is of the correct type
+    const IDataArray* dataObject = dataStructure.getDataAs<IDataArray>(pConditionalPath);
+
+    if(dataObject->getDataType() != complex::DataType::boolean && dataObject->getDataType() != complex::DataType::uint8 && dataObject->getDataType() != complex::DataType::int8)
+    {
+      return {MakeErrorResult<OutputActions>(
+          ::k_IncorrectInputArrayType, fmt::format("Conditional Array must be of type [Bool|UInt8|Int8]. The object at path '{}' is '{}'", pConditionalPath.toString(), dataObject->getTypeName()))};
+    }
+  }
 
   // Sanity check all the inputs here
   Result<> result = CheckValueConvertsToArrayType(replaceValueString, inputDataObject);
   // We can do this because nothing happens to the DataStructure. *IF* the filter is
   // modifying the DataStructure then we should be using a custom OutputActions instance
   // or hopefully an existing Actions subclass
+
+  if(result.invalid())
+  {
+    return {MakeErrorResult<OutputActions>(::k_ConvertReplaceValueTypeError, fmt::format("{}({}): Function {}: Error. Cannot convert {} to the type {}.", "ReplaceValueInArrayFunctor", __FILE__,
+                                                                                         __LINE__, replaceValueString, inputDataObject.getDataObjectType()))};
+  }
+
+  result = CheckValueConvertsToArrayType(removeValueString, inputDataObject);
 
   // convert the result from above to a Result<OutputActions> object and return. Note the
   // std::move() used for the `result` variable. We can do this because we will *NOT* be
@@ -100,16 +161,26 @@ IFilter::PreflightResult ConditionalSetValue::preflightImpl(const DataStructure&
 Result<> ConditionalSetValue::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                           const std::atomic_bool& shouldCancel) const
 {
+  auto useConditionalValue = filterArgs.value<bool>(k_ConditionalArrayPath_Key);
+  auto removeValueString = filterArgs.value<std::string>(k_RemoveValue_Key);
   auto replaceValueString = filterArgs.value<std::string>(k_ReplaceValue_Key);
   auto conditionalArrayPath = filterArgs.value<DataPath>(k_ConditionalArrayPath_Key);
   auto selectedArrayPath = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
 
-  DataObject& inputDataObject = dataStructure.getDataRef(selectedArrayPath);
+  if(useConditionalValue)
+  {
+    DataObject& inputDataObject = dataStructure.getDataRef(selectedArrayPath);
 
-  const IDataArray& conditionalArray = dataStructure.getDataRefAs<IDataArray>(conditionalArrayPath);
+    const IDataArray& conditionalArray = dataStructure.getDataRefAs<IDataArray>(conditionalArrayPath);
 
-  Result<> result = ConditionalReplaceValueInArray(replaceValueString, inputDataObject, conditionalArray);
+    Result<> result = ConditionalReplaceValueInArray(replaceValueString, inputDataObject, conditionalArray);
 
-  return result;
+    return result;
+  }
+  else
+  {
+    auto& inputDataArray = dataStructure.getDataRefAs<IDataArray>(selectedArrayPath);
+    ExecuteDataFunction(ReplaceValueInArrayFunctor{}, inputDataArray.getDataType(), inputDataArray, removeValueString, replaceValueString);
+  }
 }
 } // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
@@ -24,7 +24,7 @@ ScalarType convertFromStringToType(const std::string& convertValue)
 
   if(convertResult.invalid())
   {
-    throw std::runtime_error(fmt::format("{}({}): Function {}: Error. Cannot convert {} to the type {}.", "ReplaceValueInArrayFunctor", __FILE__, __LINE__, convertValue, ScalarType));
+    throw std::runtime_error(fmt::format("{}({}): Function {}: Error. Cannot convert {} from string.", "ReplaceValueInArrayFunctor", __FILE__, __LINE__, convertValue));
   }
 
   return static_cast<ScalarType>(convertResult.value());
@@ -33,14 +33,14 @@ ScalarType convertFromStringToType(const std::string& convertValue)
 struct ReplaceValueInArrayFunctor
 {
   template <typename ScalarType>
-  void replaceValue(IDataArray& workingArray, const std::string& removeValue, const std::string& replaceValue)
+  void operator()(IDataArray& workingArray, const std::string& removeValue, const std::string& replaceValue)
   {
     DataArray<ScalarType>& dataArray = dynamic_cast<DataArray<ScalarType>&>(workingArray);
 
     auto removeVal = convertFromStringToType<ScalarType>(removeValue);
     auto replaceVal = convertFromStringToType<ScalarType>(replaceValue);
 
-    const size = dataArray.getNumberOfTuples() * dataArray.getNumberOfComponents();
+    const auto size = dataArray.getNumberOfTuples() * dataArray.getNumberOfComponents();
 
     for(usize index = 0; index < size; index++)
     {
@@ -182,5 +182,6 @@ Result<> ConditionalSetValue::executeImpl(DataStructure& dataStructure, const Ar
     auto& inputDataArray = dataStructure.getDataRefAs<IDataArray>(selectedArrayPath);
     ExecuteDataFunction(ReplaceValueInArrayFunctor{}, inputDataArray.getDataType(), inputDataArray, removeValueString, replaceValueString);
   }
+  return {};
 }
 } // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractComponentAsArrayFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractComponentAsArrayFilter.cpp
@@ -5,11 +5,15 @@
 #include "complex/DataStructure/DataPath.hpp"
 #include "complex/DataStructure/IDataArray.hpp"
 #include "complex/Filter/Actions/CreateArrayAction.hpp"
+#include "complex/Filter/Actions/DeleteDataAction.hpp"
 #include "complex/Filter/Actions/EmptyAction.hpp"
+#include "complex/Filter/Actions/RenameDataAction.hpp"
 #include "complex/Parameters/ArrayCreationParameter.hpp"
 #include "complex/Parameters/ArraySelectionParameter.hpp"
 #include "complex/Parameters/BoolParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
+
+#include <fstream>
 
 using namespace complex;
 
@@ -36,7 +40,7 @@ Uuid ExtractComponentAsArrayFilter::uuid() const
 //------------------------------------------------------------------------------
 std::string ExtractComponentAsArrayFilter::humanName() const
 {
-  return "Extract Component as Attribute Array";
+  return "Extract/Remove Components";
 }
 
 //------------------------------------------------------------------------------
@@ -52,8 +56,10 @@ Parameters ExtractComponentAsArrayFilter::parameters() const
 
   // Create the parameter descriptors that are needed for this filter
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
-  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_MoveToNewArray_Key, "Move Extracted Components to New Array", "If false the extracted components will be deleted", false));
-  params.insert(std::make_unique<Int32Parameter>(k_CompNumber_Key, "Component Number to Extract", "The number of components to extract from the array", 0));
+  params.insertLinkableParameter(
+      std::make_unique<BoolParameter>(k_MoveComponentsToNewArray_Key, "Move Extracted Components to New Array", "If false the extracted components will not be placed in a new array", false));
+  params.insert(std::make_unique<BoolParameter>(k_RemoveComponentsFromArray_Key, "Remove Extracted Components from Old Array", "If true the extracted components will be deleted", false));
+  params.insert(std::make_unique<Int32Parameter>(k_CompNumber_Key, "Component Index to Extract", "The index of the component in each tuple to be removed", 0));
 
   params.insertSeparator(Parameters::Separator{"Required Input DataArray"});
   params.insert(
@@ -62,7 +68,8 @@ Parameters ExtractComponentAsArrayFilter::parameters() const
   params.insertSeparator(Parameters::Separator{"Created DataArray"});
   params.insert(std::make_unique<ArrayCreationParameter>(k_NewArrayPath_Key, "Scalar Attribute Array", "The DataArray to store the extracted components", DataPath({"Extracted Components"})));
 
-  params.linkParameters(k_MoveToNewArray_Key, k_NewArrayPath_Key, true);
+  params.linkParameters(k_MoveComponentsToNewArray_Key, k_NewArrayPath_Key, true);
+  params.linkParameters(k_MoveComponentsToNewArray_Key, k_RemoveComponentsFromArray_Key, true);
 
   return params;
 }
@@ -77,7 +84,8 @@ IFilter::UniquePointer ExtractComponentAsArrayFilter::clone() const
 IFilter::PreflightResult ExtractComponentAsArrayFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                                       const std::atomic_bool& shouldCancel) const
 {
-  auto pMoveToNewArrayValue = filterArgs.value<bool>(k_MoveToNewArray_Key);
+  auto pMoveComponentsToNewArrayValue = filterArgs.value<bool>(k_MoveComponentsToNewArray_Key);
+  auto pRemoveComponentsFromArrayValue = filterArgs.value<bool>(k_RemoveComponentsFromArray_Key);
   auto pCompNumberValue = filterArgs.value<int32>(k_CompNumber_Key);
   auto pSelectedArrayPathValue = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
   auto pNewArrayPathValue = filterArgs.value<DataPath>(k_NewArrayPath_Key);
@@ -88,15 +96,43 @@ IFilter::PreflightResult ExtractComponentAsArrayFilter::preflightImpl(const Data
 
   const auto& selectedArray = dataStructure.getDataRefAs<IDataArray>(pSelectedArrayPathValue);
 
-  if(selectedArray.getNumberOfComponents() < pCompNumberValue)
+  // Verify Components
+  const usize selectedArrayComp = selectedArray.getNumberOfComponents();
+  if(selectedArrayComp < 2)
   {
-    return {MakeErrorResult<OutputActions>(-45630, fmt::format("The number to remove [{}] is larger than the array component count: {} ", pCompNumberValue, selectedArray.getNumberOfComponents()))};
+    return {MakeErrorResult<OutputActions>(-45630, fmt::format("The array component count must be more than 1, this component count is: {} ", selectedArrayComp))};
+  }
+  if(selectedArrayComp < pCompNumberValue)
+  {
+    return {MakeErrorResult<OutputActions>(-45631, fmt::format("The number to remove [{}] is larger than the array component count: {} ", pCompNumberValue, selectedArrayComp))};
   }
 
-  if(pMoveToNewArrayValue)
+  if(pMoveComponentsToNewArrayValue)
   {
-    auto createArrayAction = std::make_unique<CreateArrayAction>(selectedArray.getDataType(), std::vector<usize>{1}, std::vector<usize>{static_cast<usize>(abs(pCompNumberValue))}, pNewArrayPathValue);
-    resultOutputActions.value().actions.push_back(std::move(createArrayAction));
+    // Create new array to hold extracted components
+    auto createNewComponentArrayAction = std::make_unique<CreateArrayAction>(selectedArray.getDataType(), selectedArray.getTupleShape(), std::vector<usize>{1}, pNewArrayPathValue);
+    resultOutputActions.value().actions.push_back(std::move(createNewComponentArrayAction));
+  }
+
+  // Default to removal if user elects to not extract components because parameter is hidden if move extracted components is false
+  if((!pMoveComponentsToNewArrayValue) || pRemoveComponentsFromArrayValue)
+  {
+    // Set up the array to replace original
+    auto tempSelectedArrayName = pSelectedArrayPathValue.getTargetName() + "Temp";
+    DataPath baseSelectedArrayPath = pSelectedArrayPathValue;
+
+    // Rename original array to temp
+    auto renameSelectedArrayAction = std::make_unique<RenameDataAction>(pSelectedArrayPathValue, tempSelectedArrayName);
+    resultOutputActions.value().actions.push_back(std::move(renameSelectedArrayAction));
+
+    // Create new array with old DataPath of new size
+    auto createNewSelectedArrayAction =
+        std::make_unique<CreateArrayAction>(selectedArray.getDataType(), selectedArray.getTupleShape(), std::vector<usize>{selectedArray.getNumberOfComponents() - 1}, baseSelectedArrayPath);
+    resultOutputActions.value().actions.push_back(std::move(createNewSelectedArrayAction));
+
+    // Remove the old array after execution
+    auto removeTempArrayAction = std::make_unique<DeleteDataAction>(DataPath::FromString(pSelectedArrayPathValue.toString() + "Temp", '/').value());
+    resultOutputActions.value().deferredActions.push_back(std::move(removeTempArrayAction));
   }
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
@@ -109,9 +145,14 @@ Result<> ExtractComponentAsArrayFilter::executeImpl(DataStructure& dataStructure
 {
   ExtractComponentAsArrayInputValues inputValues;
 
-  inputValues.MoveToNewArray = filterArgs.value<bool>(k_MoveToNewArray_Key);
+  inputValues.MoveComponentsToNewArray = filterArgs.value<bool>(k_MoveComponentsToNewArray_Key);
+  inputValues.RemoveComponentsFromArray = filterArgs.value<bool>(k_RemoveComponentsFromArray_Key);
   inputValues.CompNumber = filterArgs.value<int32>(k_CompNumber_Key);
-  inputValues.SelectedArrayPath = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
+  // This is the original array if remove components is true OR  move components is false
+  inputValues.TempArrayPath = DataPath::FromString(filterArgs.value<DataPath>(k_SelectedArrayPath_Key).toString() + "Temp", '/').value();
+  // This is the array on the original array path whether its removed or not
+  inputValues.BaseArrayPath = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
+  // If move components to new array is true this is a valid path
   inputValues.NewArrayPath = filterArgs.value<DataPath>(k_NewArrayPath_Key);
 
   return ExtractComponentAsArray(dataStructure, messageHandler, shouldCancel, &inputValues)();

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractComponentAsArrayFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractComponentAsArrayFilter.cpp
@@ -56,17 +56,17 @@ Parameters ExtractComponentAsArrayFilter::parameters() const
 
   // Create the parameter descriptors that are needed for this filter
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
-  params.insertLinkableParameter(
-      std::make_unique<BoolParameter>(k_MoveComponentsToNewArray_Key, "Move Extracted Components to New Array", "If false the extracted components will not be placed in a new array", false));
-  params.insert(std::make_unique<BoolParameter>(k_RemoveComponentsFromArray_Key, "Remove Extracted Components from Old Array", "If true the extracted components will be deleted", false));
   params.insert(std::make_unique<Int32Parameter>(k_CompNumber_Key, "Component Index to Extract", "The index of the component in each tuple to be removed", 0));
+  params.insertLinkableParameter(
+      std::make_unique<BoolParameter>(k_MoveComponentsToNewArray_Key, "Move Extracted Components to New Array", "If true the extracted components will be placed in a new array", false));
+  params.insert(std::make_unique<BoolParameter>(k_RemoveComponentsFromArray_Key, "Remove Extracted Components from Old Array", "If true the extracted components will be deleted", false));
 
   params.insertSeparator(Parameters::Separator{"Required Input DataArray"});
   params.insert(
       std::make_unique<ArraySelectionParameter>(k_SelectedArrayPath_Key, "Multicomponent Attribute Array", "The array to extract componenets from", DataPath{}, complex::GetAllNumericTypes()));
 
   params.insertSeparator(Parameters::Separator{"Created DataArray"});
-  params.insert(std::make_unique<ArrayCreationParameter>(k_NewArrayPath_Key, "Scalar Attribute Array", "The DataArray to store the extracted components", DataPath({"Extracted Components"})));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_NewArrayPath_Key, "Scalar Attribute Array", "The DataArray to store the extracted components", DataPath({"Extracted Component"})));
 
   params.linkParameters(k_MoveComponentsToNewArray_Key, k_NewArrayPath_Key, true);
   params.linkParameters(k_MoveComponentsToNewArray_Key, k_RemoveComponentsFromArray_Key, true);
@@ -104,7 +104,7 @@ IFilter::PreflightResult ExtractComponentAsArrayFilter::preflightImpl(const Data
   }
   if(selectedArrayComp < pCompNumberValue)
   {
-    return {MakeErrorResult<OutputActions>(-45631, fmt::format("The number to remove [{}] is larger than the array component count: {} ", pCompNumberValue, selectedArrayComp))};
+    return {MakeErrorResult<OutputActions>(-45631, fmt::format("The component index '{}' is larger than the total number of components. Valid values are between {} and {} inclusive. ", pCompNumberValue, 0, (selectedArrayComp - 1)))};
   }
 
   if(pMoveComponentsToNewArrayValue)

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractComponentAsArrayFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractComponentAsArrayFilter.cpp
@@ -1,0 +1,119 @@
+#include "ExtractComponentAsArrayFilter.hpp"
+
+#include "ComplexCore/Filters/Algorithms/ExtractComponentAsArray.hpp"
+
+#include "complex/DataStructure/DataPath.hpp"
+#include "complex/DataStructure/IDataArray.hpp"
+#include "complex/Filter/Actions/CreateArrayAction.hpp"
+#include "complex/Filter/Actions/EmptyAction.hpp"
+#include "complex/Parameters/ArrayCreationParameter.hpp"
+#include "complex/Parameters/ArraySelectionParameter.hpp"
+#include "complex/Parameters/BoolParameter.hpp"
+#include "complex/Parameters/NumberParameter.hpp"
+
+using namespace complex;
+
+namespace complex
+{
+//------------------------------------------------------------------------------
+std::string ExtractComponentAsArrayFilter::name() const
+{
+  return FilterTraits<ExtractComponentAsArrayFilter>::name.str();
+}
+
+//------------------------------------------------------------------------------
+std::string ExtractComponentAsArrayFilter::className() const
+{
+  return FilterTraits<ExtractComponentAsArrayFilter>::className;
+}
+
+//------------------------------------------------------------------------------
+Uuid ExtractComponentAsArrayFilter::uuid() const
+{
+  return FilterTraits<ExtractComponentAsArrayFilter>::uuid;
+}
+
+//------------------------------------------------------------------------------
+std::string ExtractComponentAsArrayFilter::humanName() const
+{
+  return "Extract Component as Attribute Array";
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> ExtractComponentAsArrayFilter::defaultTags() const
+{
+  return {"#Core", "#Memory Management"};
+}
+
+//------------------------------------------------------------------------------
+Parameters ExtractComponentAsArrayFilter::parameters() const
+{
+  Parameters params;
+
+  // Create the parameter descriptors that are needed for this filter
+  params.insertSeparator(Parameters::Separator{"Input Parameters"});
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_MoveToNewArray_Key, "Move Extracted Components to New Array", "If false the extracted components will be deleted", false));
+  params.insert(std::make_unique<Int32Parameter>(k_CompNumber_Key, "Component Number to Extract", "The number of components to extract from the array", 0));
+
+  params.insertSeparator(Parameters::Separator{"Required Input DataArray"});
+  params.insert(
+      std::make_unique<ArraySelectionParameter>(k_SelectedArrayPath_Key, "Multicomponent Attribute Array", "The array to extract componenets from", DataPath{}, complex::GetAllNumericTypes()));
+
+  params.insertSeparator(Parameters::Separator{"Created DataArray"});
+  params.insert(std::make_unique<ArrayCreationParameter>(k_NewArrayPath_Key, "Scalar Attribute Array", "The DataArray to store the extracted components", DataPath({"Extracted Components"})));
+
+  params.linkParameters(k_MoveToNewArray_Key, k_NewArrayPath_Key, true);
+
+  return params;
+}
+
+//------------------------------------------------------------------------------
+IFilter::UniquePointer ExtractComponentAsArrayFilter::clone() const
+{
+  return std::make_unique<ExtractComponentAsArrayFilter>();
+}
+
+//------------------------------------------------------------------------------
+IFilter::PreflightResult ExtractComponentAsArrayFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
+                                                                      const std::atomic_bool& shouldCancel) const
+{
+  auto pMoveToNewArrayValue = filterArgs.value<bool>(k_MoveToNewArray_Key);
+  auto pCompNumberValue = filterArgs.value<int32>(k_CompNumber_Key);
+  auto pSelectedArrayPathValue = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
+  auto pNewArrayPathValue = filterArgs.value<DataPath>(k_NewArrayPath_Key);
+
+  PreflightResult preflightResult;
+  complex::Result<OutputActions> resultOutputActions;
+  std::vector<PreflightValue> preflightUpdatedValues;
+
+  const auto& selectedArray = dataStructure.getDataRefAs<IDataArray>(pSelectedArrayPathValue);
+
+  if(selectedArray.getNumberOfComponents() < pCompNumberValue)
+  {
+    return {MakeErrorResult<OutputActions>(-45630, fmt::format("The number to remove [{}] is larger than the array component count: {} ", pCompNumberValue, selectedArray.getNumberOfComponents()))};
+  }
+
+  if(pMoveToNewArrayValue)
+  {
+    auto createArrayAction = std::make_unique<CreateArrayAction>(selectedArray.getDataType(), std::vector<usize>{1}, std::vector<usize>{static_cast<usize>(abs(pCompNumberValue))}, pNewArrayPathValue);
+    resultOutputActions.value().actions.push_back(std::move(createArrayAction));
+  }
+
+  // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
+  return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
+}
+
+//------------------------------------------------------------------------------
+Result<> ExtractComponentAsArrayFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                                                    const std::atomic_bool& shouldCancel) const
+{
+  ExtractComponentAsArrayInputValues inputValues;
+
+  inputValues.MoveToNewArray = filterArgs.value<bool>(k_MoveToNewArray_Key);
+  inputValues.CompNumber = filterArgs.value<int32>(k_CompNumber_Key);
+  inputValues.SelectedArrayPath = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
+  inputValues.NewArrayPath = filterArgs.value<DataPath>(k_NewArrayPath_Key);
+
+  return ExtractComponentAsArray(dataStructure, messageHandler, shouldCancel, &inputValues)();
+}
+} // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractComponentAsArrayFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractComponentAsArrayFilter.cpp
@@ -104,7 +104,8 @@ IFilter::PreflightResult ExtractComponentAsArrayFilter::preflightImpl(const Data
   }
   if(selectedArrayComp < pCompNumberValue)
   {
-    return {MakeErrorResult<OutputActions>(-45631, fmt::format("The component index '{}' is larger than the total number of components. Valid values are between {} and {} inclusive. ", pCompNumberValue, 0, (selectedArrayComp - 1)))};
+    return {MakeErrorResult<OutputActions>(
+        -45631, fmt::format("The component index '{}' is larger than the total number of components. Valid values are between {} and {} inclusive. ", pCompNumberValue, 0, (selectedArrayComp - 1)))};
   }
 
   if(pMoveComponentsToNewArrayValue)

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractComponentAsArrayFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractComponentAsArrayFilter.hpp
@@ -25,7 +25,8 @@ public:
   ExtractComponentAsArrayFilter& operator=(ExtractComponentAsArrayFilter&&) noexcept = delete;
 
   // Parameter Keys
-  static inline constexpr StringLiteral k_MoveToNewArray_Key = "move_to_new_array";
+  static inline constexpr StringLiteral k_RemoveComponentsFromArray_Key = "remove_components_from_array";
+  static inline constexpr StringLiteral k_MoveComponentsToNewArray_Key = "move_components_to_new_array";
   static inline constexpr StringLiteral k_CompNumber_Key = "comp_number";
   static inline constexpr StringLiteral k_SelectedArrayPath_Key = "selected_array_path";
   static inline constexpr StringLiteral k_NewArrayPath_Key = "new_array_path";

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractComponentAsArrayFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractComponentAsArrayFilter.hpp
@@ -8,28 +8,27 @@
 namespace complex
 {
 /**
- * @class ConditionalSetValue
- * @brief This filter replaces values in the target array with a user specified value
- * where a bool mask array specifies.
+ * @class ExtractComponentAsArrayFilter
+ * @brief This filter will extract components of an array either to a new array or
+ * delete it.
  */
-class COMPLEXCORE_EXPORT ConditionalSetValue : public IFilter
+class COMPLEXCORE_EXPORT ExtractComponentAsArrayFilter : public IFilter
 {
 public:
-  ConditionalSetValue() = default;
-  ~ConditionalSetValue() noexcept override = default;
+  ExtractComponentAsArrayFilter() = default;
+  ~ExtractComponentAsArrayFilter() noexcept override = default;
 
-  ConditionalSetValue(const ConditionalSetValue&) = delete;
-  ConditionalSetValue(ConditionalSetValue&&) noexcept = delete;
+  ExtractComponentAsArrayFilter(const ExtractComponentAsArrayFilter&) = delete;
+  ExtractComponentAsArrayFilter(ExtractComponentAsArrayFilter&&) noexcept = delete;
 
-  ConditionalSetValue& operator=(const ConditionalSetValue&) = delete;
-  ConditionalSetValue& operator=(ConditionalSetValue&&) noexcept = delete;
+  ExtractComponentAsArrayFilter& operator=(const ExtractComponentAsArrayFilter&) = delete;
+  ExtractComponentAsArrayFilter& operator=(ExtractComponentAsArrayFilter&&) noexcept = delete;
 
   // Parameter Keys
-  static inline constexpr StringLiteral k_UseConditional_Key = "use_conditional";
-  static inline constexpr StringLiteral k_RemoveValue_Key = "remove_value";
-  static inline constexpr StringLiteral k_ReplaceValue_Key = "replace_value";
-  static inline constexpr StringLiteral k_ConditionalArrayPath_Key = "conditional_array_path";
+  static inline constexpr StringLiteral k_MoveToNewArray_Key = "move_to_new_array";
+  static inline constexpr StringLiteral k_CompNumber_Key = "comp_number";
   static inline constexpr StringLiteral k_SelectedArrayPath_Key = "selected_array_path";
+  static inline constexpr StringLiteral k_NewArrayPath_Key = "new_array_path";
 
   /**
    * @brief Returns the name of the filter.
@@ -78,25 +77,24 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param dataStructure The input DataStructure instance
+   * @param ds The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& ds, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param dataStructure The input DataStructure instance
+   * @param ds The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode
    * @param messageHandler The MessageHandler object
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace complex
 
-COMPLEX_DEF_FILTER_TRAITS(complex, ConditionalSetValue, "bad9b7bd-1dc9-4f21-a889-6520e7a41881");
+COMPLEX_DEF_FILTER_TRAITS(complex, ExtractComponentAsArrayFilter, "fcc1c1cc-c37a-40fc-97fa-ce40201d34e3");
+/* LEGACY UUID FOR THIS FILTER 79d59b85-01e8-5c4a-a6e1-3fd3e2ceffb4 */

--- a/src/Plugins/ComplexCore/test/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/test/CMakeLists.txt
@@ -55,6 +55,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   TriangleDihedralAngleFilterTest.cpp
   FindNumFeaturesTest.cpp
   FindVolFractionsTest.cpp
+  ExtractComponentAsArrayTest.cpp
 )
 
 create_complex_plugin_unit_test(PLUGIN_NAME ${PLUGIN_NAME}

--- a/src/Plugins/ComplexCore/test/ConditionalSetValueTest.cpp
+++ b/src/Plugins/ComplexCore/test/ConditionalSetValueTest.cpp
@@ -19,6 +19,7 @@ void ConditionalSetValueOverFlowTest(DataStructure& dataGraph, const DataPath& s
   ConditionalSetValue filter;
   Arguments args;
   // Replace every value with a zero
+  args.insertOrAssign(ConditionalSetValue::k_UseConditional_Key, std::make_any<bool>(true));
   args.insertOrAssign(ConditionalSetValue::k_ReplaceValue_Key, std::make_any<std::string>(value));
   args.insertOrAssign(ConditionalSetValue::k_ConditionalArrayPath_Key, std::make_any<DataPath>(conditionalPath));
   args.insertOrAssign(ConditionalSetValue::k_SelectedArrayPath_Key, std::make_any<DataPath>(selectedDataPath));
@@ -52,6 +53,7 @@ TEST_CASE("ComplexCore::ConditionalSetValue: Instantiate Filter", "[ConditionalS
 
   DataPath ciDataPath = DataPath({k_SmallIN100, k_EbsdScanData, k_ConfidenceIndex});
 
+  args.insertOrAssign(ConditionalSetValue::k_UseConditional_Key, std::make_any<bool>(true));
   args.insertOrAssign(ConditionalSetValue::k_ReplaceValue_Key, std::make_any<std::string>("0.0"));
   args.insertOrAssign(ConditionalSetValue::k_ConditionalArrayPath_Key, std::make_any<DataPath>(DataPath({k_SmallIN100, k_EbsdScanData, k_ConditionalArray})));
   args.insertOrAssign(ConditionalSetValue::k_SelectedArrayPath_Key, std::make_any<DataPath>(ciDataPath));
@@ -72,6 +74,8 @@ TEST_CASE("ComplexCore::ConditionalSetValue: Missing/Empty DataPaths", "[Conditi
   DataPath ciDataPath = DataPath({k_SmallIN100, k_EbsdScanData, k_ConfidenceIndex});
 
   ConditionalSetValue filter;
+
+  args.insertOrAssign(ConditionalSetValue::k_UseConditional_Key, std::make_any<bool>(true));
 
   // Preflight the filter and check result with empty values
   args.insertOrAssign(ConditionalSetValue::k_ReplaceValue_Key, std::make_any<std::string>(""));
@@ -123,6 +127,7 @@ TEST_CASE("ComplexCore::ConditionalSetValue: Test Algorithm Bool", "[Conditional
   ConditionalSetValue filter;
   Arguments args;
   // Replace every value with a zero
+  args.insertOrAssign(ConditionalSetValue::k_UseConditional_Key, std::make_any<bool>(true));
   args.insertOrAssign(ConditionalSetValue::k_ReplaceValue_Key, std::make_any<std::string>("0.0"));
   args.insertOrAssign(ConditionalSetValue::k_ConditionalArrayPath_Key, std::make_any<DataPath>(DataPath({k_SmallIN100, k_EbsdScanData, k_ConditionalArray})));
   args.insertOrAssign(ConditionalSetValue::k_SelectedArrayPath_Key, std::make_any<DataPath>(ciDataPath));
@@ -167,6 +172,7 @@ TEST_CASE("ComplexCore::ConditionalSetValue: Test Algorithm UInt8", "[Conditiona
   ConditionalSetValue filter;
   Arguments args;
   // Replace every value with a zero
+  args.insertOrAssign(ConditionalSetValue::k_UseConditional_Key, std::make_any<bool>(true));
   args.insertOrAssign(ConditionalSetValue::k_ReplaceValue_Key, std::make_any<std::string>("0.0"));
   args.insertOrAssign(ConditionalSetValue::k_ConditionalArrayPath_Key, std::make_any<DataPath>(DataPath({k_SmallIN100, k_EbsdScanData, k_ConditionalArray})));
   args.insertOrAssign(ConditionalSetValue::k_SelectedArrayPath_Key, std::make_any<DataPath>(ciDataPath));
@@ -203,6 +209,7 @@ TEST_CASE("ComplexCore::ConditionalSetValue: Test Algorithm Int8", "[Conditional
   ConditionalSetValue filter;
   Arguments args;
   // Replace every value with a zero
+  args.insertOrAssign(ConditionalSetValue::k_UseConditional_Key, std::make_any<bool>(true));
   args.insertOrAssign(ConditionalSetValue::k_ReplaceValue_Key, std::make_any<std::string>("0.0"));
   args.insertOrAssign(ConditionalSetValue::k_ConditionalArrayPath_Key, std::make_any<DataPath>(DataPath({k_SmallIN100, k_EbsdScanData, k_ConditionalArray})));
   args.insertOrAssign(ConditionalSetValue::k_SelectedArrayPath_Key, std::make_any<DataPath>(ciDataPath));

--- a/src/Plugins/ComplexCore/test/ConditionalSetValueTest.cpp
+++ b/src/Plugins/ComplexCore/test/ConditionalSetValueTest.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 
 #include "complex/UnitTest/UnitTestCommon.hpp"
+#include "complex/Utilities/DataArrayUtilities.hpp"
 
 #include "ComplexCore/ComplexCore_test_dirs.hpp"
 #include "ComplexCore/Filters/ConditionalSetValue.hpp"
@@ -298,4 +299,46 @@ TEST_CASE("ComplexCore::ConditionalSetValue: Overflow/Underflow", "[ConditionalS
   ConditionalSetValueOverFlowTest<float64>(dataGraph, selectedDataPath, conditionalDataPath, "1.79769e+309");  // overflow
   ConditionalSetValueOverFlowTest<float64>(dataGraph, selectedDataPath, conditionalDataPath, "-2.22507e-309"); // underflow
   ConditionalSetValueOverFlowTest<float64>(dataGraph, selectedDataPath, conditionalDataPath, "-1.79769e+309"); // overflow
+}
+
+TEST_CASE("ComplexCore::ConditionalSetValue: No Conditional", "[ConditionalSetValue]")
+{
+  ConditionalSetValue filter;
+  Arguments args;
+
+  DataStructure dataGraph = UnitTest::CreateDataStructure();
+  DataPath ebsdScanPath = DataPath({k_SmallIN100, k_EbsdScanData});
+  DataPath geomPath = DataPath({k_SmallIN100, k_EbsdScanData, k_ImageGeometry});
+  std::shared_ptr<ImageGeom> imageGeometry = dataGraph.getSharedDataAs<ImageGeom>(geomPath);
+  complex::SizeVec3 imageGeomDims = imageGeometry->getDimensions();
+
+  DataPath ciDataPath = DataPath({k_SmallIN100, k_EbsdScanData, k_ConfidenceIndex});
+  DataObject* ciDataObject = dataGraph.getData(ciDataPath);
+
+  DataArray<float32>* ciDataArray = dynamic_cast<Float32Array*>(ciDataObject);
+  // Fill every value with 10.0 into the ciArray
+  ciDataArray->fill(10.0);
+
+  const std::string removeStr = "10.0";
+  const auto removeVal = static_cast<float32>(ConvertTo<float32>::convert(removeStr).value());
+
+  args.insertOrAssign(ConditionalSetValue::k_UseConditional_Key, std::make_any<bool>(false));
+  args.insertOrAssign(ConditionalSetValue::k_RemoveValue_Key, std::make_any<std::string>(removeStr));
+  args.insertOrAssign(ConditionalSetValue::k_ReplaceValue_Key, std::make_any<std::string>("0.0"));
+  args.insertOrAssign(ConditionalSetValue::k_SelectedArrayPath_Key, std::make_any<DataPath>(ciDataPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataGraph, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataGraph, args);
+  REQUIRE(executeResult.result.valid());
+
+  const auto& alteredArray = dataGraph.getDataRefAs<Float32Array>(ciDataPath);
+
+  for(const auto& value : alteredArray)
+  {
+    REQUIRE(value != removeVal);
+  }
 }

--- a/src/Plugins/ComplexCore/test/ExtractComponentAsArrayTest.cpp
+++ b/src/Plugins/ComplexCore/test/ExtractComponentAsArrayTest.cpp
@@ -1,0 +1,63 @@
+/**
+ * This file is auto generated from the original ComplexCore/ExtractComponentAsArrayFilter
+ * runtime information. These are the steps that need to be taken to utilize this
+ * unit test in the proper way.
+ *
+ * 1: Validate each of the default parameters that gets created.
+ * 2: Inspect the actual filter to determine if the filter in its default state
+ * would pass or fail BOTH the preflight() and execute() methods
+ * 3: UPDATE the ```REQUIRE(result.result.valid());``` code to have the proper
+ *
+ * 4: Add additional unit tests to actually test each code path within the filter
+ *
+ * There are some example Catch2 ```TEST_CASE``` sections for your inspiration.
+ *
+ * NOTE the format of the ```TEST_CASE``` macro. Please stick to this format to
+ * allow easier parsing of the unit tests.
+ *
+ * When you start working on this unit test remove "[ExtractComponentAsArrayFilter][.][UNIMPLEMENTED]"
+ * from the TEST_CASE macro. This will enable this unit test to be run by default
+ * and report errors.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "complex/Parameters/ArrayCreationParameter.hpp"
+#include "complex/Parameters/ArraySelectionParameter.hpp"
+#include "complex/Parameters/NumberParameter.hpp"
+
+#include "ComplexCore/ComplexCore_test_dirs.hpp"
+#include "ComplexCore/Filters/ExtractComponentAsArrayFilter.hpp"
+
+using namespace complex;
+
+TEST_CASE("ComplexCore::ExtractComponentAsArrayFilter: Instantiation and Parameter Check", "[ComplexCore][ExtractComponentAsArrayFilter][.][UNIMPLEMENTED][!mayfail]")
+{
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  ExtractComponentAsArrayFilter filter;
+  DataStructure ds;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_CompNumber_Key, std::make_any<int32>(1234356));
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_SelectedArrayPath_Key, std::make_any<DataPath>(DataPath{}));
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_NewArrayPath_Key, std::make_any<DataPath>(DataPath{}));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(ds, args);
+  REQUIRE(executeResult.result.valid());
+}
+
+// TEST_CASE("ComplexCore::ExtractComponentAsArrayFilter: Valid filter execution")
+//{
+//
+// }
+
+// TEST_CASE("ComplexCore::ExtractComponentAsArrayFilter: InValid filter execution")
+//{
+//
+// }

--- a/src/Plugins/ComplexCore/test/ExtractComponentAsArrayTest.cpp
+++ b/src/Plugins/ComplexCore/test/ExtractComponentAsArrayTest.cpp
@@ -1,47 +1,39 @@
-/**
- * This file is auto generated from the original ComplexCore/ExtractComponentAsArrayFilter
- * runtime information. These are the steps that need to be taken to utilize this
- * unit test in the proper way.
- *
- * 1: Validate each of the default parameters that gets created.
- * 2: Inspect the actual filter to determine if the filter in its default state
- * would pass or fail BOTH the preflight() and execute() methods
- * 3: UPDATE the ```REQUIRE(result.result.valid());``` code to have the proper
- *
- * 4: Add additional unit tests to actually test each code path within the filter
- *
- * There are some example Catch2 ```TEST_CASE``` sections for your inspiration.
- *
- * NOTE the format of the ```TEST_CASE``` macro. Please stick to this format to
- * allow easier parsing of the unit tests.
- *
- * When you start working on this unit test remove "[ExtractComponentAsArrayFilter][.][UNIMPLEMENTED]"
- * from the TEST_CASE macro. This will enable this unit test to be run by default
- * and report errors.
- */
-
 #include <catch2/catch.hpp>
 
 #include "complex/Parameters/ArrayCreationParameter.hpp"
 #include "complex/Parameters/ArraySelectionParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
+#include "complex/UnitTest/UnitTestCommon.hpp"
 
 #include "ComplexCore/ComplexCore_test_dirs.hpp"
 #include "ComplexCore/Filters/ExtractComponentAsArrayFilter.hpp"
 
+namespace fs = std::filesystem;
 using namespace complex;
 
-TEST_CASE("ComplexCore::ExtractComponentAsArrayFilter: Instantiation and Parameter Check", "[ComplexCore][ExtractComponentAsArrayFilter][.][UNIMPLEMENTED][!mayfail]")
+namespace
+{
+const std::string k_ExtractedComponents("Extracted Components");
+
+const DataPath k_QuatsPath({Constants::k_DataContainer, Constants::k_EbsdScanData, Constants::k_Quats});
+const DataPath k_ExtractedComponentsPath({Constants::k_DataContainer, Constants::k_EbsdScanData, k_ExtractedComponents});
+
+const fs::path k_BaseDataFilePath = fs::path(fmt::format("{}/TestFiles/6_6_find_feature_centroids.dream3d", unit_test::k_DREAM3DDataDir));
+} // namespace
+
+TEST_CASE("ComplexCore::ExtractComponentAsArrayFilter: Instantiation and Parameter Check", "[ComplexCore]")
 {
   // Instantiate the filter, a DataStructure object and an Arguments Object
   ExtractComponentAsArrayFilter filter;
-  DataStructure ds;
+  DataStructure ds = UnitTest::LoadDataStructure(k_BaseDataFilePath);
   Arguments args;
 
   // Create default Parameters for the filter.
-  args.insertOrAssign(ExtractComponentAsArrayFilter::k_CompNumber_Key, std::make_any<int32>(1234356));
-  args.insertOrAssign(ExtractComponentAsArrayFilter::k_SelectedArrayPath_Key, std::make_any<DataPath>(DataPath{}));
-  args.insertOrAssign(ExtractComponentAsArrayFilter::k_NewArrayPath_Key, std::make_any<DataPath>(DataPath{}));
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_MoveComponentsToNewArray_Key, std::make_any<bool>(true));
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_RemoveComponentsFromArray_Key, std::make_any<bool>(true));
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_CompNumber_Key, std::make_any<int32>(1));
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_SelectedArrayPath_Key, std::make_any<DataPath>(k_QuatsPath));
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_NewArrayPath_Key, std::make_any<DataPath>(k_ExtractedComponentsPath));
 
   // Preflight the filter and check result
   auto preflightResult = filter.preflight(ds, args);
@@ -52,12 +44,89 @@ TEST_CASE("ComplexCore::ExtractComponentAsArrayFilter: Instantiation and Paramet
   REQUIRE(executeResult.result.valid());
 }
 
-// TEST_CASE("ComplexCore::ExtractComponentAsArrayFilter: Valid filter execution")
-//{
-//
-// }
+TEST_CASE("ComplexCore::ExtractComponentAsArrayFilter: Valid filter execution", "[ComplexCore]")
+{
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  ExtractComponentAsArrayFilter filter;
 
-// TEST_CASE("ComplexCore::ExtractComponentAsArrayFilter: InValid filter execution")
-//{
-//
-// }
+  DataStructure alteredDs = UnitTest::LoadDataStructure(k_BaseDataFilePath);
+  const int32 removeCompIndex = 1;
+
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_MoveComponentsToNewArray_Key, std::make_any<bool>(true));
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_RemoveComponentsFromArray_Key, std::make_any<bool>(true));
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_CompNumber_Key, std::make_any<int32>(removeCompIndex));
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_SelectedArrayPath_Key, std::make_any<DataPath>(k_QuatsPath));
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_NewArrayPath_Key, std::make_any<DataPath>(k_ExtractedComponentsPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(alteredDs, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(alteredDs, args);
+  REQUIRE(executeResult.result.valid());
+
+  // Load a clean copy of the datastructure prior to resize because original array is terminated after execution
+  DataStructure unalteredDs = UnitTest::LoadDataStructure(k_BaseDataFilePath);
+  const auto& originalQuatsArray = unalteredDs.getDataRefAs<Float32Array>(k_QuatsPath); // clean array [exemplar]
+
+  const auto& reducedQuatsArray = alteredDs.getDataRefAs<Float32Array>(k_QuatsPath);
+  const auto& extractedComponentsArray = alteredDs.getDataRefAs<Float32Array>(k_ExtractedComponentsPath);
+
+  const usize originalTupleCount = originalQuatsArray.getNumberOfTuples();
+  REQUIRE(originalTupleCount == reducedQuatsArray.getNumberOfTuples());
+  REQUIRE(originalTupleCount == extractedComponentsArray.getNumberOfTuples());
+
+  const usize originalCompCount = originalQuatsArray.getNumberOfComponents();
+  const usize reducedCompCount = reducedQuatsArray.getNumberOfComponents();
+  REQUIRE((originalCompCount - 1) == reducedCompCount);
+  REQUIRE(1 == extractedComponentsArray.getNumberOfComponents());
+
+  usize extractedIndex = 0;
+  for(usize tupleIndex = 0; tupleIndex < originalTupleCount; tupleIndex++)
+  {
+    for(usize compIndex = 0; compIndex < originalCompCount; compIndex++)
+    {
+      usize originalIndex = tupleIndex * originalCompCount + compIndex;
+      usize reducedIndex = tupleIndex * reducedCompCount + compIndex;
+      if(compIndex == removeCompIndex)
+      {
+        REQUIRE(originalQuatsArray[originalIndex] == extractedComponentsArray[extractedIndex]);
+        extractedIndex++;
+      }
+      else
+      {
+        if(compIndex > removeCompIndex)
+        {
+          REQUIRE(originalQuatsArray[originalIndex] == reducedQuatsArray[reducedIndex - 1]); // account for having one less comp
+        }
+        else
+        {
+          REQUIRE(originalQuatsArray[originalIndex] == reducedQuatsArray[reducedIndex]);
+        }
+      }
+    }
+  }
+}
+
+TEST_CASE("ComplexCore::ExtractComponentAsArrayFilter: InValid filter execution", "[ComplexCore]")
+{
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  ExtractComponentAsArrayFilter filter;
+  DataStructure ds = UnitTest::LoadDataStructure(k_BaseDataFilePath);
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_MoveComponentsToNewArray_Key, std::make_any<bool>(true));
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_RemoveComponentsFromArray_Key, std::make_any<bool>(true));
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_CompNumber_Key, std::make_any<int32>(5)); // Invalid
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_SelectedArrayPath_Key, std::make_any<DataPath>(k_QuatsPath));
+  args.insertOrAssign(ExtractComponentAsArrayFilter::k_NewArrayPath_Key, std::make_any<DataPath>(k_ExtractedComponentsPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(ds, args);
+  REQUIRE(!preflightResult.outputActions.valid());
+}

--- a/src/complex/Utilities/FilterUtilities.hpp
+++ b/src/complex/Utilities/FilterUtilities.hpp
@@ -86,7 +86,8 @@ auto ExecuteNeighborFunction(FuncT&& func, DataType dataType, ArgsT&&... args)
     return func.template operator()<float64>(std::forward<ArgsT>(args)...);
   }
   case DataType::boolean: {
-    return MakeErrorResult(-89850, "Cannot create a NeighborList of booleans.");
+    throw std::runtime_error("Cannot create a NeighborList of booleans.");
+    break;
   }
   default: {
     throw std::runtime_error("complex::ExecuteDataFunction<...>(FuncT&& func, DataType dataType, ArgsT&&... args). Error: Invalid DataType");


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files.

- [x] Class and Structs are `UpperCamelCase`
- [x] Class private member variables are `m_UpperCamelCase`
- [x] Class methods are `lowerCamelCase`
- [x] Method arguments are `lowerCamelCase`
- [x] Normal variables are `lowerCamelCase`
- [x] Constants are `k_UpperCamelCase`
- [x] Global statics are `s_UpperCamelCase`
- [x] Free Functions are `UpperCamelCase`
- [x] Macros are `ALL_UPPER_SNAKE_CASE`
- [x] Unit test will test data output from the filter.
- [x] Reused strings should be constants in an anonymous namespace
- [x] If parallelization is used, proper use of the abstracted complex classes are used. Using TBB specifically in a filter should be frowned upon unless for a really good reason.

## Filter Checklist

- [x] Parameters should be generally broken down into "Input Parameters", "Required Data Objects", "Created Data Objects". There can be exceptions to this.
- [x] ChoicesParameter selections should be an enumeration defined in the filer header
- [x] Documentation copied from SIMPL Repo and updated (if necessary)
- [x] Parameter argument variables are k_CamelCase_Key
- [x] Parameter argument strings are lower_snake_case
```
static inline constexpr StringLiteral k_AlignmentType_Key = "alignment_type";
```

## Unit Testing
- [x] 1 Unit test to instantiate the filter with the default arguments.
- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] Filters should have both the Filter class and Algorithm class for anything beyond trivial needs
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added Python wrapping to new files (if any) as necessary
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented.


<!-- **Thanks for contributing to complex!** -->
