### PR TITLE
ENH: Recursive DataStructure Hierarchy Dump Debug Functions

### DIFF
--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -22,6 +22,11 @@
 
 #include <fmt/core.h>
 
+namespace
+{
+inline const std::string k_Delimiter = "|--";
+}
+
 namespace complex
 {
 
@@ -901,7 +906,7 @@ void DataStructure::dumpHierarchyToASCII(std::ostream& outputStream)
     auto topLevelPath = DataPath::FromString(object->getDataPaths()[0].getTargetName()).value();
     auto optionalDataPaths = GetAllChildDataPaths(*this, topLevelPath);
 
-    outputStream << "|-- " << topLevelPath.getTargetName() << "\n";
+    outputStream << k_Delimiter << topLevelPath.getTargetName() << "\n";
 
     if(optionalDataPaths.has_value() || optionalDataPaths.value().size() != 0)
     {
@@ -918,7 +923,7 @@ void DataStructure::recurseGraphToASCII(std::ostream& outputStream, const std::v
   for(const auto& path : paths)
   {
     // Output parent node, child node, and edge connecting them in .dot format
-    outputStream << indent << "|-- " << path.getTargetName() << "\n";
+    outputStream << indent << k_Delimiter << path.getTargetName() << "\n";
 
     // pull child paths or skip to next iteration
     auto optionalChildPaths = GetAllChildDataPaths(*this, path);

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -852,7 +852,7 @@ void DataStructure::resetIds(DataObject::IdType startingId)
   }
 }
 
-void DataStructure::dumpHierarchyToDotFile(std::ostream& outputStream)
+void DataStructure::exportHeirarchyAsGraphViz(std::ostream& outputStream)
 {
   // initialize dot file
   outputStream << "digraph DataGraph {\n"
@@ -871,14 +871,14 @@ void DataStructure::dumpHierarchyToDotFile(std::ostream& outputStream)
     }
 
     // Begin recursion
-    recurseGraphToDot(outputStream, optionalDataPaths.value(), topLevelPath.getTargetName());
+    recurseHeirarchyToGraphViz(outputStream, optionalDataPaths.value(), topLevelPath.getTargetName());
   }
 
   // close dot file
   outputStream << "}\n";
 }
 
-void DataStructure::recurseGraphToDot(std::ostream& outputStream, const std::vector<DataPath> paths, const std::string& parent)
+void DataStructure::recurseHeirarchyToGraphViz(std::ostream& outputStream, const std::vector<DataPath> paths, const std::string& parent)
 {
   for(const auto& path : paths)
   {
@@ -893,12 +893,12 @@ void DataStructure::recurseGraphToDot(std::ostream& outputStream, const std::vec
     }
 
     // recurse
-    recurseGraphToDot(outputStream, optionalChildPaths.value(), path.getTargetName());
+    recurseHeirarchyToGraphViz(outputStream, optionalChildPaths.value(), path.getTargetName());
   }
   outputStream << "\n"; // for readability
 }
 
-void DataStructure::dumpHierarchyToASCII(std::ostream& outputStream)
+void DataStructure::exportHeirarchyAsText(std::ostream& outputStream)
 {
   // set base case
   for(const auto* object : getTopLevelData())
@@ -911,12 +911,12 @@ void DataStructure::dumpHierarchyToASCII(std::ostream& outputStream)
     if(optionalDataPaths.has_value() || optionalDataPaths.value().size() != 0)
     {
       // Begin recursion
-      recurseGraphToASCII(outputStream, optionalDataPaths.value(), "");
+      recurseHeirarchyToText(outputStream, optionalDataPaths.value(), "");
     }
   }
 }
 
-void DataStructure::recurseGraphToASCII(std::ostream& outputStream, const std::vector<DataPath> paths, std::string indent)
+void DataStructure::recurseHeirarchyToText(std::ostream& outputStream, const std::vector<DataPath> paths, std::string indent)
 {
   indent += "  ";
 
@@ -933,7 +933,7 @@ void DataStructure::recurseGraphToASCII(std::ostream& outputStream, const std::v
     }
 
     // recurse
-    recurseGraphToASCII(outputStream, optionalChildPaths.value(), indent);
+    recurseHeirarchyToText(outputStream, optionalChildPaths.value(), indent);
   }
 }
 

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -893,4 +893,43 @@ void DataStructure::recurseGraphToDot(std::ostream& outputStream, const std::vec
   outputStream << "\n"; // for readability
 }
 
