### PR TITLE
FILTER: Delete Data Rework

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CombineAttributeArraysFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CombineAttributeArraysFilter.cpp
@@ -141,7 +141,7 @@ IFilter::PreflightResult CombineAttributeArraysFilter::preflightImpl(const DataS
   {
     for(const auto& dataPath : selectedDataArrayPathsValue)
     {
-      auto action = std::make_unique<DeleteDataAction>(dataPath);
+      auto action = std::make_unique<DeleteDataAction>(dataPath, DeleteDataAction::DeleteType::JustObject);
       resultOutputActions.value().deferredActions.push_back(std::move(action));
     }
   }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.cpp
@@ -1,5 +1,6 @@
 #include "DeleteData.hpp"
 
+#include "complex/DataStructure/BaseGroup.hpp"
 #include "complex/DataStructure/DataArray.hpp"
 #include "complex/Filter/Actions/DeleteDataAction.hpp"
 #include "complex/Parameters/DataPathSelectionParameter.hpp"
@@ -41,7 +42,8 @@ Parameters DeleteData::parameters() const
   Parameters params;
 
   params.insertSeparator(Parameters::Separator{"Required Input Data Objects"});
-  params.insert(std::make_unique<DataPathSelectionParameter>(k_DataPath_Key, "DataPath to remove", "The complete path to the DataObject to be removed", DataPath{}));
+  params.insert(std::make_unique<DataPathSelectionParameter>(k_DataPath_Key, "DataPath to remove", "The complete path to the DataObject to be removed", DataPath({"DataStructure", "DataObject"})));
+
   return params;
 }
 
@@ -50,17 +52,46 @@ IFilter::UniquePointer DeleteData::clone() const
   return std::make_unique<DeleteData>();
 }
 
-IFilter::PreflightResult DeleteData::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult DeleteData::preflightImpl(const DataStructure& dataGraph, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
-  auto dataArrayPath = args.value<DataPath>(k_DataPath_Key);
+  auto dataObjectPath = args.value<DataPath>(k_DataPath_Key);
 
-  auto action = std::make_unique<DeleteDataAction>(dataArrayPath);
+  // original
+  if(auto iArray = dataGraph.getDataAs<IArray>(dataObjectPath); iArray != nullptr)
+  {
+    OutputActions arrayActions;
+    auto action = std::make_unique<DeleteDataAction>(dataObjectPath, DeleteDataAction::DeleteType::JustObject);
+    arrayActions.actions.push_back(std::move(action));
+    return {std::move(arrayActions)};
+  }
 
-  OutputActions actions;
+  OutputActions baseGroupActions;
 
-  actions.actions.push_back(std::move(action));
+  auto baseGroup = dataGraph.getDataAs<BaseGroup>(dataObjectPath);
+  if(baseGroup == nullptr)
+  {
+    return {MakeErrorResult<OutputActions>(-61501, fmt::format("The object type cannot be processed. Value given is '{}'", dataGraph.getData(dataObjectPath)->getTypeName()))};
+  }
 
-  return {std::move(actions)};
+  // Remove Start Node and Children Recursively
+  // Rules:
+  // - If multiparented, any node and all children of that node will are kept
+  // - Edges that point to deleted nodes wil be removed
+  // - If start object is multiparented recommend edge removal instead
+  {
+    // check parent count (Base Case)
+    if(baseGroup->getParentIds().size() > 1)
+    {
+      return {
+          ConvertResultTo<OutputActions>(MakeWarningVoidResult(-61502, fmt::format("The object cannot be processed because it is multiparented. Consider using the Delete DataPath instead.")), {})};
+    }
+
+    // recurse action
+    auto action = std::make_unique<DeleteDataAction>(dataObjectPath, DeleteDataAction::DeleteType::IndependentChildren);
+    baseGroupActions.actions.push_back(std::move(action));
+  }
+
+  return {std::move(baseGroupActions)};
 }
 
 Result<> DeleteData::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.hpp
@@ -20,16 +20,16 @@ public:
   DeleteData& operator=(const DeleteData&) = delete;
   DeleteData& operator=(DeleteData&&) noexcept = delete;
 
-  //enum class DeletionType : uint64
+  // enum class DeletionType : uint64
   //{
-  //  DeleteDataObject = 0,
-  //  DeleteDataPath = 1,
-  //  DeleteUnsharedChildren = 2,
-  //  DeleteChildren = 3
-  //};
+  //   DeleteDataObject = 0,
+  //   DeleteDataPath = 1,
+  //   DeleteUnsharedChildren = 2,
+  //   DeleteChildren = 3
+  // };
 
   // Parameter Keys
-  //static inline constexpr StringLiteral k_DeletionType_Key = "deletion_type";
+  // static inline constexpr StringLiteral k_DeletionType_Key = "deletion_type";
   static inline constexpr StringLiteral k_DataPath_Key = "removed_data_path";
 
   /**

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.hpp
@@ -20,16 +20,16 @@ public:
   DeleteData& operator=(const DeleteData&) = delete;
   DeleteData& operator=(DeleteData&&) noexcept = delete;
 
-  enum class DeletionType : uint64
-  {
-    DeleteDataObject = 0,
-    DeleteDataPath = 1,
-    DeleteUnsharedChildren = 2,
-    DeleteChildren = 3
-  };
+  //enum class DeletionType : uint64
+  //{
+  //  DeleteDataObject = 0,
+  //  DeleteDataPath = 1,
+  //  DeleteUnsharedChildren = 2,
+  //  DeleteChildren = 3
+  //};
 
   // Parameter Keys
-  static inline constexpr StringLiteral k_DeletionType_Key = "deletion_type";
+  //static inline constexpr StringLiteral k_DeletionType_Key = "deletion_type";
   static inline constexpr StringLiteral k_DataPath_Key = "removed_data_path";
 
   /**

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.hpp
@@ -22,12 +22,14 @@ public:
 
   enum class DeletionType : uint64
   {
-    DeleteDataObjectSoft = 0,
-    DeleteDataObjectHard = 1,
-    DeleteDataPath = 2
+    DeleteDataObject = 0,
+    DeleteDataPath = 1,
+    DeleteUnsharedChildren = 2,
+    DeleteChildren = 3
   };
 
   // Parameter Keys
+  static inline constexpr StringLiteral k_DeletionType_Key = "deletion_type";
   static inline constexpr StringLiteral k_DataPath_Key = "removed_data_path";
 
   /**

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.hpp
@@ -20,6 +20,13 @@ public:
   DeleteData& operator=(const DeleteData&) = delete;
   DeleteData& operator=(DeleteData&&) noexcept = delete;
 
+  enum class DeletionType : uint64
+  {
+    DeleteDataObjectSoft = 0,
+    DeleteDataObjectHard = 1,
+    DeleteDataPath = 2
+  };
+
   // Parameter Keys
   static inline constexpr StringLiteral k_DataPath_Key = "removed_data_path";
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractVertexGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractVertexGeometryFilter.cpp
@@ -160,7 +160,7 @@ IFilter::PreflightResult ExtractVertexGeometryFilter::preflightImpl(const DataSt
     {
       if(!pUseMaskValue)
       {
-        auto deleteDataAction = std::make_unique<DeleteDataAction>(dataPath);
+        auto deleteDataAction = std::make_unique<DeleteDataAction>(dataPath, DeleteDataAction::DeleteType::JustObject);
         resultOutputActions.value().deferredActions.push_back(std::move(deleteDataAction));
       }
     }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindEuclideanDistMapFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindEuclideanDistMapFilter.cpp
@@ -160,7 +160,7 @@ IFilter::PreflightResult FindEuclideanDistMapFilter::preflightImpl(const DataStr
   // If we are NOT saving the nearest neighbors then we need to delete this array that gets created.
   if(!pSaveNearestNeighborsValue)
   {
-    auto action = std::make_unique<DeleteDataAction>(pNearestNeighborsArrayPath);
+    auto action = std::make_unique<DeleteDataAction>(pNearestNeighborsArrayPath, DeleteDataAction::DeleteType::JustObject);
     resultOutputActions.value().deferredActions.push_back(std::move(action));
   }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/SplitAttributeArrayFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/SplitAttributeArrayFilter.cpp
@@ -130,7 +130,7 @@ IFilter::PreflightResult SplitAttributeArrayFilter::preflightImpl(const DataStru
 
   if(pRemoveOriginal)
   {
-    resultOutputActions.value().deferredActions.push_back(std::make_unique<DeleteDataAction>(pInputArrayPath));
+    resultOutputActions.value().deferredActions.push_back(std::make_unique<DeleteDataAction>(pInputArrayPath, DeleteDataAction::DeleteType::JustObject));
   }
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/ComplexCore/test/DeleteDataTest.cpp
+++ b/src/Plugins/ComplexCore/test/DeleteDataTest.cpp
@@ -37,7 +37,7 @@ TEST_CASE("ComplexCore::Delete Singular Data Array", "[ComplexCore][DeleteData]"
   Arguments args;
 
   // Create default Parameters for the filter.
-  //args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
+  // args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath));
 
   DeleteData filter;
@@ -72,7 +72,7 @@ TEST_CASE("ComplexCore::Delete Data Object (Node removal)", "[ComplexCore][Delet
   Arguments args;
 
   // Create default Parameters for the filter.
-  //args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
+  // args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath));
 
   // Preflight the filter and check result
@@ -87,423 +87,423 @@ TEST_CASE("ComplexCore::Delete Data Object (Node removal)", "[ComplexCore][Delet
   REQUIRE(removedDataArray == nullptr);
 }
 
-/**This code is commented out due to the current state of dataStructure management for the 
-* project. These test cases are meant to verify the different fringe case functionality 
-* should the underlying graph structure become more exposed. These test cases are mostly
-* functional but will likely need review upon time of implementation.
-*/
+/**This code is commented out due to the current state of dataStructure management for the
+ * project. These test cases are meant to verify the different fringe case functionality
+ * should the underlying graph structure become more exposed. These test cases are mostly
+ * functional but will likely need review upon time of implementation.
+ */
 
-//TEST_CASE("ComplexCore::Delete Shared Node (Node removal)", "[ComplexCore][DeleteData]")
+// TEST_CASE("ComplexCore::Delete Shared Node (Node removal)", "[ComplexCore][DeleteData]")
 //{
-//  // For this test case the goal will be to completely wipe node (DataObject) C out of the
-//  // graph completely. Ie clear all edges (parent and child) to node C, call the destructor
-//  // on the node to ensure it doesn't become freehanging, and verify that the object is no longer
-//  // in the data-lake (DataStructure) tables by ID grep.
+//   // For this test case the goal will be to completely wipe node (DataObject) C out of the
+//   // graph completely. Ie clear all edges (parent and child) to node C, call the destructor
+//   // on the node to ensure it doesn't become freehanging, and verify that the object is no longer
+//   // in the data-lake (DataStructure) tables by ID grep.
 //
-//  // Create complex DataGraph and unpack it
-//  DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-//  std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
+//   // Create complex DataGraph and unpack it
+//   DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//   std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
 //
-//  // Select DataPath to remove
-//  DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName});
-//  bool found = false;
-//  for(const auto& path : initialPaths)
-//  {
-//    if(path.toString() == selectedDataGroupPath.toString())
-//    {
-//      found = true;
-//    }
-//  }
-//  REQUIRE(found);
+//   // Select DataPath to remove
+//   DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName});
+//   bool found = false;
+//   for(const auto& path : initialPaths)
+//   {
+//     if(path.toString() == selectedDataGroupPath.toString())
+//     {
+//       found = true;
+//     }
+//   }
+//   REQUIRE(found);
 //
-//  // Store Data prior to deletion to verify removal
-//  // The target node here is k_GroupCName (the DataGroup named C)
-//  std::weak_ptr<DataObject> objectCPtr = dataGraph.getSharedData(selectedDataGroupPath); // convert the shared ptr to a weak ptr
-//  auto groupCId = dataGraph.getId(selectedDataGroupPath).value();
+//   // Store Data prior to deletion to verify removal
+//   // The target node here is k_GroupCName (the DataGroup named C)
+//   std::weak_ptr<DataObject> objectCPtr = dataGraph.getSharedData(selectedDataGroupPath); // convert the shared ptr to a weak ptr
+//   auto groupCId = dataGraph.getId(selectedDataGroupPath).value();
 //
-//  DeleteData filter;
-//  Arguments args;
+//   DeleteData filter;
+//   Arguments args;
 //
-//  // Create default Parameters for the filter.
-//  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
-//  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+//   // Create default Parameters for the filter.
+//   args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
+//   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
 //
-//  // Preflight the filter and check result
-//  auto preflightResult = filter.preflight(dataGraph, args);
-//  REQUIRE(preflightResult.outputActions.valid());
+//   // Preflight the filter and check result
+//   auto preflightResult = filter.preflight(dataGraph, args);
+//   REQUIRE(preflightResult.outputActions.valid());
 //
-//  // Execute the filter and check the result
-//  auto executeResult = filter.execute(dataGraph, args);
-//  REQUIRE(executeResult.result.valid());
+//   // Execute the filter and check the result
+//   auto executeResult = filter.execute(dataGraph, args);
+//   REQUIRE(executeResult.result.valid());
 //
-//  // Verify edges are wiped
-//  std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
-//  for(const auto& path : alteredPaths)
-//  {
-//    for(const auto& nodeName : path.getPathVector())
-//    {
-//      REQUIRE(nodeName.compare(k_GroupCName) != 0);
-//    }
-//  }
+//   // Verify edges are wiped
+//   std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+//   for(const auto& path : alteredPaths)
+//   {
+//     for(const auto& nodeName : path.getPathVector())
+//     {
+//       REQUIRE(nodeName.compare(k_GroupCName) != 0);
+//     }
+//   }
 //
-//  // Verify node is no longer in data lake
-//  REQUIRE(dataGraph.getData(groupCId) == nullptr);
+//   // Verify node is no longer in data lake
+//   REQUIRE(dataGraph.getData(groupCId) == nullptr);
 //
-//  // Verify nodes data has been destructed
-//  REQUIRE(objectCPtr.expired());
-//}
+//   // Verify nodes data has been destructed
+//   REQUIRE(objectCPtr.expired());
+// }
 //
-//TEST_CASE("ComplexCore::Delete DataPath to Object (Edge removal)", "[ComplexCore][DeleteData]")
+// TEST_CASE("ComplexCore::Delete DataPath to Object (Edge removal)", "[ComplexCore][DeleteData]")
 //{
-//  // For this test case the goal will be to remove the edge between Top Level Group A and
-//  // subgroup C. The nuance to this is that the data graph uses a doubly-linked list structure
-//  // therefore the edge must be removed from the parent node's children list and the child node's
-//  // parents list. The node's data and other edges to the nodes should be untouched.
+//   // For this test case the goal will be to remove the edge between Top Level Group A and
+//   // subgroup C. The nuance to this is that the data graph uses a doubly-linked list structure
+//   // therefore the edge must be removed from the parent node's children list and the child node's
+//   // parents list. The node's data and other edges to the nodes should be untouched.
 //
-//  // Create complex DataGraph and unpack it
-//  DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-//  std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths(); // This queries the parent lists implicitly
+//   // Create complex DataGraph and unpack it
+//   DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//   std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths(); // This queries the parent lists implicitly
 //
-//  // Select DataPath to remove
-//  DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName});
-//  bool found = false;
-//  for(const auto& path : initialPaths)
-//  {
-//    if(path.toString() == selectedDataGroupPath.toString())
-//    {
-//      found = true;
-//    }
-//  }
-//  REQUIRE(found);
+//   // Select DataPath to remove
+//   DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName});
+//   bool found = false;
+//   for(const auto& path : initialPaths)
+//   {
+//     if(path.toString() == selectedDataGroupPath.toString())
+//     {
+//       found = true;
+//     }
+//   }
+//   REQUIRE(found);
 //
-//  DeleteData filter;
-//  Arguments args;
+//   DeleteData filter;
+//   Arguments args;
 //
-//  // Create default Parameters for the filter.
-//  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
-//  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+//   // Create default Parameters for the filter.
+//   args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
+//   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
 //
-//  // Preflight the filter and check result
-//  auto preflightResult = filter.preflight(dataGraph, args);
-//  REQUIRE(preflightResult.outputActions.valid());
+//   // Preflight the filter and check result
+//   auto preflightResult = filter.preflight(dataGraph, args);
+//   REQUIRE(preflightResult.outputActions.valid());
 //
-//  // Execute the filter and check the result
-//  auto executeResult = filter.execute(dataGraph, args);
-//  REQUIRE(executeResult.result.valid());
+//   // Execute the filter and check the result
+//   auto executeResult = filter.execute(dataGraph, args);
+//   REQUIRE(executeResult.result.valid());
 //
-//  std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths(); // This queries the parent lists implicitly
-//  for(const auto& path : alteredPaths)
-//  {
-//    REQUIRE(path.toString() != selectedDataGroupPath.toString());
-//  }
-//}
+//   std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths(); // This queries the parent lists implicitly
+//   for(const auto& path : alteredPaths)
+//   {
+//     REQUIRE(path.toString() != selectedDataGroupPath.toString());
+//   }
+// }
 //
-//TEST_CASE("ComplexCore::Orphaning A Child Node to Top Level", "[ComplexCore][DeleteData]")
+// TEST_CASE("ComplexCore::Orphaning A Child Node to Top Level", "[ComplexCore][DeleteData]")
 //{
