### PR TITLE
Updated vcpkg baseline for itk build fix

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -22,7 +22,7 @@
         "vcpkg-cmake",
         "vcpkg-cmake-config"
       ],
-      "baseline": "3a91938944e73777da26d7aa8a3cff992a453858"
+      "baseline": "04308dee1fc2f4119d0d12bac9caa949beba3557"
     }
   ]
 }


### PR DESCRIPTION
ITK now builds successfully on the latest vcpkg release. The Montage and TotalVariation module have been disabled temporarily until a permanent fix is implemented. There are no filters that use them currently.