### PR TITLE
FILTER: Generate Color Table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ set(CoreParameters
   DynamicTableParameter
   EnsembleInfoParameter
   FileSystemPathParameter
+  GenerateColorTableParameter
   GeneratedFileListParameter
   GeometrySelectionParameter
   Dream3dImportParameter

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,7 @@ set(COMPLEX_HDRS
 
   ${COMPLEX_SOURCE_DIR}/Utilities/ArrayThreshold.hpp
   ${COMPLEX_SOURCE_DIR}/Utilities/FilePathGenerator.hpp
+  ${COMPLEX_SOURCE_DIR}/Utilities/ColorPresetsUtilities.hpp
   ${COMPLEX_SOURCE_DIR}/Utilities/FilterUtilities.hpp
   ${COMPLEX_SOURCE_DIR}/Utilities/GeometryUtilities.hpp
   ${COMPLEX_SOURCE_DIR}/Utilities/GeometryHelpers.hpp

--- a/src/Plugins/ComplexCore/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/CMakeLists.txt
@@ -50,6 +50,7 @@ set(FilterList
   FindTriangleGeomCentroidsFilter
   FindTriangleGeomSizesFilter
   FindVolFractionsFilter
+  GenerateColorTableFilter
   IdentifySample
   ImportCSVDataFilter
   ImportDREAM3DFilter
@@ -106,6 +107,7 @@ set(AlgorithmList
   FindSurfaceAreaToVolume
   FindTriangleGeomCentroids
   FindTriangleGeomSizes
+  GenerateColorTable
   LaplacianSmoothing
   PointSampleTriangleGeometry
   QuickSurfaceMesh

--- a/src/Plugins/ComplexCore/docs/GenerateColorTableFilter.md
+++ b/src/Plugins/ComplexCore/docs/GenerateColorTableFilter.md
@@ -1,0 +1,40 @@
+# GenerateColorTable  #
+
+## Description ##
+
+This **Filter** generates a color table array for a given 1-component input array.  Each element of the input array
+is normalized and converted to a color based on where the value falls in the spectrum of the selected color preset.
+
+## Parameters ##
+
+| Name            | Type | Description                                                       |
+|-----------------|------|-------------------------------------------------------------------|
+| Selected Preset | JSON | The selected color preset, used to generate the color table array |
+
+## Required Geometry ###
+
+None
+
+## Required Objects ##
+
+| Kind | Default Name | Type | Component Dimensions | Description                                                    |
+|------|--------------|-----|----------------------|----------------------------------------------------------------|
+| **Attribute Array** | N/A | Any | (1) | 1-component input array used to generate the color table array |
+
+## Created Objects ##
+
+| Kind | Default Name | Type  | Component Dimensions | Description                                             |
+|------|--------------|-------|----------------------|---------------------------------------------------------|
+| **Attribute Array** | N/A | uint8 | (3) | RGB output color table array |
+
+## Example Pipelines ##
+
+
+
+## License & Copyright ##
+
+Please see the description file distributed with this plugin.
+
+## DREAM3D Mailing Lists ##
+
+If you need more help with a filter, please consider asking your question on the DREAM3D Users mailing list:

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
@@ -47,6 +47,7 @@
 #include "ComplexCore/Filters/ImportHDF5Dataset.hpp"
 #include "ComplexCore/Filters/ImportTextFilter.hpp"
 #include "ComplexCore/Filters/InitializeData.hpp"
+#include "ComplexCore/Filters/GenerateColorTableFilter.hpp"
 #include "ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp"
 #include "ComplexCore/Filters/IterativeClosestPointFilter.hpp"
 #include "ComplexCore/Filters/LaplacianSmoothingFilter.hpp"
@@ -117,6 +118,7 @@ namespace complex
     {complex::Uuid::FromString("5d586366-6b59-566e-8de1-57aa9ae8a91c").value(), complex::FilterTraits<FindSurfaceAreaToVolumeFilter>::uuid}, // FindSurfaceAreaToVolume
     {complex::Uuid::FromString("d2b0ae3d-686a-5dc0-a844-66bc0dc8f3cb").value(), complex::FilterTraits<FindSurfaceFeatures>::uuid}, // FindSurfaceFeatures
     {complex::Uuid::FromString("68246a67-7f32-5c80-815a-bec82008d7bc").value(), complex::FilterTraits<FindVolFractionsFilter>::uuid}, // FindVolFractions
+    {complex::Uuid::FromString("0d0a6535-6565-51c5-a3fc-fbc00008606d").value(), complex::FilterTraits<GenerateColorTableFilter>::uuid}, // GenerateColorTable
     {complex::Uuid::FromString("0e8c0818-a3fb-57d4-a5c8-7cb8ae54a40a").value(), complex::FilterTraits<IdentifySample>::uuid}, // IdentifySample
     {complex::Uuid::FromString("bdb978bc-96bf-5498-972c-b509c38b8d50").value(), complex::FilterTraits<ImportCSVDataFilter>::uuid}, // ReadASCIIData
     {complex::Uuid::FromString("043cbde5-3878-5718-958f-ae75714df0df").value(), complex::FilterTraits<ImportDREAM3DFilter>::uuid}, // DataContainerReader

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/GenerateColorTable.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/GenerateColorTable.cpp
@@ -11,7 +11,7 @@ using namespace complex;
 namespace
 {
 // -----------------------------------------------------------------------------
-usize findRightBinIndex(float32 nValue, std::vector<float32> binPoints)
+usize FindRightBinIndex(float32 nValue, std::vector<float32> binPoints)
 {
   usize min = 0;
   usize max = binPoints.size() - 1;
@@ -38,11 +38,11 @@ template <typename T>
 class GenerateColorTableImpl
 {
 public:
-  GenerateColorTableImpl(const DataArray<T>& arrayPtr, std::vector<float32> binPoints, std::vector<std::vector<float64>> controlPoints, int numControlColors, UInt8Array& colorArray)
+  GenerateColorTableImpl(const DataArray<T>& arrayPtr, const std::vector<float32>& binPoints, const std::vector<std::vector<float64>>& controlPoints, int numControlColors, UInt8Array& colorArray)
   : m_ArrayPtr(arrayPtr)
-  , m_BinPoints(std::move(binPoints))
+  , m_BinPoints(binPoints)
   , m_NumControlColors(numControlColors)
-  , m_ControlPoints(std::move(controlPoints))
+  , m_ControlPoints(controlPoints)
   , m_ColorArray(colorArray)
   , m_ArrayMin(arrayPtr[0])
   , m_ArrayMax(arrayPtr[0])
@@ -73,7 +73,7 @@ public:
       // Normalize value
       const float32 nValue = (static_cast<float32>(m_ArrayPtr[i] - m_ArrayMin)) / static_cast<float32>((m_ArrayMax - m_ArrayMin));
 
-      int rightBinIndex = findRightBinIndex(nValue, m_BinPoints);
+      int rightBinIndex = FindRightBinIndex(nValue, m_BinPoints);
 
       int leftBinIndex = rightBinIndex - 1;
       if(leftBinIndex < 0)
@@ -119,17 +119,17 @@ public:
 
 private:
   const DataArray<T>& m_ArrayPtr;
-  std::vector<float32> m_BinPoints;
+  const std::vector<float32>& m_BinPoints;
   T m_ArrayMin;
   T m_ArrayMax;
   int m_NumControlColors;
-  std::vector<std::vector<float64>> m_ControlPoints;
+  const std::vector<std::vector<float64>>& m_ControlPoints;
   UInt8Array& m_ColorArray;
 };
 
 // -----------------------------------------------------------------------------
 template <typename T>
-void generateColorArray(const DataArray<T>& arrayPtr, const nlohmann::json& presetControlPoints, const DataPath& rgbArrayPath, DataStructure& dataStructure)
+void GenerateColorArray(const DataArray<T>& arrayPtr, const nlohmann::json& presetControlPoints, const DataPath& rgbArrayPath, DataStructure& dataStructure)
 {
   if(arrayPtr.getNumberOfTuples() <= 0)
   {
@@ -201,57 +201,57 @@ Result<> GenerateColorTable::operator()()
   {
   case DataType::int8: {
     const auto& selectedDataArray = m_DataStructure.getDataRefAs<Int8Array>(m_InputValues->SelectedDataArrayPath);
-    generateColorArray<int8>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    GenerateColorArray<int8>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
     break;
   }
   case DataType::int16: {
     const auto& selectedDataArray = m_DataStructure.getDataRefAs<Int16Array>(m_InputValues->SelectedDataArrayPath);
-    generateColorArray<int16>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    GenerateColorArray<int16>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
     break;
   }
   case DataType::int32: {
     const auto& selectedDataArray = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->SelectedDataArrayPath);
-    generateColorArray<int32>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    GenerateColorArray<int32>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
     break;
   }
   case DataType::int64: {
     const auto& selectedDataArray = m_DataStructure.getDataRefAs<Int64Array>(m_InputValues->SelectedDataArrayPath);
-    generateColorArray<int64>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    GenerateColorArray<int64>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
     break;
   }
   case DataType::uint8: {
     const auto& selectedDataArray = m_DataStructure.getDataRefAs<UInt8Array>(m_InputValues->SelectedDataArrayPath);
-    generateColorArray<uint8>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    GenerateColorArray<uint8>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
     break;
   }
   case DataType::uint16: {
     const auto& selectedDataArray = m_DataStructure.getDataRefAs<UInt16Array>(m_InputValues->SelectedDataArrayPath);
-    generateColorArray<uint16>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    GenerateColorArray<uint16>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
     break;
   }
   case DataType::uint32: {
     const auto& selectedDataArray = m_DataStructure.getDataRefAs<UInt32Array>(m_InputValues->SelectedDataArrayPath);
-    generateColorArray<uint32>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    GenerateColorArray<uint32>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
     break;
   }
   case DataType::uint64: {
     const auto& selectedDataArray = m_DataStructure.getDataRefAs<UInt64Array>(m_InputValues->SelectedDataArrayPath);
-    generateColorArray<uint64>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    GenerateColorArray<uint64>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
     break;
   }
   case DataType::float32: {
     const auto& selectedDataArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->SelectedDataArrayPath);
-    generateColorArray<float32>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    GenerateColorArray<float32>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
     break;
   }
   case DataType::float64: {
     const auto& selectedDataArray = m_DataStructure.getDataRefAs<Float64Array>(m_InputValues->SelectedDataArrayPath);
-    generateColorArray<float64>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    GenerateColorArray<float64>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
     break;
   }
   case DataType::boolean: {
     const auto& selectedDataArray = m_DataStructure.getDataRefAs<BoolArray>(m_InputValues->SelectedDataArrayPath);
-    generateColorArray<bool>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    GenerateColorArray<bool>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
     break;
   }
   default:

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/GenerateColorTable.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/GenerateColorTable.cpp
@@ -11,22 +11,7 @@ using namespace complex;
 namespace
 {
 // -----------------------------------------------------------------------------
-template <typename T>
-int findRightBinIndex(T nValue, std::vector<float32> binPoints)
-{
-  /* This is a brute-force way of finding the proper bins.
-     We will need to change this method to a binary search. */
-  int rightBinIndex = 0;
-  while(binPoints[rightBinIndex] < nValue)
-  {
-    rightBinIndex++;
-  }
-
-  return rightBinIndex;
-}
-
-// -----------------------------------------------------------------------------
-usize findRightBinIndex_Binary(float32 nValue, std::vector<float32> binPoints)
+usize findRightBinIndex(float32 nValue, std::vector<float32> binPoints)
 {
   usize min = 0;
   usize max = binPoints.size() - 1;
@@ -88,7 +73,7 @@ public:
       // Normalize value
       const float32 nValue = (static_cast<float32>(m_ArrayPtr[i] - m_ArrayMin)) / static_cast<float32>((m_ArrayMax - m_ArrayMin));
 
-      int rightBinIndex = findRightBinIndex_Binary(nValue, m_BinPoints);
+      int rightBinIndex = findRightBinIndex(nValue, m_BinPoints);
 
       int leftBinIndex = rightBinIndex - 1;
       if(leftBinIndex < 0)
@@ -144,7 +129,7 @@ private:
 
 // -----------------------------------------------------------------------------
 template <typename T>
-void generateColorArray(const DataArray<T>& arrayPtr, const nlohmann::json& presetControlPoints, const DataPath &rgbArrayPath, DataStructure& dataStructure)
+void generateColorArray(const DataArray<T>& arrayPtr, const nlohmann::json& presetControlPoints, const DataPath& rgbArrayPath, DataStructure& dataStructure)
 {
   if(arrayPtr.getNumberOfTuples() <= 0)
   {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/GenerateColorTable.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/GenerateColorTable.cpp
@@ -101,14 +101,14 @@ public:
       }
 
       // Calculate the RGB values
-      const unsigned char r = (m_ControlPoints[leftBinIndex][1] * (1.0 - currFraction) + m_ControlPoints[rightBinIndex][1] * currFraction) * 255;
-      const unsigned char g = (m_ControlPoints[leftBinIndex][2] * (1.0 - currFraction) + m_ControlPoints[rightBinIndex][2] * currFraction) * 255;
-      const unsigned char b = (m_ControlPoints[leftBinIndex][3] * (1.0 - currFraction) + m_ControlPoints[rightBinIndex][3] * currFraction) * 255;
+      const unsigned char redVal = (m_ControlPoints[leftBinIndex][1] * (1.0 - currFraction) + m_ControlPoints[rightBinIndex][1] * currFraction) * 255;
+      const unsigned char greenVal = (m_ControlPoints[leftBinIndex][2] * (1.0 - currFraction) + m_ControlPoints[rightBinIndex][2] * currFraction) * 255;
+      const unsigned char blueVal = (m_ControlPoints[leftBinIndex][3] * (1.0 - currFraction) + m_ControlPoints[rightBinIndex][3] * currFraction) * 255;
 
       auto& colorArrayDS = m_ColorArray.getDataStoreRef();
-      colorArrayDS.setComponent(i, 0, r);
-      colorArrayDS.setComponent(i, 1, g);
-      colorArrayDS.setComponent(i, 2, b);
+      colorArrayDS.setComponent(i, 0, redVal);
+      colorArrayDS.setComponent(i, 1, greenVal);
+      colorArrayDS.setComponent(i, 2, blueVal);
     }
   }
 
@@ -176,11 +176,11 @@ void generateColorArray(const DataArray<T>& arrayPtr, const nlohmann::json& pres
 } // namespace
 
 // -----------------------------------------------------------------------------
-GenerateColorTable::GenerateColorTable(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, GenerateColorTableInputValues* inputValues)
+GenerateColorTable::GenerateColorTable(DataStructure& dataStructure, const IFilter::MessageHandler& msgHandler, const std::atomic_bool& shouldCancel, GenerateColorTableInputValues* inputValues)
 : m_DataStructure(dataStructure)
 , m_InputValues(inputValues)
 , m_ShouldCancel(shouldCancel)
-, m_MessageHandler(mesgHandler)
+, m_MessageHandler(msgHandler)
 {
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/GenerateColorTable.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/GenerateColorTable.cpp
@@ -1,0 +1,277 @@
+#include "GenerateColorTable.hpp"
+
+#include "nlohmann/json.hpp"
+
+#include "complex/DataStructure/DataArray.hpp"
+#include "complex/DataStructure/DataGroup.hpp"
+#include "complex/Utilities/ParallelDataAlgorithm.hpp"
+
+using namespace complex;
+
+namespace
+{
+// -----------------------------------------------------------------------------
+template <typename T>
+int findRightBinIndex(T nValue, std::vector<float32> binPoints)
+{
+  /* This is a brute-force way of finding the proper bins.
+     We will need to change this method to a binary search. */
+  int rightBinIndex = 0;
+  while(binPoints[rightBinIndex] < nValue)
+  {
+    rightBinIndex++;
+  }
+
+  return rightBinIndex;
+}
+
+// -----------------------------------------------------------------------------
+usize findRightBinIndex_Binary(float32 nValue, std::vector<float32> binPoints)
+{
+  usize min = 0;
+  usize max = binPoints.size() - 1;
+  while(min < max)
+  {
+    const usize middle = (min + max) / 2;
+    if(nValue > binPoints[middle])
+    {
+      min = middle + 1;
+    }
+    else
+    {
+      max = middle;
+    }
+  }
+  return min;
+}
+
+/**
+ * @brief The GenerateColorTableImpl class implements a threaded algorithm that computes the RGB values
+ * for each element in a given array of data
+ */
+template <typename T>
+class GenerateColorTableImpl
+{
+public:
+  GenerateColorTableImpl(const DataArray<T>& arrayPtr, std::vector<float32> binPoints, std::vector<std::vector<float64>> controlPoints, int numControlColors, UInt8Array& colorArray)
+  : m_ArrayPtr(arrayPtr)
+  , m_BinPoints(std::move(binPoints))
+  , m_NumControlColors(numControlColors)
+  , m_ControlPoints(std::move(controlPoints))
+  , m_ColorArray(colorArray)
+  , m_ArrayMin(arrayPtr[0])
+  , m_ArrayMax(arrayPtr[0])
+  {
+    for(int i = 1; i < arrayPtr.getNumberOfTuples(); i++)
+    {
+      if(arrayPtr[i] < m_ArrayMin)
+      {
+        m_ArrayMin = arrayPtr[i];
+      }
+      if(arrayPtr[i] > m_ArrayMax)
+      {
+        m_ArrayMax = arrayPtr[i];
+      }
+    }
+  }
+  virtual ~GenerateColorTableImpl() = default;
+
+  GenerateColorTableImpl(const GenerateColorTableImpl&) = default;
+  GenerateColorTableImpl(GenerateColorTableImpl&&) noexcept = delete;
+  GenerateColorTableImpl& operator=(const GenerateColorTableImpl&) = delete;
+  GenerateColorTableImpl& operator=(GenerateColorTableImpl&&) noexcept = delete;
+
+  void convert(size_t start, size_t end) const
+  {
+    for(size_t i = start; i < end; i++)
+    {
+      // Normalize value
+      const float32 nValue = (static_cast<float32>(m_ArrayPtr[i] - m_ArrayMin)) / static_cast<float32>((m_ArrayMax - m_ArrayMin));
+
+      int rightBinIndex = findRightBinIndex_Binary(nValue, m_BinPoints);
+
+      int leftBinIndex = rightBinIndex - 1;
+      if(leftBinIndex < 0)
+      {
+        leftBinIndex = 0;
+        rightBinIndex = 1;
+      }
+
+      // Find the fractional distance traveled between the beginning and end of the current color bin
+      float32 currFraction = 0.0f;
+      if(rightBinIndex < m_BinPoints.size())
+      {
+        currFraction = (nValue - m_BinPoints[leftBinIndex]) / (m_BinPoints[rightBinIndex] - m_BinPoints[leftBinIndex]);
+      }
+      else
+      {
+        currFraction = (nValue - m_BinPoints[leftBinIndex]) / (1 - m_BinPoints[leftBinIndex]);
+      }
+
+      // If the current color bin index is larger than the total number of control colors, automatically set the currentBinIndex
+      // to the last control color.
+      if(leftBinIndex > m_NumControlColors - 1)
+      {
+        leftBinIndex = m_NumControlColors - 1;
+      }
+
+      // Calculate the RGB values
+      const unsigned char r = (m_ControlPoints[leftBinIndex][1] * (1.0 - currFraction) + m_ControlPoints[rightBinIndex][1] * currFraction) * 255;
+      const unsigned char g = (m_ControlPoints[leftBinIndex][2] * (1.0 - currFraction) + m_ControlPoints[rightBinIndex][2] * currFraction) * 255;
+      const unsigned char b = (m_ControlPoints[leftBinIndex][3] * (1.0 - currFraction) + m_ControlPoints[rightBinIndex][3] * currFraction) * 255;
+
+      auto& colorArrayDS = m_ColorArray.getDataStoreRef();
+      colorArrayDS.setComponent(i, 0, r);
+      colorArrayDS.setComponent(i, 1, g);
+      colorArrayDS.setComponent(i, 2, b);
+    }
+  }
+
+  void operator()(const Range& range) const
+  {
+    convert(range.min(), range.max());
+  }
+
+private:
+  const DataArray<T>& m_ArrayPtr;
+  std::vector<float32> m_BinPoints;
+  T m_ArrayMin;
+  T m_ArrayMax;
+  int m_NumControlColors;
+  std::vector<std::vector<float64>> m_ControlPoints;
+  UInt8Array& m_ColorArray;
+};
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void generateColorArray(const DataArray<T>& arrayPtr, const nlohmann::json& presetControlPoints, const DataPath &rgbArrayPath, DataStructure& dataStructure)
+{
+  if(arrayPtr.getNumberOfTuples() <= 0)
+  {
+    return;
+  }
+
+  if(presetControlPoints.empty())
+  {
+    return;
+  }
+
+  const usize numControlColors = presetControlPoints.size() / 4;
+  const usize numComponents = 4;
+  std::vector<std::vector<float64>> controlPoints(numControlColors, std::vector<float64>(numComponents));
+
+  // Migrate colorControlPoints values from QJsonArray to 2D array.  Store A-values in binPoints vector.
+  std::vector<float32> binPoints;
+  for(usize i = 0; i < numControlColors; i++)
+  {
+    for(usize j = 0; j < numComponents; j++)
+    {
+      controlPoints[i][j] = static_cast<float32>(presetControlPoints[numComponents * i + j].get<float64>());
+      if(j == 0)
+      {
+        binPoints.push_back(static_cast<float32>(controlPoints[i][j]));
+      }
+    }
+  }
+
+  // Normalize binPoints values
+  const float32 binMin = binPoints[0];
+  const float32 binMax = binPoints[binPoints.size() - 1];
+  for(auto& binPoint : binPoints)
+  {
+    binPoint = (binPoint - binMin) / (binMax - binMin);
+  }
+
+  auto& colorArray = dataStructure.getDataRefAs<UInt8Array>(rgbArrayPath);
+
+  ParallelDataAlgorithm dataAlg;
+  dataAlg.setRange(0, arrayPtr.getNumberOfTuples());
+  dataAlg.execute(GenerateColorTableImpl(arrayPtr, binPoints, controlPoints, numControlColors, colorArray));
+}
+} // namespace
+
+// -----------------------------------------------------------------------------
+GenerateColorTable::GenerateColorTable(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, GenerateColorTableInputValues* inputValues)
+: m_DataStructure(dataStructure)
+, m_InputValues(inputValues)
+, m_ShouldCancel(shouldCancel)
+, m_MessageHandler(mesgHandler)
+{
+}
+
+// -----------------------------------------------------------------------------
+GenerateColorTable::~GenerateColorTable() noexcept = default;
+
+// -----------------------------------------------------------------------------
+const std::atomic_bool& GenerateColorTable::getCancel()
+{
+  return m_ShouldCancel;
+}
+
+// -----------------------------------------------------------------------------
+Result<> GenerateColorTable::operator()()
+{
+  const IDataArray& selectedIDataArray = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->SelectedDataArrayPath);
+  switch(selectedIDataArray.getDataType())
+  {
+  case DataType::int8: {
+    const auto& selectedDataArray = m_DataStructure.getDataRefAs<Int8Array>(m_InputValues->SelectedDataArrayPath);
+    generateColorArray<int8>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    break;
+  }
+  case DataType::int16: {
+    const auto& selectedDataArray = m_DataStructure.getDataRefAs<Int16Array>(m_InputValues->SelectedDataArrayPath);
+    generateColorArray<int16>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    break;
+  }
+  case DataType::int32: {
+    const auto& selectedDataArray = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->SelectedDataArrayPath);
+    generateColorArray<int32>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    break;
+  }
+  case DataType::int64: {
+    const auto& selectedDataArray = m_DataStructure.getDataRefAs<Int64Array>(m_InputValues->SelectedDataArrayPath);
+    generateColorArray<int64>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    break;
+  }
+  case DataType::uint8: {
+    const auto& selectedDataArray = m_DataStructure.getDataRefAs<UInt8Array>(m_InputValues->SelectedDataArrayPath);
+    generateColorArray<uint8>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    break;
+  }
+  case DataType::uint16: {
+    const auto& selectedDataArray = m_DataStructure.getDataRefAs<UInt16Array>(m_InputValues->SelectedDataArrayPath);
+    generateColorArray<uint16>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    break;
+  }
+  case DataType::uint32: {
+    const auto& selectedDataArray = m_DataStructure.getDataRefAs<UInt32Array>(m_InputValues->SelectedDataArrayPath);
+    generateColorArray<uint32>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    break;
+  }
+  case DataType::uint64: {
+    const auto& selectedDataArray = m_DataStructure.getDataRefAs<UInt64Array>(m_InputValues->SelectedDataArrayPath);
+    generateColorArray<uint64>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    break;
+  }
+  case DataType::float32: {
+    const auto& selectedDataArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->SelectedDataArrayPath);
+    generateColorArray<float32>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    break;
+  }
+  case DataType::float64: {
+    const auto& selectedDataArray = m_DataStructure.getDataRefAs<Float64Array>(m_InputValues->SelectedDataArrayPath);
+    generateColorArray<float64>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    break;
+  }
+  case DataType::boolean: {
+    const auto& selectedDataArray = m_DataStructure.getDataRefAs<BoolArray>(m_InputValues->SelectedDataArrayPath);
+    generateColorArray<bool>(selectedDataArray, m_InputValues->SelectedPreset["RGBPoints"], m_InputValues->RgbArrayPath, m_DataStructure);
+    break;
+  }
+  default:
+    return MakeErrorResult(-10000, fmt::format("The selected array '{}' does not have a compatible data type.", m_InputValues->SelectedDataArrayPath.toString()));
+  }
+
+  return {};
+}

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/GenerateColorTable.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/GenerateColorTable.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "ComplexCore/ComplexCore_export.hpp"
+
+#include "complex/DataStructure/DataPath.hpp"
+#include "complex/DataStructure/DataStructure.hpp"
+#include "complex/Filter/IFilter.hpp"
+#include "complex/Parameters/ArrayCreationParameter.hpp"
+#include "complex/Parameters/ArraySelectionParameter.hpp"
+#include "complex/Parameters/GenerateColorTableParameter.hpp"
+
+/**
+* This is example code to put in the Execute Method of the filter.
+  GenerateColorTableInputValues inputValues;
+
+  inputValues.SelectedPresetName = filterArgs.value<<<<NOT_IMPLEMENTED>>>>(k_SelectedPresetName_Key);
+  inputValues.SelectedDataArrayPath = filterArgs.value<DataPath>(k_SelectedDataArrayPath_Key);
+  inputValues.RgbArrayName = filterArgs.value<DataPath>(k_RgbArrayName_Key);
+
+  return GenerateColorTable(dataStructure, messageHandler, shouldCancel, &inputValues)();
+*/
+
+namespace complex
+{
+
+struct COMPLEXCORE_EXPORT GenerateColorTableInputValues
+{
+  nlohmann::json SelectedPreset;
+  DataPath SelectedDataArrayPath;
+  DataPath RgbArrayPath;
+};
+
+/**
+ * @class ConditionalSetValue
+ * @brief This filter replaces values in the target array with a user specified value
+ * where a bool mask array specifies.
+ */
+
+class COMPLEXCORE_EXPORT GenerateColorTable
+{
+public:
+  GenerateColorTable(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, GenerateColorTableInputValues* inputValues);
+  ~GenerateColorTable() noexcept;
+
+  GenerateColorTable(const GenerateColorTable&) = delete;
+  GenerateColorTable(GenerateColorTable&&) noexcept = delete;
+  GenerateColorTable& operator=(const GenerateColorTable&) = delete;
+  GenerateColorTable& operator=(GenerateColorTable&&) noexcept = delete;
+
+  Result<> operator()();
+
+  const std::atomic_bool& getCancel();
+
+private:
+  DataStructure& m_DataStructure;
+  const GenerateColorTableInputValues* m_InputValues = nullptr;
+  const std::atomic_bool& m_ShouldCancel;
+  const IFilter::MessageHandler& m_MessageHandler;
+};
+
+} // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/GenerateColorTable.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/GenerateColorTable.hpp
@@ -9,17 +9,6 @@
 #include "complex/Parameters/ArraySelectionParameter.hpp"
 #include "complex/Parameters/GenerateColorTableParameter.hpp"
 
-/**
-* This is example code to put in the Execute Method of the filter.
-  GenerateColorTableInputValues inputValues;
-
-  inputValues.SelectedPresetName = filterArgs.value<<<<NOT_IMPLEMENTED>>>>(k_SelectedPresetName_Key);
-  inputValues.SelectedDataArrayPath = filterArgs.value<DataPath>(k_SelectedDataArrayPath_Key);
-  inputValues.RgbArrayName = filterArgs.value<DataPath>(k_RgbArrayName_Key);
-
-  return GenerateColorTable(dataStructure, messageHandler, shouldCancel, &inputValues)();
-*/
-
 namespace complex
 {
 
@@ -29,12 +18,6 @@ struct COMPLEXCORE_EXPORT GenerateColorTableInputValues
   DataPath SelectedDataArrayPath;
   DataPath RgbArrayPath;
 };
-
-/**
- * @class ConditionalSetValue
- * @brief This filter replaces values in the target array with a user specified value
- * where a bool mask array specifies.
- */
 
 class COMPLEXCORE_EXPORT GenerateColorTable
 {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/GenerateColorTable.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/GenerateColorTable.hpp
@@ -22,7 +22,7 @@ struct COMPLEXCORE_EXPORT GenerateColorTableInputValues
 class COMPLEXCORE_EXPORT GenerateColorTable
 {
 public:
-  GenerateColorTable(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, GenerateColorTableInputValues* inputValues);
+  GenerateColorTable(DataStructure& dataStructure, const IFilter::MessageHandler& msgHandler, const std::atomic_bool& shouldCancel, GenerateColorTableInputValues* inputValues);
   ~GenerateColorTable() noexcept;
 
   GenerateColorTable(const GenerateColorTable&) = delete;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
@@ -50,7 +50,8 @@ Parameters GenerateColorTableFilter::parameters() const
 
   // Create the parameter descriptors that are needed for this filter
   params.insert(std::make_unique<GenerateColorTableParameter>(k_SelectedPreset_Key, "Select Preset...", "", ""));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_SelectedDataArrayPath_Key, "Data Array", "", DataPath{}, complex::GetAllDataTypes() /* This will allow ANY data type. Adjust as necessary for your filter*/));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_SelectedDataArrayPath_Key, "Data Array", "", DataPath{},
+                                                          complex::GetAllDataTypes() /* This will allow ANY data type. Adjust as necessary for your filter*/));
   params.insert(std::make_unique<ArrayCreationParameter>(k_RgbArrayPath_Key, "Output RGB Array", "", DataPath{}));
 
   return params;
@@ -63,7 +64,8 @@ IFilter::UniquePointer GenerateColorTableFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult GenerateColorTableFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult GenerateColorTableFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
+                                                                 const std::atomic_bool& shouldCancel) const
 {
   auto pSelectedPresetValue = filterArgs.value<nlohmann::json>(k_SelectedPreset_Key);
   auto pSelectedDataArrayPathValue = filterArgs.value<DataPath>(k_SelectedDataArrayPath_Key);
@@ -80,7 +82,8 @@ IFilter::PreflightResult GenerateColorTableFilter::preflightImpl(const DataStruc
 }
 
 //------------------------------------------------------------------------------
-Result<> GenerateColorTableFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+Result<> GenerateColorTableFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                                               const std::atomic_bool& shouldCancel) const
 {
   GenerateColorTableInputValues inputValues;
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
@@ -50,11 +50,13 @@ Parameters GenerateColorTableFilter::parameters() const
 
   // Create the parameter descriptors that are needed for this filter
   params.insertSeparator({"Input Parameters"});
-  params.insert(std::make_unique<GenerateColorTableParameter>(k_SelectedPreset_Key, "Select Preset...", "", ""));
+  params.insert(
+      std::make_unique<GenerateColorTableParameter>(k_SelectedPreset_Key, "Select Preset...", "Select the color preset that will be used to create the color table array.", nlohmann::json{}));
   params.insertSeparator({"Required Data Objects"});
-  params.insert(std::make_unique<ArraySelectionParameter>(k_SelectedDataArrayPath_Key, "Data Array", "", DataPath{}, complex::GetAllDataTypes(), ArraySelectionParameter::AllowedComponentShapes{{1}}));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_SelectedDataArrayPath_Key, "Data Array", "The data array that will be used to create the color table array.", DataPath{},
+                                                          complex::GetAllDataTypes(), ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insertSeparator({"Created Data Objects"});
-  params.insert(std::make_unique<ArrayCreationParameter>(k_RgbArrayPath_Key, "Output RGB Array", "", DataPath{}));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_RgbArrayPath_Key, "Output RGB Array", "The output color table array.", DataPath{}));
 
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
@@ -50,8 +50,7 @@ Parameters GenerateColorTableFilter::parameters() const
 
   // Create the parameter descriptors that are needed for this filter
   params.insert(std::make_unique<GenerateColorTableParameter>(k_SelectedPreset_Key, "Select Preset...", "", ""));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_SelectedDataArrayPath_Key, "Data Array", "", DataPath{},
-                                                          complex::GetAllDataTypes() /* This will allow ANY data type. Adjust as necessary for your filter*/));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_SelectedDataArrayPath_Key, "Data Array", "", DataPath{}, complex::GetAllDataTypes(), ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insert(std::make_unique<ArrayCreationParameter>(k_RgbArrayPath_Key, "Output RGB Array", "", DataPath{}));
 
   return params;