-//  // For this test case the goal will be to remove Group D node and check that the Array I node
-//  // has been moved to the top level. This could also occur if the edge between Group D node and
-//  // the Array I node is terminated which will be tested in a subsequent section.
+//   // For this test case the goal will be to remove Group D node and check that the Array I node
+//   // has been moved to the top level. This could also occur if the edge between Group D node and
+//   // the Array I node is terminated which will be tested in a subsequent section.
 //
-//  SECTION("Orphan Through Node Deletion")
-//  {
-//    // Create complex DataGraph and unpack it
-//    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-//    std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+//   SECTION("Orphan Through Node Deletion")
+//   {
+//     // Create complex DataGraph and unpack it
+//     DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//     std::vector<DataPath> paths = dataGraph.getAllDataPaths();
 //
-//    // Select DataPath to remove
-//    DataPath selectedDataGroupPath({k_GroupAName, k_GroupCName, k_GroupDName}); // We are aiming to delete the D group
-//    bool found = false;
-//    for(const auto& path : paths)
-//    {
-//      if(path.toString() == selectedDataGroupPath.toString())
-//      {
-//        found = true;
-//      }
-//    }
-//    REQUIRE(found);
+//     // Select DataPath to remove
+//     DataPath selectedDataGroupPath({k_GroupAName, k_GroupCName, k_GroupDName}); // We are aiming to delete the D group
+//     bool found = false;
+//     for(const auto& path : paths)
+//     {
+//       if(path.toString() == selectedDataGroupPath.toString())
+//       {
+//         found = true;
+//       }
+//     }
+//     REQUIRE(found);
 //
-//    // Store Data prior to deletion to verify removal
-//    // The target node here is k_GroupDName (the DataGroup named D)
-//    std::weak_ptr<DataObject> objectDPtr = dataGraph.getSharedData(selectedDataGroupPath); // convert the shared ptr to a weak ptr
-//    auto groupDId = dataGraph.getId(selectedDataGroupPath).value();
+//     // Store Data prior to deletion to verify removal
+//     // The target node here is k_GroupDName (the DataGroup named D)
+//     std::weak_ptr<DataObject> objectDPtr = dataGraph.getSharedData(selectedDataGroupPath); // convert the shared ptr to a weak ptr
+//     auto groupDId = dataGraph.getId(selectedDataGroupPath).value();
 //
-//    DeleteData filter;
-//    Arguments args;
+//     DeleteData filter;
+//     Arguments args;
 //
-//    // Create default Parameters for the filter.
-//    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
-//    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+//     // Create default Parameters for the filter.
+//     args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
+//     args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
 //
-//    // Preflight the filter and check result
-//    auto preflightResult = filter.preflight(dataGraph, args);
-//    REQUIRE(preflightResult.outputActions.valid());
+//     // Preflight the filter and check result
+//     auto preflightResult = filter.preflight(dataGraph, args);
+//     REQUIRE(preflightResult.outputActions.valid());
 //
-//    // Execute the filter and check the result
-//    auto executeResult = filter.execute(dataGraph, args);
-//    REQUIRE(executeResult.result.valid());
+//     // Execute the filter and check the result
+//     auto executeResult = filter.execute(dataGraph, args);
+//     REQUIRE(executeResult.result.valid());
 //
-//    // Verify edges are wiped
-//    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
-//    for(const auto& path : alteredPaths)
-//    {
-//      for(const auto& nodeName : path.getPathVector())
-//      {
-//        REQUIRE(nodeName.compare(k_GroupDName) != 0);
-//      }
-//    }
+//     // Verify edges are wiped
+//     std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+//     for(const auto& path : alteredPaths)
+//     {
+//       for(const auto& nodeName : path.getPathVector())
+//       {
+//         REQUIRE(nodeName.compare(k_GroupDName) != 0);
+//       }
+//     }
 //
-//    // Verify node is no longer in data lake
-//    REQUIRE(dataGraph.getData(groupDId) == nullptr);
+//     // Verify node is no longer in data lake
+//     REQUIRE(dataGraph.getData(groupDId) == nullptr);
 //
-//    // Verify nodes data has been destructed
-//    REQUIRE(objectDPtr.expired());
+//     // Verify nodes data has been destructed
+//     REQUIRE(objectDPtr.expired());
 //
-//    // Now that Group D is verifiably gone verify array I still exists
-//    bool arrayIFound = false;
-//    for(const auto& path : alteredPaths)
-//    {
-//      for(const auto& nodeName : path.getPathVector())
-//      {
-//        if(nodeName.compare(k_ArrayIName) == 0)
-//        {
-//          arrayIFound = true;
-//          REQUIRE(path.getLength() < 2); // must be top level
-//        }
-//      }
-//    }
+//     // Now that Group D is verifiably gone verify array I still exists
+//     bool arrayIFound = false;
+//     for(const auto& path : alteredPaths)
+//     {
+//       for(const auto& nodeName : path.getPathVector())
+//       {
+//         if(nodeName.compare(k_ArrayIName) == 0)
+//         {
+//           arrayIFound = true;
+//           REQUIRE(path.getLength() < 2); // must be top level
+//         }
+//       }
+//     }
 //
-//    // if array I has been found it has also been verified to be top level
-//    REQUIRE(arrayIFound);
-//  }
+//     // if array I has been found it has also been verified to be top level
+//     REQUIRE(arrayIFound);
+//   }
 //
-//  SECTION("Orphan Through Edge Deletion")
-//  {
-//    // Create complex DataGraph and unpack it
-//    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-//    std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
+//   SECTION("Orphan Through Edge Deletion")
+//   {
+//     // Create complex DataGraph and unpack it
+//     DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//     std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
 //
-//    // Select DataPath to remove
-//    DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName, k_GroupDName, k_ArrayIName}); // We are aiming to delete the D group
-//    bool found = false;
-//    for(const auto& path : initialPaths)
-//    {
-//      if(path.toString() == selectedDataGroupPath.toString())
-//      {
-//        found = true;
-//      }
-//    }
-//    REQUIRE(found);
+//     // Select DataPath to remove
+//     DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName, k_GroupDName, k_ArrayIName}); // We are aiming to delete the D group
+//     bool found = false;
+//     for(const auto& path : initialPaths)
+//     {
+//       if(path.toString() == selectedDataGroupPath.toString())
+//       {
+//         found = true;
+//       }
+//     }
+//     REQUIRE(found);
 //
-//    DeleteData filter;
-//    Arguments args;
+//     DeleteData filter;
+//     Arguments args;
 //
-//    // Create default Parameters for the filter.
-//    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataPath)));
-//    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+//     // Create default Parameters for the filter.
+//     args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataPath)));
+//     args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
 //
-//    // Preflight the filter and check result
-//    auto preflightResult = filter.preflight(dataGraph, args);
-//    REQUIRE(preflightResult.outputActions.valid());
+//     // Preflight the filter and check result
+//     auto preflightResult = filter.preflight(dataGraph, args);
+//     REQUIRE(preflightResult.outputActions.valid());
 //
-//    // Execute the filter and check the result
-//    auto executeResult = filter.execute(dataGraph, args);
-//    REQUIRE(executeResult.result.valid());
+//     // Execute the filter and check the result
+//     auto executeResult = filter.execute(dataGraph, args);
+//     REQUIRE(executeResult.result.valid());
 //
-//    // Verify edges are wiped
-//    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+//     // Verify edges are wiped
+//     std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
 //
-//    // Now that Group D is verifiably gone verify array I still exists
-//    bool arrayIFound = false;
-//    for(const auto& path : alteredPaths)
-//    {
-//      for(const auto& nodeName : path.getPathVector())
-//      {
-//        if(nodeName.compare(k_ArrayIName) == 0)
-//        {
-//          arrayIFound = true;
-//          REQUIRE(path.getLength() < 2); // must be top level
-//        }
-//      }
-//    }
+//     // Now that Group D is verifiably gone verify array I still exists
+//     bool arrayIFound = false;
+//     for(const auto& path : alteredPaths)
+//     {
+//       for(const auto& nodeName : path.getPathVector())
+//       {
+//         if(nodeName.compare(k_ArrayIName) == 0)
+//         {
+//           arrayIFound = true;
+//           REQUIRE(path.getLength() < 2); // must be top level
+//         }
+//       }
+//     }
 //
-//    // if array I has been found it has also been verified to be top level
-//    REQUIRE(arrayIFound);
-//  }
-//}
+//     // if array I has been found it has also been verified to be top level
+//     REQUIRE(arrayIFound);
+//   }
+// }
 //
-//TEST_CASE("ComplexCore::Attempt Delete Shared Node", "[ComplexCore][DeleteData]")
+// TEST_CASE("ComplexCore::Attempt Delete Shared Node", "[ComplexCore][DeleteData]")
 //{
-//  // The goal of this test is to attempt to delete a shared node using the delete
-//  // unshared children. Expected behaviour: the node is untouched (and in actual execution
-//  // a warning will be thrown)
+//   // The goal of this test is to attempt to delete a shared node using the delete
+//   // unshared children. Expected behaviour: the node is untouched (and in actual execution
+//   // a warning will be thrown)
 //
-//  // Create complex DataGraph and unpack it
-//  DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-//  std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
+//   // Create complex DataGraph and unpack it
+//   DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//   std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
 //
-//  // Select DataPath to remove
-//  DataPath selectedDataGroupPath({k_GroupBName, k_GroupFName, k_GroupEName});
+//   // Select DataPath to remove
+//   DataPath selectedDataGroupPath({k_GroupBName, k_GroupFName, k_GroupEName});
 //
-//  int32 firstGroupECount = 0;
-//  bool found = false;
-//  for(const auto& path : initialPaths)
-//  {
-//    if(path.toString() == selectedDataGroupPath.toString())
-//    {
-//      found = true;
-//    }
-//    for(const auto& nodeName : path.getPathVector())
-//    {
-//      if(nodeName.compare(k_GroupEName) == 0)
-//      {
-//        firstGroupECount++;
-//      }
-//    }
-//  }
-//  REQUIRE(found);
+//   int32 firstGroupECount = 0;
+//   bool found = false;
+//   for(const auto& path : initialPaths)
+//   {
+//     if(path.toString() == selectedDataGroupPath.toString())
+//     {
+//       found = true;
+//     }
+//     for(const auto& nodeName : path.getPathVector())
+//     {
+//       if(nodeName.compare(k_GroupEName) == 0)
+//       {
+//         firstGroupECount++;
+//       }
+//     }
+//   }
+//   REQUIRE(found);
 //
-//  DeleteData filter;
-//  Arguments args;
+//   DeleteData filter;
+//   Arguments args;
 //
-//  // Create default Parameters for the filter.
-//  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteUnsharedChildren)));
-//  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+//   // Create default Parameters for the filter.
+//   args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteUnsharedChildren)));
+//   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
 //
-//  // Preflight the filter and check result
-//  auto preflightResult = filter.preflight(dataGraph, args);
-//  REQUIRE(preflightResult.outputActions.valid());
+//   // Preflight the filter and check result
+//   auto preflightResult = filter.preflight(dataGraph, args);
+//   REQUIRE(preflightResult.outputActions.valid());
 //
-//  // Execute the filter and check the result
-//  auto executeResult = filter.execute(dataGraph, args);
-//  REQUIRE(executeResult.result.valid());
+//   // Execute the filter and check the result
+//   auto executeResult = filter.execute(dataGraph, args);
+//   REQUIRE(executeResult.result.valid());
 //
-//  std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+//   std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
 //
-//  int32 secondGroupECount = 0;
-//  for(const auto& path : alteredPaths)
-//  {
-//    for(const auto& nodeName : path.getPathVector())
-//    {
-//      if(nodeName.compare(k_GroupEName) == 0)
-//      {
-//        secondGroupECount++;
-//      }
-//    }
-//  }
-//  REQUIRE(secondGroupECount == firstGroupECount);
-//}
+//   int32 secondGroupECount = 0;
+//   for(const auto& path : alteredPaths)
+//   {
+//     for(const auto& nodeName : path.getPathVector())
+//     {
+//       if(nodeName.compare(k_GroupEName) == 0)
+//       {
+//         secondGroupECount++;
+//       }
+//     }
+//   }
+//   REQUIRE(secondGroupECount == firstGroupECount);
+// }
 //
-//TEST_CASE("ComplexCore::Delete Node with Multi-Parented Children", "[ComplexCore][DeleteData]")
+// TEST_CASE("ComplexCore::Delete Node with Multi-Parented Children", "[ComplexCore][DeleteData]")
 //{
-//  // For this test case the goal is to pass in a top level object [group B] with multi-nested children and verify
-//  // the results throughout the four levels according to the respective deletion type.
+//   // For this test case the goal is to pass in a top level object [group B] with multi-nested children and verify
+//   // the results throughout the four levels according to the respective deletion type.
 //
-//  // Select DataPaths
-//  DataPath groupBPath({k_GroupBName});
-//  DataPath groupFPath({k_GroupBName, k_GroupFName});
-//  DataPath groupGPath({k_GroupBName, k_GroupFName, k_GroupGName});
-//  DataPath groupEPath({k_GroupBName, k_GroupCName, k_GroupEName});
-//  DataPath arrayMPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayMName});
-//  DataPath arrayLPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayLName});
-//  DataPath arrayKPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayKName});
+//   // Select DataPaths
+//   DataPath groupBPath({k_GroupBName});
+//   DataPath groupFPath({k_GroupBName, k_GroupFName});
+//   DataPath groupGPath({k_GroupBName, k_GroupFName, k_GroupGName});
+//   DataPath groupEPath({k_GroupBName, k_GroupCName, k_GroupEName});
+//   DataPath arrayMPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayMName});
+//   DataPath arrayLPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayLName});
+//   DataPath arrayKPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayKName});
 //
-//  SECTION("Delete Top Level with delete unshared children (Recursion Check)")
-//  {
-//    // Create complex DataGraph and unpack it
-//    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-//    std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+//   SECTION("Delete Top Level with delete unshared children (Recursion Check)")
+//   {
+//     // Create complex DataGraph and unpack it
+//     DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//     std::vector<DataPath> paths = dataGraph.getAllDataPaths();
 //
-//    // Store Data prior to deletion to verify removal
-//    // The target node here is k_GroupBName (the DataGroup named B)
-//    std::map<DataObject::IdType, std::weak_ptr<DataObject>> removedValues;
-//    std::vector<DataPath> pathsRemoved = {groupBPath, groupFPath, groupGPath, arrayMPath, arrayLPath};
+//     // Store Data prior to deletion to verify removal
+//     // The target node here is k_GroupBName (the DataGroup named B)
+//     std::map<DataObject::IdType, std::weak_ptr<DataObject>> removedValues;
+//     std::vector<DataPath> pathsRemoved = {groupBPath, groupFPath, groupGPath, arrayMPath, arrayLPath};
 //
-//    for(const auto& path : pathsRemoved)
-//    {
-//      removedValues.emplace(dataGraph.getId(path).value(), dataGraph.getSharedData(path));
-//    }
+//     for(const auto& path : pathsRemoved)
+//     {
+//       removedValues.emplace(dataGraph.getId(path).value(), dataGraph.getSharedData(path));
+//     }
 //
-//    std::weak_ptr<DataObject> objectEPtr = dataGraph.getSharedData(groupEPath); // convert the shared ptr to a weak ptr
-//    auto groupEId = dataGraph.getId(groupEPath).value();
-//    std::weak_ptr<DataObject> objectKPtr = dataGraph.getSharedData(arrayKPath); // convert the shared ptr to a weak ptr
-//    auto arrayKId = dataGraph.getId(arrayKPath).value();
+//     std::weak_ptr<DataObject> objectEPtr = dataGraph.getSharedData(groupEPath); // convert the shared ptr to a weak ptr
+//     auto groupEId = dataGraph.getId(groupEPath).value();
+//     std::weak_ptr<DataObject> objectKPtr = dataGraph.getSharedData(arrayKPath); // convert the shared ptr to a weak ptr
+//     auto arrayKId = dataGraph.getId(arrayKPath).value();
 //
-//    DeleteData filter;
-//    Arguments args;
+//     DeleteData filter;
+//     Arguments args;
 //
-//    // Create default Parameters for the filter.
-//    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteUnsharedChildren)));
-//    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(groupBPath));
+//     // Create default Parameters for the filter.
+//     args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteUnsharedChildren)));
+//     args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(groupBPath));
 //
-//    // Preflight the filter and check result
-//    auto preflightResult = filter.preflight(dataGraph, args);
-//    REQUIRE(preflightResult.outputActions.valid());
+//     // Preflight the filter and check result
+//     auto preflightResult = filter.preflight(dataGraph, args);
+//     REQUIRE(preflightResult.outputActions.valid());
 //
-//    // Execute the filter and check the result
-//    auto executeResult = filter.execute(dataGraph, args);
-//    REQUIRE(executeResult.result.valid());
+//     // Execute the filter and check the result
+//     auto executeResult = filter.execute(dataGraph, args);
+//     REQUIRE(executeResult.result.valid());
 //
-//    // Verify deleted down to level Three
-//    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
-//    for(const auto& [id, weakPtr] : removedValues)
-//    {
-//      // Verify node is no longer in data lake
-//      REQUIRE(dataGraph.getData(id) == nullptr);
+//     // Verify deleted down to level Three
+//     std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+//     for(const auto& [id, weakPtr] : removedValues)
+//     {
+//       // Verify node is no longer in data lake
+//       REQUIRE(dataGraph.getData(id) == nullptr);
 //
