### PR TITLE
Added the /permissive- flag to msvc builds

### DIFF
--- a/cmake/Utility.cmake
+++ b/cmake/Utility.cmake
@@ -62,6 +62,8 @@ function(complex_enable_warnings)
         /we4457 # C4457: declaration of 'identifier' hides function parameter
         /we4458 # C4458: declaration of 'identifier' hides class member
         /we4459 # C4459: declaration of 'identifier' hides global declaration
+
+        /permissive- # Standards compliance
     )
   else()
 


### PR DESCRIPTION
Enforces greater standards compliance. See https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170 for details.