@@ -74,7 +73,7 @@ IFilter::PreflightResult GenerateColorTableFilter::preflightImpl(const DataStruc
   complex::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  const IDataArray& dataArray = dataStructure.getDataRefAs<IDataArray>(pSelectedDataArrayPathValue);
+  const auto& dataArray = dataStructure.getDataRefAs<IDataArray>(pSelectedDataArrayPathValue);
   auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::uint8, dataArray.getTupleShape(), std::vector<usize>{3}, pRgbArrayPathValue);
   resultOutputActions.value().actions.push_back(std::move(createArrayAction));
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
@@ -1,0 +1,93 @@
+#include "GenerateColorTableFilter.hpp"
+
+#include "Algorithms/GenerateColorTable.hpp"
+
+#include "complex/DataStructure/DataPath.hpp"
+#include "complex/DataStructure/IDataArray.hpp"
+#include "complex/Filter/Actions/CreateArrayAction.hpp"
+#include "complex/Parameters/ArrayCreationParameter.hpp"
+#include "complex/Parameters/ArraySelectionParameter.hpp"
+#include "complex/Parameters/GenerateColorTableParameter.hpp"
+
+using namespace complex;
+
+namespace complex
+{
+//------------------------------------------------------------------------------
+std::string GenerateColorTableFilter::name() const
+{
+  return FilterTraits<GenerateColorTableFilter>::name.str();
+}
+
+//------------------------------------------------------------------------------
+std::string GenerateColorTableFilter::className() const
+{
+  return FilterTraits<GenerateColorTableFilter>::className;
+}
+
+//------------------------------------------------------------------------------
+Uuid GenerateColorTableFilter::uuid() const
+{
+  return FilterTraits<GenerateColorTableFilter>::uuid;
+}
+
+//------------------------------------------------------------------------------
+std::string GenerateColorTableFilter::humanName() const
+{
+  return "Generate Color Table";
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> GenerateColorTableFilter::defaultTags() const
+{
+  return {"#Core", "#Image"};
+}
+
+//------------------------------------------------------------------------------
+Parameters GenerateColorTableFilter::parameters() const
+{
+  Parameters params;
+
+  // Create the parameter descriptors that are needed for this filter
+  params.insert(std::make_unique<GenerateColorTableParameter>(k_SelectedPreset_Key, "Select Preset...", "", ""));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_SelectedDataArrayPath_Key, "Data Array", "", DataPath{}, complex::GetAllDataTypes() /* This will allow ANY data type. Adjust as necessary for your filter*/));
+  params.insert(std::make_unique<ArrayCreationParameter>(k_RgbArrayPath_Key, "Output RGB Array", "", DataPath{}));
+
+  return params;
+}
+
+//------------------------------------------------------------------------------
+IFilter::UniquePointer GenerateColorTableFilter::clone() const
+{
+  return std::make_unique<GenerateColorTableFilter>();
+}
+
+//------------------------------------------------------------------------------
+IFilter::PreflightResult GenerateColorTableFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+{
+  auto pSelectedPresetValue = filterArgs.value<nlohmann::json>(k_SelectedPreset_Key);
+  auto pSelectedDataArrayPathValue = filterArgs.value<DataPath>(k_SelectedDataArrayPath_Key);
+  auto pRgbArrayPathValue = filterArgs.value<DataPath>(k_RgbArrayPath_Key);
+
+  complex::Result<OutputActions> resultOutputActions;
+  std::vector<PreflightValue> preflightUpdatedValues;
+
+  const IDataArray& dataArray = dataStructure.getDataRefAs<IDataArray>(pSelectedDataArrayPathValue);
+  auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::uint8, dataArray.getTupleShape(), std::vector<usize>{3}, pRgbArrayPathValue);
+  resultOutputActions.value().actions.push_back(std::move(createArrayAction));
+
+  return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
+}
+
+//------------------------------------------------------------------------------
+Result<> GenerateColorTableFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+{
+  GenerateColorTableInputValues inputValues;
+
+  inputValues.SelectedPreset = filterArgs.value<nlohmann::json>(k_SelectedPreset_Key);
+  inputValues.SelectedDataArrayPath = filterArgs.value<DataPath>(k_SelectedDataArrayPath_Key);
+  inputValues.RgbArrayPath = filterArgs.value<DataPath>(k_RgbArrayPath_Key);
+
+  return GenerateColorTable(dataStructure, messageHandler, shouldCancel, &inputValues)();
+}
+} // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
@@ -50,13 +50,14 @@ Parameters GenerateColorTableFilter::parameters() const
 
   // Create the parameter descriptors that are needed for this filter
   params.insertSeparator({"Input Parameters"});