-//      // Verify node's data has been destructed
-//      REQUIRE(weakPtr.expired());
-//    }
+//       // Verify node's data has been destructed
+//       REQUIRE(weakPtr.expired());
+//     }
 //
-//    // Verify unshared children not deleted
-//    // Verify E node is in data lake
-//    REQUIRE(dataGraph.getData(groupEId) != nullptr);
-//    REQUIRE(dataGraph.getData(arrayKId) != nullptr);
+//     // Verify unshared children not deleted
+//     // Verify E node is in data lake
+//     REQUIRE(dataGraph.getData(groupEId) != nullptr);
+//     REQUIRE(dataGraph.getData(arrayKId) != nullptr);
 //
-//    // Verify E node's data has not been destructed
-//    REQUIRE(!objectEPtr.expired());
-//    REQUIRE(!objectKPtr.expired());
-//  }
+//     // Verify E node's data has not been destructed
+//     REQUIRE(!objectEPtr.expired());
+//     REQUIRE(!objectKPtr.expired());
+//   }
 //
-//  SECTION("Delete Top Level without Regard to Childrens' Parent Count (Recursion Check)")
-//  {
-//    // Create complex DataGraph and unpack it
-//    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-//    std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+//   SECTION("Delete Top Level without Regard to Childrens' Parent Count (Recursion Check)")
+//   {
+//     // Create complex DataGraph and unpack it
+//     DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//     std::vector<DataPath> paths = dataGraph.getAllDataPaths();
 //
-//    // Store Data prior to deletion to verify removal
-//    // The target node here is k_GroupBName (the DataGroup named B)
-//    std::map<DataObject::IdType, std::weak_ptr<DataObject>> removedValues;
-//    std::vector<DataPath> pathsRemoved = {groupBPath, groupFPath, groupGPath, groupEPath, arrayMPath, arrayLPath, arrayKPath};
+//     // Store Data prior to deletion to verify removal
+//     // The target node here is k_GroupBName (the DataGroup named B)
+//     std::map<DataObject::IdType, std::weak_ptr<DataObject>> removedValues;
+//     std::vector<DataPath> pathsRemoved = {groupBPath, groupFPath, groupGPath, groupEPath, arrayMPath, arrayLPath, arrayKPath};
 //
-//    for(const auto& path : pathsRemoved)
-//    {
-//      removedValues.emplace(dataGraph.getId(path).value(), dataGraph.getSharedData(path));
-//    }
+//     for(const auto& path : pathsRemoved)
+//     {
+//       removedValues.emplace(dataGraph.getId(path).value(), dataGraph.getSharedData(path));
+//     }
 //
-//    DeleteData filter;
-//    Arguments args;
+//     DeleteData filter;
+//     Arguments args;
 //
-//    // Create default Parameters for the filter.
-//    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteChildren)));
-//    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(groupBPath));
+//     // Create default Parameters for the filter.
+//     args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteChildren)));
+//     args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(groupBPath));
 //
-//    // Preflight the filter and check result
-//    auto preflightResult = filter.preflight(dataGraph, args);
-//    REQUIRE(preflightResult.outputActions.valid());
+//     // Preflight the filter and check result
+//     auto preflightResult = filter.preflight(dataGraph, args);
+//     REQUIRE(preflightResult.outputActions.valid());
 //
-//    // Execute the filter and check the result
-//    auto executeResult = filter.execute(dataGraph, args);
-//    REQUIRE(executeResult.result.valid());
+//     // Execute the filter and check the result
+//     auto executeResult = filter.execute(dataGraph, args);
+//     REQUIRE(executeResult.result.valid());
 //
-//    // Verify deleted down to level Three
-//    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
-//    for(const auto& [id, weakPtr] : removedValues)
-//    {
-//      // Verify node is no longer in data lake
-//      REQUIRE(dataGraph.getData(id) == nullptr);
+//     // Verify deleted down to level Three
+//     std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+//     for(const auto& [id, weakPtr] : removedValues)
+//     {
+//       // Verify node is no longer in data lake
+//       REQUIRE(dataGraph.getData(id) == nullptr);
 //
-//      // Verify node's data has been destructed
-//      REQUIRE(weakPtr.expired());
-//    }
-//  }
-//}
+//       // Verify node's data has been destructed
+//       REQUIRE(weakPtr.expired());
+//     }
+//   }
+// }

--- a/src/Plugins/ComplexCore/test/DeleteDataTest.cpp
+++ b/src/Plugins/ComplexCore/test/DeleteDataTest.cpp
@@ -15,13 +15,12 @@ namespace fs = std::filesystem;
 
 namespace CreateImageGeometryUnitTest
 {
-
 const fs::path k_DataDir = "test/data";
 const fs::path k_TestFile = "CreateImageGeometry_Test.dream3d";
 
 } // namespace CreateImageGeometryUnitTest
 
-TEST_CASE("ComplexCore::DeleteDataArray", "[ComplexCore][DeleteData]")
+TEST_CASE("ComplexCore::Delete Singular Data Array", "[ComplexCore][DeleteData]")
 {
   // Instantiate the filter, a DataStructure object and an Arguments Object
 
@@ -52,7 +51,7 @@ TEST_CASE("ComplexCore::DeleteDataArray", "[ComplexCore][DeleteData]")
   REQUIRE(removedDataArray == nullptr);
 }
 
-TEST_CASE("ComplexCore::Delete Data Group", "[ComplexCore][DeleteData]")
+TEST_CASE("ComplexCore::Delete Data Object (Node removal)", "[ComplexCore][DeleteData]")
 {
   // Instantiate the filter, a DataStructure object and an Arguments Object
 
@@ -81,4 +80,20 @@ TEST_CASE("ComplexCore::Delete Data Group", "[ComplexCore][DeleteData]")
 
   DataObject* removedDataArray = dataGraph.getData(selectedDataGroupPath);
   REQUIRE(removedDataArray == nullptr);
+}
+
+TEST_CASE("ComplexCore::Delete DataPath to Object (Edge removal)", "[ComplexCore][DeleteData]")
+{
+}
+
+TEST_CASE("ComplexCore::Attempt Delete Shared Node", "[ComplexCore][DeleteData]")
+{
+}
+
+TEST_CASE("ComplexCore::Delete Shared Node (Node removal)", "[ComplexCore][DeleteData]")
+{
+}
+
+TEST_CASE("ComplexCore::Delete Top Level with Multi-Parented Children", "[ComplexCore][DeleteData]")
+{
 }

