### PR TITLE
ENH: Implement Dynamic Filter Instantiation Test Case

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
@@ -70,7 +70,7 @@ Parameters StlFileReaderFilter::parameters() const
   params.insert(std::make_unique<Float32Parameter>(k_ScaleFactor, "Scale Factor", "The factor by which to scale the geometry", 1.0F));
   params.linkParameters(k_ScaleOutput, k_ScaleFactor, true);
 
-  params.insert(std::make_unique<FileSystemPathParameter>(k_StlFilePath_Key, "STL File", "Input STL File", fs::path("*.stl"), FileSystemPathParameter::ExtensionsType{".stl"},
+  params.insert(std::make_unique<FileSystemPathParameter>(k_StlFilePath_Key, "STL File", "Input STL File", fs::path(""), FileSystemPathParameter::ExtensionsType{".stl"},
                                                           FileSystemPathParameter::PathType::InputFile));
 
   params.insertSeparator(Parameters::Separator{"Created Objects"});

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/WriteASCIIDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/WriteASCIIDataFilter.cpp
@@ -64,7 +64,7 @@ Parameters WriteASCIIDataFilter::parameters() const
   params.insertLinkableParameter(std::make_unique<ChoicesParameter>(k_OutputStyle_Key, "Output Type", "Whether to output a folder of files or a single file with all the data in column form",
                                                                     to_underlying(OutputStyle::MultipleFiles),
                                                                     ChoicesParameter::Choices{"Multiple Files", "Single File"})); // sequence dependent DO NOT REORDER
-  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputPath_Key, "Output Path", "The output file path", fs::path("<default output directory>"), FileSystemPathParameter::ExtensionsType{},
+  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputPath_Key, "Output Path", "The output file path", fs::path(""), FileSystemPathParameter::ExtensionsType{},
                                                           FileSystemPathParameter::PathType::OutputDir, true));
   params.insert(std::make_unique<StringParameter>(k_FileName_Key, "Name of Output File", "The name of the output file(s)", "Data"));
   params.insert(std::make_unique<StringParameter>(k_FileExtension_Key, "File Extension", "The file extension for the output file(s)", ".csv"));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/WriteBinaryDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/WriteBinaryDataFilter.cpp
@@ -75,7 +75,7 @@ Parameters WriteBinaryDataFilter::parameters() const
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
   params.insert(std::make_unique<ChoicesParameter>(k_Endianess_Key, "Endianess", "Default is little endian", to_underlying(Endianess::Little),
                                                    ChoicesParameter::Choices{"Little Endian", "Big Endian"})); // sequence dependent DO NOT REORDER
-  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputPath_Key, "Output Path", "The output file path", fs::path("<default output directory>"), FileSystemPathParameter::ExtensionsType{},
+  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputPath_Key, "Output Path", "The output file path", fs::path(""), FileSystemPathParameter::ExtensionsType{},
                                                           FileSystemPathParameter::PathType::OutputDir, true));
   params.insert(std::make_unique<StringParameter>(k_FileExtension_Key, "File Extension", "The file extension for the output file", ".bin"));
   params.insertSeparator(Parameters::Separator{"Required Data Objects"});

--- a/src/Plugins/ComplexCore/test/ArrayCalculatorTest.cpp
+++ b/src/Plugins/ComplexCore/test/ArrayCalculatorTest.cpp
@@ -811,27 +811,6 @@ void SingleComponentArrayCalculatorTest2()
   }
 }
 