-  params.insert(
-      std::make_unique<GenerateColorTableParameter>(k_SelectedPreset_Key, "Select Preset...", "Select the color preset that will be used to create the color table array.", nlohmann::json{}));
+  params.insert(std::make_unique<GenerateColorTableParameter>(k_SelectedPreset_Key, "Select Preset...", "Select a preset color scheme to apply to the created array", nlohmann::json{}));
   params.insertSeparator({"Required Data Objects"});
-  params.insert(std::make_unique<ArraySelectionParameter>(k_SelectedDataArrayPath_Key, "Data Array", "The data array that will be used to create the color table array.", DataPath{},
+  params.insert(std::make_unique<ArraySelectionParameter>(k_SelectedDataArrayPath_Key, "Data Array",
+                                                          "The complete path to the data array from which to create the rgb array by applying the selected preset color scheme", DataPath{},
                                                           complex::GetAllDataTypes(), ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insertSeparator({"Created Data Objects"});
-  params.insert(std::make_unique<ArrayCreationParameter>(k_RgbArrayPath_Key, "Output RGB Array", "The output color table array.", DataPath{}));
+  params.insert(std::make_unique<ArrayCreationParameter>(
+      k_RgbArrayPath_Key, "Output RGB Array", "The rgb array created by normalizing each element of the input array and converting to a color based on the selected preset color scheme", DataPath{}));
 
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
@@ -49,8 +49,11 @@ Parameters GenerateColorTableFilter::parameters() const
   Parameters params;
 
   // Create the parameter descriptors that are needed for this filter
+  params.insertSeparator({"Input Parameters"});
   params.insert(std::make_unique<GenerateColorTableParameter>(k_SelectedPreset_Key, "Select Preset...", "", ""));
+  params.insertSeparator({"Required Data Objects"});
   params.insert(std::make_unique<ArraySelectionParameter>(k_SelectedDataArrayPath_Key, "Data Array", "", DataPath{}, complex::GetAllDataTypes(), ArraySelectionParameter::AllowedComponentShapes{{1}}));
+  params.insertSeparator({"Created Data Objects"});
   params.insert(std::make_unique<ArrayCreationParameter>(k_RgbArrayPath_Key, "Output RGB Array", "", DataPath{}));
 
   return params;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.hpp
@@ -90,8 +90,7 @@ protected:
    * @param messageHandler The MessageHandler object
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure & data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel)
-      const override;
+  Result<> executeImpl(DataStructure& data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace complex
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.hpp
@@ -9,7 +9,9 @@ namespace complex
 {
 /**
  * @class GenerateColorTableFilter
- * @brief This filter will ....
+ * @brief This filter generates a color table array for a given 1-component input array.
+ * Each element of the input array is normalized and converted to a color based on where
+ * the value falls in the spectrum of the selected color preset.
  */
 class COMPLEXCORE_EXPORT GenerateColorTableFilter : public IFilter
 {
@@ -75,12 +77,12 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& ds, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "ComplexCore/ComplexCore_export.hpp"
+
+#include "complex/Filter/FilterTraits.hpp"
+#include "complex/Filter/IFilter.hpp"
+
+namespace complex
+{
+/**
+ * @class GenerateColorTableFilter
+ * @brief This filter will ....
+ */
+class COMPLEXCORE_EXPORT GenerateColorTableFilter : public IFilter
+{
+public:
+  GenerateColorTableFilter() = default;
+  ~GenerateColorTableFilter() noexcept override = default;
+
+  GenerateColorTableFilter(const GenerateColorTableFilter&) = delete;
+  GenerateColorTableFilter(GenerateColorTableFilter&&) noexcept = delete;
+
+  GenerateColorTableFilter& operator=(const GenerateColorTableFilter&) = delete;
+  GenerateColorTableFilter& operator=(GenerateColorTableFilter&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_SelectedPreset_Key = "selected_preset";
+  static inline constexpr StringLiteral k_SelectedDataArrayPath_Key = "selected_data_array_path";
+  static inline constexpr StringLiteral k_RgbArrayPath_Key = "rgb_array_path";
+
+  /**
+   * @brief Returns the name of the filter.
+   * @return
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the C++ classname of this filter.
+   * @return
+   */
+  std::string className() const override;
+
+  /**
+   * @brief Returns the uuid of the filter.
+   * @return
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief Returns the human readable name of the filter.
+   * @return
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
+   * @brief Returns the parameters of the filter (i.e. its inputs)
+   * @return
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief Returns a copy of the filter.
+   * @return
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param ds The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  PreflightResult preflightImpl(const DataStructure& ds, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+
+  /**
+   * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
+   * On failure, there is no guarantee that the DataStructure is in a correct state.
+   * @param ds The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  Result<> executeImpl(DataStructure & data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel)
+      const override;
+};
+} // namespace complex
+
+COMPLEX_DEF_FILTER_TRAITS(complex, GenerateColorTableFilter, "d1731177-4d70-41c0-9334-566a0b482796");

--- a/src/Plugins/ComplexCore/test/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/test/CMakeLists.txt
@@ -51,6 +51,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   FindTriangleGeomCentroidsTest.cpp
   FindTriangleGeomSizesTest.cpp
   FindVolFractionsTest.cpp
+  GenerateColorTableTest.cpp
   IdentifySampleTest.cpp
   ImageGeomTest.cpp
   ImportCSVDataTest.cpp
@@ -152,5 +153,7 @@ if(EXISTS "${DREAM3D_DATA_DIR}" AND COMPLEX_DOWNLOAD_TEST_FILES)
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR} ARCHIVE_NAME so3_cubic_high_ipf_001.tar.gz SHA512 dfe4598cd4406e8b83f244302dc4fe0d4367527835c5ddd6567fe8d8ab3484d5b10ba24a8bb31db269256ec0b5272daa4340eedb5a8b397755541b32dd616b85)  
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR} ARCHIVE_NAME 6_6_fill_bad_data.tar.gz SHA512 6898d38754e80def4b8459227a4a9f99b67baaf6a72210c50ef8e98e1cc131b10da2f8793e807d9883c6949de6aa72f71fe65df89ddc0b39cca1d550191b6c45)
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR} ARCHIVE_NAME PartitionGeometryTest.tar.gz SHA512 8074dbcff86ed206d9185065a56258b766eb24367b3481e8600e9b48542de23dbd715ef8f9eca1c9718ca5e05a9c48997f613bde6f4357b8bba206241caecbbd)
+  download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR} ARCHIVE_NAME GenerateColorTableTest.tar.gz SHA512 2b660e327f730f868dd5ccf0bc39509d731b53011c755eda64f21cc2f28ff5a5c0c1b933666e2bca49b46cfb05d03ad3b9380d338bc2794cd562aef4e7480274)  
+
 endif()
 

--- a/src/Plugins/ComplexCore/test/GenerateColorTableTest.cpp
+++ b/src/Plugins/ComplexCore/test/GenerateColorTableTest.cpp
@@ -1,0 +1,215 @@
+#include <catch2/catch.hpp>
+
+#include "complex/Parameters/ArrayCreationParameter.hpp"
+#include "complex/UnitTest/UnitTestCommon.hpp"
+#include "complex/Utilities/ColorPresetsUtilities.hpp"
+#include "complex/Utilities/StringUtilities.hpp"
+
+#include "ComplexCore/ComplexCore_test_dirs.hpp"
+#include "ComplexCore/Filters/GenerateColorTableFilter.hpp"
+#include "ComplexCore/Filters/ImportTextFilter.hpp"
+
+namespace fs = std::filesystem;
+using namespace complex;
+
+namespace
+{
+const fs::path k_TestFilesDir = fs::path(complex::unit_test::k_DREAM3DDataDir.str()) / "TestFiles" / "GenerateColorTableTest";
+const fs::path k_PresetsFilePath = k_TestFilesDir / "ColorTablePresets.json";
+const fs::path k_InputImageFilePath = k_TestFilesDir / "ColorTableTestFile.txt";
+
+const fs::path k_BlackBlueWhitePresetPath = k_TestFilesDir / "BlackBlueWhite.txt";
+const fs::path k_BlackOrangeWhitePresetPath = k_TestFilesDir / "BlackOrangeWhite.txt";
+const fs::path k_BlackBodyRadiationPresetPath = k_TestFilesDir / "BlackBodyRadiation.txt";
+const fs::path k_BlueToYellowPresetPath = k_TestFilesDir / "BlueToYellow.txt";
+const fs::path k_ColdAndHotPresetPath = k_TestFilesDir / "ColdAndHot.txt";
+const fs::path k_GrayscalePresetPath = k_TestFilesDir / "Grayscale.txt";
+const fs::path k_HazePresetPath = k_TestFilesDir / "Haze.txt";
+const fs::path k_HSVPresetPath = k_TestFilesDir / "Hsv.txt";
+const fs::path k_JetPresetPath = k_TestFilesDir / "Jet.txt";
+const fs::path k_RainbowBlendedBlackPresetPath = k_TestFilesDir / "RainbowBlendedBlack.txt";
+const fs::path k_RainbowBlendedGreyPresetPath = k_TestFilesDir / "RainbowBlendedGrey.txt";
+const fs::path k_RainbowBlendedWhitePresetPath = k_TestFilesDir / "RainbowBlendedWhite.txt";
+const fs::path k_RainbowDesaturatedPresetPath = k_TestFilesDir / "RainbowDesaturated.txt";
+const fs::path k_RainbowPresetPath = k_TestFilesDir / "Rainbow.txt";
+const fs::path k_XRayPresetPath = k_TestFilesDir / "XRay.txt";
+
+const std::string k_BlackBlueWhitePresetName = "Black, Blue and White";
+const std::string k_BlackOrangeWhitePresetName = "Black, Orange and White";
+const std::string k_BlackBodyRadiationPresetName = "Black-Body Radiation";
+const std::string k_BlueToYellowPresetName = "Blue to Yellow";
+const std::string k_ColdAndHotPresetName = "Cold and Hot";
+const std::string k_GrayscalePresetName = "Grayscale";
+const std::string k_HazePresetName = "Haze";
+const std::string k_HSVPresetName = "hsv";
+const std::string k_JetPresetName = "jet";
+const std::string k_RainbowBlendedBlackPresetName = "Rainbow Blended Black";
+const std::string k_RainbowBlendedGreyPresetName = "Rainbow Blended Grey";
+const std::string k_RainbowBlendedWhitePresetName = "Rainbow Blended White";
+const std::string k_RainbowDesaturatedPresetName = "Rainbow Desaturated";
+const std::string k_RainbowPresetName = "rainbow";
+const std::string k_XRayPresetName = "X Ray";
+
+std::map<std::string, nlohmann::json> readPresets()
+{
+  Result<nlohmann::json> result = readRGBPresets(k_PresetsFilePath);
+  COMPLEX_RESULT_REQUIRE_VALID(result)
+
+  std::map<std::string, nlohmann::json> presetsMap;
+  for(const nlohmann::json& preset : result.value())
+  {
+    if(preset.contains("Name") && preset.contains("RGBPoints") && preset["Name"].is_string())
+    {
+      presetsMap.insert({preset["Name"].get<std::string>(), preset});
+    }
+  }
+
+  return presetsMap;
+}
+} // namespace
+
+TEST_CASE("Plugins::GenerateColorTableFilter: Valid filter execution")
+{
+  DataStructure dataStructure;
+
+  std::map<std::string, nlohmann::json> presetsMap = readPresets();
+
+  // Read Image File
+  {
+    const ImportTextFilter filter;
+    Arguments args;
+
+    args.insertOrAssign(ImportTextFilter::k_InputFileKey, std::make_any<fs::path>(k_InputImageFilePath));
+    args.insertOrAssign(ImportTextFilter::k_ScalarTypeKey, std::make_any<NumericType>(NumericType::float32));
+    args.insertOrAssign(ImportTextFilter::k_NCompKey, std::make_any<uint64>(1));
+    args.insertOrAssign(ImportTextFilter::k_NTuplesKey, std::make_any<uint64>(37989));
+    args.insertOrAssign(ImportTextFilter::k_DataArrayKey, std::make_any<DataPath>(DataPath{{Constants::k_Confidence_Index.str()}}));
+
+    IFilter::ExecuteResult executeResult = filter.execute(dataStructure, args);
+    COMPLEX_RESULT_REQUIRE_VALID(executeResult.result);
+  }
+
+  // Apply Preset
+  const GenerateColorTableFilter filter;
+  Arguments args;
+  fs::path presetFilePath;
+
+  SECTION(k_BlackBlueWhitePresetName)
+  {
+    REQUIRE(!presetsMap[k_BlackBlueWhitePresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_BlackBlueWhitePresetName]));
+    presetFilePath = k_BlackBlueWhitePresetPath;
+  }
+  SECTION(k_BlackOrangeWhitePresetName)
+  {
+    REQUIRE(!presetsMap[k_BlackOrangeWhitePresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_BlackOrangeWhitePresetName]));
+    presetFilePath = k_BlackOrangeWhitePresetPath;
+  }
+  SECTION(k_BlackBodyRadiationPresetName)
+  {
+    REQUIRE(!presetsMap[k_BlackBodyRadiationPresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_BlackBodyRadiationPresetName]));
+    presetFilePath = k_BlackBodyRadiationPresetPath;
+  }
+  SECTION(k_BlueToYellowPresetName)
+  {
+    REQUIRE(!presetsMap[k_BlueToYellowPresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_BlueToYellowPresetName]));
+    presetFilePath = k_BlueToYellowPresetPath;
+  }
+  SECTION(k_ColdAndHotPresetName)
+  {
+    REQUIRE(!presetsMap[k_ColdAndHotPresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_ColdAndHotPresetName]));
+    presetFilePath = k_ColdAndHotPresetPath;
+  }
+  SECTION(k_GrayscalePresetName)
+  {
+    REQUIRE(!presetsMap[k_GrayscalePresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_GrayscalePresetName]));
+    presetFilePath = k_GrayscalePresetPath;
+  }
+  SECTION(k_HazePresetName)
+  {
+    REQUIRE(!presetsMap[k_HazePresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_HazePresetName]));
+    presetFilePath = k_HazePresetPath;
+  }
+  SECTION(k_HSVPresetName)
+  {
+    REQUIRE(!presetsMap[k_HSVPresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_HSVPresetName]));
+    presetFilePath = k_HSVPresetPath;
+  }
+  SECTION(k_JetPresetName)
+  {
+    REQUIRE(!presetsMap[k_JetPresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_JetPresetName]));
+    presetFilePath = k_JetPresetPath;
+  }
+  SECTION(k_RainbowBlendedBlackPresetName)
+  {
+    REQUIRE(!presetsMap[k_RainbowBlendedBlackPresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_RainbowBlendedBlackPresetName]));
+    presetFilePath = k_RainbowBlendedBlackPresetPath;
+  }
+  SECTION(k_RainbowBlendedGreyPresetName)
+  {
+    REQUIRE(!presetsMap[k_RainbowBlendedGreyPresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_RainbowBlendedGreyPresetName]));
+    presetFilePath = k_RainbowBlendedGreyPresetPath;
+  }
+  SECTION(k_RainbowBlendedWhitePresetName)
+  {
+    REQUIRE(!presetsMap[k_RainbowBlendedWhitePresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_RainbowBlendedWhitePresetName]));
+    presetFilePath = k_RainbowBlendedWhitePresetPath;
+  }
+  SECTION(k_RainbowDesaturatedPresetName)
+  {
+    REQUIRE(!presetsMap[k_RainbowDesaturatedPresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_RainbowDesaturatedPresetName]));
+    presetFilePath = k_RainbowDesaturatedPresetPath;
+  }
+  SECTION(k_RainbowPresetName)
+  {
+    REQUIRE(!presetsMap[k_RainbowPresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_RainbowPresetName]));
+    presetFilePath = k_RainbowPresetPath;
+  }
+  SECTION(k_XRayPresetName)
+  {
+    REQUIRE(!presetsMap[k_XRayPresetName].empty());
+    args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(presetsMap[k_XRayPresetName]));
+    presetFilePath = k_XRayPresetPath;
+  }
+
+  args.insertOrAssign(GenerateColorTableFilter::k_SelectedDataArrayPath_Key, std::make_any<DataPath>(DataPath{{Constants::k_Confidence_Index.str()}}));
+  args.insertOrAssign(GenerateColorTableFilter::k_RgbArrayPath_Key, std::make_any<DataPath>(DataPath{{"CI_RGB"}}));
+
+  IFilter::ExecuteResult executeResult = filter.execute(dataStructure, args);
+  COMPLEX_RESULT_REQUIRE_VALID(executeResult.result);
+
+  // Validate Results
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<UInt8Array>(DataPath{{"CI_RGB"}}));
+  const UInt8Array& resultArray = dataStructure.getDataRefAs<UInt8Array>(DataPath{{"CI_RGB"}});
+  const AbstractDataStore<uint8>& resultStore = resultArray.getDataStoreRef();
+
+  std::string buf;
+  std::ifstream inStream(presetFilePath);
+  usize currentLine = 0;
+  while(!inStream.eof())
+  {
+    std::getline(inStream, buf);
+    std::vector<std::string> list = StringUtilities::split(buf, ',');
+    for(int i = 0; i < list.size(); i++)
+    {
+      REQUIRE_NOTHROW(std::stoi(list[i]));
+      const uint8 exemplar = std::stoi(list[i]);
+      const uint8 generated = resultStore.getComponentValue(currentLine, i);
+      REQUIRE(exemplar == generated);
+    }
+    currentLine++;
+  }
+}

--- a/src/Plugins/ComplexCore/test/GenerateColorTableTest.cpp
+++ b/src/Plugins/ComplexCore/test/GenerateColorTableTest.cpp
@@ -50,7 +50,7 @@ const std::string k_RainbowDesaturatedPresetName = "Rainbow Desaturated";
 const std::string k_RainbowPresetName = "rainbow";
 const std::string k_XRayPresetName = "X Ray";
 
-std::map<std::string, nlohmann::json> readPresets()
+std::map<std::string, nlohmann::json> ReadPresets()
 {
   Result<nlohmann::json> result = readRGBPresets(k_PresetsFilePath);
   COMPLEX_RESULT_REQUIRE_VALID(result);
@@ -68,11 +68,28 @@ std::map<std::string, nlohmann::json> readPresets()
 }
 } // namespace
 
+TEST_CASE("Plugins::GenerateColorTableFilter: Filter Instantiation")
+{
+  const GenerateColorTableFilter filter;
+  Arguments args;
+  DataStructure dataStructure;
+
+  args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(nlohmann::json{}));
+  args.insertOrAssign(GenerateColorTableFilter::k_SelectedDataArrayPath_Key, std::make_any<DataPath>(DataPath{}));
+  args.insertOrAssign(GenerateColorTableFilter::k_RgbArrayPath_Key, std::make_any<DataPath>(DataPath{}));
+
+  auto preflightResult = filter.preflight(dataStructure, args);
+  COMPLEX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+
+  auto executeResult = filter.execute(dataStructure, args);
+  COMPLEX_RESULT_REQUIRE_INVALID(executeResult.result);
+}
+
 TEST_CASE("Plugins::GenerateColorTableFilter: Valid filter execution")
 {
   DataStructure dataStructure;
 
-  std::map<std::string, nlohmann::json> presetsMap = readPresets();
+  std::map<std::string, nlohmann::json> presetsMap = ReadPresets();
 
   // Read Image File
   {

--- a/src/Plugins/ComplexCore/test/GenerateColorTableTest.cpp
+++ b/src/Plugins/ComplexCore/test/GenerateColorTableTest.cpp
@@ -68,23 +68,6 @@ std::map<std::string, nlohmann::json> ReadPresets()
 }
 } // namespace
 
-TEST_CASE("Plugins::GenerateColorTableFilter: Filter Instantiation")
-{
-  const GenerateColorTableFilter filter;
-  Arguments args;
-  DataStructure dataStructure;
-
-  args.insertOrAssign(GenerateColorTableFilter::k_SelectedPreset_Key, std::make_any<nlohmann::json>(nlohmann::json{}));
-  args.insertOrAssign(GenerateColorTableFilter::k_SelectedDataArrayPath_Key, std::make_any<DataPath>(DataPath{}));
-  args.insertOrAssign(GenerateColorTableFilter::k_RgbArrayPath_Key, std::make_any<DataPath>(DataPath{}));
-
-  auto preflightResult = filter.preflight(dataStructure, args);
-  COMPLEX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
-
-  auto executeResult = filter.execute(dataStructure, args);
-  COMPLEX_RESULT_REQUIRE_INVALID(executeResult.result);
-}
-
 TEST_CASE("Plugins::GenerateColorTableFilter: Valid filter execution")
 {
   DataStructure dataStructure;

--- a/src/Plugins/ComplexCore/test/GenerateColorTableTest.cpp
+++ b/src/Plugins/ComplexCore/test/GenerateColorTableTest.cpp
@@ -53,7 +53,7 @@ const std::string k_XRayPresetName = "X Ray";
 std::map<std::string, nlohmann::json> readPresets()
 {
   Result<nlohmann::json> result = readRGBPresets(k_PresetsFilePath);
-  COMPLEX_RESULT_REQUIRE_VALID(result)
+  COMPLEX_RESULT_REQUIRE_VALID(result);
 
   std::map<std::string, nlohmann::json> presetsMap;
   for(const nlohmann::json& preset : result.value())

--- a/src/complex/Parameters/GenerateColorTableParameter.cpp
+++ b/src/complex/Parameters/GenerateColorTableParameter.cpp
@@ -33,12 +33,12 @@ nlohmann::json GenerateColorTableParameter::toJson(const std::any& value) const
 Result<std::any> GenerateColorTableParameter::fromJson(const nlohmann::json& json) const
 {
   static constexpr StringLiteral prefix = "FilterParameter 'GenerateColorTableParameter' JSON Error: ";
-  if(!json.is_object())
+  if(!json.empty() && !json.is_object())
   {
     return MakeErrorResult<std::any>(-2, fmt::format("{}JSON value for key '{}' is not an object", prefix, name()));
   }
 
-  return {{nonstd::make_unexpected(std::make_any<nlohmann::json>(json))}};
+  return {std::make_any<nlohmann::json>(json)};
 }
 
 IParameter::UniquePointer GenerateColorTableParameter::clone() const

--- a/src/complex/Parameters/GenerateColorTableParameter.cpp
+++ b/src/complex/Parameters/GenerateColorTableParameter.cpp
@@ -6,8 +6,6 @@
 
 #include "complex/Common/Any.hpp"
 
-#include <type_traits>
-
 namespace complex
 {
 GenerateColorTableParameter::GenerateColorTableParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue)
@@ -39,7 +37,8 @@ Result<std::any> GenerateColorTableParameter::fromJson(const nlohmann::json& jso
   {
     return MakeErrorResult<std::any>(-2, fmt::format("{}JSON value for key '{}' is not an object", prefix, name()));
   }
-  return {{json}};
+
+  return {{nonstd::make_unexpected(std::make_any<nlohmann::json>(json))}};
 }
 
 IParameter::UniquePointer GenerateColorTableParameter::clone() const

--- a/src/complex/Parameters/GenerateColorTableParameter.cpp
+++ b/src/complex/Parameters/GenerateColorTableParameter.cpp
@@ -1,0 +1,63 @@
+#include "GenerateColorTableParameter.hpp"
+
+#include <fmt/core.h>
+
+#include <nlohmann/json.hpp>
+
+#include "complex/Common/Any.hpp"
+
+namespace complex
+{
+GenerateColorTableParameter::GenerateColorTableParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue)
+: ValueParameter(name, humanName, helpText)
+, m_DefaultValue(defaultValue)
+{
+}
+
+Uuid GenerateColorTableParameter::uuid() const
+{
+  return ParameterTraits<GenerateColorTableParameter>::uuid;
+}
+
+IParameter::AcceptedTypes GenerateColorTableParameter::acceptedTypes() const
+{
+  return {typeid(ValueType)};
+}
+
+nlohmann::json GenerateColorTableParameter::toJson(const std::any& value) const
+{
+  const auto& json = GetAnyRef<ValueType>(value);
+  return json;
+}
+
+Result<std::any> GenerateColorTableParameter::fromJson(const nlohmann::json& json) const
+{
+  static constexpr StringLiteral prefix = "FilterParameter 'GenerateColorTableParameter' JSON Error: ";
+  if(!json.is_object())
+  {
+    return MakeErrorResult<std::any>(-2, fmt::format("{}JSON value for key '{}' is not an object", prefix, name()));
+  }
+  return {{json}};
+}
+
+IParameter::UniquePointer GenerateColorTableParameter::clone() const
+{
+  return std::make_unique<GenerateColorTableParameter>(name(), humanName(), helpText(), m_DefaultValue);
+}
+
+std::any GenerateColorTableParameter::defaultValue() const
+{
+  return defaultJson();
+}
+
+typename GenerateColorTableParameter::ValueType GenerateColorTableParameter::defaultJson() const
+{
+  return m_DefaultValue;
+}
+
+Result<> GenerateColorTableParameter::validate(const std::any& value) const
+{
+  [[maybe_unused]] const auto& json = GetAnyRef<ValueType>(value);
+  return {};
+}
+} // namespace complex

--- a/src/complex/Parameters/GenerateColorTableParameter.cpp
+++ b/src/complex/Parameters/GenerateColorTableParameter.cpp
@@ -58,7 +58,14 @@ typename GenerateColorTableParameter::ValueType GenerateColorTableParameter::def
 
 Result<> GenerateColorTableParameter::validate(const std::any& value) const
 {
-  [[maybe_unused]] const auto& json = GetAnyRef<ValueType>(value);
+  try
+  {
+    [[maybe_unused]] const auto& json = GetAnyRef<ValueType>(value);
+  } catch(const std::bad_any_cast& exception)
+  {
+    return MakeErrorResult(-1000, fmt::format("FilterParameter '{}' Validation Error: {}", humanName(), exception.what()));
+  }
+  
   return {};
 }
 } // namespace complex

--- a/src/complex/Parameters/GenerateColorTableParameter.cpp
+++ b/src/complex/Parameters/GenerateColorTableParameter.cpp
@@ -65,7 +65,7 @@ Result<> GenerateColorTableParameter::validate(const std::any& value) const
   {
     return MakeErrorResult(-1000, fmt::format("FilterParameter '{}' Validation Error: {}", humanName(), exception.what()));
   }
-  
+
   return {};
 }
 } // namespace complex

--- a/src/complex/Parameters/GenerateColorTableParameter.cpp
+++ b/src/complex/Parameters/GenerateColorTableParameter.cpp
@@ -6,6 +6,8 @@
 
 #include "complex/Common/Any.hpp"
 
+#include <type_traits>
+
 namespace complex
 {
 GenerateColorTableParameter::GenerateColorTableParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue)

--- a/src/complex/Parameters/GenerateColorTableParameter.cpp
+++ b/src/complex/Parameters/GenerateColorTableParameter.cpp
@@ -38,7 +38,7 @@ Result<std::any> GenerateColorTableParameter::fromJson(const nlohmann::json& jso
     return MakeErrorResult<std::any>(-2, fmt::format("{}JSON value for key '{}' is not an object", prefix, name()));
   }
 
-  return {std::make_any<nlohmann::json>(json)};
+  return {{std::make_any<nlohmann::json>(json)}};
 }
 
 IParameter::UniquePointer GenerateColorTableParameter::clone() const
@@ -58,14 +58,7 @@ typename GenerateColorTableParameter::ValueType GenerateColorTableParameter::def
 
 Result<> GenerateColorTableParameter::validate(const std::any& value) const
 {
-  try
-  {
-    [[maybe_unused]] const auto& json = GetAnyRef<ValueType>(value);
-  } catch(const std::bad_any_cast& exception)
-  {
-    return MakeErrorResult(-1000, fmt::format("FilterParameter '{}' Validation Error: {}", humanName(), exception.what()));
-  }
-
+  [[maybe_unused]] const auto& json = GetAnyRef<ValueType>(value);
   return {};
 }
 } // namespace complex

--- a/src/complex/Parameters/GenerateColorTableParameter.hpp
+++ b/src/complex/Parameters/GenerateColorTableParameter.hpp
@@ -10,6 +10,10 @@
 
 namespace complex
 {
+/**
+ * @brief This FilterParameter represents a color preset, and works specifically
+ * with the GenerateColorTable filter. The data is held in an nlohmann::json object.
+ */
 class COMPLEX_EXPORT GenerateColorTableParameter : public ValueParameter
 {
 public:

--- a/src/complex/Parameters/GenerateColorTableParameter.hpp
+++ b/src/complex/Parameters/GenerateColorTableParameter.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <string>
+
+#include "complex/Filter/ParameterTraits.hpp"
+#include "complex/Filter/ValueParameter.hpp"
+#include "complex/complex_export.hpp"
+
+#include "nlohmann/json.hpp"
+
+namespace complex
+{
+class COMPLEX_EXPORT GenerateColorTableParameter : public ValueParameter
+{
+public:
+  using ValueType = nlohmann::json;
+
+  GenerateColorTableParameter() = delete;
+  GenerateColorTableParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue);
+  ~GenerateColorTableParameter() override = default;
+
+  GenerateColorTableParameter(const GenerateColorTableParameter&) = delete;
+  GenerateColorTableParameter(GenerateColorTableParameter&&) noexcept = delete;
+
+  GenerateColorTableParameter& operator=(const GenerateColorTableParameter&) = delete;
+  GenerateColorTableParameter& operator=(GenerateColorTableParameter&&) noexcept = delete;
+
+  /**
+   * @brief
+   * @return
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief
+   * @return
+   */
+  AcceptedTypes acceptedTypes() const override;
+
+  /**
+   * @brief
+   * @param value
+   */
+  nlohmann::json toJson(const std::any& value) const override;
+
+  /**
+   * @brief
+   * @return
+   */
+  Result<std::any> fromJson(const nlohmann::json& json) const override;
+
+  /**
+   * @brief
+   * @return
+   */
+  UniquePointer clone() const override;
+
+  /**
+   * @brief
+   * @return
+   */
+  std::any defaultValue() const override;
+
+  /**
+   * @brief
+   * @return
+   */
+  ValueType defaultJson() const;
+
+  /**
+   * @brief
+   * @param value
+   * @return
+   */
+  Result<> validate(const std::any& value) const override;
+
+private:
+  ValueType m_DefaultValue = {};
+};
+} // namespace complex
+
+COMPLEX_DEF_PARAMETER_TRAITS(complex::GenerateColorTableParameter, "7b0e5b25-564e-4797-b154-4324ef276bf0");

--- a/src/complex/Utilities/ColorPresetsUtilities.hpp
+++ b/src/complex/Utilities/ColorPresetsUtilities.hpp
@@ -2,10 +2,10 @@
 
 #include "complex/Common/Result.hpp"
 
+#include "nlohmann/json.hpp"
 #include <fmt/format.h>
 #include <fstream>
 #include <sstream>
-#include "nlohmann/json.hpp"
 
 namespace fs = std::filesystem;
 
@@ -41,7 +41,7 @@ Result<nlohmann::json> readRGBPresets(const std::string& presetsJson)
 // Description:
 // Reads the RGB presets using the path to the presets JSON file.
 // -----------------------------------------------------------------------------
-Result<nlohmann::json> readRGBPresets(const fs::path &presetsFilePath)
+Result<nlohmann::json> readRGBPresets(const fs::path& presetsFilePath)
 {
   const std::ifstream iStream(presetsFilePath.string());
   std::stringstream buffer;

--- a/src/complex/Utilities/ColorPresetsUtilities.hpp
+++ b/src/complex/Utilities/ColorPresetsUtilities.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "complex/Common/Result.hpp"
+
+#include <fmt/format.h>
+#include <fstream>
+#include <sstream>
+#include "nlohmann/json.hpp"
+
+namespace fs = std::filesystem;
+
+namespace complex
+{
+// Description:
+// Reads the RGB presets using a JSON string.
+// -----------------------------------------------------------------------------
+Result<nlohmann::json> readRGBPresets(const std::string& presetsJson)
+{
+  nlohmann::json allPresets;
+  try
+  {
+    allPresets = nlohmann::json::parse(presetsJson);
+  } catch(nlohmann::json::parse_error& exception)
+  {
+    // "Failed to parse presets file" error
+    return MakeErrorResult<nlohmann::json>(-1000, fmt::format("Failed to parse presets json string: {}", exception.what()));
+  }
+
+  nlohmann::json rgbPresets;
+  for(const auto& preset : allPresets)
+  {
+    if(preset.contains("ColorSpace") && preset["ColorSpace"] == "RGB")
+    {
+      rgbPresets.push_back(preset);
+    }
+  }
+
+  return {rgbPresets};
+}
+
+// Description:
+// Reads the RGB presets using the path to the presets JSON file.
+// -----------------------------------------------------------------------------
+Result<nlohmann::json> readRGBPresets(const fs::path &presetsFilePath)
+{
+  const std::ifstream iStream(presetsFilePath.string());
+  std::stringstream buffer;
+  buffer << iStream.rdbuf();
+  return readRGBPresets(buffer.str());
+}
+} // namespace complex


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files.

- [x] Class and Structs are `UpperCamelCase`
- [x] Class private member variables are `m_UpperCamelCase`
- [x] Class methods are `lowerCamelCase`
- [x] Method arguments are `lowerCamelCase`
- [x] Normal variables are `lowerCamelCase`
- [x] Constants are `k_UpperCamelCase`
- [x] Global statics are `s_UpperCamelCase`
- [x] Free Functions are `UpperCamelCase`
- [x] Macros are `ALL_UPPER_SNAKE_CASE`
- [x] Unit test will test data output from the filter.
- [x] Reused strings should be constants in an anonymous namespace
- [x] If parallelization is used, proper use of the abstracted complex classes are used. Using TBB specifically in a filter should be frowned upon unless for a really good reason.

## Filter Checklist

- [x] Parameters should be generally broken down into "Input Parameters", "Required Data Objects", "Created Data Objects". There can be exceptions to this.
- [x] ChoicesParameter selections should be an enumeration defined in the filer header
- [x] Documentation copied from SIMPL Repo and updated (if necessary)
- [x] Parameter argument variables are k_CamelCase_Key
- [x] Parameter argument strings are lower_snake_case
```
static inline constexpr StringLiteral k_AlignmentType_Key = "alignment_type";
```

## Unit Testing
- [x] 1 Unit test to instantiate the filter with the default arguments.
- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] Filters should have both the Filter class and Algorithm class for anything beyond trivial needs
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added Python wrapping to new files (if any) as necessary
- [ ] Added example pipelines that use the filter
- [x] Classes and methods are properly documented.


<!-- **Thanks for contributing to complex!** -->