--- a/src/Plugins/ComplexCore/test/DeleteDataTest.cpp
+++ b/src/Plugins/ComplexCore/test/DeleteDataTest.cpp
@@ -37,7 +37,7 @@ TEST_CASE("ComplexCore::Delete Singular Data Array", "[ComplexCore][DeleteData]"
   Arguments args;
 
   // Create default Parameters for the filter.
-  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
+  //args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath));
 
   DeleteData filter;
@@ -72,7 +72,7 @@ TEST_CASE("ComplexCore::Delete Data Object (Node removal)", "[ComplexCore][Delet
   Arguments args;
 
   // Create default Parameters for the filter.
-  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
+  //args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath));
 
   // Preflight the filter and check result
@@ -87,417 +87,423 @@ TEST_CASE("ComplexCore::Delete Data Object (Node removal)", "[ComplexCore][Delet
   REQUIRE(removedDataArray == nullptr);
 }
 
-TEST_CASE("ComplexCore::Delete Shared Node (Node removal)", "[ComplexCore][DeleteData]")
-{
-  // For this test case the goal will be to completely wipe node (DataObject) C out of the
-  // graph completely. Ie clear all edges (parent and child) to node C, call the destructor
-  // on the node to ensure it doesn't become freehanging, and verify that the object is no longer
-  // in the data-lake (DataStructure) tables by ID grep.
-
-  // Create complex DataGraph and unpack it
-  DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-  std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
-
-  // Select DataPath to remove
-  DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName});
-  bool found = false;
-  for(const auto& path : initialPaths)
-  {
-    if(path.toString() == selectedDataGroupPath.toString())
-    {
-      found = true;
-    }
-  }
-  REQUIRE(found);
-
-  // Store Data prior to deletion to verify removal
-  // The target node here is k_GroupCName (the DataGroup named C)
-  std::weak_ptr<DataObject> objectCPtr = dataGraph.getSharedData(selectedDataGroupPath); // convert the shared ptr to a weak ptr
-  auto groupCId = dataGraph.getId(selectedDataGroupPath).value();
-
-  DeleteData filter;
-  Arguments args;
-
-  // Create default Parameters for the filter.
-  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
-  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
-
-  // Preflight the filter and check result
-  auto preflightResult = filter.preflight(dataGraph, args);
-  REQUIRE(preflightResult.outputActions.valid());
-
-  // Execute the filter and check the result
-  auto executeResult = filter.execute(dataGraph, args);
-  REQUIRE(executeResult.result.valid());
-
-  // Verify edges are wiped
-  std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
-  for(const auto& path : alteredPaths)
-  {
-    for(const auto& nodeName : path.getPathVector())
-    {
-      REQUIRE(nodeName.compare(k_GroupCName) != 0);
-    }
-  }
-
-  // Verify node is no longer in data lake
-  REQUIRE(dataGraph.getData(groupCId) == nullptr);
-
-  // Verify nodes data has been destructed
-  REQUIRE(objectCPtr.expired());
-}
-
-TEST_CASE("ComplexCore::Delete DataPath to Object (Edge removal)", "[ComplexCore][DeleteData]")
-{
-  // For this test case the goal will be to remove the edge between Top Level Group A and
-  // subgroup C. The nuance to this is that the data graph uses a doubly-linked list structure
-  // therefore the edge must be removed from the parent node's children list and the child node's
-  // parents list. The node's data and other edges to the nodes should be untouched.
-
-  // Create complex DataGraph and unpack it
-  DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-  std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths(); // This queries the parent lists implicitly
-
-  // Select DataPath to remove
-  DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName});
-  bool found = false;
-  for(const auto& path : initialPaths)
-  {
-    if(path.toString() == selectedDataGroupPath.toString())
-    {
-      found = true;
-    }
-  }
-  REQUIRE(found);
-
-  DeleteData filter;
-  Arguments args;
-
-  // Create default Parameters for the filter.
-  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
-  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
-
-  // Preflight the filter and check result
-  auto preflightResult = filter.preflight(dataGraph, args);
-  REQUIRE(preflightResult.outputActions.valid());
-
-  // Execute the filter and check the result
-  auto executeResult = filter.execute(dataGraph, args);
-  REQUIRE(executeResult.result.valid());
-
-  std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths(); // This queries the parent lists implicitly
-  for(const auto& path : alteredPaths)
-  {
-    REQUIRE(path.toString() != selectedDataGroupPath.toString());
-  }
-}
-
-TEST_CASE("ComplexCore::Orphaning A Child Node to Top Level", "[ComplexCore][DeleteData]")
-{
-  // For this test case the goal will be to remove Group D node and check that the Array I node
-  // has been moved to the top level. This could also occur if the edge between Group D node and
-  // the Array I node is terminated which will be tested in a subsequent section.
-
-  SECTION("Orphan Through Node Deletion")
-  {
-    // Create complex DataGraph and unpack it
-    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-    std::vector<DataPath> paths = dataGraph.getAllDataPaths();
-
-    // Select DataPath to remove
-    DataPath selectedDataGroupPath({k_GroupAName, k_GroupCName, k_GroupDName}); // We are aiming to delete the D group
-    bool found = false;
-    for(const auto& path : paths)
-    {
-      if(path.toString() == selectedDataGroupPath.toString())
-      {
-        found = true;
-      }
-    }
-    REQUIRE(found);
-
-    // Store Data prior to deletion to verify removal
-    // The target node here is k_GroupDName (the DataGroup named D)
-    std::weak_ptr<DataObject> objectDPtr = dataGraph.getSharedData(selectedDataGroupPath); // convert the shared ptr to a weak ptr
-    auto groupDId = dataGraph.getId(selectedDataGroupPath).value();
-
-    DeleteData filter;
-    Arguments args;
-
-    // Create default Parameters for the filter.
-    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
-    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataGraph, args);
-    REQUIRE(preflightResult.outputActions.valid());
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataGraph, args);
-    REQUIRE(executeResult.result.valid());
-
-    // Verify edges are wiped
-    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
-    for(const auto& path : alteredPaths)
-    {
-      for(const auto& nodeName : path.getPathVector())
-      {
-        REQUIRE(nodeName.compare(k_GroupDName) != 0);
-      }
-    }
-
-    // Verify node is no longer in data lake
-    REQUIRE(dataGraph.getData(groupDId) == nullptr);
-
-    // Verify nodes data has been destructed
-    REQUIRE(objectDPtr.expired());
-
-    // Now that Group D is verifiably gone verify array I still exists
-    bool arrayIFound = false;
-    for(const auto& path : alteredPaths)
-    {
-      for(const auto& nodeName : path.getPathVector())
-      {
-        if(nodeName.compare(k_ArrayIName) == 0)
-        {
-          arrayIFound = true;
-          REQUIRE(path.getLength() < 2); // must be top level
-        }
-      }
-    }
-
-    // if array I has been found it has also been verified to be top level
-    REQUIRE(arrayIFound);
-  }
-
-  SECTION("Orphan Through Edge Deletion")
-  {
-    // Create complex DataGraph and unpack it
-    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-    std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
-
-    // Select DataPath to remove
-    DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName, k_GroupDName, k_ArrayIName}); // We are aiming to delete the D group
-    bool found = false;
-    for(const auto& path : initialPaths)
-    {
-      if(path.toString() == selectedDataGroupPath.toString())
-      {
-        found = true;
-      }
-    }
-    REQUIRE(found);
-
-    DeleteData filter;
-    Arguments args;
-
-    // Create default Parameters for the filter.
-    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataPath)));
-    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataGraph, args);
-    REQUIRE(preflightResult.outputActions.valid());
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataGraph, args);
-    REQUIRE(executeResult.result.valid());
-
-    // Verify edges are wiped
-    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
-
-    // Now that Group D is verifiably gone verify array I still exists
-    bool arrayIFound = false;
-    for(const auto& path : alteredPaths)
-    {
-      for(const auto& nodeName : path.getPathVector())
-      {
-        if(nodeName.compare(k_ArrayIName) == 0)
-        {
-          arrayIFound = true;
-          REQUIRE(path.getLength() < 2); // must be top level
-        }
-      }
-    }
-
-    // if array I has been found it has also been verified to be top level
-    REQUIRE(arrayIFound);
-  }
-}
-
-TEST_CASE("ComplexCore::Attempt Delete Shared Node", "[ComplexCore][DeleteData]")
-{
-  // The goal of this test is to attempt to delete a shared node using the delete
-  // unshared children. Expected behaviour: the node is untouched (and in actual execution
-  // a warning will be thrown)
-
-  // Create complex DataGraph and unpack it
-  DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-  std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
-
-  // Select DataPath to remove
-  DataPath selectedDataGroupPath({k_GroupBName, k_GroupFName, k_GroupEName});
-
-  int32 firstGroupECount = 0;
-  bool found = false;
-  for(const auto& path : initialPaths)
-  {
-    if(path.toString() == selectedDataGroupPath.toString())
-    {
-      found = true;
-    }
-    for(const auto& nodeName : path.getPathVector())
-    {
-      if(nodeName.compare(k_GroupEName) == 0)
-      {
-        firstGroupECount++;
-      }
-    }
-  }
-  REQUIRE(found);
-
-  DeleteData filter;
-  Arguments args;
-
-  // Create default Parameters for the filter.
-  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteUnsharedChildren)));
-  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
-
-  // Preflight the filter and check result
-  auto preflightResult = filter.preflight(dataGraph, args);
-  REQUIRE(preflightResult.outputActions.valid());
-
-  // Execute the filter and check the result
-  auto executeResult = filter.execute(dataGraph, args);
-  REQUIRE(executeResult.result.valid());
-
-  std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
-
-  int32 secondGroupECount = 0;
-  for(const auto& path : alteredPaths)
-  {
-    for(const auto& nodeName : path.getPathVector())
-    {
-      if(nodeName.compare(k_GroupEName) == 0)
-      {
-        secondGroupECount++;
-      }
-    }
-  }
-  REQUIRE(secondGroupECount == firstGroupECount);
-}
-
-TEST_CASE("ComplexCore::Delete Node with Multi-Parented Children", "[ComplexCore][DeleteData]")
-{
-  // For this test case the goal is to pass in a top level object [group B] with multi-nested children and verify
-  // the results throughout the four levels according to the respective deletion type.
-
-  // Select DataPaths
-  DataPath groupBPath({k_GroupBName});
-  DataPath groupFPath({k_GroupBName, k_GroupFName});
-  DataPath groupGPath({k_GroupBName, k_GroupFName, k_GroupGName});
-  DataPath groupEPath({k_GroupBName, k_GroupCName, k_GroupEName});
-  DataPath arrayMPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayMName});
-  DataPath arrayLPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayLName});
-  DataPath arrayKPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayKName});
-
-  SECTION("Delete Top Level with delete unshared children (Recursion Check)")
-  {
-    // Create complex DataGraph and unpack it
-    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-    std::vector<DataPath> paths = dataGraph.getAllDataPaths();
-
-    // Store Data prior to deletion to verify removal
-    // The target node here is k_GroupBName (the DataGroup named B)
-    std::map<DataObject::IdType, std::weak_ptr<DataObject>> removedValues;
-    std::vector<DataPath> pathsRemoved = {groupBPath, groupFPath, groupGPath, arrayMPath, arrayLPath};
-
-    for(const auto& path : pathsRemoved)
-    {
-      removedValues.emplace(dataGraph.getId(path).value(), dataGraph.getSharedData(path));
-    }
-
-    std::weak_ptr<DataObject> objectEPtr = dataGraph.getSharedData(groupEPath); // convert the shared ptr to a weak ptr
-    auto groupEId = dataGraph.getId(groupEPath).value();
-    std::weak_ptr<DataObject> objectKPtr = dataGraph.getSharedData(arrayKPath); // convert the shared ptr to a weak ptr
-    auto arrayKId = dataGraph.getId(arrayKPath).value();
-
-    DeleteData filter;
-    Arguments args;
-
-    // Create default Parameters for the filter.
-    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteUnsharedChildren)));
-    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(groupBPath));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataGraph, args);
-    REQUIRE(preflightResult.outputActions.valid());
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataGraph, args);
-    REQUIRE(executeResult.result.valid());
-
-    // Verify deleted down to level Three
-    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
-    for(const auto& [id, weakPtr] : removedValues)
-    {
-      // Verify node is no longer in data lake
-      REQUIRE(dataGraph.getData(id) == nullptr);
-
-      // Verify node's data has been destructed
-      REQUIRE(weakPtr.expired());
-    }
-
-    // Verify unshared children not deleted
-    // Verify E node is in data lake
-    REQUIRE(dataGraph.getData(groupEId) != nullptr);
-    REQUIRE(dataGraph.getData(arrayKId) != nullptr);
-
-    // Verify E node's data has not been destructed
-    REQUIRE(!objectEPtr.expired());
-    REQUIRE(!objectKPtr.expired());
-  }
-
-  SECTION("Delete Top Level without Regard to Childrens' Parent Count (Recursion Check)")
-  {
-    // Create complex DataGraph and unpack it
-    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-    std::vector<DataPath> paths = dataGraph.getAllDataPaths();
-
-    // Store Data prior to deletion to verify removal
-    // The target node here is k_GroupBName (the DataGroup named B)
-    std::map<DataObject::IdType, std::weak_ptr<DataObject>> removedValues;
-    std::vector<DataPath> pathsRemoved = {groupBPath, groupFPath, groupGPath, groupEPath, arrayMPath, arrayLPath, arrayKPath};
-
-    for(const auto& path : pathsRemoved)
-    {
-      removedValues.emplace(dataGraph.getId(path).value(), dataGraph.getSharedData(path));
-    }
-
-    DeleteData filter;
-    Arguments args;
-
-    // Create default Parameters for the filter.
-    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteChildren)));
-    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(groupBPath));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataGraph, args);
-    REQUIRE(preflightResult.outputActions.valid());
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataGraph, args);
-    REQUIRE(executeResult.result.valid());
-
-    // Verify deleted down to level Three
-    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
-    for(const auto& [id, weakPtr] : removedValues)
-    {
-      // Verify node is no longer in data lake
-      REQUIRE(dataGraph.getData(id) == nullptr);
-
-      // Verify node's data has been destructed
-      REQUIRE(weakPtr.expired());
-    }
-  }
-}
+/**This code is commented out due to the current state of dataStructure management for the 
+* project. These test cases are meant to verify the different fringe case functionality 
+* should the underlying graph structure become more exposed. These test cases are mostly
+* functional but will likely need review upon time of implementation.
+*/
+
+//TEST_CASE("ComplexCore::Delete Shared Node (Node removal)", "[ComplexCore][DeleteData]")
+//{
+//  // For this test case the goal will be to completely wipe node (DataObject) C out of the
+//  // graph completely. Ie clear all edges (parent and child) to node C, call the destructor
+//  // on the node to ensure it doesn't become freehanging, and verify that the object is no longer
+//  // in the data-lake (DataStructure) tables by ID grep.
+//
+//  // Create complex DataGraph and unpack it
+//  DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//  std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
+//
+//  // Select DataPath to remove
+//  DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName});
+//  bool found = false;
+//  for(const auto& path : initialPaths)
+//  {
+//    if(path.toString() == selectedDataGroupPath.toString())
+//    {
+//      found = true;
+//    }
+//  }
+//  REQUIRE(found);
+//
+//  // Store Data prior to deletion to verify removal
+//  // The target node here is k_GroupCName (the DataGroup named C)
+//  std::weak_ptr<DataObject> objectCPtr = dataGraph.getSharedData(selectedDataGroupPath); // convert the shared ptr to a weak ptr
+//  auto groupCId = dataGraph.getId(selectedDataGroupPath).value();
+//
+//  DeleteData filter;
+//  Arguments args;
+//
+//  // Create default Parameters for the filter.
+//  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
+//  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+//
+//  // Preflight the filter and check result
+//  auto preflightResult = filter.preflight(dataGraph, args);
+//  REQUIRE(preflightResult.outputActions.valid());
+//
+//  // Execute the filter and check the result
+//  auto executeResult = filter.execute(dataGraph, args);
+//  REQUIRE(executeResult.result.valid());
+//
+//  // Verify edges are wiped
+//  std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+//  for(const auto& path : alteredPaths)
+//  {
+//    for(const auto& nodeName : path.getPathVector())
+//    {
+//      REQUIRE(nodeName.compare(k_GroupCName) != 0);
+//    }
+//  }
+//
+//  // Verify node is no longer in data lake
+//  REQUIRE(dataGraph.getData(groupCId) == nullptr);
+//
+//  // Verify nodes data has been destructed
+//  REQUIRE(objectCPtr.expired());
+//}
+//
+//TEST_CASE("ComplexCore::Delete DataPath to Object (Edge removal)", "[ComplexCore][DeleteData]")
+//{
+//  // For this test case the goal will be to remove the edge between Top Level Group A and
+//  // subgroup C. The nuance to this is that the data graph uses a doubly-linked list structure
+//  // therefore the edge must be removed from the parent node's children list and the child node's
+//  // parents list. The node's data and other edges to the nodes should be untouched.
+//
+//  // Create complex DataGraph and unpack it
+//  DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//  std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths(); // This queries the parent lists implicitly
+//
+//  // Select DataPath to remove
+//  DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName});
+//  bool found = false;
+//  for(const auto& path : initialPaths)
+//  {
+//    if(path.toString() == selectedDataGroupPath.toString())
+//    {
+//      found = true;
+//    }
+//  }
+//  REQUIRE(found);
+//
+//  DeleteData filter;
+//  Arguments args;
+//
+//  // Create default Parameters for the filter.
+//  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
+//  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+//
+//  // Preflight the filter and check result
+//  auto preflightResult = filter.preflight(dataGraph, args);
+//  REQUIRE(preflightResult.outputActions.valid());
+//
+//  // Execute the filter and check the result
+//  auto executeResult = filter.execute(dataGraph, args);
+//  REQUIRE(executeResult.result.valid());
+//
+//  std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths(); // This queries the parent lists implicitly
+//  for(const auto& path : alteredPaths)
+//  {
+//    REQUIRE(path.toString() != selectedDataGroupPath.toString());
+//  }
+//}
+//
+//TEST_CASE("ComplexCore::Orphaning A Child Node to Top Level", "[ComplexCore][DeleteData]")
+//{
+//  // For this test case the goal will be to remove Group D node and check that the Array I node
+//  // has been moved to the top level. This could also occur if the edge between Group D node and
+//  // the Array I node is terminated which will be tested in a subsequent section.
+//
+//  SECTION("Orphan Through Node Deletion")
+//  {
+//    // Create complex DataGraph and unpack it
+//    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//    std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+//
+//    // Select DataPath to remove
+//    DataPath selectedDataGroupPath({k_GroupAName, k_GroupCName, k_GroupDName}); // We are aiming to delete the D group
+//    bool found = false;
+//    for(const auto& path : paths)
+//    {
+//      if(path.toString() == selectedDataGroupPath.toString())
+//      {
+//        found = true;
+//      }
+//    }
+//    REQUIRE(found);
+//
+//    // Store Data prior to deletion to verify removal
+//    // The target node here is k_GroupDName (the DataGroup named D)
+//    std::weak_ptr<DataObject> objectDPtr = dataGraph.getSharedData(selectedDataGroupPath); // convert the shared ptr to a weak ptr
+//    auto groupDId = dataGraph.getId(selectedDataGroupPath).value();
+//
+//    DeleteData filter;
+//    Arguments args;
+//
+//    // Create default Parameters for the filter.
+//    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
+//    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+//
+//    // Preflight the filter and check result
+//    auto preflightResult = filter.preflight(dataGraph, args);
+//    REQUIRE(preflightResult.outputActions.valid());
+//
+//    // Execute the filter and check the result
+//    auto executeResult = filter.execute(dataGraph, args);
+//    REQUIRE(executeResult.result.valid());
+//
+//    // Verify edges are wiped
+//    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+//    for(const auto& path : alteredPaths)
+//    {
+//      for(const auto& nodeName : path.getPathVector())
+//      {
+//        REQUIRE(nodeName.compare(k_GroupDName) != 0);
+//      }
+//    }
+//
+//    // Verify node is no longer in data lake
+//    REQUIRE(dataGraph.getData(groupDId) == nullptr);
+//
+//    // Verify nodes data has been destructed
+//    REQUIRE(objectDPtr.expired());
+//
+//    // Now that Group D is verifiably gone verify array I still exists
+//    bool arrayIFound = false;
+//    for(const auto& path : alteredPaths)
+//    {
+//      for(const auto& nodeName : path.getPathVector())
+//      {
+//        if(nodeName.compare(k_ArrayIName) == 0)
+//        {
+//          arrayIFound = true;
+//          REQUIRE(path.getLength() < 2); // must be top level
+//        }
+//      }
+//    }
+//
+//    // if array I has been found it has also been verified to be top level
+//    REQUIRE(arrayIFound);
+//  }
+//
+//  SECTION("Orphan Through Edge Deletion")
+//  {
+//    // Create complex DataGraph and unpack it
+//    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//    std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
+//
+//    // Select DataPath to remove
+//    DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName, k_GroupDName, k_ArrayIName}); // We are aiming to delete the D group
+//    bool found = false;
+//    for(const auto& path : initialPaths)
+//    {
+//      if(path.toString() == selectedDataGroupPath.toString())
+//      {
+//        found = true;
+//      }
+//    }
+//    REQUIRE(found);
+//
+//    DeleteData filter;
+//    Arguments args;
+//
+//    // Create default Parameters for the filter.
+//    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataPath)));
+//    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+//
+//    // Preflight the filter and check result
+//    auto preflightResult = filter.preflight(dataGraph, args);
+//    REQUIRE(preflightResult.outputActions.valid());
+//
+//    // Execute the filter and check the result
+//    auto executeResult = filter.execute(dataGraph, args);
+//    REQUIRE(executeResult.result.valid());
+//
+//    // Verify edges are wiped
+//    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+//
+//    // Now that Group D is verifiably gone verify array I still exists
+//    bool arrayIFound = false;
+//    for(const auto& path : alteredPaths)
+//    {
+//      for(const auto& nodeName : path.getPathVector())
+//      {
+//        if(nodeName.compare(k_ArrayIName) == 0)
+//        {
+//          arrayIFound = true;
+//          REQUIRE(path.getLength() < 2); // must be top level
+//        }
+//      }
+//    }
+//
+//    // if array I has been found it has also been verified to be top level
+//    REQUIRE(arrayIFound);
+//  }
+//}
+//
+//TEST_CASE("ComplexCore::Attempt Delete Shared Node", "[ComplexCore][DeleteData]")
+//{
+//  // The goal of this test is to attempt to delete a shared node using the delete
+//  // unshared children. Expected behaviour: the node is untouched (and in actual execution
+//  // a warning will be thrown)
+//
+//  // Create complex DataGraph and unpack it
+//  DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//  std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
+//
+//  // Select DataPath to remove
+//  DataPath selectedDataGroupPath({k_GroupBName, k_GroupFName, k_GroupEName});
+//
+//  int32 firstGroupECount = 0;
+//  bool found = false;
+//  for(const auto& path : initialPaths)
+//  {
+//    if(path.toString() == selectedDataGroupPath.toString())
+//    {
+//      found = true;
+//    }
+//    for(const auto& nodeName : path.getPathVector())
+//    {
+//      if(nodeName.compare(k_GroupEName) == 0)
+//      {
+//        firstGroupECount++;
+//      }
+//    }
+//  }
+//  REQUIRE(found);
+//
+//  DeleteData filter;
+//  Arguments args;
+//
+//  // Create default Parameters for the filter.
+//  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteUnsharedChildren)));
+//  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+//
+//  // Preflight the filter and check result
+//  auto preflightResult = filter.preflight(dataGraph, args);
+//  REQUIRE(preflightResult.outputActions.valid());
+//
+//  // Execute the filter and check the result
+//  auto executeResult = filter.execute(dataGraph, args);
+//  REQUIRE(executeResult.result.valid());
+//
+//  std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+//
+//  int32 secondGroupECount = 0;
+//  for(const auto& path : alteredPaths)
+//  {
+//    for(const auto& nodeName : path.getPathVector())
+//    {
+//      if(nodeName.compare(k_GroupEName) == 0)
+//      {
+//        secondGroupECount++;
+//      }
+//    }
+//  }
+//  REQUIRE(secondGroupECount == firstGroupECount);
+//}
+//
+//TEST_CASE("ComplexCore::Delete Node with Multi-Parented Children", "[ComplexCore][DeleteData]")
+//{
+//  // For this test case the goal is to pass in a top level object [group B] with multi-nested children and verify
+//  // the results throughout the four levels according to the respective deletion type.
+//
+//  // Select DataPaths
+//  DataPath groupBPath({k_GroupBName});
+//  DataPath groupFPath({k_GroupBName, k_GroupFName});
+//  DataPath groupGPath({k_GroupBName, k_GroupFName, k_GroupGName});
+//  DataPath groupEPath({k_GroupBName, k_GroupCName, k_GroupEName});
+//  DataPath arrayMPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayMName});
+//  DataPath arrayLPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayLName});
+//  DataPath arrayKPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayKName});
+//
+//  SECTION("Delete Top Level with delete unshared children (Recursion Check)")
+//  {
+//    // Create complex DataGraph and unpack it
+//    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//    std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+//
+//    // Store Data prior to deletion to verify removal
+//    // The target node here is k_GroupBName (the DataGroup named B)
+//    std::map<DataObject::IdType, std::weak_ptr<DataObject>> removedValues;
+//    std::vector<DataPath> pathsRemoved = {groupBPath, groupFPath, groupGPath, arrayMPath, arrayLPath};
+//
+//    for(const auto& path : pathsRemoved)
+//    {
+//      removedValues.emplace(dataGraph.getId(path).value(), dataGraph.getSharedData(path));
+//    }
+//
+//    std::weak_ptr<DataObject> objectEPtr = dataGraph.getSharedData(groupEPath); // convert the shared ptr to a weak ptr
+//    auto groupEId = dataGraph.getId(groupEPath).value();
+//    std::weak_ptr<DataObject> objectKPtr = dataGraph.getSharedData(arrayKPath); // convert the shared ptr to a weak ptr
+//    auto arrayKId = dataGraph.getId(arrayKPath).value();
+//
+//    DeleteData filter;
+//    Arguments args;
+//
+//    // Create default Parameters for the filter.
+//    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteUnsharedChildren)));
+//    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(groupBPath));
+//
+//    // Preflight the filter and check result
+//    auto preflightResult = filter.preflight(dataGraph, args);
+//    REQUIRE(preflightResult.outputActions.valid());
+//
+//    // Execute the filter and check the result
+//    auto executeResult = filter.execute(dataGraph, args);
+//    REQUIRE(executeResult.result.valid());
+//
+//    // Verify deleted down to level Three
+//    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+//    for(const auto& [id, weakPtr] : removedValues)
+//    {
+//      // Verify node is no longer in data lake
+//      REQUIRE(dataGraph.getData(id) == nullptr);
+//
+//      // Verify node's data has been destructed
+//      REQUIRE(weakPtr.expired());
+//    }
+//
+//    // Verify unshared children not deleted
+//    // Verify E node is in data lake
+//    REQUIRE(dataGraph.getData(groupEId) != nullptr);
+//    REQUIRE(dataGraph.getData(arrayKId) != nullptr);
+//
+//    // Verify E node's data has not been destructed
+//    REQUIRE(!objectEPtr.expired());
+//    REQUIRE(!objectKPtr.expired());
+//  }
+//
+//  SECTION("Delete Top Level without Regard to Childrens' Parent Count (Recursion Check)")
+//  {
+//    // Create complex DataGraph and unpack it
+//    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//    std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+//
+//    // Store Data prior to deletion to verify removal
+//    // The target node here is k_GroupBName (the DataGroup named B)
+//    std::map<DataObject::IdType, std::weak_ptr<DataObject>> removedValues;
+//    std::vector<DataPath> pathsRemoved = {groupBPath, groupFPath, groupGPath, groupEPath, arrayMPath, arrayLPath, arrayKPath};
+//
+//    for(const auto& path : pathsRemoved)
+//    {
+//      removedValues.emplace(dataGraph.getId(path).value(), dataGraph.getSharedData(path));
+//    }
+//
+//    DeleteData filter;
+//    Arguments args;
+//
+//    // Create default Parameters for the filter.
+//    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteChildren)));
+//    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(groupBPath));
+//
+//    // Preflight the filter and check result
+//    auto preflightResult = filter.preflight(dataGraph, args);
+//    REQUIRE(preflightResult.outputActions.valid());
+//
+//    // Execute the filter and check the result
+//    auto executeResult = filter.execute(dataGraph, args);
+//    REQUIRE(executeResult.result.valid());
+//
+//    // Verify deleted down to level Three
+//    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+//    for(const auto& [id, weakPtr] : removedValues)
+//    {
+//      // Verify node is no longer in data lake
+//      REQUIRE(dataGraph.getData(id) == nullptr);
+//
+//      // Verify node's data has been destructed
+//      REQUIRE(weakPtr.expired());
+//    }
+//  }
+//}