+void DataStructure::dumpHierarchyToASCII(std::ostream& outputStream)
+{
+  // set base case
+  for(const auto* object : getTopLevelData())
+  {
+    auto topLevelPath = DataPath::FromString(object->getDataPaths()[0].getTargetName()).value();
+    auto optionalDataPaths = GetAllChildDataPaths(*this, topLevelPath);
+
+    outputStream << "|-- " << topLevelPath.getTargetName() << "\n";
+
+    if(optionalDataPaths.has_value() || optionalDataPaths.value().size() != 0)
+    {
+      // Begin recursion
+      recurseGraphToASCII(outputStream, optionalDataPaths.value(), "");
+    }
+  }
+}
+
+void DataStructure::recurseGraphToASCII(std::ostream& outputStream, const std::vector<DataPath> paths, std::string indent)
+{
+  indent += "  ";
+
+  for(const auto& path : paths)
+  {
+    // Output parent node, child node, and edge connecting them in .dot format
+    outputStream << indent << "|-- " << path.getTargetName() << "\n";
+
+    // pull child paths or skip to next iteration
+    auto optionalChildPaths = GetAllChildDataPaths(*this, path);
+    if(!optionalChildPaths.has_value() || optionalChildPaths.value().size() == 0)
+    {
+      continue;
+    }
+
+    // recurse
+    recurseGraphToASCII(outputStream, optionalChildPaths.value(), indent);
+  }
+}
+
 } // namespace complex

--- a/src/complex/DataStructure/DataStructure.hpp
+++ b/src/complex/DataStructure/DataStructure.hpp
@@ -629,14 +629,14 @@ public:
    * @param outputStream the child class of ostream to output dot syntax to
    * @return
    */
-  void dumpHierarchyToDotFile(std::ostream& outputStream);
+  void exportHeirarchyAsGraphViz(std::ostream& outputStream);
 
   /**
    * @brief Outputs data graph in console readable format
    * @param outputStream the child class of ostream to output to
    * @return
    */
-  void dumpHierarchyToASCII(std::ostream& outputStream);
+  void exportHeirarchyAsText(std::ostream& outputStream);
 
   /**
    * @brief Copy assignment operator. The copied DataStructure's observers are not retained.
@@ -750,7 +750,7 @@ private:
    * @param parent name of the calling parent to output
    * @return
    */
-  void recurseGraphToDot(std::ostream& outputStream, const std::vector<DataPath> paths, const std::string& parent);
+  void recurseHeirarchyToGraphViz(std::ostream& outputStream, const std::vector<DataPath> paths, const std::string& parent);
 
   /**
    * @brief The recursive function to parse graph and dump names to and output stream in
@@ -760,7 +760,7 @@ private:
    * @param indent the indent for the heirarchy
    * @return
    */
-  void recurseGraphToASCII(std::ostream& outputStream, const std::vector<DataPath> paths, std::string indent);
+  void recurseHeirarchyToText(std::ostream& outputStream, const std::vector<DataPath> paths, std::string indent);
 
   /**
    * @brief Notifies observers to the provided message.

--- a/src/complex/DataStructure/DataStructure.hpp
+++ b/src/complex/DataStructure/DataStructure.hpp
@@ -632,6 +632,13 @@ public:
   void dumpHierarchyToDotFile(std::ostream& outputStream);
 
   /**
+   * @brief Outputs data graph in console readable format
+   * @param outputStream the child class of ostream to output to
+   * @return
+   */
+  void dumpHierarchyToASCII(std::ostream& outputStream);
+
+  /**
    * @brief Copy assignment operator. The copied DataStructure's observers are not retained.
    * @param rhs
    * @return DataStructure&
@@ -744,6 +751,16 @@ private:
    * @return
    */
   void recurseGraphToDot(std::ostream& outputStream, const std::vector<DataPath> paths, const std::string& parent);
+
+  /**
+   * @brief The recursive function to parse graph and dump names to and output stream in
+   * readable syntax
+   * @param outputStream ostream to write to
+   * @param paths list of paths to parse
+   * @param indent the indent for the heirarchy
+   * @return
+   */
+  void recurseGraphToASCII(std::ostream& outputStream, const std::vector<DataPath> paths, std::string indent);
 
   /**
    * @brief Notifies observers to the provided message.

--- a/src/complex/DataStructure/DataStructure.hpp
+++ b/src/complex/DataStructure/DataStructure.hpp
@@ -625,6 +625,13 @@ public:
   void resetIds(DataObject::IdType startingId);
 
   /**
+   * @brief Outputs data graph in .dot file format
+   * @param outputStream the child class of ostream to output dot syntax to
+   * @return
+   */
+  void dumpHierarchyToDotFile(std::ostream& outputStream);
+
+  /**
    * @brief Copy assignment operator. The copied DataStructure's observers are not retained.
    * @param rhs
    * @return DataStructure&
@@ -727,6 +734,16 @@ private:
    * This method exists for methods that copy or move another DataStructure.
    */
   void applyAllDataStructure();