-TEST_CASE("ComplexCore::ArrayCalculatorFilter: Instantiation and Parameter Check", "[ComplexCore][ArrayCalculatorFilter]")
-{
-  // Instantiate the filter, a DataStructure object and an Arguments Object
-  ArrayCalculatorFilter filter;
-  DataStructure dataStructure;
-  Arguments args;
-
-  // Create default Parameters for the filter.
-  args.insertOrAssign(ArrayCalculatorFilter::k_InfixEquation_Key, std::make_any<CalculatorParameter::ValueType>(CalculatorParameter::ValueType{}));
-  args.insertOrAssign(ArrayCalculatorFilter::k_ScalarType_Key, std::make_any<NumericTypeParameter::ValueType>(NumericType::int16));
-  args.insertOrAssign(ArrayCalculatorFilter::k_CalculatedArray_Key, std::make_any<DataPath>(DataPath({k_CalculatedArray})));
-
-  // Preflight the filter and check result
-  auto preflightResult = filter.preflight(dataStructure, args);
-  COMPLEX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
-
-  // Execute the filter and check the result
-  auto executeResult = filter.execute(dataStructure, args);
-  COMPLEX_RESULT_REQUIRE_INVALID(executeResult.result);
-}
-
 TEST_CASE("ComplexCore::ArrayCalculatorFilter: Filter Execution")
 {
   std::cout << "#### ArrayCalculatorTest Starting ####" << std::endl;

--- a/src/Plugins/ComplexCore/test/ChangeAngleRepresentationTest.cpp
+++ b/src/Plugins/ComplexCore/test/ChangeAngleRepresentationTest.cpp
@@ -9,7 +9,7 @@
 
 using namespace complex;
 
-TEST_CASE("ComplexCore::ChangeAngleRepresentation: Instantiation and Parameter Check", "[OrientationAnalysis][ChangeAngleRepresentation]")
+TEST_CASE("ComplexCore::ChangeAngleRepresentation: Invalid Execution", "[OrientationAnalysis][ChangeAngleRepresentation]")
 {
   // Instantiate the filter, a DataStructure object and an Arguments Object
   ChangeAngleRepresentation filter;

--- a/src/Plugins/ComplexCore/test/CombineAttributeArraysTest.cpp
+++ b/src/Plugins/ComplexCore/test/CombineAttributeArraysTest.cpp
@@ -35,7 +35,7 @@ DataStructure CreateTestDataStructure()
   return dataStructure;
 }
 
-TEST_CASE("ComplexCore::CombineAttributeArrays: Instantiation and Parameter Check", "[ComplexCore][CombineAttributeArrays]")
+TEST_CASE("ComplexCore::CombineAttributeArrays: Parameter Check", "[ComplexCore][CombineAttributeArrays]")
 {
 
   // Instantiate the filter, a DataStructure object and an Arguments Object

--- a/src/Plugins/ComplexCore/test/ConvertColorToGrayScaleTest.cpp
+++ b/src/Plugins/ComplexCore/test/ConvertColorToGrayScaleTest.cpp
@@ -331,7 +331,7 @@ void RunTest(const uint8& algoMapIndex, const ConvertColorToGrayScale::Conversio
   CompareResults(algoMapIndex, dataStruct);
 }
 
-TEST_CASE("ComplexCore::ConvertColorToGrayScale: Instantiation and Parameter Check", "[ComplexCore][ConvertColorToGrayScaleFilter]")
+TEST_CASE("ComplexCore::ConvertColorToGrayScale: Valid Execution", "[ComplexCore][ConvertColorToGrayScaleFilter]")
 {
   // Luminosity Algorithm testing
   // Test defaults

--- a/src/Plugins/ComplexCore/test/ConvertDataTest.cpp
+++ b/src/Plugins/ComplexCore/test/ConvertDataTest.cpp
@@ -431,7 +431,7 @@ void TestOverwriteArray()
 }
 
 // -----------------------------------------------------------------------------
-TEST_CASE("ComplexCore::ConvertData: Instantiation and Parameter Check", "[ComplexCore][ConvertDataFilter]")
+TEST_CASE("ComplexCore::ConvertData: Valid Execution", "[ComplexCore][ConvertDataFilter]")
 {
   std::cout << "#### ConvertDataTest Starting ####" << std::endl;
 

--- a/src/Plugins/ComplexCore/test/CopyFeatureArrayToElementArrayTest.cpp
+++ b/src/Plugins/ComplexCore/test/CopyFeatureArrayToElementArrayTest.cpp
@@ -16,7 +16,7 @@ const std::string k_CellTempArrayName("Cell Temperature");
 const std::string k_FeatureDataArrayName("Feature Temperature");
 } // namespace
 
-TEST_CASE("ComplexCore::CopyFeatureArrayToElementArray: Instantiation and Parameter Check", "[Core][CopyFeatureArrayToElementArray]")
+TEST_CASE("ComplexCore::CopyFeatureArrayToElementArray: Parameter Check", "[Core][CopyFeatureArrayToElementArray]")
 {
   // Instantiate the filter, a DataStructure object and an Arguments Object
   CopyFeatureArrayToElementArray filter;

--- a/src/Plugins/ComplexCore/test/CreateFeatureArrayFromElementArrayTest.cpp
+++ b/src/Plugins/ComplexCore/test/CreateFeatureArrayFromElementArrayTest.cpp
@@ -1,25 +1,3 @@
-/**
- * This file is auto generated from the original Core/CreateFeatureArrayFromElementArray
- * runtime information. These are the steps that need to be taken to utilize this
- * unit test in the proper way.
- *
- * 1: Validate each of the default parameters that gets created.
- * 2: Inspect the actual filter to determine if the filter in its default state
- * would pass or fail BOTH the preflight() and execute() methods
- * 3: UPDATE the ```REQUIRE(result.result.valid());``` code to have the proper
- *
- * 4: Add additional unit tests to actually test each code path within the filter
- *
- * There are some example Catch2 ```TEST_CASE``` sections for your inspiration.
- *
- * NOTE the format of the ```TEST_CASE``` macro. Please stick to this format to
- * allow easier parsing of the unit tests.
- *
- * When you start working on this unit test remove "[CreateFeatureArrayFromElementArray][.][UNIMPLEMENTED]"
- * from the TEST_CASE macro. This will enable this unit test to be run by default
- * and report errors.
- */
-
 #include <catch2/catch.hpp>
 
 #include "complex/Parameters/ArrayCreationParameter.hpp"
@@ -89,27 +67,6 @@ void testElementArray(const DataPath& cellDataPath)
   }
 }
 } // namespace