--- a/src/Plugins/ComplexCore/test/DeleteDataTest.cpp
+++ b/src/Plugins/ComplexCore/test/DeleteDataTest.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch.hpp>
 
+#include "complex/Common/TypeTraits.hpp"
+#include "complex/Parameters/ChoicesParameter.hpp"
 #include "complex/Parameters/DataGroupSelectionParameter.hpp"
 #include "complex/Parameters/VectorParameter.hpp"
 #include "complex/unit_test/complex_test_dirs.hpp"
@@ -17,7 +19,6 @@ namespace CreateImageGeometryUnitTest
 {
 const fs::path k_DataDir = "test/data";
 const fs::path k_TestFile = "CreateImageGeometry_Test.dream3d";
-
 } // namespace CreateImageGeometryUnitTest
 
 TEST_CASE("ComplexCore::Delete Singular Data Array", "[ComplexCore][DeleteData]")
@@ -30,10 +31,11 @@ TEST_CASE("ComplexCore::Delete Singular Data Array", "[ComplexCore][DeleteData]"
 
   VectorUInt64Parameter::ValueType inputDims = {imageDims[0], imageDims[1], imageDims[2]};
 
-  DataStructure dataGraph = complex::UnitTest::CreateAllPrimitiveTypes(imageDims);
+  DataStructure dataGraph = UnitTest::CreateAllPrimitiveTypes(imageDims);
 
   DataPath selectedDataGroupPath({k_LevelZero, k_LevelOne, k_Int8DataSet});
   Arguments args;
+
   // Create default Parameters for the filter.
   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath));
 
@@ -61,14 +63,15 @@ TEST_CASE("ComplexCore::Delete Data Object (Node removal)", "[ComplexCore][Delet
 
   VectorUInt64Parameter::ValueType inputDims = {imageDims[0], imageDims[1], imageDims[2]};
 
-  DataStructure dataGraph = complex::UnitTest::CreateAllPrimitiveTypes(imageDims);
+  DataStructure dataGraph = UnitTest::CreateAllPrimitiveTypes(imageDims);
 
   DataPath selectedDataGroupPath({k_LevelZero, k_LevelOne});
-  Arguments args;
-  // Create default Parameters for the filter.
-  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath));
 
   DeleteData filter;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath));
 
   // Preflight the filter and check result
   auto preflightResult = filter.preflight(dataGraph, args);
@@ -82,18 +85,237 @@ TEST_CASE("ComplexCore::Delete Data Object (Node removal)", "[ComplexCore][Delet
   REQUIRE(removedDataArray == nullptr);
 }
 
-TEST_CASE("ComplexCore::Delete DataPath to Object (Edge removal)", "[ComplexCore][DeleteData]")
-{
-}
+/**These Test Cases Should be Implemented down the line if Advanced Data Graph Management is implemented
+ * They require the following:
+ * Actual values for selectedDataGroupPath
+ * Updated parameters to get desired functionality
+ * Requires after filter execution
+ */
 
-TEST_CASE("ComplexCore::Attempt Delete Shared Node", "[ComplexCore][DeleteData]")
-{
-}
+// TEST_CASE("ComplexCore::Delete DataPath to Object (Edge removal)", "[ComplexCore][DeleteData]")
+//{
+//   // Create complex DataGraph and unpack it
+//   DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//   std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+//
+//   // Select DataPath to remove
+//   DataPath selectedDataGroupPath;
+//   bool found = false;
+//   for (const auto& path : paths)
+//   {
+//     if(path == selectedDataGroupPath)
+//     {
+//       found = true;
+//     }
+//   }
+//   REQUIRE(found);
+//
+//   DeleteData filter;
+//   Arguments args;
+//
+//   // Create default Parameters for the filter.
+//   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+//
+//   // Preflight the filter and check result
+//   auto preflightResult = filter.preflight(dataGraph, args);
+//   REQUIRE(preflightResult.outputActions.valid());
+//
+//   // Execute the filter and check the result
+//   auto executeResult = filter.execute(dataGraph, args);
+//   REQUIRE(executeResult.result.valid());
+// }
+
+// TEST_CASE("ComplexCore::Attempt Delete Shared Node", "[ComplexCore][DeleteData]")
+//{
+//   // Create complex DataGraph and unpack it
+//   DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//   std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+//
+//   // Select DataPath to remove
+//   DataPath selectedDataGroupPath;
+//   bool found = false;
+//   for(const auto& path : paths)
+//   {
+//     if(path == selectedDataGroupPath)
+//     {
+//       found = true;
+//     }
+//   }
+//   REQUIRE(found);
+//
+//   DeleteData filter;
+//   Arguments args;
+//
+//   // Create default Parameters for the filter.
+//   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+//
+//   // Preflight the filter and check result
+//   auto preflightResult = filter.preflight(dataGraph, args);
+//   REQUIRE(preflightResult.outputActions.valid());
+//
+//   // Execute the filter and check the result
+//   auto executeResult = filter.execute(dataGraph, args);
+//   REQUIRE(executeResult.result.valid());
+// }
 
 TEST_CASE("ComplexCore::Delete Shared Node (Node removal)", "[ComplexCore][DeleteData]")
 {
+  // For this test case the goal will be to completely wipe node (DataObject) C out of the
+  // graph completely. Ie clear all edges (parent and child) to node C, call the destructor
+  // on the node to ensure it doesn't become freehanging, and verify that the object is no longer
+  // in the data-lake (DataStructure) tables by ID grep.
+
+  // Create complex DataGraph and unpack it
+  DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+  std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
+
+  // Select DataPath to remove
+  DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName});
+  bool found = false;
+  for(const auto& path : initialPaths)
+  {
+    if(path == selectedDataGroupPath)
+    {
+      found = true;
+    }
+  }
+  REQUIRE(found);
+
+  // Store Data prior to deletion to verify removal
+  // The target node here is k_GroupCName (the DataGroup named C)
+  std::weak_ptr<DataObject> objectCPtr = dataGraph.getSharedData(selectedDataGroupPath); // convert the shared ptr to a weak ptr
+  auto groupCId = dataGraph.getId(selectedDataGroupPath).value();
+
+  DeleteData filter;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataGraph, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataGraph, args);
+  REQUIRE(executeResult.result.valid());
+
+  // Verify edges are wiped
+  std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+  for(const auto& path : alteredPaths)
+  {
+    for(const auto& nodeName : path.getPathVector())
+    {
+      REQUIRE(nodeName != k_GroupCName);
+    }
+  }
+
+  // Verify node is no longer in data lake
+  REQUIRE(dataGraph.getData(groupCId) == nullptr);
+
+  // Verify nodes data has been destructed
+  REQUIRE(objectCPtr.expired());
 }
 
 TEST_CASE("ComplexCore::Delete Top Level with Multi-Parented Children", "[ComplexCore][DeleteData]")
 {
+  // For this test case the goal is to pass in a top level object with multi-nested children and set
+  // parameters so that the multiparented children (and their subsequent children regardless of number
+  // of parents) remain.  
+
+  // Create complex DataGraph and unpack it
+  DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+  std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+
+  // Select DataPath to remove
+  DataPath selectedDataGroupPath;
+  bool found = false;
+  for(const auto& path : paths)
+  {
+    if(path == selectedDataGroupPath)
+    {
+      found = true;
+    }
+  }
+  REQUIRE(found);
+
+  DeleteData filter;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataGraph, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataGraph, args);
+  REQUIRE(executeResult.result.valid());
 }
+
+// TEST_CASE("ComplexCore::Orphaning A Child Node to Top Level", "[ComplexCore][DeleteData]")
+//{
+//   // Create complex DataGraph and unpack it
+//   DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//   std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+//
+//   // Select DataPath to remove
+//   DataPath selectedDataGroupPath;
+//   bool found = false;
+//   for(const auto& path : paths)
+//   {
+//     if(path == selectedDataGroupPath)
+//     {
+//       found = true;
+//     }
+//   }
+//   REQUIRE(found);
+//
+//   DeleteData filter;
+//   Arguments args;
+//
+//   // Create default Parameters for the filter.
+//   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+//
+//   // Preflight the filter and check result
+//   auto preflightResult = filter.preflight(dataGraph, args);
+//   REQUIRE(preflightResult.outputActions.valid());
+//
+//   // Execute the filter and check the result
+//   auto executeResult = filter.execute(dataGraph, args);
+//   REQUIRE(executeResult.result.valid());
+// }
+
+// TEST_CASE("ComplexCore::Delete Level Zero Object and Test Level Three Children", "[ComplexCore][DeleteData]")
+//{
+//   // Create complex DataGraph and unpack it
+//   DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+//   std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+//
+//   // Select DataPath to remove
+//   DataPath selectedDataGroupPath;
+//   bool found = false;
+//   for(const auto& path : paths)
+//   {
+//     if(path == selectedDataGroupPath)
+//     {
+//       found = true;
+//     }
+//   }
+//   REQUIRE(found);
+//
+//   DeleteData filter;
+//   Arguments args;
+//
+//   // Create default Parameters for the filter.
+//   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+//
+//   // Preflight the filter and check result
+//   auto preflightResult = filter.preflight(dataGraph, args);
+//   REQUIRE(preflightResult.outputActions.valid());
+//
+//   // Execute the filter and check the result
+//   auto executeResult = filter.execute(dataGraph, args);
+//   REQUIRE(executeResult.result.valid());
+// }

--- a/src/Plugins/ComplexCore/test/DeleteDataTest.cpp
+++ b/src/Plugins/ComplexCore/test/DeleteDataTest.cpp
@@ -37,6 +37,7 @@ TEST_CASE("ComplexCore::Delete Singular Data Array", "[ComplexCore][DeleteData]"
   Arguments args;
 
   // Create default Parameters for the filter.
+  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath));
 
   DeleteData filter;
@@ -71,6 +72,7 @@ TEST_CASE("ComplexCore::Delete Data Object (Node removal)", "[ComplexCore][Delet
   Arguments args;
 
   // Create default Parameters for the filter.
+  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath));
 
   // Preflight the filter and check result
@@ -84,79 +86,6 @@ TEST_CASE("ComplexCore::Delete Data Object (Node removal)", "[ComplexCore][Delet
   DataObject* removedDataArray = dataGraph.getData(selectedDataGroupPath);
   REQUIRE(removedDataArray == nullptr);
 }
