### PR TITLE
REPROC: Add option to disable the ExecuteProcess filter

### DIFF
--- a/src/Plugins/ComplexCore/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/CMakeLists.txt
@@ -31,7 +31,6 @@ set(FilterList
   CropImageGeometry
   CropVertexGeometry
   DeleteData
-  ExecuteProcessFilter
   ExportDREAM3DFilter
   ExtractComponentAsArrayFilter
   ExtractInternalSurfacesFromTriangleGeometry
@@ -99,7 +98,6 @@ set(AlgorithmList
   CombineAttributeArrays
   ConvertColorToGrayScale
   ConvertData
-  ExecuteProcess
   ExtractComponentAsArray
   ExtractVertexGeometry
   FillBadData
@@ -125,6 +123,14 @@ set(AlgorithmList
   TupleTransfer
 )
 
+
+option(COMPLEXCORE_ENABLE_REPROC "Compile the ExecuteProcess filter" OFF)
+
+if(COMPLEXCORE_ENABLE_REPROC)
+  set(FilterList ${FilterList} ExecuteProcessFilter)
+  set(AlgorithmList ${AlgorithmList} ExecuteProcess)
+endif()
+
 create_complex_plugin(NAME ${PLUGIN_NAME}
                       FILTER_LIST ${FilterList}
                       ACTION_LIST ${ActionList}
@@ -146,12 +152,14 @@ add_subdirectory(${${PLUGIN_NAME}_SOURCE_DIR}/test)
 # ------------------------------------------------------------------------------
 # The ExecuteProcess Filter requires the `reproc` library
 # ------------------------------------------------------------------------------
-find_package("reproc++" CONFIG REQUIRED)
+if(COMPLEXCORE_ENABLE_REPROC)
+  find_package("reproc++" CONFIG REQUIRED)
+  target_link_libraries(${PLUGIN_NAME} PRIVATE reproc++)
+endif()
 
 #------------------------------------------------------------------------------
 # If there are additional libraries that this plugin needs to link against you
 # can use the target_link_libraries() cmake call
-target_link_libraries(${PLUGIN_NAME} PRIVATE reproc++)
 
 #------------------------------------------------------------------------------
 # If there are additional source files that need to be compiled for this plugin

--- a/src/Plugins/ComplexCore/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/CMakeLists.txt
@@ -124,7 +124,7 @@ set(AlgorithmList
 )
 
 
-option(COMPLEXCORE_ENABLE_REPROC "Compile the ExecuteProcess filter" OFF)
+option(s "Compile the ExecuteProcess filter" OFF)
 
 if(COMPLEXCORE_ENABLE_REPROC)
   set(FilterList ${FilterList} ExecuteProcessFilter)
@@ -155,6 +155,7 @@ add_subdirectory(${${PLUGIN_NAME}_SOURCE_DIR}/test)
 if(COMPLEXCORE_ENABLE_REPROC)
   find_package("reproc++" CONFIG REQUIRED)
   target_link_libraries(${PLUGIN_NAME} PRIVATE reproc++)
+  target_compile_definitions(${PLUGIN_NAME} PUBLIC "COMPLEXCORE_ENABLE_REPROC")
 endif()
 
 #------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
@@ -70,7 +70,9 @@
 #include "ComplexCore/Filters/TriangleDihedralAngleFilter.hpp"
 #include "ComplexCore/Filters/TriangleNormalFilter.hpp"
 #include "ComplexCore/Filters/ExtractComponentAsArrayFilter.hpp"
+#ifdef COMPLEXCORE_ENABLE_REPROC
 #include "ComplexCore/Filters/ExecuteProcessFilter.hpp"
+#endif
 #include "ComplexCore/Filters/TriangleCentroidFilter.hpp"
 #include "ComplexCore/Filters/ResampleImageGeomFilter.hpp"
 #include "ComplexCore/Filters/RotateSampleRefFrameFilter.hpp"
@@ -153,7 +155,9 @@ namespace complex
     {complex::Uuid::FromString("8133d419-1919-4dbf-a5bf-1c97282ba63f").value(), complex::FilterTraits<TriangleNormalFilter>::uuid}, // TriangleNormalFilter
     {complex::Uuid::FromString("088ef69b-ca98-51a9-97ac-369862015d71").value(), complex::FilterTraits<CopyDataObjectFilter>::uuid}, // CopyObject
     {complex::Uuid::FromString("79d59b85-01e8-5c4a-a6e1-3fd3e2ceffb4").value(), complex::FilterTraits<ExtractComponentAsArrayFilter>::uuid}, // ExtractComponentAsArray
+#ifdef COMPLEXCORE_ENABLE_REPROC
     {complex::Uuid::FromString("8a2308ec-86cd-5636-9a0a-6c7d383e9e7f").value(), complex::FilterTraits<ExecuteProcessFilter>::uuid}, // ExecuteProcessFilter
+#endif
     {complex::Uuid::FromString("1b4b9941-62e4-52f2-9918-15d48147ab88").value(), complex::FilterTraits<ExtractComponentAsArrayFilter>::uuid}, // RemoveComponentFromArray
     {complex::Uuid::FromString("7aa33007-4186-5d7f-ba9d-d0a561b3351d").value(), complex::FilterTraits<TriangleCentroidFilter>::uuid}, // TriangleCentroid
     {complex::Uuid::FromString("1966e540-759c-5798-ae26-0c6a3abc65c0").value(), complex::FilterTraits<ResampleImageGeomFilter>::uuid}, // ResampleImageGeom

--- a/src/Plugins/ComplexCore/test/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/test/CMakeLists.txt
@@ -9,7 +9,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   CoreFilterTest.cpp
   DREAM3DFileTest.cpp
   PipelineTest.cpp
-  
+
   AlignGeometriesTest.cpp
   AlignSectionsListTest.cpp
   ApplyTransformationToGeometryFilterTest.cpp
@@ -33,7 +33,6 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   CropImageGeometryTest.cpp
   CropVertexGeometryTest.cpp
   DeleteDataTest.cpp
-  ExecuteProcessTest.cpp
   ExtractComponentAsArrayTest.cpp
   ExtractInternalSurfacesFromTriangleGeometryTest.cpp
   ExtractVertexGeometryTest.cpp
@@ -85,6 +84,10 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   WriteASCIIDataTest.cpp
   WriteBinaryDataTest.cpp
 )
+
+if(COMPLEXCORE_ENABLE_REPROC)
+  set(${PLUGIN_NAME}UnitTest_SRCS ${${PLUGIN_NAME}UnitTest_SRCS} ExecuteProcessTest.cpp)
+endif()
 
 create_complex_plugin_unit_test(PLUGIN_NAME ${PLUGIN_NAME}
   FILTER_LIST ${${PLUGIN_NAME}UnitTest_SRCS})


### PR DESCRIPTION
This allows the developer to disable the ExecuteProcess filter which disables the need for the reproc++ library.

There are real issues on all 3 platforms compiling against the reproc++ library.

Linux and MacOS: Since VCPKG does not work in any meaningful way we have to build using the NXSuperbuild. While the NXSuperbuild has been updated to build reproc++ there are configuration issues that those platforms are facing.
Windows with NXSuperbuild (VCPKG isn't used on the Azure self hosted build bots): There are link errors against the reproc library which I think are related to static/dynamic/multithreaded msvc runtime libraries.