### PR TITLE
BUG: Fix filter default tags

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/LaplacianSmoothing.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/LaplacianSmoothing.cpp
@@ -214,7 +214,7 @@ void LaplacianSmoothing::writeVTKFile(const QString& outputVtkFile)
   }
   Detail::ScopedFileMonitor vtkFileMonitor(vtkFile);
 
-  fprintf(vtkFile, " vtk DataFile Version 2.0\n");
+  fprintf(vtkFile, "# vtk DataFile Version 2.0\n");
   fprintf(vtkFile, "Data set from DREAM.3D Surface Meshing Module\n");
   if (m_WriteBinaryFile)
   {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/LaplacianSmoothing.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/LaplacianSmoothing.cpp
@@ -214,7 +214,7 @@ void LaplacianSmoothing::writeVTKFile(const QString& outputVtkFile)
   }
   Detail::ScopedFileMonitor vtkFileMonitor(vtkFile);
 
-  fprintf(vtkFile, "# vtk DataFile Version 2.0\n");
+  fprintf(vtkFile, " vtk DataFile Version 2.0\n");
   fprintf(vtkFile, "Data set from DREAM.3D Surface Meshing Module\n");
   if (m_WriteBinaryFile)
   {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignGeometries.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignGeometries.cpp
@@ -369,26 +369,37 @@ void translateGeometry(IGeometry& geometry, const FloatVec3& translation)
 namespace complex
 {
 
+//------------------------------------------------------------------------------
 std::string AlignGeometries::name() const
 {
   return FilterTraits<AlignGeometries>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string AlignGeometries::className() const
 {
   return FilterTraits<AlignGeometries>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid AlignGeometries::uuid() const
 {
   return FilterTraits<AlignGeometries>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string AlignGeometries::humanName() const
 {
   return "Align Geometries";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> AlignGeometries::defaultTags() const
+{
+  return {"#Match", "#Align", "#Geometry", "#Move"};
+}
+
+//------------------------------------------------------------------------------
 Parameters AlignGeometries::parameters() const
 {
   GeometrySelectionParameter::AllowedTypes geomTypes = IGeometry::GetAllGeomTypes();
@@ -402,11 +413,13 @@ Parameters AlignGeometries::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer AlignGeometries::clone() const
 {
   return std::make_unique<AlignGeometries>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult AlignGeometries::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                         const std::atomic_bool& shouldCancel) const
 {
@@ -427,6 +440,7 @@ IFilter::PreflightResult AlignGeometries::preflightImpl(const DataStructure& dat
   return {std::move(actions)};
 }
 
+//------------------------------------------------------------------------------
 Result<> AlignGeometries::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto movingGeometryPath = args.value<DataPath>(k_MovingGeometry_Key);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignGeometries.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignGeometries.cpp
@@ -396,7 +396,7 @@ std::string AlignGeometries::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> AlignGeometries::defaultTags() const
 {
-  return {"#Match", "#Align", "#Geometry", "#Move"};
+  return {"Match","Align","Geometry","Move"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignGeometries.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignGeometries.cpp
@@ -396,7 +396,7 @@ std::string AlignGeometries::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> AlignGeometries::defaultTags() const
 {
-  return {"Match","Align","Geometry","Move"};
+  return {"Match", "Align", "Geometry", "Move"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignGeometries.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignGeometries.hpp
@@ -50,6 +50,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsFeatureCentroidFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsFeatureCentroidFilter.cpp
@@ -56,7 +56,7 @@ std::string AlignSectionsFeatureCentroidFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> AlignSectionsFeatureCentroidFilter::defaultTags() const
 {
-  return {"#Reconstruction", "#Alignment"};
+  return {"Reconstruction","Alignment"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsFeatureCentroidFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsFeatureCentroidFilter.cpp
@@ -56,7 +56,7 @@ std::string AlignSectionsFeatureCentroidFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> AlignSectionsFeatureCentroidFilter::defaultTags() const
 {
-  return {"Reconstruction","Alignment"};
+  return {"Reconstruction", "Alignment"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsListFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsListFilter.cpp
@@ -43,7 +43,7 @@ std::string AlignSectionsListFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> AlignSectionsListFilter::defaultTags() const
 {
-  return {"Reconstruction","Alignment"};
+  return {"Reconstruction", "Alignment"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsListFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsListFilter.cpp
@@ -43,7 +43,7 @@ std::string AlignSectionsListFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> AlignSectionsListFilter::defaultTags() const
 {
-  return {"#Reconstruction", "#Alignment"};
+  return {"Reconstruction","Alignment"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApplyTransformationToGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApplyTransformationToGeometryFilter.cpp
@@ -122,7 +122,7 @@ std::string ApplyTransformationToGeometryFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ApplyTransformationToGeometryFilter::defaultTags() const
 {
-  return {"#ComplexCore", "Rotation", "Transforming"};
+  return {"ComplexCore", "Rotation", "Transforming"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.cpp
@@ -24,26 +24,37 @@ bool validNeighbor(const SizeVec3& dims, int64 neighborhood[78], usize index, in
 }
 } // namespace
 
+//------------------------------------------------------------------------------
 std::string ApproximatePointCloudHull::name() const
 {
   return FilterTraits<ApproximatePointCloudHull>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string ApproximatePointCloudHull::className() const
 {
   return FilterTraits<ApproximatePointCloudHull>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid ApproximatePointCloudHull::uuid() const
 {
   return FilterTraits<ApproximatePointCloudHull>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string ApproximatePointCloudHull::humanName() const
 {
   return "Approximate Point Cloud Hull";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> ApproximatePointCloudHull::defaultTags() const
+{
+  return {"#Point Cloud", "#Grid", "#Vertex Geometry", "#Geometry", "#Hull"};
+}
+
+//------------------------------------------------------------------------------
 Parameters ApproximatePointCloudHull::parameters() const
 {
   Parameters params;
@@ -51,16 +62,22 @@ Parameters ApproximatePointCloudHull::parameters() const
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
   params.insert(std::make_unique<VectorFloat32Parameter>(k_GridResolution_Key, "Grid Resolution", "Geometry resolution", std::vector<float32>{0, 0, 0}, std::vector<std::string>{"X", "Y", "Z"}));
   params.insert(std::make_unique<UInt64Parameter>(k_MinEmptyNeighbors_Key, "Minimum Number of Empty Neighbors", "Minimum number of empty neighbors", 0));
+
+  params.insertSeparator(Parameters::Separator{"Required Geometry"});
   params.insert(std::make_unique<DataPathSelectionParameter>(k_VertexGeomPath_Key, "Vertex Geometry", "Path to the target Vertex geometry", DataPath()));
+
+  params.insertSeparator(Parameters::Separator{"Created Geometry"});
   params.insert(std::make_unique<DataGroupCreationParameter>(k_HullVertexGeomPath_Key, "Hull Vertex Geometry", "Path to create the hull Vertex geometry", DataPath{}));
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer ApproximatePointCloudHull::clone() const
 {
   return std::make_unique<ApproximatePointCloudHull>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult ApproximatePointCloudHull::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto gridResolution = args.value<std::vector<float32>>(k_GridResolution_Key);
@@ -91,6 +108,7 @@ IFilter::PreflightResult ApproximatePointCloudHull::preflightImpl(const DataStru
   return {std::move(actions)};
 }
 
+//------------------------------------------------------------------------------
 Result<> ApproximatePointCloudHull::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                                 const std::atomic_bool& shouldCancel) const
 {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.cpp
@@ -51,7 +51,7 @@ std::string ApproximatePointCloudHull::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ApproximatePointCloudHull::defaultTags() const
 {
-  return {"#Point Cloud", "#Grid", "#Vertex Geometry", "#Geometry", "#Hull"};
+  return {"Point Cloud","Grid", "Vertex Geometry", "Geometry", "Hull"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.cpp
@@ -51,7 +51,7 @@ std::string ApproximatePointCloudHull::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ApproximatePointCloudHull::defaultTags() const
 {
-  return {"Point Cloud","Grid", "Vertex Geometry", "Geometry", "Hull"};
+  return {"Point Cloud", "Grid", "Vertex Geometry", "Geometry", "Hull"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApproximatePointCloudHull.hpp
@@ -55,6 +55,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief Returns a copy of the filter's parameters.
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ArrayCalculatorFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ArrayCalculatorFilter.cpp
@@ -42,7 +42,7 @@ std::string ArrayCalculatorFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ArrayCalculatorFilter::defaultTags() const
 {
-  return {"#Core", "#Generation"};
+  return {"Core","Generation"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ArrayCalculatorFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ArrayCalculatorFilter.cpp
@@ -42,7 +42,7 @@ std::string ArrayCalculatorFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ArrayCalculatorFilter::defaultTags() const
 {
-  return {"Core","Generation"};
+  return {"Core", "Generation"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateArrayHistogramFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateArrayHistogramFilter.cpp
@@ -41,7 +41,7 @@ std::string CalculateArrayHistogramFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CalculateArrayHistogramFilter::defaultTags() const
 {
-  return {"#Statistics", "#Ensemble"};
+  return {"Statistics", "Ensemble"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateFeatureSizesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateFeatureSizesFilter.cpp
@@ -47,7 +47,7 @@ std::string CalculateFeatureSizesFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CalculateFeatureSizesFilter::defaultTags() const
 {
-  return {"#Statistics", "#Morphological", "#Feature Calculation", "#Find Feature Sizes"};
+  return {"Statistics", "Morphological", "Feature Calculation", "Find Feature Sizes"};
 }
 
 Parameters CalculateFeatureSizesFilter::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateTriangleAreasFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CalculateTriangleAreasFilter.cpp
@@ -93,7 +93,7 @@ std::string CalculateTriangleAreasFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CalculateTriangleAreasFilter::defaultTags() const
 {
-  return {"#Surface Meshing", "#Misc", "#Triangle Geometry"};
+  return {"Surface Meshing", "Misc", "Triangle Geometry"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ChangeAngleRepresentation.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ChangeAngleRepresentation.cpp
@@ -80,7 +80,7 @@ std::string ChangeAngleRepresentation::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ChangeAngleRepresentation::defaultTags() const
 {
-  return {"Processing","Conversion"};
+  return {"Processing", "Conversion"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ChangeAngleRepresentation.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ChangeAngleRepresentation.cpp
@@ -80,7 +80,7 @@ std::string ChangeAngleRepresentation::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ChangeAngleRepresentation::defaultTags() const
 {
-  return {"#Processing", "#Conversion"};
+  return {"Processing","Conversion"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CombineAttributeArraysFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CombineAttributeArraysFilter.cpp
@@ -41,10 +41,10 @@ std::string CombineAttributeArraysFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CombineAttributeArraysFilter::defaultTags() const
 {
-  return {"#Core",
-          "#Memory Management"
-          "#Combine",
-          "#Arrays"};
+  return {"Core",
+          "Memory Management"
+          "Combine",
+          "Arrays"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
@@ -77,7 +77,7 @@ std::string ConditionalSetValue::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ConditionalSetValue::defaultTags() const
 {
-  return {"#Core", "#Processing", "#DataArray"};
+  return {"Core","Processing","DataArray"};
 }
 
 Parameters ConditionalSetValue::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
@@ -77,7 +77,7 @@ std::string ConditionalSetValue::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ConditionalSetValue::defaultTags() const
 {
-  return {"Core","Processing","DataArray"};
+  return {"Core", "Processing", "DataArray"};
 }
 
 Parameters ConditionalSetValue::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConvertColorToGrayScaleFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConvertColorToGrayScaleFilter.cpp
@@ -44,7 +44,7 @@ std::string ConvertColorToGrayScaleFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ConvertColorToGrayScaleFilter::defaultTags() const
 {
-  return {"#Core", "#Image"};
+  return {"Core", "Image"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConvertDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConvertDataFilter.cpp
@@ -41,7 +41,7 @@ std::string ConvertDataFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ConvertDataFilter::defaultTags() const
 {
-  return {"Core","Convert"};
+  return {"Core", "Convert"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConvertDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConvertDataFilter.cpp
@@ -41,7 +41,7 @@ std::string ConvertDataFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ConvertDataFilter::defaultTags() const
 {
-  return {"#Core", "#Convert"};
+  return {"Core","Convert"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyDataObjectFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyDataObjectFilter.cpp
@@ -39,7 +39,7 @@ std::string CopyDataObjectFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CopyDataObjectFilter::defaultTags() const
 {
-  return {"Copy","Data Management","Memory Management","Data Structure","Duplicate"};
+  return {"Copy", "Data Management", "Memory Management", "Data Structure", "Duplicate"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyDataObjectFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyDataObjectFilter.cpp
@@ -39,7 +39,7 @@ std::string CopyDataObjectFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CopyDataObjectFilter::defaultTags() const
 {
-  return {"#Copy", "#Data Management", "#Memory Management", "#Data Structure", "#Duplicate"};
+  return {"Copy","Data Management","Memory Management","Data Structure","Duplicate"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyDataObjectFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyDataObjectFilter.cpp
@@ -12,26 +12,37 @@
 namespace complex
 {
 
+//------------------------------------------------------------------------------
 std::string CopyDataObjectFilter::name() const
 {
   return FilterTraits<CopyDataObjectFilter>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string CopyDataObjectFilter::className() const
 {
   return FilterTraits<CopyDataObjectFilter>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid CopyDataObjectFilter::uuid() const
 {
   return FilterTraits<CopyDataObjectFilter>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string CopyDataObjectFilter::humanName() const
 {
   return "Copy Data Object";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> CopyDataObjectFilter::defaultTags() const
+{
+  return {"#Copy", "#Data Management", "#Memory Management", "#Data Structure", "#Duplicate"};
+}
+
+//------------------------------------------------------------------------------
 Parameters CopyDataObjectFilter::parameters() const
 {
   Parameters params;
@@ -48,11 +59,13 @@ Parameters CopyDataObjectFilter::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer CopyDataObjectFilter::clone() const
 {
   return std::make_unique<CopyDataObjectFilter>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult CopyDataObjectFilter::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto dataArrayPaths = args.value<MultiPathSelectionParameter::ValueType>(k_DataPath_Key);
@@ -96,6 +109,7 @@ IFilter::PreflightResult CopyDataObjectFilter::preflightImpl(const DataStructure
   return {std::move(actions)};
 }
 
+//------------------------------------------------------------------------------
 Result<> CopyDataObjectFilter::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                            const std::atomic_bool& shouldCancel) const
 {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyDataObjectFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyDataObjectFilter.hpp
@@ -51,6 +51,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyFeatureArrayToElementArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyFeatureArrayToElementArray.cpp
@@ -73,7 +73,7 @@ std::string CopyFeatureArrayToElementArray::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CopyFeatureArrayToElementArray::defaultTags() const
 {
-  return {"#Core", "#Memory Management"};
+  return {"Core", "Memory Management"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateAttributeMatrixFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateAttributeMatrixFilter.cpp
@@ -31,7 +31,7 @@ std::string CreateAttributeMatrixFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CreateAttributeMatrixFilter::defaultTags() const
 {
-  return {"Core","Generation", "AttributeMatrix", "Create"};
+  return {"Core", "Generation", "AttributeMatrix", "Create"};
 }
 
 Parameters CreateAttributeMatrixFilter::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateAttributeMatrixFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateAttributeMatrixFilter.cpp
@@ -31,7 +31,7 @@ std::string CreateAttributeMatrixFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CreateAttributeMatrixFilter::defaultTags() const
 {
-  return {"#Core", "#Generation", "#AttributeMatrix", "#Create"};
+  return {"Core","Generation", "AttributeMatrix", "Create"};
 }
 
 Parameters CreateAttributeMatrixFilter::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.cpp
@@ -57,7 +57,7 @@ std::string CreateDataArray::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CreateDataArray::defaultTags() const
 {
-  return {"Create","Data Structure","Data Array","Initialize", "Make"};
+  return {"Create", "Data Structure", "Data Array", "Initialize", "Make"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.cpp
@@ -30,26 +30,37 @@ void CreateAndInitArray(DataStructure& data, const DataPath& path, const std::st
 
 namespace complex
 {
+//------------------------------------------------------------------------------
 std::string CreateDataArray::name() const
 {
   return FilterTraits<CreateDataArray>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string CreateDataArray::className() const
 {
   return FilterTraits<CreateDataArray>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid CreateDataArray::uuid() const
 {
   return FilterTraits<CreateDataArray>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string CreateDataArray::humanName() const
 {
   return "Create Data Array";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> CreateDataArray::defaultTags() const
+{
+  return {"#Create", "#Data Structure", "#Data Array", "#Initialize", "#Make"};
+}
+
+//------------------------------------------------------------------------------
 Parameters CreateDataArray::parameters() const
 {
   Parameters params;
@@ -68,11 +79,13 @@ Parameters CreateDataArray::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer CreateDataArray::clone() const
 {
   return std::make_unique<CreateDataArray>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult CreateDataArray::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                         const std::atomic_bool& shouldCancel) const
 {
@@ -108,6 +121,7 @@ IFilter::PreflightResult CreateDataArray::preflightImpl(const DataStructure& dat
   return {std::move(actions)};
 }
 
+//------------------------------------------------------------------------------
 Result<> CreateDataArray::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto numericType = args.value<NumericType>(k_NumericType_Key);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.cpp
@@ -57,7 +57,7 @@ std::string CreateDataArray::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CreateDataArray::defaultTags() const
 {
-  return {"#Create", "#Data Structure", "#Data Array", "#Initialize", "#Make"};
+  return {"Create","Data Structure","Data Array","Initialize", "Make"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.hpp
@@ -52,6 +52,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief Returns a collection of parameters required to execute the filter.
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataGroup.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataGroup.cpp
@@ -30,7 +30,7 @@ std::string CreateDataGroup::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CreateDataGroup::defaultTags() const
 {
-  return {"#Core", "#Generation", "#DataGroup", "#Create"};
+  return {"Core","Generation","DataGroup","Create"};
 }
 
 Parameters CreateDataGroup::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataGroup.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataGroup.cpp
@@ -30,7 +30,7 @@ std::string CreateDataGroup::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CreateDataGroup::defaultTags() const
 {
-  return {"Core","Generation","DataGroup","Create"};
+  return {"Core", "Generation", "DataGroup", "Create"};
 }
 
 Parameters CreateDataGroup::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateFeatureArrayFromElementArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateFeatureArrayFromElementArray.cpp
@@ -100,7 +100,7 @@ std::string CreateFeatureArrayFromElementArray::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CreateFeatureArrayFromElementArray::defaultTags() const
 {
-  return {"Core","Memory Management"};
+  return {"Core", "Memory Management"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateFeatureArrayFromElementArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateFeatureArrayFromElementArray.cpp
@@ -100,7 +100,7 @@ std::string CreateFeatureArrayFromElementArray::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CreateFeatureArrayFromElementArray::defaultTags() const
 {
-  return {"#Core", "#Memory Management"};
+  return {"Core","Memory Management"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateGeometryFilter.cpp
@@ -102,9 +102,9 @@ std::string CreateGeometryFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CreateGeometryFilter::defaultTags() const
 {
-  return {"#Core", "#Generation",
-          "#Geometry"
-          "#Create Geometry"};
+  return {"Core","Generation",
+          "Geometry"
+          "Create Geometry"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateGeometryFilter.cpp
@@ -102,7 +102,7 @@ std::string CreateGeometryFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CreateGeometryFilter::defaultTags() const
 {
-  return {"Core","Generation",
+  return {"Core", "Generation",
           "Geometry"
           "Create Geometry"};
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateImageGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateImageGeometry.cpp
@@ -43,7 +43,7 @@ std::string CreateImageGeometry::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CreateImageGeometry::defaultTags() const
 {
-  return {"Core","Generation",
+  return {"Core", "Generation",
           "ImageGeometry"
           "Create Geometry"};
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateImageGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateImageGeometry.cpp
@@ -43,9 +43,9 @@ std::string CreateImageGeometry::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CreateImageGeometry::defaultTags() const
 {
-  return {"#Core", "#Generation",
-          "#ImageGeometry"
-          "#Create Geometry"};
+  return {"Core","Generation",
+          "ImageGeometry"
+          "Create Geometry"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropImageGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropImageGeometry.cpp
@@ -146,10 +146,10 @@ std::string CropImageGeometry::humanName() const
 std::vector<std::string> CropImageGeometry::defaultTags() const
 {
   return {
-      "#Core",
-      "#Crop Image Geometry",
-      "#Image Geometry",
-      "#Conversion",
+      "Core",
+      "Crop Image Geometry",
+      "Image Geometry",
+      "Conversion",
   };
 }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
@@ -67,7 +67,7 @@ std::string CropVertexGeometry::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CropVertexGeometry::defaultTags() const
 {
-  return {"Crop","Vertex Geometry","Geometry","Memory Management","Cut"};
+  return {"Crop", "Vertex Geometry", "Geometry", "Memory Management", "Cut"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
@@ -67,7 +67,7 @@ std::string CropVertexGeometry::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> CropVertexGeometry::defaultTags() const
 {
-  return {"#Crop", "#Vertex Geometry", "#Geometry", "#Memory Management", "#Cut"};
+  return {"Crop","Vertex Geometry","Geometry","Memory Management","Cut"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
@@ -40,26 +40,37 @@ struct CopyDataToCroppedGeometryFunctor
 };
 } // namespace
 
+//------------------------------------------------------------------------------
 std::string CropVertexGeometry::name() const
 {
   return FilterTraits<CropVertexGeometry>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string CropVertexGeometry::className() const
 {
   return FilterTraits<CropVertexGeometry>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid CropVertexGeometry::uuid() const
 {
   return FilterTraits<CropVertexGeometry>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string CropVertexGeometry::humanName() const
 {
   return "Crop Geometry (Vertex)";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> CropVertexGeometry::defaultTags() const
+{
+  return {"#Crop", "#Vertex Geometry", "#Geometry", "#Memory Management", "#Cut"};
+}
+
+//------------------------------------------------------------------------------
 Parameters CropVertexGeometry::parameters() const
 {
   Parameters params;
@@ -76,11 +87,13 @@ Parameters CropVertexGeometry::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer CropVertexGeometry::clone() const
 {
   return std::make_unique<CropVertexGeometry>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult CropVertexGeometry::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto vertexGeomPath = args.value<DataPath>(k_VertexGeom_Key);
@@ -152,6 +165,7 @@ IFilter::PreflightResult CropVertexGeometry::preflightImpl(const DataStructure& 
   return {std::move(actions)};
 }
 
+//------------------------------------------------------------------------------
 Result<> CropVertexGeometry::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                          const std::atomic_bool& shouldCancel) const
 {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.hpp
@@ -53,6 +53,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.cpp
@@ -43,7 +43,7 @@ std::string DeleteData::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> DeleteData::defaultTags() const
 {
-  return {"#Core", "#Memory Management", "#Remove Data", "#Delete Data"};
+  return {"Core","Memory Management","Remove Data","Delete Data"};
 }
 
 Parameters DeleteData::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.cpp
@@ -43,7 +43,7 @@ std::string DeleteData::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> DeleteData::defaultTags() const
 {
-  return {"Core","Memory Management","Remove Data","Delete Data"};
+  return {"Core", "Memory Management", "Remove Data", "Delete Data"};
 }
 
 Parameters DeleteData::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExecuteProcessFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExecuteProcessFilter.cpp
@@ -40,7 +40,7 @@ std::string ExecuteProcessFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ExecuteProcessFilter::defaultTags() const
 {
-  return {"Core","Misc"};
+  return {"Core", "Misc"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExecuteProcessFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExecuteProcessFilter.cpp
@@ -40,7 +40,7 @@ std::string ExecuteProcessFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ExecuteProcessFilter::defaultTags() const
 {
-  return {"#Core", "#Misc"};
+  return {"Core","Misc"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExportDREAM3DFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExportDREAM3DFilter.cpp
@@ -43,7 +43,7 @@ std::string ExportDREAM3DFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ExportDREAM3DFilter::defaultTags() const
 {
-  return {"#IO", "#Output", "#Write", "#Export", "Binary"};
+  return {"IO","Output","Write","Export", "Binary"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExportDREAM3DFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExportDREAM3DFilter.cpp
@@ -16,26 +16,37 @@ constexpr complex::int32 k_FailedFindPipelineError = -15;
 
 namespace complex
 {
+//------------------------------------------------------------------------------
 std::string ExportDREAM3DFilter::name() const
 {
   return FilterTraits<ExportDREAM3DFilter>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string ExportDREAM3DFilter::className() const
 {
   return FilterTraits<ExportDREAM3DFilter>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid ExportDREAM3DFilter::uuid() const
 {
   return FilterTraits<ExportDREAM3DFilter>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string ExportDREAM3DFilter::humanName() const
 {
   return "Write DREAM3D NX File (V8)";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> ExportDREAM3DFilter::defaultTags() const
+{
+  return {"#IO", "#Output", "#Write", "#Export", "Binary"};
+}
+
+//------------------------------------------------------------------------------
 Parameters ExportDREAM3DFilter::parameters() const
 {
   Parameters params;
@@ -47,11 +58,13 @@ Parameters ExportDREAM3DFilter::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer ExportDREAM3DFilter::clone() const
 {
   return std::make_unique<ExportDREAM3DFilter>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult ExportDREAM3DFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto exportFilePath = args.value<std::filesystem::path>(k_ExportFilePath);
@@ -62,6 +75,7 @@ IFilter::PreflightResult ExportDREAM3DFilter::preflightImpl(const DataStructure&
   return {};
 }
 
+//------------------------------------------------------------------------------
 Result<> ExportDREAM3DFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                           const std::atomic_bool& shouldCancel) const
 {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExportDREAM3DFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExportDREAM3DFilter.cpp
@@ -43,7 +43,7 @@ std::string ExportDREAM3DFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ExportDREAM3DFilter::defaultTags() const
 {
-  return {"IO","Output","Write","Export", "Binary"};
+  return {"IO", "Output", "Write", "Export", "Binary"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExportDREAM3DFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExportDREAM3DFilter.hpp
@@ -55,6 +55,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief Returns a collection of the filter's parameters (i.e. its inputs)
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractComponentAsArrayFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractComponentAsArrayFilter.cpp
@@ -43,7 +43,7 @@ std::string ExtractComponentAsArrayFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ExtractComponentAsArrayFilter::defaultTags() const
 {
-  return {"#Core", "#Memory Management"};
+  return {"Core", "Memory Management"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -91,26 +91,37 @@ struct RemoveFlaggedVerticesFunctor
 namespace complex
 {
 
+//------------------------------------------------------------------------------
 std::string ExtractInternalSurfacesFromTriangleGeometry::name() const
 {
   return FilterTraits<ExtractInternalSurfacesFromTriangleGeometry>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string ExtractInternalSurfacesFromTriangleGeometry::className() const
 {
   return FilterTraits<ExtractInternalSurfacesFromTriangleGeometry>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid ExtractInternalSurfacesFromTriangleGeometry::uuid() const
 {
   return FilterTraits<ExtractInternalSurfacesFromTriangleGeometry>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string ExtractInternalSurfacesFromTriangleGeometry::humanName() const
 {
   return "Extract Internal Surfaces From Triangle Geometry";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> ExtractInternalSurfacesFromTriangleGeometry::defaultTags() const
+{
+  return {"#Geometry", "#Triangle Geometry", "#Memory Management"};
+}
+
+//------------------------------------------------------------------------------
 Parameters ExtractInternalSurfacesFromTriangleGeometry::parameters() const
 {
   Parameters params;
@@ -135,11 +146,13 @@ Parameters ExtractInternalSurfacesFromTriangleGeometry::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer ExtractInternalSurfacesFromTriangleGeometry::clone() const
 {
   return std::make_unique<ExtractInternalSurfacesFromTriangleGeometry>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult ExtractInternalSurfacesFromTriangleGeometry::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                                                     const std::atomic_bool& shouldCancel) const
 {
@@ -233,6 +246,7 @@ IFilter::PreflightResult ExtractInternalSurfacesFromTriangleGeometry::preflightI
   return {std::move(actions)};
 }
 
+//------------------------------------------------------------------------------
 Result<> ExtractInternalSurfacesFromTriangleGeometry::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                                                   const std::atomic_bool& shouldCancel) const
 {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -118,7 +118,7 @@ std::string ExtractInternalSurfacesFromTriangleGeometry::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ExtractInternalSurfacesFromTriangleGeometry::defaultTags() const
 {
-  return {"Geometry","Triangle Geometry","Memory Management"};
+  return {"Geometry", "Triangle Geometry", "Memory Management"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -118,7 +118,7 @@ std::string ExtractInternalSurfacesFromTriangleGeometry::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ExtractInternalSurfacesFromTriangleGeometry::defaultTags() const
 {
-  return {"#Geometry", "#Triangle Geometry", "#Memory Management"};
+  return {"Geometry","Triangle Geometry","Memory Management"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.hpp
@@ -54,6 +54,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief Returns a collection of parameters required to execute the filter.
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractVertexGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractVertexGeometryFilter.cpp
@@ -45,7 +45,7 @@ std::string ExtractVertexGeometryFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ExtractVertexGeometryFilter::defaultTags() const
 {
-  return {"#Core", "#Conversion"};
+  return {"Core","Conversion"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractVertexGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractVertexGeometryFilter.cpp
@@ -45,7 +45,7 @@ std::string ExtractVertexGeometryFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ExtractVertexGeometryFilter::defaultTags() const
 {
-  return {"Core","Conversion"};
+  return {"Core", "Conversion"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FeatureDataCSVWriterFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FeatureDataCSVWriterFilter.cpp
@@ -46,7 +46,7 @@ std::string FeatureDataCSVWriterFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FeatureDataCSVWriterFilter::defaultTags() const
 {
-  return {"IO","Output","Write", "Export"};
+  return {"IO", "Output", "Write", "Export"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FeatureDataCSVWriterFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FeatureDataCSVWriterFilter.cpp
@@ -46,7 +46,7 @@ std::string FeatureDataCSVWriterFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FeatureDataCSVWriterFilter::defaultTags() const
 {
-  return {"#IO", "#Output", "#Write", "#Export"};
+  return {"IO","Output","Write", "Export"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FillBadDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FillBadDataFilter.cpp
@@ -42,7 +42,7 @@ std::string FillBadDataFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FillBadDataFilter::defaultTags() const
 {
-  return {"#Processing", "#Cleanup"};
+  return {"Processing","Cleanup"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FillBadDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FillBadDataFilter.cpp
@@ -42,7 +42,7 @@ std::string FillBadDataFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FillBadDataFilter::defaultTags() const
 {
-  return {"Processing","Cleanup"};
+  return {"Processing", "Cleanup"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindArrayStatisticsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindArrayStatisticsFilter.cpp
@@ -129,7 +129,7 @@ std::string FindArrayStatisticsFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindArrayStatisticsFilter::defaultTags() const
 {
-  return {"#ComplexCore", "#Statistics"};
+  return {"ComplexCore","Statistics"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindArrayStatisticsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindArrayStatisticsFilter.cpp
@@ -129,7 +129,7 @@ std::string FindArrayStatisticsFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindArrayStatisticsFilter::defaultTags() const
 {
-  return {"ComplexCore","Statistics"};
+  return {"ComplexCore", "Statistics"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindDifferencesMap.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindDifferencesMap.cpp
@@ -156,7 +156,7 @@ std::string FindDifferencesMap::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindDifferencesMap::defaultTags() const
 {
-  return {"Statistics","ComplexCore"};
+  return {"Statistics", "ComplexCore"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindDifferencesMap.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindDifferencesMap.cpp
@@ -156,7 +156,7 @@ std::string FindDifferencesMap::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindDifferencesMap::defaultTags() const
 {
-  return {"#Statistics", "#ComplexCore"};
+  return {"Statistics","ComplexCore"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindDifferencesMap.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindDifferencesMap.cpp
@@ -129,26 +129,37 @@ struct ExecuteFindDifferenceMapFunctor
 };
 } // namespace
 
+//------------------------------------------------------------------------------
 std::string FindDifferencesMap::name() const
 {
   return FilterTraits<FindDifferencesMap>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string FindDifferencesMap::className() const
 {
   return FilterTraits<FindDifferencesMap>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid FindDifferencesMap::uuid() const
 {
   return FilterTraits<FindDifferencesMap>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string FindDifferencesMap::humanName() const
 {
   return "Find Differences Map";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> FindDifferencesMap::defaultTags() const
+{
+  return {"#Statistics", "#ComplexCore"};
+}
+
+//------------------------------------------------------------------------------
 Parameters FindDifferencesMap::parameters() const
 {
   Parameters params;
@@ -160,11 +171,13 @@ Parameters FindDifferencesMap::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer FindDifferencesMap::clone() const
 {
   return std::make_unique<FindDifferencesMap>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult FindDifferencesMap::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto firstInputArrayPath = args.value<DataPath>(k_FirstInputArrayPath_Key);
@@ -231,6 +244,7 @@ IFilter::PreflightResult FindDifferencesMap::preflightImpl(const DataStructure& 
   return {std::move(actions)};
 }
 
+//------------------------------------------------------------------------------
 Result<> FindDifferencesMap::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                          const std::atomic_bool& shouldCancel) const
 {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindDifferencesMap.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindDifferencesMap.hpp
@@ -54,6 +54,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief Returns the parameters required to run the filter.
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindEuclideanDistMapFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindEuclideanDistMapFilter.cpp
@@ -42,7 +42,7 @@ std::string FindEuclideanDistMapFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindEuclideanDistMapFilter::defaultTags() const
 {
-  return {"#Statistics", "#Morphological"};
+  return {"Statistics","Morphological"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindEuclideanDistMapFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindEuclideanDistMapFilter.cpp
@@ -42,7 +42,7 @@ std::string FindEuclideanDistMapFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindEuclideanDistMapFilter::defaultTags() const
 {
-  return {"Statistics","Morphological"};
+  return {"Statistics", "Morphological"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindFeatureCentroidsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindFeatureCentroidsFilter.cpp
@@ -42,7 +42,7 @@ std::string FindFeatureCentroidsFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindFeatureCentroidsFilter::defaultTags() const
 {
-  return {"Generic","Morphological"};
+  return {"Generic", "Morphological"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindFeatureCentroidsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindFeatureCentroidsFilter.cpp
@@ -42,7 +42,7 @@ std::string FindFeatureCentroidsFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindFeatureCentroidsFilter::defaultTags() const
 {
-  return {"#Generic", "#Morphological"};
+  return {"Generic","Morphological"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindFeaturePhasesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindFeaturePhasesFilter.cpp
@@ -39,7 +39,7 @@ std::string FindFeaturePhasesFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindFeaturePhasesFilter::defaultTags() const
 {
-  return {"#Generic", "#Morphological"};
+  return {"Generic","Morphological"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindFeaturePhasesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindFeaturePhasesFilter.cpp
@@ -39,7 +39,7 @@ std::string FindFeaturePhasesFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindFeaturePhasesFilter::defaultTags() const
 {
-  return {"Generic","Morphological"};
+  return {"Generic", "Morphological"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighborListStatistics.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighborListStatistics.cpp
@@ -242,7 +242,7 @@ std::string FindNeighborListStatistics::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindNeighborListStatistics::defaultTags() const
 {
-  return {"#NeighborList", "#Statistics", "#Analytics"};
+  return {"NeighborList", "Statistics", "Analytics"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighborListStatistics.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighborListStatistics.cpp
@@ -152,6 +152,7 @@ private:
 };
 } // namespace
 
+//------------------------------------------------------------------------------
 OutputActions FindNeighborListStatistics::createCompatibleArrays(const DataStructure& data, const Arguments& args) const
 {
   auto findLength = args.value<bool>(k_FindLength_Key);
@@ -214,26 +215,37 @@ OutputActions FindNeighborListStatistics::createCompatibleArrays(const DataStruc
   return std::move(actions);
 }
 
+//------------------------------------------------------------------------------
 std::string FindNeighborListStatistics::name() const
 {
   return FilterTraits<FindNeighborListStatistics>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string FindNeighborListStatistics::className() const
 {
   return FilterTraits<FindNeighborListStatistics>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid FindNeighborListStatistics::uuid() const
 {
   return FilterTraits<FindNeighborListStatistics>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string FindNeighborListStatistics::humanName() const
 {
   return "Find Neighbor List Statistics";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> FindNeighborListStatistics::defaultTags() const
+{
+  return {"#NeighborList", "#Statistics", "#Analytics"};
+}
+
+//------------------------------------------------------------------------------
 Parameters FindNeighborListStatistics::parameters() const
 {
   Parameters params;
@@ -264,11 +276,13 @@ Parameters FindNeighborListStatistics::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer FindNeighborListStatistics::clone() const
 {
   return std::make_unique<FindNeighborListStatistics>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult FindNeighborListStatistics::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto findLength = args.value<bool>(k_FindLength_Key);
@@ -302,6 +316,7 @@ IFilter::PreflightResult FindNeighborListStatistics::preflightImpl(const DataStr
   return {std::move(createCompatibleArrays(data, args))};
 }
 
+//------------------------------------------------------------------------------
 Result<> FindNeighborListStatistics::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                                  const std::atomic_bool& shouldCancel) const
 {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighborListStatistics.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighborListStatistics.hpp
@@ -66,6 +66,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief Returns the parameters required to run the filter.
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighbors.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighbors.cpp
@@ -44,7 +44,7 @@ std::string FindNeighbors::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindNeighbors::defaultTags() const
 {
-  return {"Statistics","Neighbors","Features"};
+  return {"Statistics", "Neighbors", "Features"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighbors.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighbors.cpp
@@ -44,7 +44,7 @@ std::string FindNeighbors::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindNeighbors::defaultTags() const
 {
-  return {"#Statistics", "#Neighbors", "#Features"};
+  return {"Statistics","Neighbors","Features"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighbors.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighbors.cpp
@@ -17,26 +17,37 @@
 
 namespace complex
 {
+//------------------------------------------------------------------------------
 std::string FindNeighbors::name() const
 {
   return FilterTraits<FindNeighbors>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string FindNeighbors::className() const
 {
   return FilterTraits<FindNeighbors>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid FindNeighbors::uuid() const
 {
   return FilterTraits<FindNeighbors>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string FindNeighbors::humanName() const
 {
   return "Find Feature Neighbors";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> FindNeighbors::defaultTags() const
+{
+  return {"#Statistics", "#Neighbors", "#Features"};
+}
+
+//------------------------------------------------------------------------------
 Parameters FindNeighbors::parameters() const
 {
   Parameters params;
@@ -74,11 +85,13 @@ Parameters FindNeighbors::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer FindNeighbors::clone() const
 {
   return std::make_unique<FindNeighbors>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult FindNeighbors::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto storeBoundaryCells = args.value<bool>(k_StoreBoundary_Key);
@@ -148,6 +161,7 @@ IFilter::PreflightResult FindNeighbors::preflightImpl(const DataStructure& data,
   return {std::move(actions)};
 }
 
+//------------------------------------------------------------------------------
 Result<> FindNeighbors::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto storeBoundaryCells = args.value<bool>(k_StoreBoundary_Key);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighbors.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighbors.hpp
@@ -63,6 +63,12 @@ public:
   Parameters parameters() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return IFilter::UniquePointer
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNumFeaturesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNumFeaturesFilter.cpp
@@ -38,7 +38,7 @@ std::string FindNumFeaturesFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindNumFeaturesFilter::defaultTags() const
 {
-  return {"Statistics","Morphological"};
+  return {"Statistics", "Morphological"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNumFeaturesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNumFeaturesFilter.cpp
@@ -38,7 +38,7 @@ std::string FindNumFeaturesFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindNumFeaturesFilter::defaultTags() const
 {
-  return {"#Statistics", "#Morphological"};
+  return {"Statistics","Morphological"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindSurfaceAreaToVolumeFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindSurfaceAreaToVolumeFilter.cpp
@@ -41,7 +41,7 @@ std::string FindSurfaceAreaToVolumeFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindSurfaceAreaToVolumeFilter::defaultTags() const
 {
-  return {"#Statistics", "#Morphological", "#Volumes", "#Surface Area"};
+  return {"Statistics", "Morphological", "Volumes", "Surface Area"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindSurfaceFeatures.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindSurfaceFeatures.cpp
@@ -215,7 +215,7 @@ std::string FindSurfaceFeatures::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindSurfaceFeatures::defaultTags() const
 {
-  return {"Generic","Spatial"};
+  return {"Generic", "Spatial"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindSurfaceFeatures.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindSurfaceFeatures.cpp
@@ -215,7 +215,7 @@ std::string FindSurfaceFeatures::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindSurfaceFeatures::defaultTags() const
 {
-  return {"#Generic", "#Spatial"};
+  return {"Generic","Spatial"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindTriangleGeomCentroidsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindTriangleGeomCentroidsFilter.cpp
@@ -41,7 +41,7 @@ std::string FindTriangleGeomCentroidsFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindTriangleGeomCentroidsFilter::defaultTags() const
 {
-  return {"#Generic", "#Morphological", "#SurfaceMesh", "#Statistics", "#Triangle"};
+  return {"Generic","Morphological","SurfaceMesh","Statistics","Triangle"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindTriangleGeomCentroidsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindTriangleGeomCentroidsFilter.cpp
@@ -41,7 +41,7 @@ std::string FindTriangleGeomCentroidsFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindTriangleGeomCentroidsFilter::defaultTags() const
 {
-  return {"Generic","Morphological","SurfaceMesh","Statistics","Triangle"};
+  return {"Generic", "Morphological", "SurfaceMesh", "Statistics", "Triangle"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindTriangleGeomSizesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindTriangleGeomSizesFilter.cpp
@@ -42,7 +42,7 @@ std::string FindTriangleGeomSizesFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindTriangleGeomSizesFilter::defaultTags() const
 {
-  return {"Generic","Morphological", "SurfaceMesh", "Statistics", "Triangle"};
+  return {"Generic", "Morphological", "SurfaceMesh", "Statistics", "Triangle"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindTriangleGeomSizesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindTriangleGeomSizesFilter.cpp
@@ -42,7 +42,7 @@ std::string FindTriangleGeomSizesFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindTriangleGeomSizesFilter::defaultTags() const
 {
-  return {"#Generic", "#Morphological", "#SurfaceMesh", "#Statistics", "#Triangle"};
+  return {"Generic","Morphological", "SurfaceMesh", "Statistics", "Triangle"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindVolFractionsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindVolFractionsFilter.cpp
@@ -38,7 +38,7 @@ std::string FindVolFractionsFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindVolFractionsFilter::defaultTags() const
 {
-  return {"#Statistics", "#Morphological"};
+  return {"Statistics","Morphological"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindVolFractionsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindVolFractionsFilter.cpp
@@ -38,7 +38,7 @@ std::string FindVolFractionsFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> FindVolFractionsFilter::defaultTags() const
 {
-  return {"Statistics","Morphological"};
+  return {"Statistics", "Morphological"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
@@ -40,7 +40,7 @@ std::string GenerateColorTableFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> GenerateColorTableFilter::defaultTags() const
 {
-  return {"#Core", "#Image"};
+  return {"Core","Image"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/GenerateColorTableFilter.cpp
@@ -40,7 +40,7 @@ std::string GenerateColorTableFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> GenerateColorTableFilter::defaultTags() const
 {
-  return {"Core","Image"};
+  return {"Core", "Image"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/IdentifySample.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/IdentifySample.cpp
@@ -264,7 +264,7 @@ std::string IdentifySample::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> IdentifySample::defaultTags() const
 {
-  return {"Core","Identify Sample"};
+  return {"Core", "Identify Sample"};
 }
 
 Parameters IdentifySample::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/IdentifySample.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/IdentifySample.cpp
@@ -264,7 +264,7 @@ std::string IdentifySample::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> IdentifySample::defaultTags() const
 {
-  return {"#Core", "#Identify Sample"};
+  return {"Core","Identify Sample"};
 }
 
 Parameters IdentifySample::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportCSVDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportCSVDataFilter.cpp
@@ -307,7 +307,7 @@ std::string ImportCSVDataFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ImportCSVDataFilter::defaultTags() const
 {
-  return {"IO","Input","Read","Import", "ASCII", "ascii", "CSV", "csv", "Column"};
+  return {"IO", "Input", "Read", "Import", "ASCII", "ascii", "CSV", "csv", "Column"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportCSVDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportCSVDataFilter.cpp
@@ -307,7 +307,7 @@ std::string ImportCSVDataFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ImportCSVDataFilter::defaultTags() const
 {
-  return {"#IO", "#Input", "#Read", "#Import", "#ASCII", "#ascii", "#CSV", "#csv", "#Column"};
+  return {"IO","Input","Read","Import", "ASCII", "ascii", "CSV", "csv", "Column"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportDREAM3DFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportDREAM3DFilter.cpp
@@ -20,26 +20,37 @@ constexpr complex::int32 k_FailedOpenFileReaderError = -25;
 
 namespace complex
 {
+//------------------------------------------------------------------------------
 std::string ImportDREAM3DFilter::name() const
 {
   return FilterTraits<ImportDREAM3DFilter>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string ImportDREAM3DFilter::className() const
 {
   return FilterTraits<ImportDREAM3DFilter>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid ImportDREAM3DFilter::uuid() const
 {
   return FilterTraits<ImportDREAM3DFilter>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string ImportDREAM3DFilter::humanName() const
 {
   return "Read DREAM.3D File (v8)";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> ImportDREAM3DFilter::defaultTags() const
+{
+  return {"#IO", "#Input", "#Read", "#Import"};
+}
+
+//------------------------------------------------------------------------------
 Parameters ImportDREAM3DFilter::parameters() const
 {
   Parameters params;
@@ -48,6 +59,7 @@ Parameters ImportDREAM3DFilter::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer ImportDREAM3DFilter::clone() const
 {
   return std::make_unique<ImportDREAM3DFilter>();

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportDREAM3DFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportDREAM3DFilter.cpp
@@ -47,7 +47,7 @@ std::string ImportDREAM3DFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ImportDREAM3DFilter::defaultTags() const
 {
-  return {"IO","Input", "Read", "Import"};
+  return {"IO", "Input", "Read", "Import"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportDREAM3DFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportDREAM3DFilter.cpp
@@ -47,7 +47,7 @@ std::string ImportDREAM3DFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ImportDREAM3DFilter::defaultTags() const
 {
-  return {"#IO", "#Input", "#Read", "#Import"};
+  return {"IO","Input", "Read", "Import"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportDREAM3DFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportDREAM3DFilter.hpp
@@ -54,6 +54,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief Returns a collection of the filter's parameters (i.e. its inputs)
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportHDF5Dataset.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportHDF5Dataset.cpp
@@ -86,7 +86,7 @@ std::string ImportHDF5Dataset::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ImportHDF5Dataset::defaultTags() const
 {
-  return {"IO","Input","Read","Import"};
+  return {"IO", "Input", "Read", "Import"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportHDF5Dataset.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportHDF5Dataset.cpp
@@ -86,7 +86,7 @@ std::string ImportHDF5Dataset::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ImportHDF5Dataset::defaultTags() const
 {
-  return {"#IO", "#Input", "#Read", "#Import"};
+  return {"IO","Input","Read","Import"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
@@ -36,7 +36,7 @@ Uuid ImportTextFilter::uuid() const
 
 std::vector<std::string> ImportTextFilter::defaultTags() const
 {
-  return {"#IO", "#Input", "#Read", "#Import", "#Text"};
+  return {"IO","Input","Read","Import","Text"};
 }
 
 std::string ImportTextFilter::humanName() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
@@ -36,7 +36,7 @@ Uuid ImportTextFilter::uuid() const
 
 std::vector<std::string> ImportTextFilter::defaultTags() const
 {
-  return {"IO","Input","Read","Import","Text"};
+  return {"IO", "Input", "Read", "Import", "Text"};
 }
 
 std::string ImportTextFilter::humanName() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
@@ -176,7 +176,7 @@ std::string InitializeData::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> InitializeData::defaultTags() const
 {
-  return {"#Memory Management", "#Initialize", "#Create", "#Generate", "#Data"};
+  return {"Memory Management","Initialize","Create", "Generate", "Data"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
@@ -176,7 +176,7 @@ std::string InitializeData::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> InitializeData::defaultTags() const
 {
-  return {"Memory Management","Initialize","Create", "Generate", "Data"};
+  return {"Memory Management", "Initialize", "Create", "Generate", "Data"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
@@ -149,26 +149,37 @@ struct InitializeArrayFunctor
 
 namespace complex
 {
+//------------------------------------------------------------------------------
 std::string InitializeData::name() const
 {
   return FilterTraits<InitializeData>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string InitializeData::className() const
 {
   return FilterTraits<InitializeData>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid InitializeData::uuid() const
 {
   return FilterTraits<InitializeData>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string InitializeData::humanName() const
 {
   return "Initialize Data";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> InitializeData::defaultTags() const
+{
+  return {"#Memory Management", "#Initialize", "#Create", "#Generate", "#Data"};
+}
+
+//------------------------------------------------------------------------------
 Parameters InitializeData::parameters() const
 {
   Parameters params;
@@ -196,11 +207,13 @@ Parameters InitializeData::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer InitializeData::clone() const
 {
   return std::make_unique<InitializeData>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult InitializeData::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto cellArrayPaths = args.value<MultiArraySelectionParameter::ValueType>(k_CellArrayPaths_Key);
@@ -287,6 +300,7 @@ IFilter::PreflightResult InitializeData::preflightImpl(const DataStructure& data
   return {};
 }
 
+//------------------------------------------------------------------------------
 Result<> InitializeData::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto cellArrayPaths = args.value<MultiArraySelectionParameter::ValueType>(k_CellArrayPaths_Key);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.hpp
@@ -61,6 +61,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
@@ -142,26 +142,37 @@ void mapKernelDistances(NeighborList<float32>* kernelDistances, std::vector<floa
 }
 } // namespace
 
+//------------------------------------------------------------------------------
 std::string InterpolatePointCloudToRegularGridFilter::name() const
 {
   return FilterTraits<InterpolatePointCloudToRegularGridFilter>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string InterpolatePointCloudToRegularGridFilter::className() const
 {
   return FilterTraits<InterpolatePointCloudToRegularGridFilter>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid InterpolatePointCloudToRegularGridFilter::uuid() const
 {
   return FilterTraits<InterpolatePointCloudToRegularGridFilter>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string InterpolatePointCloudToRegularGridFilter::humanName() const
 {
   return "Interpolate Point Cloud to Regular Grid";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> InterpolatePointCloudToRegularGridFilter::defaultTags() const
+{
+  return {"#Geometry", "#Gaussian", "#Kernel", "Interpolation", "Point Cloud", "Vertex Geometry"};
+}
+
+//------------------------------------------------------------------------------
 Parameters InterpolatePointCloudToRegularGridFilter::parameters() const
 {
   Parameters params;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
@@ -169,7 +169,7 @@ std::string InterpolatePointCloudToRegularGridFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> InterpolatePointCloudToRegularGridFilter::defaultTags() const
 {
-  return {"#Geometry", "#Gaussian", "#Kernel", "Interpolation", "Point Cloud", "Vertex Geometry"};
+  return {"Geometry","Gaussian","Kernel", "Interpolation", "Point Cloud", "Vertex Geometry"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
@@ -169,7 +169,7 @@ std::string InterpolatePointCloudToRegularGridFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> InterpolatePointCloudToRegularGridFilter::defaultTags() const
 {
-  return {"Geometry","Gaussian","Kernel", "Interpolation", "Point Cloud", "Vertex Geometry"};
+  return {"Geometry", "Gaussian", "Kernel", "Interpolation", "Point Cloud", "Vertex Geometry"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp
@@ -64,6 +64,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief Returns a collection of filter parameters.
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/IterativeClosestPointFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/IterativeClosestPointFilter.cpp
@@ -62,26 +62,37 @@ struct VertexGeomAdaptor
 };
 } // namespace
 
+//------------------------------------------------------------------------------
 std::string IterativeClosestPointFilter::name() const
 {
   return FilterTraits<IterativeClosestPointFilter>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string IterativeClosestPointFilter::className() const
 {
   return FilterTraits<IterativeClosestPointFilter>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid IterativeClosestPointFilter::uuid() const
 {
   return FilterTraits<IterativeClosestPointFilter>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string IterativeClosestPointFilter::humanName() const
 {
   return "Iterative Closest Point";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> IterativeClosestPointFilter::defaultTags() const
+{
+  return {"#Transformation", "#Align", "#Geometry", "#ICP"};
+}
+
+//------------------------------------------------------------------------------
 Parameters IterativeClosestPointFilter::parameters() const
 {
   Parameters params;
@@ -99,11 +110,13 @@ Parameters IterativeClosestPointFilter::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer IterativeClosestPointFilter::clone() const
 {
   return std::make_unique<IterativeClosestPointFilter>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult IterativeClosestPointFilter::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto movingVertexPath = args.value<DataPath>(k_MovingVertexPath_Key);
@@ -137,6 +150,7 @@ IFilter::PreflightResult IterativeClosestPointFilter::preflightImpl(const DataSt
   return {std::move(actions)};
 }
 
+//------------------------------------------------------------------------------
 Result<> IterativeClosestPointFilter::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                                   const std::atomic_bool& shouldCancel) const
 {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/IterativeClosestPointFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/IterativeClosestPointFilter.cpp
@@ -89,7 +89,7 @@ std::string IterativeClosestPointFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> IterativeClosestPointFilter::defaultTags() const
 {
-  return {"#Transformation", "#Align", "#Geometry", "#ICP"};
+  return {"Transformation", "Align", "Geometry", "ICP"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/IterativeClosestPointFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/IterativeClosestPointFilter.hpp
@@ -52,6 +52,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/LaplacianSmoothingFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/LaplacianSmoothingFilter.cpp
@@ -40,7 +40,7 @@ std::string LaplacianSmoothingFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> LaplacianSmoothingFilter::defaultTags() const
 {
-  return {"#Surface Meshing", "#Smoothing", "#Triangle Geometry"};
+  return {"Surface Meshing","Smoothing", "Triangle Geometry"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/LaplacianSmoothingFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/LaplacianSmoothingFilter.cpp
@@ -40,7 +40,7 @@ std::string LaplacianSmoothingFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> LaplacianSmoothingFilter::defaultTags() const
 {
-  return {"Surface Meshing","Smoothing", "Triangle Geometry"};
+  return {"Surface Meshing", "Smoothing", "Triangle Geometry"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.cpp
@@ -191,26 +191,37 @@ void createRegularGrid(DataStructure& data, const Arguments& args)
 }
 } // namespace
 
+//------------------------------------------------------------------------------
 std::string MapPointCloudToRegularGridFilter::name() const
 {
   return FilterTraits<MapPointCloudToRegularGridFilter>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string MapPointCloudToRegularGridFilter::className() const
 {
   return FilterTraits<MapPointCloudToRegularGridFilter>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid MapPointCloudToRegularGridFilter::uuid() const
 {
   return FilterTraits<MapPointCloudToRegularGridFilter>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string MapPointCloudToRegularGridFilter::humanName() const
 {
   return "Map Point Cloud to Regular Grid";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> MapPointCloudToRegularGridFilter::defaultTags() const
+{
+  return {"#Alignment", "#Point Cloud", "#Grid", "#Sampling", "#Geometry"};
+}
+
+//------------------------------------------------------------------------------
 Parameters MapPointCloudToRegularGridFilter::parameters() const
 {
   Parameters params;
@@ -240,11 +251,13 @@ Parameters MapPointCloudToRegularGridFilter::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer MapPointCloudToRegularGridFilter::clone() const
 {
   return std::make_unique<MapPointCloudToRegularGridFilter>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult MapPointCloudToRegularGridFilter::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler,
                                                                          const std::atomic_bool& shouldCancel) const
 {
@@ -332,6 +345,7 @@ IFilter::PreflightResult MapPointCloudToRegularGridFilter::preflightImpl(const D
   return {std::move(actions)};
 }
 
+//------------------------------------------------------------------------------
 Result<> MapPointCloudToRegularGridFilter::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                                        const std::atomic_bool& shouldCancel) const
 {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.cpp
@@ -218,7 +218,7 @@ std::string MapPointCloudToRegularGridFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> MapPointCloudToRegularGridFilter::defaultTags() const
 {
-  return {"#Alignment", "#Point Cloud", "#Grid", "#Sampling", "#Geometry"};
+  return {"Alignment","Point Cloud","Grid","Sampling","Geometry"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.cpp
@@ -218,7 +218,7 @@ std::string MapPointCloudToRegularGridFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> MapPointCloudToRegularGridFilter::defaultTags() const
 {
-  return {"Alignment","Point Cloud","Grid","Sampling","Geometry"};
+  return {"Alignment", "Point Cloud", "Grid", "Sampling", "Geometry"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MapPointCloudToRegularGridFilter.hpp
@@ -61,6 +61,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
@@ -276,26 +276,37 @@ nonstd::expected<std::vector<bool>, Error> mergeContainedFeatures(DataStructure&
 }
 } // namespace
 
+//------------------------------------------------------------------------------
 std::string MinNeighbors::name() const
 {
   return FilterTraits<MinNeighbors>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string MinNeighbors::className() const
 {
   return FilterTraits<MinNeighbors>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid MinNeighbors::uuid() const
 {
   return FilterTraits<MinNeighbors>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string MinNeighbors::humanName() const
 {
   return "Minimum Number of Neighbors";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> MinNeighbors::defaultTags() const
+{
+  return {"#Minimum", "#Neighbors", "#Memory Management", "#Cleanup"};
+}
+
+//------------------------------------------------------------------------------
 Parameters MinNeighbors::parameters() const
 {
   Parameters params;
@@ -330,11 +341,13 @@ Parameters MinNeighbors::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer MinNeighbors::clone() const
 {
   return std::make_unique<MinNeighbors>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult MinNeighbors::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto imageGeomPath = args.value<DataPath>(k_ImageGeom_Key);
@@ -375,6 +388,7 @@ IFilter::PreflightResult MinNeighbors::preflightImpl(const DataStructure& data, 
   return {std::move(actions)};
 }
 
+//------------------------------------------------------------------------------
 Result<> MinNeighbors::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto featurePhasesPath = args.value<DataPath>(k_FeaturePhases_Key);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
@@ -303,7 +303,7 @@ std::string MinNeighbors::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> MinNeighbors::defaultTags() const
 {
-  return {"#Minimum", "#Neighbors", "#Memory Management", "#Cleanup"};
+  return {"Minimum","Neighbors","Memory Management","Cleanup"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
@@ -303,7 +303,7 @@ std::string MinNeighbors::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> MinNeighbors::defaultTags() const
 {
-  return {"Minimum","Neighbors","Memory Management","Cleanup"};
+  return {"Minimum", "Neighbors", "Memory Management", "Cleanup"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.hpp
@@ -56,6 +56,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MoveData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MoveData.cpp
@@ -40,7 +40,7 @@ std::string MoveData::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> MoveData::defaultTags() const
 {
-  return {"#Move", "#Memory Management", "#Data Management", "#Data Structure"};
+  return {"Move","Memory Management","Data Management","Data Structure"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MoveData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MoveData.cpp
@@ -40,7 +40,7 @@ std::string MoveData::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> MoveData::defaultTags() const
 {
-  return {"Move","Memory Management","Data Management","Data Structure"};
+  return {"Move", "Memory Management", "Data Management", "Data Structure"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MoveData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MoveData.cpp
@@ -13,26 +13,37 @@ constexpr int64 k_MissingFeaturePhasesError = -251;
 
 } // namespace
 
+//------------------------------------------------------------------------------
 std::string MoveData::name() const
 {
   return FilterTraits<MoveData>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string MoveData::className() const
 {
   return FilterTraits<MoveData>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid MoveData::uuid() const
 {
   return FilterTraits<MoveData>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string MoveData::humanName() const
 {
   return "Move Data";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> MoveData::defaultTags() const
+{
+  return {"#Move", "#Memory Management", "#Data Management", "#Data Structure"};
+}
+
+//------------------------------------------------------------------------------
 Parameters MoveData::parameters() const
 {
   Parameters params;
@@ -43,11 +54,13 @@ Parameters MoveData::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer MoveData::clone() const
 {
   return std::make_unique<MoveData>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult MoveData::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto dataPath = args.value<DataPath>(k_Data_Key);
@@ -67,6 +80,7 @@ IFilter::PreflightResult MoveData::preflightImpl(const DataStructure& data, cons
   return {std::move(actions)};
 }
 
+//------------------------------------------------------------------------------
 Result<> MoveData::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   return {};

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MoveData.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MoveData.hpp
@@ -50,6 +50,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MultiThresholdObjects.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MultiThresholdObjects.cpp
@@ -298,7 +298,7 @@ std::string MultiThresholdObjects::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> MultiThresholdObjects::defaultTags() const
 {
-  return {"#Find Outliers", "#Threshold", "#Isolate", "Data Management"};
+  return {"Find Outliers","Threshold","Isolate", "Data Management"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MultiThresholdObjects.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MultiThresholdObjects.cpp
@@ -277,25 +277,31 @@ std::string MultiThresholdObjects::name() const
   return FilterTraits<MultiThresholdObjects>::name;
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 std::string MultiThresholdObjects::className() const
 {
   return FilterTraits<MultiThresholdObjects>::className;
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 Uuid MultiThresholdObjects::uuid() const
 {
   return FilterTraits<MultiThresholdObjects>::uuid;
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 std::string MultiThresholdObjects::humanName() const
 {
   return "Multi-Threshold Objects";
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+std::vector<std::string> MultiThresholdObjects::defaultTags() const
+{
+  return {"#Find Outliers", "#Threshold", "#Isolate", "Data Management"};
+}
+
+//------------------------------------------------------------------------------
 Parameters MultiThresholdObjects::parameters() const
 {
   Parameters params;
@@ -307,7 +313,7 @@ Parameters MultiThresholdObjects::parameters() const
   return params;
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 IFilter::UniquePointer MultiThresholdObjects::clone() const
 {
   return std::make_unique<MultiThresholdObjects>();

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MultiThresholdObjects.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MultiThresholdObjects.cpp
@@ -298,7 +298,7 @@ std::string MultiThresholdObjects::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> MultiThresholdObjects::defaultTags() const
 {
-  return {"Find Outliers","Threshold","Isolate", "Data Management"};
+  return {"Find Outliers", "Threshold", "Isolate", "Data Management"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MultiThresholdObjects.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MultiThresholdObjects.hpp
@@ -45,6 +45,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/PartitionGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/PartitionGeometryFilter.cpp
@@ -231,7 +231,7 @@ std::string PartitionGeometryFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> PartitionGeometryFilter::defaultTags() const
 {
-  return {"Processing","Segmentation"};
+  return {"Processing", "Segmentation"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/PartitionGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/PartitionGeometryFilter.cpp
@@ -231,7 +231,7 @@ std::string PartitionGeometryFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> PartitionGeometryFilter::defaultTags() const
 {
-  return {"#Processing", "#Segmentation"};
+  return {"Processing","Segmentation"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.cpp
@@ -44,7 +44,7 @@ std::string PointSampleTriangleGeometryFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> PointSampleTriangleGeometryFilter::defaultTags() const
 {
-  return {"ComplexCore","Geometry","TriangleGeometry","Resample"};
+  return {"ComplexCore", "Geometry", "TriangleGeometry", "Resample"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/PointSampleTriangleGeometryFilter.cpp
@@ -44,7 +44,7 @@ std::string PointSampleTriangleGeometryFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> PointSampleTriangleGeometryFilter::defaultTags() const
 {
-  return {"#ComplexCore", "#Geometry", "#TriangleGeometry", "#Resample"};
+  return {"ComplexCore","Geometry","TriangleGeometry","Resample"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
@@ -46,7 +46,7 @@ std::string QuickSurfaceMeshFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> QuickSurfaceMeshFilter::defaultTags() const
 {
-  return {"Surface Meshing","Generation","Create","Triangle", "Geoemtry"};
+  return {"Surface Meshing", "Generation", "Create", "Triangle", "Geoemtry"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/QuickSurfaceMeshFilter.cpp
@@ -46,7 +46,7 @@ std::string QuickSurfaceMeshFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> QuickSurfaceMeshFilter::defaultTags() const
 {
-  return {"#Surface Meshing", "#Generation", "#Create", "#Triangle", "#Geoemtry"};
+  return {"Surface Meshing","Generation","Create","Triangle", "Geoemtry"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
@@ -53,7 +53,7 @@ std::string RawBinaryReaderFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> RawBinaryReaderFilter::defaultTags() const
 {
-  return {"#IO", "#Input", "#Read", "#Import"};
+  return {"IO","Input","Read", "Import"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RawBinaryReaderFilter.cpp
@@ -53,7 +53,7 @@ std::string RawBinaryReaderFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> RawBinaryReaderFilter::defaultTags() const
 {
-  return {"IO","Input","Read", "Import"};
+  return {"IO", "Input", "Read", "Import"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
@@ -74,7 +74,7 @@ std::string RemoveFlaggedVertices::humanName() const
 
 std::vector<std::string> RemoveFlaggedVertices::defaultTags() const
 {
-  return {"#Remove", "#Memory Management", "#Vertex Geometry", "#Delete", "#Reduce"};
+  return {"Remove","Memory Management","Vertex Geometry","Delete","Reduce"};
 }
 
 Parameters RemoveFlaggedVertices::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
@@ -74,7 +74,7 @@ std::string RemoveFlaggedVertices::humanName() const
 
 std::vector<std::string> RemoveFlaggedVertices::defaultTags() const
 {
-  return {"Remove","Memory Management","Vertex Geometry","Delete","Reduce"};
+  return {"Remove", "Memory Management", "Vertex Geometry", "Delete", "Reduce"};
 }
 
 Parameters RemoveFlaggedVertices::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
@@ -74,7 +74,7 @@ std::string RemoveFlaggedVertices::humanName() const
 
 std::vector<std::string> RemoveFlaggedVertices::defaultTags() const
 {
-  return IFilter::defaultTags();
+  return {"#Remove", "#Memory Management", "#Vertex Geometry", "#Delete", "#Reduce"};
 }
 
 Parameters RemoveFlaggedVertices::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveMinimumSizeFeaturesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveMinimumSizeFeaturesFilter.cpp
@@ -277,7 +277,7 @@ std::string RemoveMinimumSizeFeaturesFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> RemoveMinimumSizeFeaturesFilter::defaultTags() const
 {
-  return {"Processing","Cleanup","MinSize"};
+  return {"Processing", "Cleanup", "MinSize"};
 }
 
 Parameters RemoveMinimumSizeFeaturesFilter::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveMinimumSizeFeaturesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveMinimumSizeFeaturesFilter.cpp
@@ -277,7 +277,7 @@ std::string RemoveMinimumSizeFeaturesFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> RemoveMinimumSizeFeaturesFilter::defaultTags() const
 {
-  return {"#Processing", "#Cleanup", "#MinSize"};
+  return {"Processing","Cleanup","MinSize"};
 }
 
 Parameters RemoveMinimumSizeFeaturesFilter::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RenameDataObject.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RenameDataObject.cpp
@@ -17,26 +17,38 @@ constexpr int32 k_EmptyParameterError = -520;
 
 namespace complex
 {
+
+//------------------------------------------------------------------------------
 std::string RenameDataObject::name() const
 {
   return FilterTraits<RenameDataObject>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string RenameDataObject::className() const
 {
   return FilterTraits<RenameDataObject>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid RenameDataObject::uuid() const
 {
   return FilterTraits<RenameDataObject>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string RenameDataObject::humanName() const
 {
   return "Rename DataObject";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> RenameDataObject::defaultTags() const
+{
+  return {"#Data Management", "#Rename", "#Data Structure", "#Data Object"};
+}
+
+//------------------------------------------------------------------------------
 Parameters RenameDataObject::parameters() const
 {
   Parameters params;
@@ -47,11 +59,13 @@ Parameters RenameDataObject::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer RenameDataObject::clone() const
 {
   return std::make_unique<RenameDataObject>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult RenameDataObject::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                          const std::atomic_bool& shouldCancel) const
 {
@@ -65,6 +79,7 @@ IFilter::PreflightResult RenameDataObject::preflightImpl(const DataStructure& da
   return {std::move(actions)};
 }
 
+//------------------------------------------------------------------------------
 Result<> RenameDataObject::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   return {};

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RenameDataObject.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RenameDataObject.cpp
@@ -45,7 +45,7 @@ std::string RenameDataObject::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> RenameDataObject::defaultTags() const
 {
-  return {"#Data Management", "#Rename", "#Data Structure", "#Data Object"};
+  return {"Data Management","Rename","Data Structure","Data Object"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RenameDataObject.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RenameDataObject.cpp
@@ -45,7 +45,7 @@ std::string RenameDataObject::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> RenameDataObject::defaultTags() const
 {
-  return {"Data Management","Rename","Data Structure","Data Object"};
+  return {"Data Management", "Rename", "Data Structure", "Data Object"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RenameDataObject.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RenameDataObject.hpp
@@ -53,6 +53,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.cpp
@@ -41,7 +41,7 @@ std::string ReplaceElementAttributesWithNeighborValuesFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ReplaceElementAttributesWithNeighborValuesFilter::defaultTags() const
 {
-  return {"#Processing", "#Cleanup"};
+  return {"Processing","Cleanup"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.cpp
@@ -41,7 +41,7 @@ std::string ReplaceElementAttributesWithNeighborValuesFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ReplaceElementAttributesWithNeighborValuesFilter::defaultTags() const
 {
-  return {"Processing","Cleanup"};
+  return {"Processing", "Cleanup"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ResampleImageGeomFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ResampleImageGeomFilter.cpp
@@ -59,7 +59,7 @@ std::string ResampleImageGeomFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ResampleImageGeomFilter::defaultTags() const
 {
-  return {"Sampling","Spacing","Image Geometry","Conversion"};
+  return {"Sampling", "Spacing", "Image Geometry", "Conversion"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ResampleImageGeomFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ResampleImageGeomFilter.cpp
@@ -59,7 +59,7 @@ std::string ResampleImageGeomFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ResampleImageGeomFilter::defaultTags() const
 {
-  return {"#Sampling", "#Spacing", "#Image Geometry", "#Conversion"};
+  return {"Sampling","Spacing","Image Geometry","Conversion"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RobustAutomaticThreshold.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RobustAutomaticThreshold.cpp
@@ -123,7 +123,7 @@ std::string RobustAutomaticThreshold::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> RobustAutomaticThreshold::defaultTags() const
 {
-  return {"#ComplexCore", "#Threshold"};
+  return {"ComplexCore","Threshold"};
 }
 
 Parameters RobustAutomaticThreshold::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RobustAutomaticThreshold.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RobustAutomaticThreshold.cpp
@@ -123,7 +123,7 @@ std::string RobustAutomaticThreshold::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> RobustAutomaticThreshold::defaultTags() const
 {
-  return {"ComplexCore","Threshold"};
+  return {"ComplexCore", "Threshold"};
 }
 
 Parameters RobustAutomaticThreshold::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RotateSampleRefFrameFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RotateSampleRefFrameFilter.cpp
@@ -405,7 +405,7 @@ std::string RotateSampleRefFrameFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> RotateSampleRefFrameFilter::defaultTags() const
 {
-  return {"#Processing", "#Conversion", "#ReferenceFrame"};
+  return {"Processing", "Conversion", "ReferenceFrame"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ScalarSegmentFeaturesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ScalarSegmentFeaturesFilter.cpp
@@ -57,7 +57,7 @@ std::string ScalarSegmentFeaturesFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ScalarSegmentFeaturesFilter::defaultTags() const
 {
-  return {"#Reconstruction", "#Segmentation"};
+  return {"Reconstruction", "Segmentation"};
 }
 
 Parameters ScalarSegmentFeaturesFilter::parameters() const

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/SetImageGeomOriginScalingFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/SetImageGeomOriginScalingFilter.cpp
@@ -14,26 +14,37 @@
 namespace complex
 {
 
+//------------------------------------------------------------------------------
 std::string SetImageGeomOriginScalingFilter::name() const
 {
   return FilterTraits<SetImageGeomOriginScalingFilter>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string SetImageGeomOriginScalingFilter::className() const
 {
   return FilterTraits<SetImageGeomOriginScalingFilter>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid SetImageGeomOriginScalingFilter::uuid() const
 {
   return FilterTraits<SetImageGeomOriginScalingFilter>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string SetImageGeomOriginScalingFilter::humanName() const
 {
   return "Set Origin & Spacing (Image Geom)";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> SetImageGeomOriginScalingFilter::defaultTags() const
+{
+  return {"#Image Geometry", "#Shift", "#Spacing", "#Mutate"};
+}
+
+//------------------------------------------------------------------------------
 Parameters SetImageGeomOriginScalingFilter::parameters() const
 {
   Parameters params;
@@ -51,11 +62,13 @@ Parameters SetImageGeomOriginScalingFilter::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer SetImageGeomOriginScalingFilter::clone() const
 {
   return std::make_unique<SetImageGeomOriginScalingFilter>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult SetImageGeomOriginScalingFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                                         const std::atomic_bool& shouldCancel) const
 {
@@ -84,6 +97,7 @@ IFilter::PreflightResult SetImageGeomOriginScalingFilter::preflightImpl(const Da
   return {std::move(actions)};
 }
 
+//------------------------------------------------------------------------------
 Result<> SetImageGeomOriginScalingFilter::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                                       const std::atomic_bool& shouldCancel) const
 {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/SetImageGeomOriginScalingFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/SetImageGeomOriginScalingFilter.cpp
@@ -41,7 +41,7 @@ std::string SetImageGeomOriginScalingFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> SetImageGeomOriginScalingFilter::defaultTags() const
 {
-  return {"Image Geometry","Shift","Spacing","Mutate"};
+  return {"Image Geometry", "Shift", "Spacing", "Mutate"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/SetImageGeomOriginScalingFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/SetImageGeomOriginScalingFilter.cpp
@@ -41,7 +41,7 @@ std::string SetImageGeomOriginScalingFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> SetImageGeomOriginScalingFilter::defaultTags() const
 {
-  return {"#Image Geometry", "#Shift", "#Spacing", "#Mutate"};
+  return {"Image Geometry","Shift","Spacing","Mutate"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/SetImageGeomOriginScalingFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/SetImageGeomOriginScalingFilter.hpp
@@ -52,6 +52,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return Parameters
    */

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/SharedFeatureFaceFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/SharedFeatureFaceFilter.cpp
@@ -40,7 +40,7 @@ std::string SharedFeatureFaceFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> SharedFeatureFaceFilter::defaultTags() const
 {
-  return {"#Surface Meshing", "#Connectivity Arrangement", "#SurfaceMesh"};
+  return {"Surface Meshing","Connectivity Arrangement", "SurfaceMesh"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/SharedFeatureFaceFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/SharedFeatureFaceFilter.cpp
@@ -40,7 +40,7 @@ std::string SharedFeatureFaceFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> SharedFeatureFaceFilter::defaultTags() const
 {
-  return {"Surface Meshing","Connectivity Arrangement", "SurfaceMesh"};
+  return {"Surface Meshing", "Connectivity Arrangement", "SurfaceMesh"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/SplitAttributeArrayFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/SplitAttributeArrayFilter.cpp
@@ -43,7 +43,7 @@ std::string SplitAttributeArrayFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> SplitAttributeArrayFilter::defaultTags() const
 {
-  return {"Core","Split"};
+  return {"Core", "Split"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/SplitAttributeArrayFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/SplitAttributeArrayFilter.cpp
@@ -43,7 +43,7 @@ std::string SplitAttributeArrayFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> SplitAttributeArrayFilter::defaultTags() const
 {
-  return {"#Core", "#Split"};
+  return {"Core","Split"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
@@ -52,7 +52,7 @@ std::string StlFileReaderFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> StlFileReaderFilter::defaultTags() const
 {
-  return {"#IO", "#Input", "#Read", "#Import"};
+  return {"IO","Input", "Read", "Import"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
@@ -52,7 +52,7 @@ std::string StlFileReaderFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> StlFileReaderFilter::defaultTags() const
 {
-  return {"IO","Input", "Read", "Import"};
+  return {"IO", "Input", "Read", "Import"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleCentroidFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleCentroidFilter.cpp
@@ -44,7 +44,7 @@ std::string TriangleCentroidFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> TriangleCentroidFilter::defaultTags() const
 {
-  return {"#Surface Meshing", "#Misc"};
+  return {"Surface Meshing","Misc"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleCentroidFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleCentroidFilter.cpp
@@ -44,7 +44,7 @@ std::string TriangleCentroidFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> TriangleCentroidFilter::defaultTags() const
 {
-  return {"Surface Meshing","Misc"};
+  return {"Surface Meshing", "Misc"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleDihedralAngleFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleDihedralAngleFilter.cpp
@@ -131,7 +131,7 @@ std::string TriangleDihedralAngleFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> TriangleDihedralAngleFilter::defaultTags() const
 {
-  return {"#Surface Meshing", "#Misc", "#Statistics", "#Triangle"};
+  return {"Surface Meshing", "Misc", "Statistics", "Triangle"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleNormalFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleNormalFilter.cpp
@@ -97,7 +97,7 @@ std::string TriangleNormalFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> TriangleNormalFilter::defaultTags() const
 {
-  return {"Surface Meshing","Misc"};
+  return {"Surface Meshing", "Misc"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleNormalFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/TriangleNormalFilter.cpp
@@ -97,7 +97,7 @@ std::string TriangleNormalFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> TriangleNormalFilter::defaultTags() const
 {
-  return {"#Surface Meshing", "#Misc"};
+  return {"Surface Meshing","Misc"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/WriteASCIIDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/WriteASCIIDataFilter.cpp
@@ -50,7 +50,7 @@ std::string WriteASCIIDataFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> WriteASCIIDataFilter::defaultTags() const
 {
-  return {"#IO", "#Output", "#Write", "#Export", "#Text", "#CSV", "#ASCII"};
+  return {"IO","Output","Write", "Export", "Text", "CSV", "ASCII"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/WriteASCIIDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/WriteASCIIDataFilter.cpp
@@ -50,7 +50,7 @@ std::string WriteASCIIDataFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> WriteASCIIDataFilter::defaultTags() const
 {
-  return {"IO","Output","Write", "Export", "Text", "CSV", "ASCII"};
+  return {"IO", "Output", "Write", "Export", "Text", "CSV", "ASCII"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/WriteBinaryDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/WriteBinaryDataFilter.cpp
@@ -63,7 +63,7 @@ std::string WriteBinaryDataFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> WriteBinaryDataFilter::defaultTags() const
 {
-  return {"IO","Output","Write","Export", "Binary"};
+  return {"IO", "Output", "Write", "Export", "Binary"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/WriteBinaryDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/WriteBinaryDataFilter.cpp
@@ -63,7 +63,7 @@ std::string WriteBinaryDataFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> WriteBinaryDataFilter::defaultTags() const
 {
-  return {"#IO", "#Output", "#Write", "#Export", "Binary"};
+  return {"IO","Output","Write","Export", "Binary"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExample.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExample.cpp
@@ -15,26 +15,38 @@ constexpr StringLiteral k_Param4 = "param4";
 
 namespace complex
 {
+
+//------------------------------------------------------------------------------
 std::string DynamicTableExample::name() const
 {
   return FilterTraits<DynamicTableExample>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string DynamicTableExample::className() const
 {
   return FilterTraits<DynamicTableExample>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid DynamicTableExample::uuid() const
 {
   return FilterTraits<DynamicTableExample>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string DynamicTableExample::humanName() const
 {
   return "Dynamic Table Examples";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> DynamicTableExample::defaultTags() const
+{
+  return {"#Example", "#Test"};
+}
+
+//------------------------------------------------------------------------------
 Parameters DynamicTableExample::parameters() const
 {
   Parameters params;
@@ -75,16 +87,19 @@ Parameters DynamicTableExample::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer DynamicTableExample::clone() const
 {
   return std::make_unique<DynamicTableExample>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult DynamicTableExample::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   return {};
 }
 
+//------------------------------------------------------------------------------
 Result<> DynamicTableExample::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineFilter, const MessageHandler& messageHandler,
                                           const std::atomic_bool& shouldCancel) const
 {

--- a/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExample.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExample.cpp
@@ -43,7 +43,7 @@ std::string DynamicTableExample::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> DynamicTableExample::defaultTags() const
 {
-  return {"Example","Test"};
+  return {"Example", "Test"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExample.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExample.cpp
@@ -43,7 +43,7 @@ std::string DynamicTableExample::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> DynamicTableExample::defaultTags() const
 {
-  return {"#Example", "#Test"};
+  return {"Example","Test"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExample.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExample.hpp
@@ -44,6 +44,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return
    */

--- a/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.cpp
@@ -35,26 +35,37 @@
 
 using namespace complex;
 
+//------------------------------------------------------------------------------
 std::string ErrorWarningFilter::name() const
 {
   return FilterTraits<ErrorWarningFilter>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string ErrorWarningFilter::className() const
 {
   return FilterTraits<ErrorWarningFilter>::className;
 }
 
+//------------------------------------------------------------------------------
 complex::Uuid ErrorWarningFilter::uuid() const
 {
   return FilterTraits<ErrorWarningFilter>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string ErrorWarningFilter::humanName() const
 {
   return "Error Warning and Test Filter";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> ErrorWarningFilter::defaultTags() const
+{
+  return {"#Example", "#Test", "#Error"};
+}
+
+//------------------------------------------------------------------------------
 complex::Parameters ErrorWarningFilter::parameters() const
 {
   Parameters params;
@@ -67,11 +78,13 @@ complex::Parameters ErrorWarningFilter::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer ErrorWarningFilter::clone() const
 {
   return std::make_unique<ErrorWarningFilter>();
 }
 
+//------------------------------------------------------------------------------
 complex::IFilter::PreflightResult ErrorWarningFilter::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto preflightWarning = args.value<bool>(k_PreflightWarning_Key);
@@ -96,6 +109,7 @@ complex::IFilter::PreflightResult ErrorWarningFilter::preflightImpl(const DataSt
   return {std::move(resultOutputActions)};
 }
 
+//------------------------------------------------------------------------------
 complex::Result<> ErrorWarningFilter::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                                   const std::atomic_bool& shouldCancel) const
 {

--- a/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.cpp
@@ -62,7 +62,7 @@ std::string ErrorWarningFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ErrorWarningFilter::defaultTags() const
 {
-  return {"#Example", "#Test", "#Error"};
+  return {"Example","Test","Error"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.cpp
@@ -62,7 +62,7 @@ std::string ErrorWarningFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ErrorWarningFilter::defaultTags() const
 {
-  return {"Example","Test","Error"};
+  return {"Example", "Test", "Error"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.hpp
@@ -55,6 +55,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief Returns a collection of parameters used.
    * @return Parameters
    */

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1.cpp
@@ -34,26 +34,37 @@ constexpr StringLiteral k_Param10 = "param10";
 
 namespace complex
 {
+//------------------------------------------------------------------------------
 std::string ExampleFilter1::name() const
 {
   return FilterTraits<ExampleFilter1>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string ExampleFilter1::className() const
 {
   return FilterTraits<ExampleFilter1>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid ExampleFilter1::uuid() const
 {
   return FilterTraits<ExampleFilter1>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string ExampleFilter1::humanName() const
 {
   return "Example Filter 1";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> ExampleFilter1::defaultTags() const
+{
+  return {"#Example", "#Test"};
+}
+
+//------------------------------------------------------------------------------
 Parameters ExampleFilter1::parameters() const
 {
   Parameters params;
@@ -100,11 +111,13 @@ Parameters ExampleFilter1::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer ExampleFilter1::clone() const
 {
   return std::make_unique<ExampleFilter1>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult ExampleFilter1::preflightImpl(const DataStructure& data, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   //  auto inputDir = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputDir_Key);
@@ -157,6 +170,7 @@ IFilter::PreflightResult ExampleFilter1::preflightImpl(const DataStructure& data
   return {};
 }
 
+//------------------------------------------------------------------------------
 Result<> ExampleFilter1::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   return MakeWarningVoidResult(-100, "Example Warning from within an execute message");

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1.cpp
@@ -61,7 +61,7 @@ std::string ExampleFilter1::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ExampleFilter1::defaultTags() const
 {
-  return {"#Example", "#Test"};
+  return {"Example","Test"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1.cpp
@@ -61,7 +61,7 @@ std::string ExampleFilter1::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ExampleFilter1::defaultTags() const
 {
-  return {"Example","Test"};
+  return {"Example", "Test"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1.hpp
@@ -50,6 +50,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return
    */

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
@@ -64,7 +64,7 @@ std::string ExampleFilter2::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ExampleFilter2::defaultTags() const
 {
-  return {"#Example", "#Test"};
+  return {"Example","Test"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
@@ -64,7 +64,7 @@ std::string ExampleFilter2::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ExampleFilter2::defaultTags() const
 {
-  return {"Example","Test"};
+  return {"Example", "Test"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.cpp
@@ -37,26 +37,37 @@ constexpr StringLiteral k_Param16 = "param16";
 
 namespace complex
 {
+//------------------------------------------------------------------------------
 std::string ExampleFilter2::name() const
 {
   return FilterTraits<ExampleFilter2>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string ExampleFilter2::className() const
 {
   return FilterTraits<ExampleFilter2>::className;
 }
 
+//------------------------------------------------------------------------------
 Uuid ExampleFilter2::uuid() const
 {
   return FilterTraits<ExampleFilter2>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string ExampleFilter2::humanName() const
 {
   return "Example Filter 2";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> ExampleFilter2::defaultTags() const
+{
+  return {"#Example", "#Test"};
+}
+
+//------------------------------------------------------------------------------
 Parameters ExampleFilter2::parameters() const
 {
   Parameters params;
@@ -93,16 +104,19 @@ Parameters ExampleFilter2::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 IFilter::UniquePointer ExampleFilter2::clone() const
 {
   return std::make_unique<ExampleFilter2>();
 }
 
+//------------------------------------------------------------------------------
 IFilter::PreflightResult ExampleFilter2::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   return {};
 }
 
+//------------------------------------------------------------------------------
 Result<> ExampleFilter2::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineFilter, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   return {};

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2.hpp
@@ -44,6 +44,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief
    * @return
    */

--- a/src/Plugins/TestOne/src/TestOne/Filters/TestFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/TestFilter.cpp
@@ -18,26 +18,37 @@ TestFilter::TestFilter() = default;
 
 TestFilter::~TestFilter() = default;
 
+//------------------------------------------------------------------------------
 std::string TestFilter::name() const
 {
   return FilterTraits<TestFilter>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string TestFilter::className() const
 {
   return FilterTraits<TestFilter>::className;
 }
 
+//------------------------------------------------------------------------------
 complex::Uuid TestFilter::uuid() const
 {
   return FilterTraits<TestFilter>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string TestFilter::humanName() const
 {
   return "Test Filter";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> TestFilter::defaultTags() const
+{
+  return {"#Example", "#Test"};
+}
+
+//------------------------------------------------------------------------------
 complex::Parameters TestFilter::parameters() const
 {
   Parameters params;
@@ -47,16 +58,19 @@ complex::Parameters TestFilter::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 complex::IFilter::UniquePointer TestFilter::clone() const
 {
   return std::make_unique<TestFilter>();
 }
 
+//------------------------------------------------------------------------------
 complex::IFilter::PreflightResult TestFilter::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   return {};
 }
 
+//------------------------------------------------------------------------------
 complex::Result<> TestFilter::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                           const std::atomic_bool& shouldCancel) const
 {

--- a/src/Plugins/TestOne/src/TestOne/Filters/TestFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/TestFilter.cpp
@@ -45,7 +45,7 @@ std::string TestFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> TestFilter::defaultTags() const
 {
-  return {"#Example", "#Test"};
+  return {"Example","Test"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/TestOne/src/TestOne/Filters/TestFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/TestFilter.cpp
@@ -45,7 +45,7 @@ std::string TestFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> TestFilter::defaultTags() const
 {
-  return {"Example","Test"};
+  return {"Example", "Test"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/TestOne/src/TestOne/Filters/TestFilter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/TestFilter.hpp
@@ -38,6 +38,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief Returns a collection of parameters used.
    * @return Parameters
    */

--- a/src/Plugins/TestTwo/src/TestTwo/Filters/Test2Filter.cpp
+++ b/src/Plugins/TestTwo/src/TestTwo/Filters/Test2Filter.cpp
@@ -18,26 +18,37 @@ Test2Filter::Test2Filter() = default;
 
 Test2Filter::~Test2Filter() = default;
 
+//------------------------------------------------------------------------------
 std::string Test2Filter::name() const
 {
   return FilterTraits<Test2Filter>::name;
 }
 
+//------------------------------------------------------------------------------
 std::string Test2Filter::className() const
 {
   return FilterTraits<Test2Filter>::className;
 }
 
+//------------------------------------------------------------------------------
 complex::Uuid Test2Filter::uuid() const
 {
   return FilterTraits<Test2Filter>::uuid;
 }
 
+//------------------------------------------------------------------------------
 std::string Test2Filter::humanName() const
 {
   return "Test Filter 2";
 }
 
+//------------------------------------------------------------------------------
+std::vector<std::string> Test2Filter::defaultTags() const
+{
+  return {"#Example", "#Test"};
+}
+
+//------------------------------------------------------------------------------
 complex::Parameters Test2Filter::parameters() const
 {
   Parameters params;
@@ -47,16 +58,19 @@ complex::Parameters Test2Filter::parameters() const
   return params;
 }
 
+//------------------------------------------------------------------------------
 complex::IFilter::UniquePointer Test2Filter::clone() const
 {
   return std::make_unique<Test2Filter>();
 }
 
+//------------------------------------------------------------------------------
 complex::IFilter::PreflightResult Test2Filter::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   return {};
 }
 
+//------------------------------------------------------------------------------
 complex::Result<> Test2Filter::executeImpl(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                            const std::atomic_bool& shouldCancel) const
 {

--- a/src/Plugins/TestTwo/src/TestTwo/Filters/Test2Filter.cpp
+++ b/src/Plugins/TestTwo/src/TestTwo/Filters/Test2Filter.cpp
@@ -45,7 +45,7 @@ std::string Test2Filter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> Test2Filter::defaultTags() const
 {
-  return {"Example","Test"};
+  return {"Example", "Test"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/TestTwo/src/TestTwo/Filters/Test2Filter.cpp
+++ b/src/Plugins/TestTwo/src/TestTwo/Filters/Test2Filter.cpp
@@ -45,7 +45,7 @@ std::string Test2Filter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> Test2Filter::defaultTags() const
 {
-  return {"#Example", "#Test"};
+  return {"Example","Test"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/TestTwo/src/TestTwo/Filters/Test2Filter.hpp
+++ b/src/Plugins/TestTwo/src/TestTwo/Filters/Test2Filter.hpp
@@ -37,6 +37,12 @@ public:
   std::string humanName() const override;
 
   /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
    * @brief Returns a collection of parameters used.
    * @return Parameters
    */

--- a/test/DynamicFilterInstantiationTest.cpp
+++ b/test/DynamicFilterInstantiationTest.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Filter List Instantiation")
       args.insert(name, param->defaultValue());
     }
 
-      REQUIRE(!filter->defaultTags().empty());
+    REQUIRE(!filter->defaultTags().empty());
 
     auto preflightResult = filter->preflight(dataStructure, args);
     REQUIRE((preflightResult.outputActions.valid() || preflightResult.outputActions.invalid())); // Preflight exists

--- a/test/DynamicFilterInstantiationTest.cpp
+++ b/test/DynamicFilterInstantiationTest.cpp
@@ -25,24 +25,23 @@ TEST_CASE("Filter List Instantiation")
     auto filter = filterList->createFilter(handle);
     REQUIRE(filter != nullptr);
 
-    SECTION(("Filter List Instantiation::" + filter->className() + ": Instantiation"), ("[complex][" + filter->name() + "]"))
+    UNSCOPED_INFO(fmt::format("Filter List Instantiation::{} Instantiation. [complex][{}]", filter->className(), filter->name()));
+
+    complex::Arguments args;
+    dataStructure.clear();
+
+    auto params = filter->parameters();
+    for(const auto& [name, param] : params)
     {
-      complex::Arguments args;
-      dataStructure.clear();
-
-      auto params = filter->parameters();
-      for(const auto& [name, param] : params)
-      {
-        args.insert(name, param->defaultValue());
-      }
-
-      if(filter->defaultTags().empty())
-      {
-        REQUIRE(!filter->defaultTags().empty());
-      }
-
-      auto preflightResult = filter->preflight(dataStructure, args);
-      REQUIRE((preflightResult.outputActions.valid() || preflightResult.outputActions.invalid())); // Preflight exists
+      args.insert(name, param->defaultValue());
     }
+
+    if(filter->defaultTags().empty())
+    {
+      REQUIRE(!filter->defaultTags().empty());
+    }
+
+    auto preflightResult = filter->preflight(dataStructure, args);
+    REQUIRE((preflightResult.outputActions.valid() || preflightResult.outputActions.invalid())); // Preflight exists
   }
 }

--- a/test/DynamicFilterInstantiationTest.cpp
+++ b/test/DynamicFilterInstantiationTest.cpp
@@ -36,6 +36,11 @@ TEST_CASE("Filter List Instantiation")
         args.insert(name, param->defaultValue());
       }
 
+      if(filter->defaultTags().empty())
+      {
+        REQUIRE(!filter->defaultTags().empty());
+      }
+
       auto preflightResult = filter->preflight(dataStructure, args);
       REQUIRE((preflightResult.outputActions.valid() || preflightResult.outputActions.invalid())); // Preflight exists
     }

--- a/test/DynamicFilterInstantiationTest.cpp
+++ b/test/DynamicFilterInstantiationTest.cpp
@@ -36,10 +36,7 @@ TEST_CASE("Filter List Instantiation")
       args.insert(name, param->defaultValue());
     }
 
-    if(filter->defaultTags().empty())
-    {
       REQUIRE(!filter->defaultTags().empty());
-    }
 
     auto preflightResult = filter->preflight(dataStructure, args);
     REQUIRE((preflightResult.outputActions.valid() || preflightResult.outputActions.invalid())); // Preflight exists


### PR DESCRIPTION
Mostly stylistic change to fix missing tags and update testing to verify all filters have tags.
Remove the '#' character from the tag values