-
-/**These Test Cases Should be Implemented down the line if Advanced Data Graph Management is implemented
- * They require the following:
- * Actual values for selectedDataGroupPath
- * Updated parameters to get desired functionality
- * Requires after filter execution
- */
-
-// TEST_CASE("ComplexCore::Delete DataPath to Object (Edge removal)", "[ComplexCore][DeleteData]")
-//{
-//   // Create complex DataGraph and unpack it
-//   DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-//   std::vector<DataPath> paths = dataGraph.getAllDataPaths();
-//
-//   // Select DataPath to remove
-//   DataPath selectedDataGroupPath;
-//   bool found = false;
-//   for (const auto& path : paths)
-//   {
-//     if(path == selectedDataGroupPath)
-//     {
-//       found = true;
-//     }
-//   }
-//   REQUIRE(found);
-//
-//   DeleteData filter;
-//   Arguments args;
-//
-//   // Create default Parameters for the filter.
-//   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
-//
-//   // Preflight the filter and check result
-//   auto preflightResult = filter.preflight(dataGraph, args);
-//   REQUIRE(preflightResult.outputActions.valid());
-//
-//   // Execute the filter and check the result
-//   auto executeResult = filter.execute(dataGraph, args);
-//   REQUIRE(executeResult.result.valid());
-// }
-
-// TEST_CASE("ComplexCore::Attempt Delete Shared Node", "[ComplexCore][DeleteData]")
-//{
-//   // Create complex DataGraph and unpack it
-//   DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-//   std::vector<DataPath> paths = dataGraph.getAllDataPaths();
-//
-//   // Select DataPath to remove
-//   DataPath selectedDataGroupPath;
-//   bool found = false;
-//   for(const auto& path : paths)
-//   {
-//     if(path == selectedDataGroupPath)
-//     {
-//       found = true;
-//     }
-//   }
-//   REQUIRE(found);
-//
-//   DeleteData filter;
-//   Arguments args;
-//
-//   // Create default Parameters for the filter.
-//   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
-//
-//   // Preflight the filter and check result
-//   auto preflightResult = filter.preflight(dataGraph, args);
-//   REQUIRE(preflightResult.outputActions.valid());
-//
-//   // Execute the filter and check the result
-//   auto executeResult = filter.execute(dataGraph, args);
-//   REQUIRE(executeResult.result.valid());
-// }
 
 TEST_CASE("ComplexCore::Delete Shared Node (Node removal)", "[ComplexCore][DeleteData]")
 {
@@ -174,7 +103,7 @@ TEST_CASE("ComplexCore::Delete Shared Node (Node removal)", "[ComplexCore][Delet
   bool found = false;
   for(const auto& path : initialPaths)
   {
-    if(path == selectedDataGroupPath)
+    if(path.toString() == selectedDataGroupPath.toString())
     {
       found = true;
     }
@@ -190,6 +119,7 @@ TEST_CASE("ComplexCore::Delete Shared Node (Node removal)", "[ComplexCore][Delet
   Arguments args;
 
   // Create default Parameters for the filter.
+  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
 
   // Preflight the filter and check result
@@ -206,7 +136,7 @@ TEST_CASE("ComplexCore::Delete Shared Node (Node removal)", "[ComplexCore][Delet
   {
     for(const auto& nodeName : path.getPathVector())
     {
-      REQUIRE(nodeName != k_GroupCName);
+      REQUIRE(nodeName.compare(k_GroupCName) != 0);
     }
   }
 
@@ -217,22 +147,23 @@ TEST_CASE("ComplexCore::Delete Shared Node (Node removal)", "[ComplexCore][Delet
   REQUIRE(objectCPtr.expired());
 }
 
-TEST_CASE("ComplexCore::Delete Top Level with Multi-Parented Children", "[ComplexCore][DeleteData]")
+TEST_CASE("ComplexCore::Delete DataPath to Object (Edge removal)", "[ComplexCore][DeleteData]")
 {
-  // For this test case the goal is to pass in a top level object with multi-nested children and set
-  // parameters so that the multiparented children (and their subsequent children regardless of number
-  // of parents) remain.  
+  // For this test case the goal will be to remove the edge between Top Level Group A and
+  // subgroup C. The nuance to this is that the data graph uses a doubly-linked list structure
+  // therefore the edge must be removed from the parent node's children list and the child node's
+  // parents list. The node's data and other edges to the nodes should be untouched.
 
   // Create complex DataGraph and unpack it
   DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-  std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+  std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths(); // This queries the parent lists implicitly
 
   // Select DataPath to remove
-  DataPath selectedDataGroupPath;
+  DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName});
   bool found = false;
-  for(const auto& path : paths)
+  for(const auto& path : initialPaths)
   {
-    if(path == selectedDataGroupPath)
+    if(path.toString() == selectedDataGroupPath.toString())
     {
       found = true;
     }
@@ -243,6 +174,7 @@ TEST_CASE("ComplexCore::Delete Top Level with Multi-Parented Children", "[Comple
   Arguments args;
 
   // Create default Parameters for the filter.
+  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
 
   // Preflight the filter and check result
@@ -252,70 +184,320 @@ TEST_CASE("ComplexCore::Delete Top Level with Multi-Parented Children", "[Comple
   // Execute the filter and check the result
   auto executeResult = filter.execute(dataGraph, args);
   REQUIRE(executeResult.result.valid());
+
+  std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths(); // This queries the parent lists implicitly
+  for(const auto& path : alteredPaths)
+  {
+    REQUIRE(path.toString() != selectedDataGroupPath.toString());
+  }
 }
 
-// TEST_CASE("ComplexCore::Orphaning A Child Node to Top Level", "[ComplexCore][DeleteData]")
-//{
-//   // Create complex DataGraph and unpack it
-//   DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-//   std::vector<DataPath> paths = dataGraph.getAllDataPaths();
-//
-//   // Select DataPath to remove
-//   DataPath selectedDataGroupPath;
-//   bool found = false;
-//   for(const auto& path : paths)
-//   {
-//     if(path == selectedDataGroupPath)
-//     {
-//       found = true;
-//     }
-//   }
-//   REQUIRE(found);
-//
-//   DeleteData filter;
-//   Arguments args;
-//
-//   // Create default Parameters for the filter.
-//   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
-//
-//   // Preflight the filter and check result
-//   auto preflightResult = filter.preflight(dataGraph, args);
-//   REQUIRE(preflightResult.outputActions.valid());
-//
-//   // Execute the filter and check the result
-//   auto executeResult = filter.execute(dataGraph, args);
-//   REQUIRE(executeResult.result.valid());
-// }
+TEST_CASE("ComplexCore::Orphaning A Child Node to Top Level", "[ComplexCore][DeleteData]")
+{
+  // For this test case the goal will be to remove Group D node and check that the Array I node
+  // has been moved to the top level. This could also occur if the edge between Group D node and
+  // the Array I node is terminated which will be tested in a subsequent section.
 
-// TEST_CASE("ComplexCore::Delete Level Zero Object and Test Level Three Children", "[ComplexCore][DeleteData]")
-//{
-//   // Create complex DataGraph and unpack it
-//   DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
-//   std::vector<DataPath> paths = dataGraph.getAllDataPaths();
-//
-//   // Select DataPath to remove
-//   DataPath selectedDataGroupPath;
-//   bool found = false;
-//   for(const auto& path : paths)
-//   {
-//     if(path == selectedDataGroupPath)
-//     {
-//       found = true;
-//     }
-//   }
-//   REQUIRE(found);
-//
-//   DeleteData filter;
-//   Arguments args;
-//
-//   // Create default Parameters for the filter.
-//   args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
-//
-//   // Preflight the filter and check result
-//   auto preflightResult = filter.preflight(dataGraph, args);
-//   REQUIRE(preflightResult.outputActions.valid());
-//
-//   // Execute the filter and check the result
-//   auto executeResult = filter.execute(dataGraph, args);
-//   REQUIRE(executeResult.result.valid());
-// }
+  SECTION("Orphan Through Node Deletion")
+  {
+    // Create complex DataGraph and unpack it
+    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+    std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+
+    // Select DataPath to remove
+    DataPath selectedDataGroupPath({k_GroupAName, k_GroupCName, k_GroupDName}); // We are aiming to delete the D group
+    bool found = false;
+    for(const auto& path : paths)
+    {
+      if(path.toString() == selectedDataGroupPath.toString())
+      {
+        found = true;
+      }
+    }
+    REQUIRE(found);
+
+    // Store Data prior to deletion to verify removal
+    // The target node here is k_GroupDName (the DataGroup named D)
+    std::weak_ptr<DataObject> objectDPtr = dataGraph.getSharedData(selectedDataGroupPath); // convert the shared ptr to a weak ptr
+    auto groupDId = dataGraph.getId(selectedDataGroupPath).value();
+
+    DeleteData filter;
+    Arguments args;
+
+    // Create default Parameters for the filter.
+    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
+    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataGraph, args);
+    REQUIRE(preflightResult.outputActions.valid());
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(dataGraph, args);
+    REQUIRE(executeResult.result.valid());
+
+    // Verify edges are wiped
+    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+    for(const auto& path : alteredPaths)
+    {
+      for(const auto& nodeName : path.getPathVector())
+      {
+        REQUIRE(nodeName.compare(k_GroupDName) != 0);
+      }
+    }
+
+    // Verify node is no longer in data lake
+    REQUIRE(dataGraph.getData(groupDId) == nullptr);
+
+    // Verify nodes data has been destructed
+    REQUIRE(objectDPtr.expired());
+
+    // Now that Group D is verifiably gone verify array I still exists
+    bool arrayIFound = false;
+    for(const auto& path : alteredPaths)
+    {
+      for(const auto& nodeName : path.getPathVector())
+      {
+        if(nodeName.compare(k_ArrayIName) == 0)
+        {
+          arrayIFound = true;
+          REQUIRE(path.getLength() < 2); // must be top level
+        }
+      }
+    }
+
+    // if array I has been found it has also been verified to be top level
+    REQUIRE(arrayIFound);
+  }
+
+  SECTION("Orphan Through Edge Deletion")
+  {
+    // Create complex DataGraph and unpack it
+    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+    std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
+
+    // Select DataPath to remove
+    DataPath selectedDataGroupPath({k_GroupBName, k_GroupCName, k_GroupDName, k_ArrayIName}); // We are aiming to delete the D group
+    bool found = false;
+    for(const auto& path : initialPaths)
+    {
+      if(path.toString() == selectedDataGroupPath.toString())
+      {
+        found = true;
+      }
+    }
+    REQUIRE(found);
+
+    DeleteData filter;
+    Arguments args;
+
+    // Create default Parameters for the filter.
+    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataPath)));
+    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataGraph, args);
+    REQUIRE(preflightResult.outputActions.valid());
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(dataGraph, args);
+    REQUIRE(executeResult.result.valid());
+
+    // Verify edges are wiped
+    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+
+    // Now that Group D is verifiably gone verify array I still exists
+    bool arrayIFound = false;
+    for(const auto& path : alteredPaths)
+    {
+      for(const auto& nodeName : path.getPathVector())
+      {
+        if(nodeName.compare(k_ArrayIName) == 0)
+        {
+          arrayIFound = true;
+          REQUIRE(path.getLength() < 2); // must be top level
+        }
+      }
+    }
+
+    // if array I has been found it has also been verified to be top level
+    REQUIRE(arrayIFound);
+  }
+}
+
+TEST_CASE("ComplexCore::Attempt Delete Shared Node", "[ComplexCore][DeleteData]")
+{
+  // The goal of this test is to attempt to delete a shared node using the delete
+  // unshared children. Expected behaviour: the node is untouched (and in actual execution
+  // a warning will be thrown)
+
+  // Create complex DataGraph and unpack it
+  DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+  std::vector<DataPath> initialPaths = dataGraph.getAllDataPaths();
+
+  // Select DataPath to remove
+  DataPath selectedDataGroupPath({k_GroupBName, k_GroupFName, k_GroupEName});
+
+  int32 firstGroupECount = 0;
+  bool found = false;
+  for(const auto& path : initialPaths)
+  {
+    if(path.toString() == selectedDataGroupPath.toString())
+    {
+      found = true;
+    }
+    for(const auto& nodeName : path.getPathVector())
+    {
+      if(nodeName.compare(k_GroupEName) == 0)
+      {
+        firstGroupECount++;
+      }
+    }
+  }
+  REQUIRE(found);
+
+  DeleteData filter;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteUnsharedChildren)));
+  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath)); // already verified to exist
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataGraph, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataGraph, args);
+  REQUIRE(executeResult.result.valid());
+
+  std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+
+  int32 secondGroupECount = 0;
+  for(const auto& path : alteredPaths)
+  {
+    for(const auto& nodeName : path.getPathVector())
+    {
+      if(nodeName.compare(k_GroupEName) == 0)
+      {
+        secondGroupECount++;
+      }
+    }
+  }
+  REQUIRE(secondGroupECount == firstGroupECount);
+}
+
+TEST_CASE("ComplexCore::Delete Node with Multi-Parented Children", "[ComplexCore][DeleteData]")
+{
+  // For this test case the goal is to pass in a top level object [group B] with multi-nested children and verify
+  // the results throughout the four levels according to the respective deletion type.
+
+  // Select DataPaths
+  DataPath groupBPath({k_GroupBName});
+  DataPath groupFPath({k_GroupBName, k_GroupFName});
+  DataPath groupGPath({k_GroupBName, k_GroupFName, k_GroupGName});
+  DataPath groupEPath({k_GroupBName, k_GroupCName, k_GroupEName});
+  DataPath arrayMPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayMName});
+  DataPath arrayLPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayLName});
+  DataPath arrayKPath({k_GroupBName, k_GroupFName, k_GroupGName, k_ArrayKName});
+
+  SECTION("Delete Top Level with delete unshared children (Recursion Check)")
+  {
+    // Create complex DataGraph and unpack it
+    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+    std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+
+    // Store Data prior to deletion to verify removal
+    // The target node here is k_GroupBName (the DataGroup named B)
+    std::map<DataObject::IdType, std::weak_ptr<DataObject>> removedValues;
+    std::vector<DataPath> pathsRemoved = {groupBPath, groupFPath, groupGPath, arrayMPath, arrayLPath};
+
+    for(const auto& path : pathsRemoved)
+    {
+      removedValues.emplace(dataGraph.getId(path).value(), dataGraph.getSharedData(path));
+    }
+
+    std::weak_ptr<DataObject> objectEPtr = dataGraph.getSharedData(groupEPath); // convert the shared ptr to a weak ptr
+    auto groupEId = dataGraph.getId(groupEPath).value();
+    std::weak_ptr<DataObject> objectKPtr = dataGraph.getSharedData(arrayKPath); // convert the shared ptr to a weak ptr
+    auto arrayKId = dataGraph.getId(arrayKPath).value();
+
+    DeleteData filter;
+    Arguments args;
+
+    // Create default Parameters for the filter.
+    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteUnsharedChildren)));
+    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(groupBPath));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataGraph, args);
+    REQUIRE(preflightResult.outputActions.valid());
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(dataGraph, args);
+    REQUIRE(executeResult.result.valid());
+
+    // Verify deleted down to level Three
+    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+    for(const auto& [id, weakPtr] : removedValues)
+    {
+      // Verify node is no longer in data lake
+      REQUIRE(dataGraph.getData(id) == nullptr);
+
+      // Verify node's data has been destructed
+      REQUIRE(weakPtr.expired());
+    }
+
+    // Verify unshared children not deleted
+    // Verify E node is in data lake
+    REQUIRE(dataGraph.getData(groupEId) != nullptr);
+    REQUIRE(dataGraph.getData(arrayKId) != nullptr);
+
+    // Verify E node's data has not been destructed
+    REQUIRE(!objectEPtr.expired());
+    REQUIRE(!objectKPtr.expired());
+  }
+
+  SECTION("Delete Top Level without Regard to Childrens' Parent Count (Recursion Check)")
+  {
+    // Create complex DataGraph and unpack it
+    DataStructure dataGraph(std::move(UnitTest::CreateComplexMultiLevelDataGraph()));
+    std::vector<DataPath> paths = dataGraph.getAllDataPaths();
+
+    // Store Data prior to deletion to verify removal
+    // The target node here is k_GroupBName (the DataGroup named B)
+    std::map<DataObject::IdType, std::weak_ptr<DataObject>> removedValues;
+    std::vector<DataPath> pathsRemoved = {groupBPath, groupFPath, groupGPath, groupEPath, arrayMPath, arrayLPath, arrayKPath};
+
+    for(const auto& path : pathsRemoved)
+    {
+      removedValues.emplace(dataGraph.getId(path).value(), dataGraph.getSharedData(path));
+    }
+
+    DeleteData filter;
+    Arguments args;
+
+    // Create default Parameters for the filter.
+    args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteChildren)));
+    args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(groupBPath));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataGraph, args);
+    REQUIRE(preflightResult.outputActions.valid());
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(dataGraph, args);
+    REQUIRE(executeResult.result.valid());
+
+    // Verify deleted down to level Three
+    std::vector<DataPath> alteredPaths = dataGraph.getAllDataPaths();
+    for(const auto& [id, weakPtr] : removedValues)
+    {
+      // Verify node is no longer in data lake
+      REQUIRE(dataGraph.getData(id) == nullptr);
+
+      // Verify node's data has been destructed
+      REQUIRE(weakPtr.expired());
+    }
+  }
+}

--- a/src/complex/DataStructure/BaseGroup.cpp
+++ b/src/complex/DataStructure/BaseGroup.cpp
@@ -228,6 +228,11 @@ std::set<std::string> BaseGroup::StringListFromGroupType(const std::set<GroupTyp
   return stringValues;
 }
 
+std::vector<std::string> BaseGroup::GetChildrenNames()
+{
+  return m_DataMap.getNames();
+}
+
 H5::ErrorType BaseGroup::readHdf5(H5::DataStructureReader& dataStructureReader, const H5::GroupReader& groupReader, bool preflight)
 {
   return m_DataMap.readH5Group(dataStructureReader, groupReader, getId(), preflight);

--- a/src/complex/DataStructure/BaseGroup.hpp
+++ b/src/complex/DataStructure/BaseGroup.hpp
@@ -317,6 +317,11 @@ public:
    */
   static std::set<std::string> StringListFromGroupType(const std::set<GroupType>& groupTypes);
 
+  /**
+   * @brief Querys the DataMap for the object names in m_DataMap
+   */
+  std::vector<std::string> GetChildrenNames();
+
 protected:
   /**
    * @brief Creates a BaseGroup with the target DataStructure and name.

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -867,7 +867,7 @@ void DataStructure::exportHeirarchyAsGraphViz(std::ostream& outputStream)
 
     if(!optionalDataPaths.has_value() || optionalDataPaths.value().size() == 0)
     {
-      outputStream << topLevelPath.getTargetName() << ";\n\n";
+      outputStream << "\"" << topLevelPath.getTargetName() << "\";\n\n";
     }
 
     // Begin recursion
@@ -875,7 +875,7 @@ void DataStructure::exportHeirarchyAsGraphViz(std::ostream& outputStream)
   }
 
   // close dot file
-  outputStream << "}\n";
+  outputStream << std::endl; // for readability
 }
 
 void DataStructure::recurseHeirarchyToGraphViz(std::ostream& outputStream, const std::vector<DataPath> paths, const std::string& parent)
@@ -883,7 +883,7 @@ void DataStructure::recurseHeirarchyToGraphViz(std::ostream& outputStream, const
   for(const auto& path : paths)
   {
     // Output parent node, child node, and edge connecting them in .dot format
-    outputStream << parent << " -> " << path.getTargetName() << "\n";
+    outputStream << "\"" << parent << "\" -> \"" << path.getTargetName() << "\"\n";
 
     // pull child paths or skip to next iteration
     auto optionalChildPaths = GetAllChildDataPaths(*this, path);
@@ -914,6 +914,7 @@ void DataStructure::exportHeirarchyAsText(std::ostream& outputStream)
       recurseHeirarchyToText(outputStream, optionalDataPaths.value(), "");
     }
   }
+  outputStream << std::endl; // for readability
 }
 
 void DataStructure::recurseHeirarchyToText(std::ostream& outputStream, const std::vector<DataPath> paths, std::string indent)

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -875,7 +875,7 @@ void DataStructure::exportHeirarchyAsGraphViz(std::ostream& outputStream)
   }
 
   // close dot file
-  outputStream << std::endl; // for readability
+  outputStream << "}" << std::endl; // for readability
 }
 
 void DataStructure::recurseHeirarchyToGraphViz(std::ostream& outputStream, const std::vector<DataPath> paths, const std::string& parent)

--- a/src/complex/Filter/Actions/DeleteDataAction.cpp
+++ b/src/complex/Filter/Actions/DeleteDataAction.cpp
@@ -16,62 +16,6 @@ namespace
 constexpr int32 k_TargetNotFoundErrorCode = -3245;
 constexpr int32 k_ClassTypeErrorCode = -3246;
 
-std::optional<std::vector<DataPath>> GetEveryChildDataPath(DataStructure& dataStructure, const DataPath& parent)
-{
-  std::vector<DataPath> childDataObjects;
-  try
-  {
-    std::vector<std::string> childrenNames;
-    if(parent.empty())
-    {
-      childrenNames = dataStructure.getDataMap().getNames();
-    }
-    else
-    {
-      childrenNames = dataStructure.getDataRefAs<BaseGroup>(parent).GetChildrenNames();
-    }
-
-    for(const auto& childName : childrenNames)
-    {
-      DataPath childPath = parent.createChildPath(childName);
-      const DataObject* dataObject = dataStructure.getData(childPath);
-      childDataObjects.push_back(childPath);
-    }
-  } catch(std::exception& e)
-  {
-    return {};
-  }
-  return {childDataObjects};
-}
-
-Result<> TerminateNodesRecursively(DataStructure& dataStructure, const DataPath& path, IDataAction::Mode mode, const bool checkDependence)
-{
-  Result<> result = {};
-  DataObject* node = dataStructure.getData(path);
-
-  if(checkDependence)
-  {
-    auto parentIds = node->getParentIds();
-    if(parentIds.size() > 1)
-    {
-      return {};
-    }
-  }
-
-  auto optionalChildPaths = GetEveryChildDataPath(dataStructure, path);
-  if(optionalChildPaths.has_value() && optionalChildPaths.value().size() > 0)
-  {
-    for(const auto& child : optionalChildPaths.value())
-    {
-      result = MergeResults(result, std::move(TerminateNodesRecursively(dataStructure, child, mode, checkDependence)));
-    }
-  }
-
-  dataStructure.removeData(node->getId());
-
-  return result;
-}
-
 Result<> TerminateNode(DataStructure& dataStructure, const DataPath& path, IDataAction::Mode mode)
 {
   DataObject* targetObject = dataStructure.getData(path);
@@ -84,18 +28,75 @@ Result<> TerminateNode(DataStructure& dataStructure, const DataPath& path, IData
   return {};
 }
 
-Result<> TerminateEdge(DataStructure& dataStructure, const DataPath& path, IDataAction::Mode mode)
-{
-  DataObject* targetObject = dataStructure.getData(path);
-  if(targetObject == nullptr)
-  {
-    return {nonstd::make_unexpected(std::vector<Error>{{k_TargetNotFoundErrorCode, fmt::format("Trying to delete DataPath '{}' which does not exist.", path.toString())}})};
-  }
-
-  auto parent = dataStructure.getDataAs<BaseGroup>(path.getParent());
-  parent->remove(targetObject);
-  return {};
-}
+/* Can be implemented down the line (Also be sure to uncomment Enum and switch options) MAY NEED REVIEW! */
+// std::optional<std::vector<DataPath>> GetEveryChildDataPath(DataStructure& dataStructure, const DataPath& parent)
+//{
+//   std::vector<DataPath> childDataObjects;
+//   try
+//   {
+//     std::vector<std::string> childrenNames;
+//     if(parent.empty())
+//     {
+//       childrenNames = dataStructure.getDataMap().getNames();
+//     }
+//     else
+//     {
+//       childrenNames = dataStructure.getDataRefAs<BaseGroup>(parent).GetChildrenNames();
+//     }
+//
+//     for(const auto& childName : childrenNames)
+//     {
+//       DataPath childPath = parent.createChildPath(childName);
+//       const DataObject* dataObject = dataStructure.getData(childPath);
+//       childDataObjects.push_back(childPath);
+//     }
+//   } catch(std::exception& e)
+//   {
+//     return {};
+//   }
+//   return {childDataObjects};
+// }
+//
+// Result<> TerminateNodesRecursively(DataStructure& dataStructure, const DataPath& path, IDataAction::Mode mode, const bool checkDependence)
+//{
+//   Result<> result = {};
+//   DataObject* node = dataStructure.getData(path);
+//
+//   if(checkDependence)
+//   {
+//     auto parentIds = node->getParentIds();
+//     if(parentIds.size() > 1)
+//     {
+//       return {};
+//     }
+//   }
+//
+//   auto optionalChildPaths = GetEveryChildDataPath(dataStructure, path);
+//   if(optionalChildPaths.has_value() && optionalChildPaths.value().size() > 0)
+//   {
+//     for(const auto& child : optionalChildPaths.value())
+//     {
+//       result = MergeResults(result, std::move(TerminateNodesRecursively(dataStructure, child, mode, checkDependence)));
+//     }
+//   }
+//
+//   dataStructure.removeData(node->getId());
+//
+//   return result;
+// }
+//
+// Result<> TerminateEdge(DataStructure& dataStructure, const DataPath& path, IDataAction::Mode mode)
+//{
+//   DataObject* targetObject = dataStructure.getData(path);
+//   if(targetObject == nullptr)
+//   {
+//     return {nonstd::make_unexpected(std::vector<Error>{{k_TargetNotFoundErrorCode, fmt::format("Trying to delete DataPath '{}' which does not exist.", path.toString())}})};
+//   }
+//
+//   auto parent = dataStructure.getDataAs<BaseGroup>(path.getParent());
+//   parent->remove(targetObject);
+//   return {};
+// }
 } // namespace
 
 namespace complex