+
+  /**
+   * @brief The recursive function to parse graph and dump names to and output stream in
+   * dot file syntax
+   * @param outputStream ostream to write to
+   * @param paths list of paths to parse
+   * @param parent name of the calling parent to output
+   * @return
+   */
+  void recurseGraphToDot(std::ostream& outputStream, const std::vector<DataPath> paths, const std::string& parent);
 
   /**
    * @brief Notifies observers to the provided message.

--- a/src/complex/Utilities/DataGroupUtilities.cpp
+++ b/src/complex/Utilities/DataGroupUtilities.cpp
@@ -231,7 +231,6 @@ std::optional<std::vector<DataPath>> GetAllChildDataPaths(const DataStructure& d
 
     for(const auto& childName : childrenNames)
     {
-      bool ignore = false;
       DataPath childPath = parent.createChildPath(childName);
       const DataObject* dataObject = dataStructure.getData(childPath);
       childDataObjects.push_back(childPath);

--- a/src/complex/Utilities/DataGroupUtilities.cpp
+++ b/src/complex/Utilities/DataGroupUtilities.cpp
@@ -214,6 +214,35 @@ std::optional<std::vector<DataPath>> GetAllChildDataPaths(const DataStructure& d
   return {childDataObjects};
 }
 
+std::optional<std::vector<DataPath>> GetAllChildDataPaths(const DataStructure& dataStructure, const DataPath& parent)
+{
+  std::vector<DataPath> childDataObjects;
+  try
+  {
+    std::vector<std::string> childrenNames;
+    if(parent.empty())
+    {
+      childrenNames = dataStructure.getDataMap().getNames();
+    }
+    else
+    {
+      childrenNames = dataStructure.getDataRefAs<BaseGroup>(parent).getDataMap().getNames();
+    }
+
+    for(const auto& childName : childrenNames)
+    {
+      bool ignore = false;
+      DataPath childPath = parent.createChildPath(childName);
+      const DataObject* dataObject = dataStructure.getData(childPath);
+      childDataObjects.push_back(childPath);
+    }
+  } catch(std::exception& e)
+  {
+    return {};
+  }
+  return {childDataObjects};
+}
+
 std::optional<std::vector<DataPath>> GetAllChildArrayDataPaths(const DataStructure& dataStructure, const DataPath& parentGroup, const std::vector<DataPath>& ignoredDataPaths)
 {
   std::vector<DataPath> childDataObjects;

--- a/src/complex/Utilities/DataGroupUtilities.hpp
+++ b/src/complex/Utilities/DataGroupUtilities.hpp
@@ -45,6 +45,14 @@ COMPLEX_EXPORT std::optional<std::vector<DataPath>> GetAllChildDataPaths(const D
                                                                          const std::vector<DataPath>& ignoredDataPaths = {});
 
 /**
+ * @brief This function will return all the DataPaths within a BaseGroup that are of a certain type
+ * @param dataStructure The DataStructure to use
+ * @param parentGroup The parent group whose children you want to get
+ * @return std::optional<std::vector<DataPath>> of child paths if there no errors during the process.
+ */
+COMPLEX_EXPORT std::optional<std::vector<DataPath>> GetAllChildDataPaths(const DataStructure& dataStructure, const DataPath& parent);
+
+/**
  * @brief This function will return all the DataPaths within a BaseGroup that are of an IArray type
  * @param dataStructure The DataStructure to use
  * @param parentGroup The parent group whose children you want to get


### PR DESCRIPTION
This includes two functions that are capable of displaying the DataStructure, along with the associated API updates that allow for parsing all of a DataPath's children not just children of a specific type.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files.

- [x] Class and Structs are `UpperCamelCase`
- [x] Class private member variables are `m_UpperCamelCase`
- [x] Class methods are `lowerCamelCase`
- [x] Method arguments are `lowerCamelCase`
- [x] Normal variables are `lowerCamelCase`
- [x] Constants are `k_UpperCamelCase`
- [x] Global statics are `s_UpperCamelCase`
- [x] Free Functions are `UpperCamelCase`
- [x] Macros are `ALL_UPPER_SNAKE_CASE`
- [x] Unit test will test data output from the filter.
- [x] Reused strings should be constants in an anonymous namespace

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] Filters should have both the Filter class and Algorithm class for anything beyond trivial needs
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added Python wrapping to new files (if any) as necessary
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented.

<!-- **Thanks for contributing to complex!** -->