-
-TEST_CASE("ComplexCore::CreateFeatureArrayFromElementArray: Instantiation and Parameter Check", "[Core][CreateFeatureArrayFromElementArray]")
-{
-  // Instantiate the filter, a DataStructure object and an Arguments Object
-  CreateFeatureArrayFromElementArray filter;
-  DataStructure dataStructure;
-  Arguments args;
-
-  // Create default Parameters for the filter.
-  args.insertOrAssign(CreateFeatureArrayFromElementArray::k_SelectedCellArrayPath_Key, std::make_any<DataPath>(DataPath{}));
-  args.insertOrAssign(CreateFeatureArrayFromElementArray::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(DataPath{}));
-  args.insertOrAssign(CreateFeatureArrayFromElementArray::k_CreatedArrayName_Key, std::make_any<DataPath>(DataPath{}));
-
-  // Preflight the filter and check result
-  auto preflightResult = filter.preflight(dataStructure, args);
-  COMPLEX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
-
-  // Execute the filter and check the result
-  auto executeResult = filter.execute(dataStructure, args);
-  COMPLEX_RESULT_REQUIRE_INVALID(executeResult.result);
-}
 
 TEST_CASE("ComplexCore::CreateFeatureArrayFromElementArray: Valid filter execution - 1 Component")
 {

--- a/src/Plugins/ComplexCore/test/CreateGeometryTest.cpp
+++ b/src/Plugins/ComplexCore/test/CreateGeometryTest.cpp
@@ -2306,7 +2306,7 @@ void CreateIncompatibleVerticesArray(DataStructure& dataStructure, const std::st
   (*verticesArray)[5] = 0;
 }
 
-TEST_CASE("ComplexCore::CreateGeometry: Instantiation and Parameter Check", "[ComplexCore][CreateGeometry]")
+TEST_CASE("ComplexCore::CreateGeometry: Valid Execution", "[ComplexCore][CreateGeometry]")
 {
   // Instantiate the filter, a DataStructure object and an Arguments Object
   CreateGeometryFilter filter;

--- a/src/Plugins/ComplexCore/test/ExtractComponentAsArrayTest.cpp
+++ b/src/Plugins/ComplexCore/test/ExtractComponentAsArrayTest.cpp
@@ -21,29 +21,6 @@ const DataPath k_ExtractedComponentsPath({Constants::k_DataContainer, Constants:
 const fs::path k_BaseDataFilePath = fs::path(fmt::format("{}/6_6_find_feature_centroids.dream3d", unit_test::k_TestFilesDir));
 } // namespace
 
-TEST_CASE("ComplexCore::ExtractComponentAsArrayFilter: Instantiation and Parameter Check", "[ComplexCore]")
-{
-  // Instantiate the filter, a DataStructure object and an Arguments Object
-  ExtractComponentAsArrayFilter filter;
-  DataStructure dataStructure = UnitTest::LoadDataStructure(k_BaseDataFilePath);
-  Arguments args;
-
-  // Create default Parameters for the filter.
-  args.insertOrAssign(ExtractComponentAsArrayFilter::k_MoveComponentsToNewArray_Key, std::make_any<bool>(true));
-  args.insertOrAssign(ExtractComponentAsArrayFilter::k_RemoveComponentsFromArray_Key, std::make_any<bool>(true));
-  args.insertOrAssign(ExtractComponentAsArrayFilter::k_CompNumber_Key, std::make_any<int32>(1));
-  args.insertOrAssign(ExtractComponentAsArrayFilter::k_SelectedArrayPath_Key, std::make_any<DataPath>(k_QuatsPath));
-  args.insertOrAssign(ExtractComponentAsArrayFilter::k_NewArrayPath_Key, std::make_any<DataPath>(k_ExtractedComponentsPath));
-
-  // Preflight the filter and check result
-  auto preflightResult = filter.preflight(dataStructure, args);
-  REQUIRE(preflightResult.outputActions.valid());
-
-  // Execute the filter and check the result
-  auto executeResult = filter.execute(dataStructure, args);
-  REQUIRE(executeResult.result.valid());
-}
-
 TEST_CASE("ComplexCore::ExtractComponentAsArrayFilter: Valid filter execution", "[ComplexCore]")
 {
   // Instantiate the filter, a DataStructure object and an Arguments Object

--- a/src/Plugins/ComplexCore/test/FeatureDataCSVWriterTest.cpp
+++ b/src/Plugins/ComplexCore/test/FeatureDataCSVWriterTest.cpp
@@ -48,27 +48,6 @@ std::vector<char> readIn(fs::path filePath)
   return {};
 }
 
-TEST_CASE("ComplexCore::FeatureDataCSVWriterFilter: Instantiate Filter", "[FeatureDataCSVWriterFilter]")
-{
-  FeatureDataCSVWriterFilter filter;
-  DataStructure dataStructure;
-  Arguments args;
-  AttributeMatrix& topLevelGroup = *AttributeMatrix::Create(dataStructure, "TestData");
-
-  auto file = std::filesystem::path(fmt::format("{}/{}.csv", k_TestOutput, "CSV_Test"));
-  auto path = dataStructure.getAllDataPaths()[0];
-
-  args.insertOrAssign(FeatureDataCSVWriterFilter::k_FeatureDataFile_Key, std::make_any<FileSystemPathParameter::ValueType>(file));
-  args.insertOrAssign(FeatureDataCSVWriterFilter::k_WriteNeighborListData_Key, std::make_any<bool>(true));
-  args.insertOrAssign(FeatureDataCSVWriterFilter::k_WriteNumFeaturesLine_Key, std::make_any<bool>(true));
-  args.insertOrAssign(FeatureDataCSVWriterFilter::k_DelimiterChoiceInt_Key, std::make_any<ChoicesParameter::ValueType>(2ULL));
-  args.insertOrAssign(FeatureDataCSVWriterFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(path));
-
-  // Preflight the filter
-  auto preflightResult = filter.preflight(dataStructure, args);
-  COMPLEX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
-}
-
 TEST_CASE("ComplexCore::FeatureDataCSVWriterFilter: Test Algorithm", "[FeatureDataCSVWriterFilter]")
 {
   FeatureDataCSVWriterFilter filter;

--- a/src/Plugins/ComplexCore/test/FindNumFeaturesTest.cpp
+++ b/src/Plugins/ComplexCore/test/FindNumFeaturesTest.cpp
@@ -25,27 +25,6 @@ const DataPath k_FeatureCountsPathNX({Constants::k_DataContainer, Constants::k_C
 const fs::path k_BaseDataFilePath = fs::path(fmt::format("{}/6_6_volume_fraction_feature_count.dream3d", unit_test::k_TestFilesDir));
 } // namespace
 
-TEST_CASE("ComplexCore::FindNumFeaturesFilter: Instantiation and Parameter Check", "[ComplexCore][FindNumFeaturesFilter]")
-{
-  // Instantiate the filter, a DataStructure object and an Arguments Object
-  FindNumFeaturesFilter filter;
-  Arguments args;
-
-  DataStructure dataStructure = UnitTest::LoadDataStructure(k_BaseDataFilePath);
-
-  // Create default Parameters for the filter.
-  args.insertOrAssign(FindNumFeaturesFilter::k_FeaturePhasesArrayPath_Key, std::make_any<DataPath>(k_FeaturePhasesPath));
-  args.insertOrAssign(FindNumFeaturesFilter::k_NumFeaturesArrayPath_Key, std::make_any<DataPath>(k_FeatureCountsPathNX));
-
-  // Preflight the filter and check result
-  auto preflightResult = filter.preflight(dataStructure, args);
-  REQUIRE(preflightResult.outputActions.valid());
-
-  // Execute the filter and check the result
-  auto executeResult = filter.execute(dataStructure, args);
-  REQUIRE(executeResult.result.valid());
-}
-
 TEST_CASE("ComplexCore::FindNumFeaturesFilter: Valid filter execution", "[ComplexCore][FindNumFeaturesFilter]")
 {
   // Instantiate the filter, a DataStructure object and an Arguments Object

--- a/src/Plugins/ComplexCore/test/FindSurfaceFeaturesTest.cpp
+++ b/src/Plugins/ComplexCore/test/FindSurfaceFeaturesTest.cpp
@@ -95,27 +95,6 @@ void test_impl(const std::vector<uint64>& geometryDims, const std::string& featu
 }
 } // namespace
 
-TEST_CASE("ComplexCore::FindSurfaceFeatures: Instantiation and Parameter Check", "[ComplexCore][FindSurfaceFeatures]")
-{
-  // Instantiate the filter, a DataStructure object and an Arguments Object
-  FindSurfaceFeatures filter;
-  DataStructure dataStructure;
-  Arguments args;
-
-  // Create default Parameters for the filter.
-  args.insertOrAssign(FindSurfaceFeatures::k_FeatureGeometryPath_Key, std::make_any<DataPath>(DataPath{}));
-  args.insertOrAssign(FindSurfaceFeatures::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(DataPath{}));
-  args.insertOrAssign(FindSurfaceFeatures::k_SurfaceFeaturesArrayPath_Key, std::make_any<DataPath>(DataPath{}));
-
-  // Preflight the filter and check result
-  auto preflightResult = filter.preflight(dataStructure, args);
-  COMPLEX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
-
-  // Execute the filter and check the result
-  auto executeResult = filter.execute(dataStructure, args);
-  COMPLEX_RESULT_REQUIRE_INVALID(executeResult.result);
-}
-
 TEST_CASE("ComplexCore::FindSurfaceFeatures: Valid filter execution in 3D", "[ComplexCore][FindSurfaceFeatures]")
 {
   // Read the Small IN100 Data set

--- a/src/Plugins/ComplexCore/test/FindVolFractionsTest.cpp
+++ b/src/Plugins/ComplexCore/test/FindVolFractionsTest.cpp
@@ -24,27 +24,6 @@ const DataPath k_VolumeFractionsPathNX({Constants::k_DataContainer, Constants::k
 const fs::path k_BaseDataFilePath = fs::path(fmt::format("{}/6_6_volume_fraction_feature_count.dream3d", unit_test::k_TestFilesDir));
 } // namespace
 
-TEST_CASE("ComplexCore::FindVolFractionsFilter: Instantiation and Parameter Check", "[ComplexCore]")
-{
-  // Instantiate the filter, a DataStructure object and an Arguments Object
-  FindVolFractionsFilter filter;
-  Arguments args;
-
-  DataStructure dataStructure = UnitTest::LoadDataStructure(k_BaseDataFilePath);
-
-  // Create default Parameters for the filter.
-  args.insertOrAssign(FindVolFractionsFilter::k_CellPhasesArrayPath_Key, std::make_any<DataPath>(k_CellPhasesPath));
-  args.insertOrAssign(FindVolFractionsFilter::k_VolFractionsArrayPath_Key, std::make_any<DataPath>(k_VolumeFractionsPathNX));
-
-  // Preflight the filter and check result
-  auto preflightResult = filter.preflight(dataStructure, args);
-  REQUIRE(preflightResult.outputActions.valid());
-
-  // Execute the filter and check the result
-  auto executeResult = filter.execute(dataStructure, args);
-  REQUIRE(executeResult.result.valid());
-}
-
 TEST_CASE("ComplexCore::FindVolFractionsFilter: Valid filter execution", "[ComplexCore]")
 {
   // Instantiate the filter, a DataStructure object and an Arguments Object

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1.cpp
@@ -64,8 +64,8 @@ Parameters ExampleFilter1::parameters() const
                                                           FileSystemPathParameter::PathType::InputFile, true));
   params.insert(std::make_unique<FileSystemPathParameter>(k_OutputDir_Key, "Ouptut Directory", "Example output directory help text", "Output Data", FileSystemPathParameter::ExtensionsType{},
                                                           FileSystemPathParameter::PathType::OutputDir));
-  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputFile_Key, "Output File", "Example output file help text", "",
-                                                          FileSystemPathParameter::ExtensionsType{}, FileSystemPathParameter::PathType::OutputFile));
+  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputFile_Key, "Output File", "Example output file help text", "", FileSystemPathParameter::ExtensionsType{},
+                                                          FileSystemPathParameter::PathType::OutputFile));
 
   params.insertSeparator({"Linked Parameter"});
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_Param2, "BoolParameter", "The 2nd parameter", true));

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1.cpp
@@ -64,7 +64,7 @@ Parameters ExampleFilter1::parameters() const
                                                           FileSystemPathParameter::PathType::InputFile, true));
   params.insert(std::make_unique<FileSystemPathParameter>(k_OutputDir_Key, "Ouptut Directory", "Example output directory help text", "Output Data", FileSystemPathParameter::ExtensionsType{},
                                                           FileSystemPathParameter::PathType::OutputDir));