@@ -113,22 +114,24 @@ Result<> DeleteDataAction::apply(DataStructure& dataStructure, Mode mode) const
   auto* targetObject = dataStructure.getDataAs<BaseGroup>(path());
   switch(type())
   {
-  case DeleteType::IndependentChildren:
-    if(dynamic_cast<BaseGroup*>(targetObject) == nullptr)
-    {
-      return {nonstd::make_unexpected(std::vector<Error>{{k_ClassTypeErrorCode, fmt::format("The type of DataObject '{}' is not a subclass of BaseGroup.", path().getTargetName())}})};
-    }
-    return TerminateNodesRecursively(dataStructure, path(), mode, true);
-  case DeleteType::AllChildren:
-    if(dynamic_cast<BaseGroup*>(targetObject) == nullptr)
-    {
-      return {nonstd::make_unexpected(std::vector<Error>{{k_ClassTypeErrorCode, fmt::format("The type of DataObject '{}' is not a subclass of BaseGroup.", path().getTargetName())}})};
-    }
-    return TerminateNodesRecursively(dataStructure, path(), mode, false);
   case DeleteType::JustObject:
     return TerminateNode(dataStructure, path(), mode);
-  case DeleteType::JustPath:
-    return TerminateEdge(dataStructure, path(), mode);
+
+    /* Can be implemented down the line for better DataStructure handling*/
+    // case DeleteType::IndependentChildren:
+    //   if(dynamic_cast<BaseGroup*>(targetObject) == nullptr)
+    //   {
+    //     return {nonstd::make_unexpected(std::vector<Error>{{k_ClassTypeErrorCode, fmt::format("The type of DataObject '{}' is not a subclass of BaseGroup.", path().getTargetName())}})};
+    //   }
+    //   return TerminateNodesRecursively(dataStructure, path(), mode, true);
+    // case DeleteType::AllChildren:
+    //   if(dynamic_cast<BaseGroup*>(targetObject) == nullptr)
+    //   {
+    //     return {nonstd::make_unexpected(std::vector<Error>{{k_ClassTypeErrorCode, fmt::format("The type of DataObject '{}' is not a subclass of BaseGroup.", path().getTargetName())}})};
+    //   }
+    //   return TerminateNodesRecursively(dataStructure, path(), mode, false);
+    // case DeleteType::JustPath:
+    //   return TerminateEdge(dataStructure, path(), mode);
   }
   return {};
 }

--- a/src/complex/Filter/Actions/DeleteDataAction.cpp
+++ b/src/complex/Filter/Actions/DeleteDataAction.cpp
@@ -2,7 +2,10 @@
 
 #include <fmt/core.h>
 
+#include "complex/Common/Result.hpp"
+#include "complex/DataStructure/BaseGroup.hpp"
 #include "complex/DataStructure/DataArray.hpp"
+#include "complex/DataStructure/DataObject.hpp"
 #include "complex/DataStructure/DataStore.hpp"
 #include "complex/DataStructure/EmptyDataStore.hpp"
 
@@ -11,8 +14,77 @@ using namespace complex;
 namespace
 {
 constexpr int32 k_TargetNotFoundErrorCode = -3245;
+constexpr int32 k_ClassTypeErrorCode = -3246;
 
-Result<> RemoveFromParent(DataStructure& dataStructure, const DataPath& path, IDataAction::Mode mode)
+std::optional<std::vector<DataPath>> GetEveryChildDataPath(DataStructure& dataStructure, const DataPath& parent)
+{
+  std::vector<DataPath> childDataObjects;
+  try
+  {
+    std::vector<std::string> childrenNames;
+    if(parent.empty())
+    {
+      childrenNames = dataStructure.getDataMap().getNames();
+    }
+    else
+    {
+      childrenNames = dataStructure.getDataRefAs<BaseGroup>(parent).GetChildrenNames();
+    }
+
+    for(const auto& childName : childrenNames)
+    {
+      DataPath childPath = parent.createChildPath(childName);
+      const DataObject* dataObject = dataStructure.getData(childPath);
+      childDataObjects.push_back(childPath);
+    }
+  } catch(std::exception& e)
+  {
+    return {};
+  }
+  return {childDataObjects};
+}
+
+Result<> TerminateNodesRecursively(DataStructure& dataStructure, const DataPath& path, IDataAction::Mode mode, const bool checkDependence)
+{
+  Result<> result = {};
+  DataObject* node = dataStructure.getData(path);
+
+  if(checkDependence)
+  {
+    auto parentIds = node->getParentIds();
+    if(parentIds.size() > 1)
+    {
+      return {};
+    }
+  }
+
+  auto optionalChildPaths = GetEveryChildDataPath(dataStructure, path);
+  if(optionalChildPaths.has_value() && optionalChildPaths.value().size() > 0)
+  {
+    for(const auto& child : optionalChildPaths.value())
+    {
+      result = MergeResults(result, std::move(TerminateNodesRecursively(dataStructure, child, mode, checkDependence)));
+    }
+  }
+
+  dataStructure.removeData(node->getId());
+
+  return result;
+}
+
+Result<> TerminateNode(DataStructure& dataStructure, const DataPath& path, IDataAction::Mode mode)
+{
+  DataObject* targetObject = dataStructure.getData(path);
+  if(targetObject == nullptr)
+  {
+    return {nonstd::make_unexpected(std::vector<Error>{{k_TargetNotFoundErrorCode, fmt::format("Trying to delete DataObject '{}' which does not exist.", path.getTargetName())}})};
+  }
+
+  dataStructure.removeData(targetObject->getId());
+  return {};
+}
+
+Result<> TerminateEdge(DataStructure& dataStructure, const DataPath& path, IDataAction::Mode mode)
 {
   DataObject* targetObject = dataStructure.getData(path);
   if(targetObject == nullptr)
@@ -20,15 +92,17 @@ Result<> RemoveFromParent(DataStructure& dataStructure, const DataPath& path, ID
     return {nonstd::make_unexpected(std::vector<Error>{{k_TargetNotFoundErrorCode, fmt::format("Trying to delete DataPath '{}' which does not exist.", path.toString())}})};
   }
 
-  dataStructure.removeData(targetObject->getId());
+  auto parent = dataStructure.getDataAs<BaseGroup>(path.getParent());
+  parent->remove(targetObject);
   return {};
 }
 } // namespace
 
 namespace complex
 {
-DeleteDataAction::DeleteDataAction(const DataPath& path)
+DeleteDataAction::DeleteDataAction(const DataPath& path, DeleteDataAction::DeleteType type)
 : m_Path(path)
+, m_Type(type)
 {
 }
 
@@ -36,11 +110,36 @@ DeleteDataAction::~DeleteDataAction() noexcept = default;
 
 Result<> DeleteDataAction::apply(DataStructure& dataStructure, Mode mode) const
 {
-  return RemoveFromParent(dataStructure, path(), mode);
+  auto* targetObject = dataStructure.getDataAs<BaseGroup>(path());
+  switch(type())
+  {
+  case DeleteType::IndependentChildren:
+    if(dynamic_cast<BaseGroup*>(targetObject) == nullptr)
+    {
+      return {nonstd::make_unexpected(std::vector<Error>{{k_ClassTypeErrorCode, fmt::format("The type of DataObject '{}' is not a subclass of BaseGroup.", path().getTargetName())}})};
+    }
+    return TerminateNodesRecursively(dataStructure, path(), mode, true);
+  case DeleteType::AllChildren:
+    if(dynamic_cast<BaseGroup*>(targetObject) == nullptr)
+    {
+      return {nonstd::make_unexpected(std::vector<Error>{{k_ClassTypeErrorCode, fmt::format("The type of DataObject '{}' is not a subclass of BaseGroup.", path().getTargetName())}})};
+    }
+    return TerminateNodesRecursively(dataStructure, path(), mode, false);
+  case DeleteType::JustObject:
+    return TerminateNode(dataStructure, path(), mode);
+  case DeleteType::JustPath:
+    return TerminateEdge(dataStructure, path(), mode);
+  }
+  return {};
 }
 
 DataPath DeleteDataAction::path() const
 {
   return m_Path;
+}
+
+DeleteDataAction::DeleteType DeleteDataAction::type() const
+{
+  return m_Type;
 }
 } // namespace complex

--- a/src/complex/Filter/Actions/DeleteDataAction.hpp
+++ b/src/complex/Filter/Actions/DeleteDataAction.hpp
@@ -13,10 +13,10 @@ class COMPLEX_EXPORT DeleteDataAction : public IDataAction
 public:
   enum class DeleteType : uint64
   {
-    IndependentChildren = 0,
-    AllChildren = 1,
-    JustObject = 2,
-    JustPath = 3,
+    JustObject = 0,
+    //IndependentChildren = 1,
+    //AllChildren = 2,
+    //JustPath = 3
   };
 
   DeleteDataAction() = delete;
@@ -49,6 +49,7 @@ public:
    * @return DeleteType
    */
   DeleteType type() const;
+
 
 private:
   DataPath m_Path;

--- a/src/complex/Filter/Actions/DeleteDataAction.hpp
+++ b/src/complex/Filter/Actions/DeleteDataAction.hpp
@@ -14,9 +14,9 @@ public:
   enum class DeleteType : uint64
   {
     JustObject = 0,
-    //IndependentChildren = 1,
-    //AllChildren = 2,
-    //JustPath = 3
+    // IndependentChildren = 1,
+    // AllChildren = 2,
+    // JustPath = 3
   };
 
   DeleteDataAction() = delete;
@@ -49,7 +49,6 @@ public:
    * @return DeleteType
    */
   DeleteType type() const;
-
 
 private:
   DataPath m_Path;

--- a/src/complex/Filter/Actions/DeleteDataAction.hpp
+++ b/src/complex/Filter/Actions/DeleteDataAction.hpp
@@ -50,7 +50,6 @@ public:
    */
   DeleteType type() const;
 
-
 private:
   DataPath m_Path;
   DeleteType m_Type;

--- a/src/complex/Filter/Actions/DeleteDataAction.hpp
+++ b/src/complex/Filter/Actions/DeleteDataAction.hpp
@@ -11,9 +11,17 @@ namespace complex
 class COMPLEX_EXPORT DeleteDataAction : public IDataAction
 {
 public:
+  enum class DeleteType : uint64
+  {
+    IndependentChildren = 0,
+    AllChildren = 1,
+    JustObject = 2,
+    JustPath = 3,
+  };
+
   DeleteDataAction() = delete;
 
-  DeleteDataAction(const DataPath& path);
+  DeleteDataAction(const DataPath& path, DeleteType type = DeleteType::JustObject);
 
   ~DeleteDataAction() noexcept override;
 
@@ -36,7 +44,15 @@ public:
    */
   DataPath path() const;
 
+  /**
+   * @brief Returns the type to be used
+   * @return DeleteType
+   */
+  DeleteType type() const;
+
+
 private:
   DataPath m_Path;
+  DeleteType m_Type;
 };
 } // namespace complex

--- a/src/complex/Utilities/DataGroupUtilities.hpp
+++ b/src/complex/Utilities/DataGroupUtilities.hpp
@@ -45,10 +45,10 @@ COMPLEX_EXPORT std::optional<std::vector<DataPath>> GetAllChildDataPaths(const D
                                                                          const std::vector<DataPath>& ignoredDataPaths = {});
 
 /**
- * @brief This function will return all the DataPaths within a BaseGroup that are of a certain type
+ * @brief This function will return all the DataPaths within a BaseGroup
  * @param dataStructure The DataStructure to use
  * @param parentGroup The parent group whose children you want to get
- * @return std::optional<std::vector<DataPath>> of child paths if there no errors during the process.
+ * @return std::optional<std::vector<DataPath>>  of child paths  if there no errors during the process.
  */
 COMPLEX_EXPORT std::optional<std::vector<DataPath>> GetAllChildDataPaths(const DataStructure& dataStructure, const DataPath& parent);
 

--- a/test/UnitTestCommon/include/complex/UnitTest/UnitTestCommon.hpp
+++ b/test/UnitTestCommon/include/complex/UnitTest/UnitTestCommon.hpp
@@ -719,80 +719,81 @@ inline void CompareExemplarToGeneratedData(const DataStructure& dataStructure, c
  *   H   C | F		    Level One
  *  /   / \|/ \
  * N   D   E   G		Level Two
- *    / \ /|  / \
- *   I   J K L   M	    Level Three
+ *    / \ / \ /|\
+ *   I   J   K L M	    Level Three
  */
-std::tuple<DataStructure, std::vector<DataPath>> CreateComplexMultiLevelDataGraph()
+inline DataStructure CreateComplexMultiLevelDataGraph()
 {
   DataStructure dataGraph;
-  std::vector<DataPath> paths;
 
   // Level Zero //
   auto* groupA = DataGroup::Create(dataGraph, Constants::k_GroupAName);
   auto* groupB = DataGroup::Create(dataGraph, Constants::k_GroupBName);
 
-  paths.emplace_back(DataPath::FromString(groupA->getName()));
-  paths.emplace_back(DataPath::FromString(groupB->getName()));
+  auto groupAPath = DataPath({groupA->getName()});
+  auto groupBPath = DataPath({groupB->getName()});
 
   // Level One //
   auto* groupH = DataGroup::Create(dataGraph, Constants::k_GroupHName, groupA->getId());
   auto* groupC = DataGroup::Create(dataGraph, Constants::k_GroupCName, groupA->getId());
-  groupB->insert(std::shared_ptr<DataGroup>(groupC));
+  groupB->insert(dataGraph.getSharedData(groupC->getId()));
   auto* groupF = DataGroup::Create(dataGraph, Constants::k_GroupFName, groupB->getId());
 
-  paths.emplace_back(DataPath({groupA->getName(), groupH->getName()}));
+  auto groupAHPath = groupAPath.createChildPath(groupH->getName());
 
-  paths.emplace_back(DataPath({groupA->getName(), groupC->getName()}));
-  paths.emplace_back(DataPath({groupB->getName(), groupC->getName()}));
+  auto groupACPath = groupAPath.createChildPath(groupC->getName());
+  auto groupBCPath = groupBPath.createChildPath(groupC->getName());
 
-  paths.emplace_back(DataPath({groupB->getName(), groupF->getName()}));
+  auto groupBFPath = groupBPath.createChildPath(groupF->getName());
 
   // Level Two //
   auto* groupD = DataGroup::Create(dataGraph, Constants::k_GroupDName, groupC->getId());
   auto* groupE = DataGroup::Create(dataGraph, Constants::k_GroupEName, groupC->getId());
-  groupB->insert(std::shared_ptr<DataGroup>(groupE));
-  groupF->insert(std::shared_ptr<DataGroup>(groupE));
+  groupB->insert(dataGraph.getSharedData(groupE->getId()));
+  groupF->insert(dataGraph.getSharedData(groupE->getId()));
   auto* groupG = DataGroup::Create(dataGraph, Constants::k_GroupGName, groupF->getId());
-  auto* arrayN = UnitTest::CreateTestDataArray<int8>(dataGraph, Constants::k_ArrayNName, {1ULL}, {1ULL}, groupH->getId());
+  auto* arrayN = CreateTestDataArray<int8>(dataGraph, Constants::k_ArrayNName, {1ULL}, {1ULL}, groupH->getId());
 
-  paths.emplace_back(DataPath({groupA->getName(), groupH->getName(), arrayN->getName()}));
+  groupAHPath.createChildPath(arrayN->getName());
 
-  paths.emplace_back(DataPath({groupA->getName(), groupC->getName(), groupD->getName()}));
-  paths.emplace_back(DataPath({groupB->getName(), groupC->getName(), groupD->getName()}));
+  auto groupACDPath = groupACPath.createChildPath(groupD->getName());
+  auto groupBCDPath = groupBCPath.createChildPath(groupD->getName());
 
-  paths.emplace_back(DataPath({groupA->getName(), groupC->getName(), groupE->getName()}));
-  paths.emplace_back(DataPath({groupB->getName(), groupC->getName(), groupE->getName()}));
-  paths.emplace_back(DataPath({groupB->getName(), groupE->getName()}));
-  paths.emplace_back(DataPath({groupB->getName(), groupF->getName(), groupE->getName()}));
+  auto groupACEPath = groupACPath.createChildPath(groupE->getName());
+  auto groupBCEPath = groupBCPath.createChildPath(groupE->getName());
+  auto groupBEPath = groupBPath.createChildPath(groupE->getName());
+  auto groupBFEPath = groupBFPath.createChildPath(groupE->getName());
 
-  paths.emplace_back(DataPath({groupB->getName(), groupF->getName(), groupG->getName()}));
+  auto groupBFGPath = groupBFPath.createChildPath(groupG->getName());
 
   // Level Three //
-  auto* arrayI = UnitTest::CreateTestDataArray<uint8>(dataGraph, Constants::k_ArrayIName, {1ULL}, {1ULL}, groupH->getId());
-  auto* arrayJ = UnitTest::CreateTestDataArray<float32>(dataGraph, Constants::k_ArrayJName, {1ULL}, {1ULL}, groupD->getId());
-  groupE->insert(std::shared_ptr<Float32Array>(arrayJ));
-  auto* arrayK = UnitTest::CreateTestDataArray<float64>(dataGraph, Constants::k_ArrayKName, {1ULL}, {1ULL}, groupE->getId());
-  auto* arrayL = UnitTest::CreateTestDataArray<uint32>(dataGraph, Constants::k_ArrayLName, {1ULL}, {1ULL}, groupH->getId());
-  auto* arrayM = UnitTest::CreateTestDataArray<int64>(dataGraph, Constants::k_ArrayMName, {1ULL}, {1ULL}, groupG->getId());
+  auto* arrayI = CreateTestDataArray<uint8>(dataGraph, Constants::k_ArrayIName, {1ULL}, {1ULL}, groupH->getId());
+  auto* arrayJ = CreateTestDataArray<float32>(dataGraph, Constants::k_ArrayJName, {1ULL}, {1ULL}, groupD->getId());
+  groupE->insert(dataGraph.getSharedData(arrayJ->getId()));
+  auto* arrayK = CreateTestDataArray<float64>(dataGraph, Constants::k_ArrayKName, {1ULL}, {1ULL}, groupE->getId());
+  groupG->insert(dataGraph.getSharedData(arrayK->getId()));
+  auto* arrayL = CreateTestDataArray<uint32>(dataGraph, Constants::k_ArrayLName, {1ULL}, {1ULL}, groupH->getId());
+  auto* arrayM = CreateTestDataArray<int64>(dataGraph, Constants::k_ArrayMName, {1ULL}, {1ULL}, groupG->getId());
 
-  paths.emplace_back(DataPath({groupA->getName(), groupC->getName(), groupD->getName(), arrayI->getName()}));
-  paths.emplace_back(DataPath({groupB->getName(), groupC->getName(), groupD->getName(), arrayI->getName()}));
+  groupACDPath.createChildPath(arrayI->getName());
+  groupBCDPath.createChildPath(arrayI->getName());
 
-  paths.emplace_back(DataPath({groupB->getName(), groupC->getName(), groupD->getName(), arrayJ->getName()}));
-  paths.emplace_back(DataPath({groupA->getName(), groupC->getName(), groupE->getName(), arrayJ->getName()}));
-  paths.emplace_back(DataPath({groupB->getName(), groupC->getName(), groupE->getName(), arrayJ->getName()}));
-  paths.emplace_back(DataPath({groupB->getName(), groupE->getName(), arrayJ->getName()}));
-  paths.emplace_back(DataPath({groupB->getName(), groupF->getName(), groupE->getName(), arrayJ->getName()}));
+  groupBCDPath.createChildPath(arrayJ->getName());
+  groupACEPath.createChildPath(arrayJ->getName());
+  groupBCEPath.createChildPath(arrayJ->getName());
+  groupBEPath.createChildPath(arrayJ->getName());
+  groupBFEPath.createChildPath(arrayJ->getName());
 
-  paths.emplace_back(DataPath({groupA->getName(), groupC->getName(), groupE->getName(), arrayK->getName()}));
-  paths.emplace_back(DataPath({groupB->getName(), groupC->getName(), groupE->getName(), arrayK->getName()}));
-  paths.emplace_back(DataPath({groupB->getName(), groupE->getName(), arrayK->getName()}));
-  paths.emplace_back(DataPath({groupB->getName(), groupF->getName(), groupE->getName(), arrayK->getName()}));
+  groupACEPath.createChildPath(arrayK->getName());
+  groupBCEPath.createChildPath(arrayK->getName());
+  groupBEPath.createChildPath(arrayK->getName());
+  groupBFEPath.createChildPath(arrayK->getName());
 
-  paths.emplace_back(DataPath({groupB->getName(), groupF->getName(), groupG->getName(), arrayL->getName()}));
-  paths.emplace_back(DataPath({groupB->getName(), groupF->getName(), groupG->getName(), arrayM->getName()}));
+  groupBFGPath.createChildPath(arrayL->getName());
 
-  return {std::move(dataGraph), std::move(paths)};
+  groupBFGPath.createChildPath(arrayM->getName());
+
+  return dataGraph;
 }
 
 } // namespace UnitTest

--- a/test/UnitTestCommon/include/complex/UnitTest/UnitTestCommon.hpp
+++ b/test/UnitTestCommon/include/complex/UnitTest/UnitTestCommon.hpp
@@ -132,6 +132,21 @@ inline constexpr StringLiteral k_Float64DataSet("float64 DataSet");
 inline constexpr StringLiteral k_ConditionalArray("Conditional [bool]");
 inline constexpr StringLiteral k_ReducedGeometry("Reduced Geometry");
 
+inline constexpr StringLiteral k_GroupAName("A");
+inline constexpr StringLiteral k_GroupBName("B");
+inline constexpr StringLiteral k_GroupCName("C");
+inline constexpr StringLiteral k_GroupDName("D");
+inline constexpr StringLiteral k_GroupEName("E");
+inline constexpr StringLiteral k_GroupFName("F");
+inline constexpr StringLiteral k_GroupGName("G");
+inline constexpr StringLiteral k_GroupHName("H");
+inline constexpr StringLiteral k_ArrayIName("I");
+inline constexpr StringLiteral k_ArrayJName("J");
+inline constexpr StringLiteral k_ArrayKName("K");
+inline constexpr StringLiteral k_ArrayLName("L");
+inline constexpr StringLiteral k_ArrayMName("M");
+inline constexpr StringLiteral k_ArrayNName("N");
+
 // Data Container DataPath
 const DataPath k_DataContainerPath({k_DataContainer});
 
@@ -694,6 +709,90 @@ inline void CompareExemplarToGeneratedData(const DataStructure& dataStructure, c
     }
     }
   }
+}
+
+/**
+ * Here's the DataStructure we will be working with:
+ *
+ *     A   B			Level Zero
+ *    / \ /|\
+ *   H   C | F		    Level One
+ *  /   / \|/ \
+ * N   D   E   G		Level Two
+ *    / \ /|  / \
+ *   I   J K L   M	    Level Three
+ */
+std::tuple<DataStructure, std::vector<DataPath>> CreateComplexMultiLevelDataGraph()
+{
+  DataStructure dataGraph;
+  std::vector<DataPath> paths;
+
+  // Level Zero //
+  auto* groupA = DataGroup::Create(dataGraph, Constants::k_GroupAName);
+  auto* groupB = DataGroup::Create(dataGraph, Constants::k_GroupBName);
+
+  paths.emplace_back(DataPath::FromString(groupA->getName()));
+  paths.emplace_back(DataPath::FromString(groupB->getName()));
+
+  // Level One //
+  auto* groupH = DataGroup::Create(dataGraph, Constants::k_GroupHName, groupA->getId());
+  auto* groupC = DataGroup::Create(dataGraph, Constants::k_GroupCName, groupA->getId());
+  groupB->insert(std::shared_ptr<DataGroup>(groupC));
+  auto* groupF = DataGroup::Create(dataGraph, Constants::k_GroupFName, groupB->getId());
+
+  paths.emplace_back(DataPath({groupA->getName(), groupH->getName()}));
+
+  paths.emplace_back(DataPath({groupA->getName(), groupC->getName()}));
+  paths.emplace_back(DataPath({groupB->getName(), groupC->getName()}));
+
+  paths.emplace_back(DataPath({groupB->getName(), groupF->getName()}));
+
+  // Level Two //
+  auto* groupD = DataGroup::Create(dataGraph, Constants::k_GroupDName, groupC->getId());
+  auto* groupE = DataGroup::Create(dataGraph, Constants::k_GroupEName, groupC->getId());
+  groupB->insert(std::shared_ptr<DataGroup>(groupE));
+  groupF->insert(std::shared_ptr<DataGroup>(groupE));
+  auto* groupG = DataGroup::Create(dataGraph, Constants::k_GroupGName, groupF->getId());
+  auto* arrayN = UnitTest::CreateTestDataArray<int8>(dataGraph, Constants::k_ArrayNName, {1ULL}, {1ULL}, groupH->getId());
+
+  paths.emplace_back(DataPath({groupA->getName(), groupH->getName(), arrayN->getName()}));
+
+  paths.emplace_back(DataPath({groupA->getName(), groupC->getName(), groupD->getName()}));
+  paths.emplace_back(DataPath({groupB->getName(), groupC->getName(), groupD->getName()}));
+
+  paths.emplace_back(DataPath({groupA->getName(), groupC->getName(), groupE->getName()}));
+  paths.emplace_back(DataPath({groupB->getName(), groupC->getName(), groupE->getName()}));
+  paths.emplace_back(DataPath({groupB->getName(), groupE->getName()}));
+  paths.emplace_back(DataPath({groupB->getName(), groupF->getName(), groupE->getName()}));
+
+  paths.emplace_back(DataPath({groupB->getName(), groupF->getName(), groupG->getName()}));
+
+  // Level Three //
+  auto* arrayI = UnitTest::CreateTestDataArray<uint8>(dataGraph, Constants::k_ArrayIName, {1ULL}, {1ULL}, groupH->getId());
+  auto* arrayJ = UnitTest::CreateTestDataArray<float32>(dataGraph, Constants::k_ArrayJName, {1ULL}, {1ULL}, groupD->getId());
+  groupE->insert(std::shared_ptr<Float32Array>(arrayJ));
+  auto* arrayK = UnitTest::CreateTestDataArray<float64>(dataGraph, Constants::k_ArrayKName, {1ULL}, {1ULL}, groupE->getId());
+  auto* arrayL = UnitTest::CreateTestDataArray<uint32>(dataGraph, Constants::k_ArrayLName, {1ULL}, {1ULL}, groupH->getId());
+  auto* arrayM = UnitTest::CreateTestDataArray<int64>(dataGraph, Constants::k_ArrayMName, {1ULL}, {1ULL}, groupG->getId());
+
+  paths.emplace_back(DataPath({groupA->getName(), groupC->getName(), groupD->getName(), arrayI->getName()}));
+  paths.emplace_back(DataPath({groupB->getName(), groupC->getName(), groupD->getName(), arrayI->getName()}));
+
+  paths.emplace_back(DataPath({groupB->getName(), groupC->getName(), groupD->getName(), arrayJ->getName()}));
+  paths.emplace_back(DataPath({groupA->getName(), groupC->getName(), groupE->getName(), arrayJ->getName()}));
+  paths.emplace_back(DataPath({groupB->getName(), groupC->getName(), groupE->getName(), arrayJ->getName()}));
+  paths.emplace_back(DataPath({groupB->getName(), groupE->getName(), arrayJ->getName()}));
+  paths.emplace_back(DataPath({groupB->getName(), groupF->getName(), groupE->getName(), arrayJ->getName()}));
+
+  paths.emplace_back(DataPath({groupA->getName(), groupC->getName(), groupE->getName(), arrayK->getName()}));
+  paths.emplace_back(DataPath({groupB->getName(), groupC->getName(), groupE->getName(), arrayK->getName()}));
+  paths.emplace_back(DataPath({groupB->getName(), groupE->getName(), arrayK->getName()}));
+  paths.emplace_back(DataPath({groupB->getName(), groupF->getName(), groupE->getName(), arrayK->getName()}));
+
+  paths.emplace_back(DataPath({groupB->getName(), groupF->getName(), groupG->getName(), arrayL->getName()}));
+  paths.emplace_back(DataPath({groupB->getName(), groupF->getName(), groupG->getName(), arrayM->getName()}));
+
+  return {std::move(dataGraph), std::move(paths)};
 }
 
 } // namespace UnitTest

--- a/test/UnitTestCommon/include/complex/UnitTest/UnitTestCommon.hpp
+++ b/test/UnitTestCommon/include/complex/UnitTest/UnitTestCommon.hpp
@@ -767,12 +767,12 @@ inline DataStructure CreateComplexMultiLevelDataGraph()
   auto groupBFGPath = groupBFPath.createChildPath(groupG->getName());
 
   // Level Three //
-  auto* arrayI = CreateTestDataArray<uint8>(dataGraph, Constants::k_ArrayIName, {1ULL}, {1ULL}, groupH->getId());
+  auto* arrayI = CreateTestDataArray<uint8>(dataGraph, Constants::k_ArrayIName, {1ULL}, {1ULL}, groupD->getId());
   auto* arrayJ = CreateTestDataArray<float32>(dataGraph, Constants::k_ArrayJName, {1ULL}, {1ULL}, groupD->getId());
   groupE->insert(dataGraph.getSharedData(arrayJ->getId()));
   auto* arrayK = CreateTestDataArray<float64>(dataGraph, Constants::k_ArrayKName, {1ULL}, {1ULL}, groupE->getId());
   groupG->insert(dataGraph.getSharedData(arrayK->getId()));
-  auto* arrayL = CreateTestDataArray<uint32>(dataGraph, Constants::k_ArrayLName, {1ULL}, {1ULL}, groupH->getId());
+  auto* arrayL = CreateTestDataArray<uint32>(dataGraph, Constants::k_ArrayLName, {1ULL}, {1ULL}, groupG->getId());
   auto* arrayM = CreateTestDataArray<int64>(dataGraph, Constants::k_ArrayMName, {1ULL}, {1ULL}, groupG->getId());
 
   groupACDPath.createChildPath(arrayI->getName());


### PR DESCRIPTION
This includes a lot of advanced data management methods related to data removal that have been commented out. 
There is a new extensive DataStructure factory method in UnitTestCommon.
Changes to DeleteDataAction have been implemented.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files.

- [x] Class and Structs are `UpperCamelCase`
- [x] Class private member variables are `m_UpperCamelCase`
- [x] Class methods are `lowerCamelCase`
- [x] Method arguments are `lowerCamelCase`
- [x] Normal variables are `lowerCamelCase`
- [x] Constants are `k_UpperCamelCase`
- [x] Global statics are `s_UpperCamelCase`
- [x] Free Functions are `UpperCamelCase`
- [x] Macros are `ALL_UPPER_SNAKE_CASE`
- [x] Unit test will test data output from the filter.
- [x] Reused strings should be constants in an anonymous namespace
- [x] If parallelization is used, proper use of the abstracted complex classes are used. Using TBB specifically in a filter should be frowned upon unless for a really good reason.

## Filter Checklist

- [x] Parameters should be generally broken down into "Input Parameters", "Required Data Objects", "Created Data Objects". There can be exceptions to this.
- [x] ChoicesParameter selections should be an enumeration defined in the filer header
- [x] Documentation copied from SIMPL Repo and updated (if necessary)
- [x] Parameter argument variables are k_CamelCase_Key
- [x] Parameter argument strings are lower_snake_case
```
static inline constexpr StringLiteral k_AlignmentType_Key = "alignment_type";
```

## Unit Testing
- [x] 1 Unit test to instantiate the filter with the default arguments.
- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [ ] No commented out code (rare exceptions to this is allowed..)
- [x] Filters should have both the Filter class and Algorithm class for anything beyond trivial needs
- [ ] No API changes were made (or the changes have been approved)
- [ ] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added Python wrapping to new files (if any) as necessary
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented.


<!-- **Thanks for contributing to complex!** -->