-  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputFile_Key, "Output File", "Example output file help text", "Output Data/Some Really Cool File.txt",
+  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputFile_Key, "Output File", "Example output file help text", "",
                                                           FileSystemPathParameter::ExtensionsType{}, FileSystemPathParameter::PathType::OutputFile));
 
   params.insertSeparator({"Linked Parameter"});

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,20 +25,21 @@ add_executable(complex_test
   ${COMPLEX_TEST_DIRS_HEADER}
   complex_test_main.cpp
   ArgumentsTest.cpp
-  DataStructTest.cpp
-  GeometryTest.cpp
-  H5Test.cpp
+  BitTest.cpp
+  DataArrayTest.cpp
   DataStructObserver.hpp
   DataStructObserver.cpp
-  MontageTest.cpp
-  BitTest.cpp
-  UuidTest.cpp
-  PluginTest.cpp
+  DataStructTest.cpp
+  DynamicFilterInstantiationTest.cpp
   FilePathGeneratorTest.cpp
-  DataArrayTest.cpp
+  GeometryTest.cpp
   GeometryTestUtilities.hpp
+  H5Test.cpp
+  MontageTest.cpp
+  PluginTest.cpp
   ParametersTest.cpp
   PipelineSaveTest.cpp
+  UuidTest.cpp
 )
 
 target_link_libraries(complex_test

--- a/test/DynamicFilterInstantiationTest.cpp
+++ b/test/DynamicFilterInstantiationTest.cpp
@@ -1,0 +1,44 @@
+#include <catch2/catch.hpp>
+
+#include "complex/Core/Application.hpp"
+#include "complex/Filter/IFilter.hpp"
+
+#include "complex/UnitTest/UnitTestCommon.hpp"
+#include "complex/unit_test/complex_test_dirs.hpp"
+
+/**
+ * @brief Test every currently compiled filters instantiation.
+ */
+TEST_CASE("Filter List Instantiation")
+{
+  std::shared_ptr<complex::UnitTest::make_shared_enabler> app = std::make_shared<complex::UnitTest::make_shared_enabler>();
+  app->loadPlugins(complex::unit_test::k_BuildDir.view(), true);
+  auto* filterList = complex::Application::Instance()->getFilterList();
+  REQUIRE(filterList != nullptr);
+
+  const auto& handles = filterList->getFilterHandles();
+  REQUIRE(!handles.empty());
+
+  complex::DataStructure dataStructure;
+
+  for(const auto& handle : handles)
+  {
+    auto filter = filterList->createFilter(handle);
+    REQUIRE(filter != nullptr);
+
+    SECTION(("Filter List Instantiation::" + filter->className() + ": Instantiation"), ("[complex][" + filter->name() + "]"))
+    {
+      complex::Arguments args;
+      dataStructure.clear();
+
+      auto params = filter->parameters();
+      for(const auto& [name, param] : params)
+      {
+        args.insert(name, param->defaultValue());
+      }
+
+      auto preflightResult = filter->preflight(dataStructure, args);
+      REQUIRE((preflightResult.outputActions.valid() || preflightResult.outputActions.invalid())); // Preflight exists
+    }
+  }
+}


### PR DESCRIPTION
Implemented the following:
- DynamicFilterInstantiationTest - Instantiates every filter from current plugins
- Removed redundant instantiations in each individual test case
- Reordered CMake for tests alphabetically

## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files.

- [x] Class and Structs are `UpperCamelCase`
- [x] Class private member variables are `m_UpperCamelCase`
- [x] Class methods are `lowerCamelCase`
- [x] Method arguments are `lowerCamelCase`
- [x] Normal variables are `lowerCamelCase`
- [x] Constants are `k_UpperCamelCase`
- [x] Global statics are `s_UpperCamelCase`
- [x] Free Functions are `UpperCamelCase`
- [x] Macros are `ALL_UPPER_SNAKE_CASE`

## Unit Testing
- [x] 1 Unit test to instantiate the filter with the default arguments.

## Code Cleanup
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
