### PR TITLE
STYLE: Templated Trivial DataType Switches

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/SplitAttributeArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/SplitAttributeArray.cpp
@@ -1,8 +1,8 @@
 #include "SplitAttributeArray.hpp"
 
 #include "complex/DataStructure/DataArray.hpp"
-#include "complex/Utilities/StringUtilities.hpp"
 #include "complex/Utilities/FilterUtilities.hpp"
+#include "complex/Utilities/StringUtilities.hpp"
 
 using namespace complex;
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/SplitAttributeArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/SplitAttributeArray.cpp
@@ -2,29 +2,33 @@
 
 #include "complex/DataStructure/DataArray.hpp"
 #include "complex/Utilities/StringUtilities.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 using namespace complex;
 
 namespace
 {
-template <typename T>
-void SplitArrays(DataStructure& dataStructure, const SplitAttributeArrayInputValues* inputValues)
+struct SplitArraysFunctor
 {
-  DataArray<T>& inputArray = dataStructure.getDataRefAs<DataArray<T>>(inputValues->InputArrayPath);
-  usize numTuples = inputArray.getNumberOfTuples();
-  usize numComponents = inputArray.getNumberOfComponents();
-  for(const auto& j : inputValues->ExtractComponents)
+  template <typename T>
+  void operator()(DataStructure& dataStructure, const SplitAttributeArrayInputValues* inputValues)
   {
-    std::string arrayName = inputValues->InputArrayPath.getTargetName() + inputValues->SplitArraysSuffix + StringUtilities::number(j);
-    DataPath splitArrayPath = inputValues->InputArrayPath.getParent().createChildPath(arrayName);
-    DataArray<T>& splitArray = dataStructure.getDataRefAs<DataArray<T>>(splitArrayPath);
-
-    for(usize i = 0; i < numTuples; i++)
+    auto& inputArray = dataStructure.getDataRefAs<DataArray<T>>(inputValues->InputArrayPath);
+    usize numTuples = inputArray.getNumberOfTuples();
+    usize numComponents = inputArray.getNumberOfComponents();
+    for(const auto& j : inputValues->ExtractComponents)
     {
-      splitArray[i] = inputArray[numComponents * i + j];
+      std::string arrayName = inputValues->InputArrayPath.getTargetName() + inputValues->SplitArraysSuffix + StringUtilities::number(j);
+      DataPath splitArrayPath = inputValues->InputArrayPath.getParent().createChildPath(arrayName);
+      auto& splitArray = dataStructure.getDataRefAs<DataArray<T>>(splitArrayPath);
+
+      for(usize i = 0; i < numTuples; i++)
+      {
+        splitArray[i] = inputArray[numComponents * i + j];
+      }
     }
   }
-}
+};
 } // namespace
 
 // -----------------------------------------------------------------------------
@@ -49,56 +53,8 @@ const std::atomic_bool& SplitAttributeArray::getCancel()
 Result<> SplitAttributeArray::operator()()
 {
   auto& inputArray = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->InputArrayPath);
-  switch(inputArray.getDataType())
-  {
-  case DataType::int8: {
-    SplitArrays<int8>(m_DataStructure, m_InputValues);
-    break;
-  }
-  case DataType::uint8: {
-    SplitArrays<uint8>(m_DataStructure, m_InputValues);
-    break;
-  }
-  case DataType::int16: {
-    SplitArrays<int16>(m_DataStructure, m_InputValues);
-    break;
-  }
-  case DataType::uint16: {
-    SplitArrays<uint16>(m_DataStructure, m_InputValues);
-    break;
-  }
-  case DataType::int32: {
-    SplitArrays<int32>(m_DataStructure, m_InputValues);
-    break;
-  }
-  case DataType::uint32: {
-    SplitArrays<uint32>(m_DataStructure, m_InputValues);
-    break;
-  }
-  case DataType::int64: {
-    SplitArrays<int64>(m_DataStructure, m_InputValues);
-    break;
-  }
-  case DataType::uint64: {
-    SplitArrays<uint64>(m_DataStructure, m_InputValues);
-    break;
-  }
-  case DataType::float32: {
-    SplitArrays<float32>(m_DataStructure, m_InputValues);
-    break;
-  }
-  case DataType::float64: {
-    SplitArrays<float64>(m_DataStructure, m_InputValues);
-    break;
-  }
-  case DataType::boolean: {
-    SplitArrays<bool>(m_DataStructure, m_InputValues);
-    break;
-  }
-  default: {
-    return MakeErrorResult(-84601, fmt::format("Invalid DataType for data array at path '{}'", m_InputValues->InputArrayPath.toString()));
-  }
-  }
+
+  ExecuteDataFunction(SplitArraysFunctor{}, inputArray.getDataType(), m_DataStructure, m_InputValues);
 
   return {};
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.cpp
@@ -16,8 +16,6 @@ using namespace complex;
 namespace
 {
 constexpr int32 k_EmptyParameterError = -123;
-constexpr int32 k_RbrTupleDimsError = -196;
-constexpr int32 k_RbrTupleDimsInconsistent = -197;
 
 template <class T>
 void CreateAndInitArray(DataStructure& data, const DataPath& path, const std::string& initValue)

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateFeatureArrayFromElementArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateFeatureArrayFromElementArray.cpp
@@ -7,63 +7,68 @@
 #include "complex/Filter/Actions/CreateArrayAction.hpp"
 #include "complex/Parameters/ArrayCreationParameter.hpp"
 #include "complex/Parameters/ArraySelectionParameter.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 using namespace complex;
 
 namespace
 {
-template <typename T>
-Result<> copyCellData(DataStructure& dataStructure, const DataPath& selectedCellArrayPathValue, const DataPath& featureIdsArrayPathValue, const DataPath& createdArrayNameValue,
-                      const std::atomic_bool& shouldCancel)
+struct CopyCellDataFunctor
 {
-  const DataArray<T>& selectedCellArray = dataStructure.getDataRefAs<DataArray<T>>(selectedCellArrayPathValue);
-  const DataStore<T> selectedCellArrayStore = selectedCellArray.template getIDataStoreRefAs<DataStore<T>>();
-  const Int32Array& featureIds = dataStructure.getDataRefAs<Int32Array>(featureIdsArrayPathValue);
-  DataArray<T>& createdArray = dataStructure.getDataRefAs<DataArray<T>>(createdArrayNameValue);
-
-  // Initialize the output array with a default value
-  createdArray.fill(0);
-
-  usize totalCellArrayComponents = selectedCellArray.getNumberOfComponents();
-
-  std::map<int32, usize> featureMap;
-  Result<> result;
-
-  usize totalCellArrayTuples = selectedCellArray.getNumberOfTuples();
-  for(usize cellTupleIdx = 0; cellTupleIdx < totalCellArrayTuples; cellTupleIdx++)
+  template <typename T>
+  Result<> operator()(DataStructure& dataStructure, const DataPath& selectedCellArrayPathValue, const DataPath& featureIdsArrayPathValue, const DataPath& createdArrayNameValue,
+                        const std::atomic_bool& shouldCancel)
   {
-    if(shouldCancel)
-    {
-      return {};
-    }
+    const DataArray<T>& selectedCellArray = dataStructure.getDataRefAs<DataArray<T>>(selectedCellArrayPathValue);
+    const DataStore<T> selectedCellArrayStore = selectedCellArray.template getIDataStoreRefAs<DataStore<T>>();
+    const Int32Array& featureIds = dataStructure.getDataRefAs<Int32Array>(featureIdsArrayPathValue);
+    auto& createdArray = dataStructure.getDataRefAs<DataArray<T>>(createdArrayNameValue);
 
-    // Get the feature identifier (or what ever the user has selected as their "Feature" identifier
-    int32 featureIdx = featureIds[cellTupleIdx];
+    // Initialize the output array with a default value
+    createdArray.fill(0);
 
-    // Store the index of the first tuple with this feature identifier in the map
-    if(featureMap.find(featureIdx) == featureMap.end())
-    {
-      featureMap[featureIdx] = totalCellArrayComponents * cellTupleIdx;
-    }
+    usize totalCellArrayComponents = selectedCellArray.getNumberOfComponents();
 
-    // Check that the values at the current index match the value at the first index
-    usize firstInstanceCellTupleIdx = featureMap[featureIdx];
-    for(usize cellCompIdx = 0; cellCompIdx < totalCellArrayComponents; cellCompIdx++)
+    std::map<int32, usize> featureMap;
+    Result<> result;
+
+    usize totalCellArrayTuples = selectedCellArray.getNumberOfTuples();
+    for(usize cellTupleIdx = 0; cellTupleIdx < totalCellArrayTuples; cellTupleIdx++)
     {
-      T firstInstanceCellVal = selectedCellArray[firstInstanceCellTupleIdx + cellCompIdx];
-      T currentCellVal = selectedCellArray[totalCellArrayComponents * cellTupleIdx + cellCompIdx];
-      if(currentCellVal != firstInstanceCellVal && result.warnings().empty())
+      if(shouldCancel)
       {
-        // The values are inconsistent with the first values for this feature identifier, so throw a warning
-        result.warnings().push_back(Warning{-1000, fmt::format("Elements from Feature {} do not all have the same value. The last value copied into Feature {} will be used", featureIdx, featureIdx)});
+        return {};
       }
 
-      createdArray[totalCellArrayComponents * featureIdx + cellCompIdx] = selectedCellArray[totalCellArrayComponents * cellTupleIdx + cellCompIdx];
-    }
-  }
+      // Get the feature identifier (or what ever the user has selected as their "Feature" identifier
+      int32 featureIdx = featureIds[cellTupleIdx];
 
-  return result;
-}
+      // Store the index of the first tuple with this feature identifier in the map
+      if(featureMap.find(featureIdx) == featureMap.end())
+      {
+        featureMap[featureIdx] = totalCellArrayComponents * cellTupleIdx;
+      }
+
+      // Check that the values at the current index match the value at the first index
+      usize firstInstanceCellTupleIdx = featureMap[featureIdx];
+      for(usize cellCompIdx = 0; cellCompIdx < totalCellArrayComponents; cellCompIdx++)
+      {
+        T firstInstanceCellVal = selectedCellArray[firstInstanceCellTupleIdx + cellCompIdx];
+        T currentCellVal = selectedCellArray[totalCellArrayComponents * cellTupleIdx + cellCompIdx];
+        if(currentCellVal != firstInstanceCellVal && result.warnings().empty())
+        {
+          // The values are inconsistent with the first values for this feature identifier, so throw a warning
+          result.warnings().push_back(
+              Warning{-1000, fmt::format("Elements from Feature {} do not all have the same value. The last value copied into Feature {} will be used", featureIdx, featureIdx)});
+        }
+
+        createdArray[totalCellArrayComponents * featureIdx + cellCompIdx] = selectedCellArray[totalCellArrayComponents * cellTupleIdx + cellCompIdx];
+      }
+    }
+
+    return result;
+  }
+};
 } // namespace
 
 namespace complex
@@ -129,7 +134,7 @@ IFilter::PreflightResult CreateFeatureArrayFromElementArray::preflightImpl(const
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
   auto pCreatedArrayNameValue = filterArgs.value<DataPath>(k_CreatedArrayName_Key);
 
-  const IDataArray& selectedCellArray = dataStructure.getDataRefAs<IDataArray>(pSelectedCellArrayPathValue);
+  const auto& selectedCellArray = dataStructure.getDataRefAs<IDataArray>(pSelectedCellArrayPathValue);
   const IDataStore& selectedCellArrayStore = selectedCellArray.getIDataStoreRef();
 
   complex::Result<OutputActions> resultOutputActions;
@@ -155,41 +160,15 @@ Result<> CreateFeatureArrayFromElementArray::executeImpl(DataStructure& dataStru
 
   const IDataArray& selectedCellArray = dataStructure.getDataRefAs<IDataArray>(pSelectedCellArrayPathValue);
   const Int32Array& featureIds = dataStructure.getDataRefAs<Int32Array>(pFeatureIdsArrayPathValue);
-  IDataArray& createdArray = dataStructure.getDataRefAs<IDataArray>(pCreatedArrayNameValue);
+  auto& createdArray = dataStructure.getDataRefAs<IDataArray>(pCreatedArrayNameValue);
 
   // Resize the created array to the proper size
   usize featureIdsMaxIdx = std::distance(featureIds.begin(), std::max_element(featureIds.cbegin(), featureIds.cend()));
   usize maxValue = featureIds[featureIdsMaxIdx];
 
-  IDataStore& createdArrayStore = createdArray.getIDataStoreRefAs<IDataStore>();
+  auto& createdArrayStore = createdArray.getIDataStoreRefAs<IDataStore>();
   createdArrayStore.reshapeTuples(std::vector<usize>{maxValue + 1});
 
-  switch(selectedCellArray.getDataType())
-  {
-  case DataType::int8:
-    return copyCellData<int8>(dataStructure, pSelectedCellArrayPathValue, pFeatureIdsArrayPathValue, pCreatedArrayNameValue, shouldCancel);
-  case DataType::uint8:
-    return copyCellData<uint8>(dataStructure, pSelectedCellArrayPathValue, pFeatureIdsArrayPathValue, pCreatedArrayNameValue, shouldCancel);
-  case DataType::int16:
-    return copyCellData<int16>(dataStructure, pSelectedCellArrayPathValue, pFeatureIdsArrayPathValue, pCreatedArrayNameValue, shouldCancel);
-  case DataType::uint16:
-    return copyCellData<uint16>(dataStructure, pSelectedCellArrayPathValue, pFeatureIdsArrayPathValue, pCreatedArrayNameValue, shouldCancel);
-  case DataType::int32:
-    return copyCellData<int32>(dataStructure, pSelectedCellArrayPathValue, pFeatureIdsArrayPathValue, pCreatedArrayNameValue, shouldCancel);
-  case DataType::uint32:
-    return copyCellData<uint32>(dataStructure, pSelectedCellArrayPathValue, pFeatureIdsArrayPathValue, pCreatedArrayNameValue, shouldCancel);
-  case DataType::int64:
-    return copyCellData<int64>(dataStructure, pSelectedCellArrayPathValue, pFeatureIdsArrayPathValue, pCreatedArrayNameValue, shouldCancel);
-  case DataType::uint64:
-    return copyCellData<uint64>(dataStructure, pSelectedCellArrayPathValue, pFeatureIdsArrayPathValue, pCreatedArrayNameValue, shouldCancel);
-  case DataType::float32:
-    return copyCellData<float>(dataStructure, pSelectedCellArrayPathValue, pFeatureIdsArrayPathValue, pCreatedArrayNameValue, shouldCancel);
-  case DataType::float64:
-    return copyCellData<double>(dataStructure, pSelectedCellArrayPathValue, pFeatureIdsArrayPathValue, pCreatedArrayNameValue, shouldCancel);
-  case DataType::boolean:
-    return copyCellData<bool>(dataStructure, pSelectedCellArrayPathValue, pFeatureIdsArrayPathValue, pCreatedArrayNameValue, shouldCancel);
-  default:
-    return MakeErrorResult(-14000, fmt::format("The selected array was of unsupported type. The path is {}", pSelectedCellArrayPathValue.toString()));
-  }
+  return ExecuteDataFunction(CopyCellDataFunctor{}, selectedCellArray.getDataType(), dataStructure, pSelectedCellArrayPathValue, pFeatureIdsArrayPathValue, pCreatedArrayNameValue, shouldCancel);
 }
 } // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateFeatureArrayFromElementArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateFeatureArrayFromElementArray.cpp
@@ -17,7 +17,7 @@ struct CopyCellDataFunctor
 {
   template <typename T>
   Result<> operator()(DataStructure& dataStructure, const DataPath& selectedCellArrayPathValue, const DataPath& featureIdsArrayPathValue, const DataPath& createdArrayNameValue,
-                        const std::atomic_bool& shouldCancel)
+                      const std::atomic_bool& shouldCancel)
   {
     const DataArray<T>& selectedCellArray = dataStructure.getDataRefAs<DataArray<T>>(selectedCellArrayPathValue);
     const DataStore<T> selectedCellArrayStore = selectedCellArray.template getIDataStoreRefAs<DataStore<T>>();

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
@@ -8,6 +8,7 @@
 #include "complex/Parameters/MultiArraySelectionParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
 #include "complex/Parameters/VectorParameter.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 #include <fmt/core.h>
 
@@ -42,38 +43,41 @@ InitializeData::InitType ConvertIndexToInitType(uint64 index)
   }
 }
 
-template <class T>
-std::optional<Error> CheckInitialization(const IDataArray& dataArray, InitializeData::InitType initType, float64 initValue, const std::pair<float64, float64>& initRange)
+struct CheckInitializationFunctor
 {
-  std::string arrayName = dataArray.getName();
-
-  if(initType == InitializeData::InitType::Manual)
+  template <class T>
+  std::optional<Error> operator()(const IDataArray& dataArray, InitializeData::InitType initType, float64 initValue, const std::pair<float64, float64>& initRange)
   {
-    if(initValue < static_cast<double>(std::numeric_limits<T>().lowest()) || initValue > static_cast<double>(std::numeric_limits<T>().max()))
-    {
-      return Error{-4000, fmt::format("{}: The initialization value could not be converted. The valid range is {} to {}", arrayName, std::numeric_limits<T>::min(), std::numeric_limits<T>::max())};
-    }
-  }
-  else if(initType == InitializeData::InitType::RandomWithRange)
-  {
-    float64 min = initRange.first;
-    float64 max = initRange.second;
-    if(min > max)
-    {
-      return Error{-5550, fmt::format("{}: Invalid initialization range.  Minimum value is larger than maximum value.", arrayName)};
-    }
-    if(min < static_cast<double>(std::numeric_limits<T>().lowest()) || max > static_cast<double>(std::numeric_limits<T>().max()))
-    {
-      return Error{-4001, fmt::format("{}: The initialization range can only be from {} to {}", arrayName, std::numeric_limits<T>::min(), std::numeric_limits<T>::max())};
-    }
-    if(min == max)
-    {
-      return Error{-4002, fmt::format("{}: The initialization range must have differing values", arrayName)};
-    }
-  }
+    std::string arrayName = dataArray.getName();
 
-  return {};
-}
+    if(initType == InitializeData::InitType::Manual)
+    {
+      if(initValue < static_cast<double>(std::numeric_limits<T>().lowest()) || initValue > static_cast<double>(std::numeric_limits<T>().max()))
+      {
+        return Error{-4000, fmt::format("{}: The initialization value could not be converted. The valid range is {} to {}", arrayName, std::numeric_limits<T>::min(), std::numeric_limits<T>::max())};
+      }
+    }
+    else if(initType == InitializeData::InitType::RandomWithRange)
+    {
+      float64 min = initRange.first;
+      float64 max = initRange.second;
+      if(min > max)
+      {
+        return Error{-5550, fmt::format("{}: Invalid initialization range.  Minimum value is larger than maximum value.", arrayName)};
+      }
+      if(min < static_cast<double>(std::numeric_limits<T>().lowest()) || max > static_cast<double>(std::numeric_limits<T>().max()))
+      {
+        return Error{-4001, fmt::format("{}: The initialization range can only be from {} to {}", arrayName, std::numeric_limits<T>::min(), std::numeric_limits<T>::max())};
+      }
+      if(min == max)
+      {
+        return Error{-4002, fmt::format("{}: The initialization range must have differing values", arrayName)};
+      }
+    }
+
+    return {};
+  }
+};
 
 template <class T>
 auto CreateRandomGenerator(T rangeMin, T rangeMax)
@@ -95,49 +99,52 @@ auto CreateRandomGenerator(T rangeMin, T rangeMax)
   }
 }
 
-template <class T>
-void InitializeArray(IDataArray& dataArray, const std::array<usize, 3>& dims, uint64 xMin, uint64 xMax, uint64 yMin, uint64 yMax, uint64 zMin, uint64 zMax, InitializeData::InitType initType,
-                     float64 initValue, const RangeType& initRange)
+struct InitializeArrayFunctor
 {
-  T rangeMin;
-  T rangeMax;
-  if(initType == InitializeData::InitType::RandomWithRange)
+  template <class T>
+  void operator()(IDataArray& dataArray, const std::array<usize, 3>& dims, uint64 xMin, uint64 xMax, uint64 yMin, uint64 yMax, uint64 zMin, uint64 zMax, InitializeData::InitType initType,
+                  float64 initValue, const RangeType& initRange)
   {
-    rangeMin = static_cast<T>(initRange.first);
-    rangeMax = static_cast<T>(initRange.second);
-  }
-  else
-  {
-    rangeMin = std::numeric_limits<T>().min();
-    rangeMax = std::numeric_limits<T>().max();
-  }
-
-  auto& dataStore = dataArray.getIDataStoreRefAs<AbstractDataStore<T>>();
-
-  auto&& [distribution, generator] = CreateRandomGenerator(rangeMin, rangeMax);
-
-  for(uint64 k = zMin; k < zMax + 1; k++)
-  {
-    for(uint64 j = yMin; j < yMax + 1; j++)
+    T rangeMin;
+    T rangeMax;
+    if(initType == InitializeData::InitType::RandomWithRange)
     {
-      for(uint64 i = xMin; i < xMax + 1; i++)
-      {
-        usize index = (k * dims[0] * dims[1]) + (j * dims[0]) + i;
+      rangeMin = static_cast<T>(initRange.first);
+      rangeMax = static_cast<T>(initRange.second);
+    }
+    else
+    {
+      rangeMin = std::numeric_limits<T>().min();
+      rangeMax = std::numeric_limits<T>().max();
+    }
 
-        if(initType == InitializeData::InitType::Manual)
+    auto& dataStore = dataArray.getIDataStoreRefAs<AbstractDataStore<T>>();
+
+    auto&& [distribution, generator] = CreateRandomGenerator(rangeMin, rangeMax);
+
+    for(uint64 k = zMin; k < zMax + 1; k++)
+    {
+      for(uint64 j = yMin; j < yMax + 1; j++)
+      {
+        for(uint64 i = xMin; i < xMax + 1; i++)
         {
-          T num = static_cast<T>(initValue);
-          dataStore.fillTuple(index, num);
-        }
-        else
-        {
-          T randNum = distribution(generator);
-          dataStore.fillTuple(index, randNum);
+          usize index = (k * dims[0] * dims[1]) + (j * dims[0]) + i;
+
+          if(initType == InitializeData::InitType::Manual)
+          {
+            T num = static_cast<T>(initValue);
+            dataStore.fillTuple(index, num);
+          }
+          else
+          {
+            T randNum = distribution(generator);
+            dataStore.fillTuple(index, randNum);
+          }
         }
       }
     }
   }
-}
+};
 } // namespace
 
 namespace complex
@@ -182,7 +189,7 @@ Parameters InitializeData::parameters() const
 
   params.insertSeparator(Parameters::Separator{"Required Data Objects"});
 
-  params.insert(std::make_unique<MultiArraySelectionParameter>(k_CellArrayPaths_Key, "Cell Arrays", "The cell data arrays in which to initialize a subvolume to zeros", std::vector<DataPath>{},
+  params.insert(std::make_unique<MultiArraySelectionParameter>(k_CellArrayPaths_Key, "Cell Arrays", "The cell data arrays in which to initialize a sub-volume to zeros", std::vector<DataPath>{},
                                                                MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray}, complex::GetAllDataTypes()));
   params.insert(std::make_unique<GeometrySelectionParameter>(k_ImageGeometryPath_Key, "Image Geometry", "The geometry containing the cell data for which to initialize", DataPath{},
                                                              GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image}));
@@ -235,7 +242,7 @@ IFilter::PreflightResult InitializeData::preflightImpl(const DataStructure& data
     errors.push_back(Error{-5553, fmt::format("Z Max ({}) less than Z Min ({})", zMax, zMin)});
   }
 
-  const ImageGeom& imageGeom = data.getDataRefAs<ImageGeom>(imageGeomPath);
+  const auto& imageGeom = data.getDataRefAs<ImageGeom>(imageGeomPath);
 
   if(xMax > (static_cast<int64>(imageGeom.getNumXCells()) - 1))
   {
@@ -256,8 +263,7 @@ IFilter::PreflightResult InitializeData::preflightImpl(const DataStructure& data
 
   for(const DataPath& path : cellArrayPaths)
   {
-    const IDataArray& dataArray = data.getDataRefAs<IDataArray>(path);
-
+    const auto& dataArray = data.getDataRefAs<IDataArray>(path);
     std::vector<usize> tupleShape = dataArray.getIDataStoreRef().getTupleShape();
 
     if(tupleShape.size() != reversedImageDims.size())
@@ -266,94 +272,10 @@ IFilter::PreflightResult InitializeData::preflightImpl(const DataStructure& data
       continue;
     }
 
-    DataType type = dataArray.getDataType();
-
-    switch(type)
+    std::optional<Error> maybeError = ExecuteDataFunction(CheckInitializationFunctor{}, dataArray.getDataType(), dataArray, initType, initValue, initRange);
+    if(maybeError.has_value())
     {
-    case DataType::int8: {
-      std::optional<Error> maybeError = CheckInitialization<int8>(dataArray, initType, initValue, initRange);
-      if(maybeError.has_value())
-      {
-        errors.push_back(std::move(*maybeError));
-      }
-      break;
-    }
-    case DataType::int16: {
-      std::optional<Error> maybeError = CheckInitialization<int16>(dataArray, initType, initValue, initRange);
-      if(maybeError.has_value())
-      {
-        errors.push_back(std::move(*maybeError));
-      }
-      break;
-    }
-    case DataType::int32: {
-      std::optional<Error> maybeError = CheckInitialization<int32>(dataArray, initType, initValue, initRange);
-      if(maybeError.has_value())
-      {
-        errors.push_back(std::move(*maybeError));
-      }
-      break;
-    }
-    case DataType::int64: {
-      std::optional<Error> maybeError = CheckInitialization<int64>(dataArray, initType, initValue, initRange);
-      if(maybeError.has_value())
-      {
-        errors.push_back(std::move(*maybeError));
-      }
-      break;
-    }
-    case DataType::uint8: {
-      std::optional<Error> maybeError = CheckInitialization<uint8>(dataArray, initType, initValue, initRange);
-      if(maybeError.has_value())
-      {
-        errors.push_back(std::move(*maybeError));
-      }
-      break;
-    }
-    case DataType::uint16: {
-      std::optional<Error> maybeError = CheckInitialization<uint16>(dataArray, initType, initValue, initRange);
-      if(maybeError.has_value())
-      {
-        errors.push_back(std::move(*maybeError));
-      }
-      break;
-    }
-    case DataType::uint32: {
-      std::optional<Error> maybeError = CheckInitialization<uint32>(dataArray, initType, initValue, initRange);
-      if(maybeError.has_value())
-      {
-        errors.push_back(std::move(*maybeError));
-      }
-      break;
-    }
-    case DataType::uint64: {
-      std::optional<Error> maybeError = CheckInitialization<uint64>(dataArray, initType, initValue, initRange);
-      if(maybeError.has_value())
-      {
-        errors.push_back(std::move(*maybeError));
-      }
-      break;
-    }
-    case DataType::float32: {
-      std::optional<Error> maybeError = CheckInitialization<float32>(dataArray, initType, initValue, initRange);
-      if(maybeError.has_value())
-      {
-        errors.push_back(std::move(*maybeError));
-      }
-      break;
-    }
-    case DataType::float64: {
-      std::optional<Error> maybeError = CheckInitialization<float64>(dataArray, initType, initValue, initRange);
-      if(maybeError.has_value())
-      {
-        errors.push_back(std::move(*maybeError));
-      }
-      break;
-    }
-    default: {
-      errors.push_back(Error{-5560, fmt::format("'{}' is an invalid type", path.toString())});
-      break;
-    }
+      errors.push_back(std::move(*maybeError));
     }
   }
 
@@ -392,58 +314,11 @@ Result<> InitializeData::executeImpl(DataStructure& data, const Arguments& args,
 
   for(const DataPath& path : cellArrayPaths)
   {
-    IDataArray& dataArray = data.getDataRefAs<IDataArray>(path);
+    auto& iDataArray = data.getDataRefAs<IDataArray>(path);
 
-    DataType type = dataArray.getDataType();
+    ExecuteNeighborFunction(InitializeArrayFunctor{}, iDataArray.getDataType(), iDataArray, dims, xMin, xMax, yMin, yMax, zMin, zMin, initType, initValue, initRange);
 
-    switch(type)
-    {
-    case DataType::int8: {
-      InitializeArray<int8>(dataArray, dims, xMin, xMax, yMin, yMax, zMin, zMin, initType, initValue, initRange);
-      break;
-    }
-    case DataType::int16: {
-      InitializeArray<int16>(dataArray, dims, xMin, xMax, yMin, yMax, zMin, zMin, initType, initValue, initRange);
-      break;
-    }
-    case DataType::int32: {
-      InitializeArray<int32>(dataArray, dims, xMin, xMax, yMin, yMax, zMin, zMin, initType, initValue, initRange);
-      break;
-    }
-    case DataType::int64: {
-      InitializeArray<int64>(dataArray, dims, xMin, xMax, yMin, yMax, zMin, zMin, initType, initValue, initRange);
-      break;
-    }
-    case DataType::uint8: {
-      InitializeArray<uint8>(dataArray, dims, xMin, xMax, yMin, yMax, zMin, zMin, initType, initValue, initRange);
-      break;
-    }
-    case DataType::uint16: {
-      InitializeArray<uint16>(dataArray, dims, xMin, xMax, yMin, yMax, zMin, zMin, initType, initValue, initRange);
-      break;
-    }
-    case DataType::uint32: {
-      InitializeArray<uint32>(dataArray, dims, xMin, xMax, yMin, yMax, zMin, zMin, initType, initValue, initRange);
-      break;
-    }
-    case DataType::uint64: {
-      InitializeArray<uint64>(dataArray, dims, xMin, xMax, yMin, yMax, zMin, zMin, initType, initValue, initRange);
-      break;
-    }
-    case DataType::float32: {
-      InitializeArray<float32>(dataArray, dims, xMin, xMax, yMin, yMax, zMin, zMin, initType, initValue, initRange);
-      break;
-    }
-    case DataType::float64: {
-      InitializeArray<float32>(dataArray, dims, xMin, xMax, yMin, yMax, zMin, zMin, initType, initValue, initRange);
-      break;
-    }
-    default: {
-      throw std::runtime_error(fmt::format("InitializeData: Invalid array type for '{}'", path.toString()));
-    }
-    }
-
-    // Delay the execution by 1 second to avoid the exact same seedings for each array
+    // Delay the execution by 1 second to avoid the exact same seeding for each array
     {
       using namespace std::chrono_literals;
       std::this_thread::sleep_for(1s);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
@@ -272,7 +272,7 @@ IFilter::PreflightResult InitializeData::preflightImpl(const DataStructure& data
       continue;
     }
 
-    std::optional<Error> maybeError = ExecuteNeighborFunction(CheckInitializationFunctor{}, dataArray.getDataType(), dataArray, initType, initValue, initRange); //NO BOOL
+    std::optional<Error> maybeError = ExecuteNeighborFunction(CheckInitializationFunctor{}, dataArray.getDataType(), dataArray, initType, initValue, initRange); // NO BOOL
     if(maybeError.has_value())
     {
       errors.push_back(std::move(*maybeError));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
@@ -316,7 +316,7 @@ Result<> InitializeData::executeImpl(DataStructure& data, const Arguments& args,
   {
     auto& iDataArray = data.getDataRefAs<IDataArray>(path);
 
-    ExecuteNeighborFunction(InitializeArrayFunctor{}, iDataArray.getDataType(), iDataArray, dims, xMin, xMax, yMin, yMax, zMin, zMin, initType, initValue, initRange);
+    ExecuteNeighborFunction(InitializeArrayFunctor{}, iDataArray.getDataType(), iDataArray, dims, xMin, xMax, yMin, yMax, zMin, zMin, initType, initValue, initRange); // NO BOOL
 
     // Delay the execution by 1 second to avoid the exact same seeding for each array
     {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InitializeData.cpp
@@ -272,7 +272,7 @@ IFilter::PreflightResult InitializeData::preflightImpl(const DataStructure& data
       continue;
     }
 
-    std::optional<Error> maybeError = ExecuteDataFunction(CheckInitializationFunctor{}, dataArray.getDataType(), dataArray, initType, initValue, initRange);
+    std::optional<Error> maybeError = ExecuteNeighborFunction(CheckInitializationFunctor{}, dataArray.getDataType(), dataArray, initType, initValue, initRange); //NO BOOL
     if(maybeError.has_value())
     {
       errors.push_back(std::move(*maybeError));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
@@ -495,7 +495,7 @@ Result<> InterpolatePointCloudToRegularGridFilter::executeImpl(DataStructure& da
           continue;
         }
 
-        //NO BOOL
+        // NO BOOL
         ExecuteNeighborFunction(MapPointCloudDataByKernelFunctor{}, type, interpolatedArray, dynamicArrayToInterpolate, kernel, kernelNumVoxels, dims.data(), x, y, z, i);
       }
     }
@@ -514,7 +514,7 @@ Result<> InterpolatePointCloudToRegularGridFilter::executeImpl(DataStructure& da
           continue;
         }
 
-        //NO BOOL
+        // NO BOOL
         ExecuteNeighborFunction(MapPointCloudDataByKernelFunctor{}, type, copyArray, dynamicArrayToCopy, uniformKernel, kernelNumVoxels, dims.data(), x, y, z, i);
       }
     }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
@@ -14,6 +14,7 @@
 #include "complex/Parameters/DataPathSelectionParameter.hpp"
 #include "complex/Parameters/MultiArraySelectionParameter.hpp"
 #include "complex/Parameters/VectorParameter.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 #include <cmath>
 
@@ -24,85 +25,46 @@ namespace
 constexpr int64 k_MissingVertexGeom = -24500;
 constexpr int64 k_MissingImageGeom = -24501;
 
-template <typename T>
-void mapPointCloudDataByKernel(IDataArray* source, INeighborList* dynamic, std::vector<float>& kernelVals, int64 kernel[3], usize dims[3], usize curX, usize curY, usize curZ, usize vertIdx)
+struct MapPointCloudDataByKernelFunctor
 {
-  auto* inputDataArray = dynamic_cast<DataArray<T>*>(source);
-  auto& inputData = inputDataArray->getDataStoreRef();
-  auto* interpolatedDataPtr = dynamic_cast<NeighborList<T>*>(dynamic);
-
-  usize index = 0;
-  int64 startKernel[3] = {0, 0, 0};
-  int64 endKernel[3] = {0, 0, 0};
-  usize counter = 0;
-
-  kernel[0] > int64(curX) ? startKernel[0] = 0 : startKernel[0] = curX - kernel[0];
-  kernel[1] > int64(curY) ? startKernel[1] = 0 : startKernel[1] = curY - kernel[1];
-  kernel[2] > int64(curZ) ? startKernel[2] = 0 : startKernel[2] = curZ - kernel[2];
-
-  int64(curX) + kernel[0] >= int64(dims[0]) ? endKernel[0] = dims[0] - 1 : endKernel[0] = curX + kernel[0];
-  int64(curY) + kernel[1] >= int64(dims[1]) ? endKernel[1] = dims[1] - 1 : endKernel[1] = curY + kernel[1];
-  endKernel[2] = int64(curZ);
-
-  for(int64 z = startKernel[2]; z <= endKernel[2]; z++)
+  template <typename T>
+  void operator()(IDataArray* source, INeighborList* dynamic, std::vector<float>& kernelVals, int64 kernel[3], usize dims[3], usize curX, usize curY, usize curZ, usize vertIdx)
   {
-    for(int64 y = startKernel[1]; y <= endKernel[1]; y++)
+    auto* inputDataArray = dynamic_cast<DataArray<T>*>(source);
+    auto& inputData = inputDataArray->getDataStoreRef();
+    auto* interpolatedDataPtr = dynamic_cast<NeighborList<T>*>(dynamic);
+
+    usize index = 0;
+    int64 startKernel[3] = {0, 0, 0};
+    int64 endKernel[3] = {0, 0, 0};
+    usize counter = 0;
+
+    kernel[0] > int64(curX) ? startKernel[0] = 0 : startKernel[0] = curX - kernel[0];
+    kernel[1] > int64(curY) ? startKernel[1] = 0 : startKernel[1] = curY - kernel[1];
+    kernel[2] > int64(curZ) ? startKernel[2] = 0 : startKernel[2] = curZ - kernel[2];
+
+    int64(curX) + kernel[0] >= int64(dims[0]) ? endKernel[0] = dims[0] - 1 : endKernel[0] = curX + kernel[0];
+    int64(curY) + kernel[1] >= int64(dims[1]) ? endKernel[1] = dims[1] - 1 : endKernel[1] = curY + kernel[1];
+    endKernel[2] = int64(curZ);
+
+    for(int64 z = startKernel[2]; z <= endKernel[2]; z++)
     {
-      for(int64 x = startKernel[0]; x <= endKernel[0]; x++)
+      for(int64 y = startKernel[1]; y <= endKernel[1]; y++)
       {
-        if(kernelVals[counter] == 0.0f)
+        for(int64 x = startKernel[0]; x <= endKernel[0]; x++)
         {
-          continue;
+          if(kernelVals[counter] == 0.0f)
+          {
+            continue;
+          }
+          index = (z * dims[1] * dims[0]) + (y * dims[0]) + x;
+          interpolatedDataPtr->addEntry(index, kernelVals[counter] * inputData[vertIdx]);
+          counter++;
         }
-        index = (z * dims[1] * dims[0]) + (y * dims[0]) + x;
-        interpolatedDataPtr->addEntry(index, kernelVals[counter] * inputData[vertIdx]);
-        counter++;
       }
     }
   }
-}
-
-void mapPointCloudDataByKernel(IDataArray* source, INeighborList* dynamic, std::vector<float>& kernelVals, int64 kernel[3], usize dims[3], usize curX, usize curY, usize curZ, usize vertIdx)
-{
-  // Because we are using INeighborList we CANNOT accept Boolean template parameters.
-  // We silently skip over the boolean types. Not really sure if this is a problem.
-
-  switch(source->getDataType())
-  {
-  case DataType::int8:
-    mapPointCloudDataByKernel<int8>(source, dynamic, kernelVals, kernel, dims, curX, curY, curZ, vertIdx);
-    break;
-  case DataType::int16:
-    mapPointCloudDataByKernel<int16>(source, dynamic, kernelVals, kernel, dims, curX, curY, curZ, vertIdx);
-    break;
-  case DataType::int32:
-    mapPointCloudDataByKernel<int32>(source, dynamic, kernelVals, kernel, dims, curX, curY, curZ, vertIdx);
-    break;
-  case DataType::int64:
-    mapPointCloudDataByKernel<int64>(source, dynamic, kernelVals, kernel, dims, curX, curY, curZ, vertIdx);
-    break;
-  case DataType::uint8:
-    mapPointCloudDataByKernel<uint8>(source, dynamic, kernelVals, kernel, dims, curX, curY, curZ, vertIdx);
-    break;
-  case DataType::uint16:
-    mapPointCloudDataByKernel<uint16>(source, dynamic, kernelVals, kernel, dims, curX, curY, curZ, vertIdx);
-    break;
-  case DataType::uint32:
-    mapPointCloudDataByKernel<uint32>(source, dynamic, kernelVals, kernel, dims, curX, curY, curZ, vertIdx);
-    break;
-  case DataType::uint64:
-    mapPointCloudDataByKernel<uint64>(source, dynamic, kernelVals, kernel, dims, curX, curY, curZ, vertIdx);
-    break;
-  case DataType::float32:
-    mapPointCloudDataByKernel<float32>(source, dynamic, kernelVals, kernel, dims, curX, curY, curZ, vertIdx);
-    break;
-  case DataType::float64:
-    mapPointCloudDataByKernel<float64>(source, dynamic, kernelVals, kernel, dims, curX, curY, curZ, vertIdx);
-    break;
-  case DataType::boolean:
-    break;
-  }
-}
+};
 
 void determineKernel(uint64 interpolationTechnique, const FloatVec3& sigmas, std::vector<float32>& kernel, int64 kernelNumVoxels[3])
 {
@@ -526,7 +488,8 @@ Result<> InterpolatePointCloudToRegularGridFilter::executeImpl(DataStructure& da
         auto dynamicArrayPath = parentPath.createChildPath(interpolatedDataPathItem.getTargetName() + "Neighbors");
         auto* dynamicArrayToInterpolate = data.getDataAs<INeighborList>(dynamicArrayPath);
         auto* interpolatedArray = data.getDataAs<IDataArray>(interpolatedDataPathItem);
-        mapPointCloudDataByKernel(interpolatedArray, dynamicArrayToInterpolate, kernel, kernelNumVoxels, dims.data(), x, y, z, i);
+        //NO BOOL
+        ExecuteNeighborFunction(MapPointCloudDataByKernelFunctor{}, interpolatedArray->getDataType(), interpolatedArray, dynamicArrayToInterpolate, kernel, kernelNumVoxels, dims.data(), x, y, z, i);
       }
     }
 
@@ -537,7 +500,8 @@ Result<> InterpolatePointCloudToRegularGridFilter::executeImpl(DataStructure& da
         auto dynamicArrayPath = interpolatedDataPath.createChildPath(copyDataPath.getTargetName() + " Neighbors");
         auto* dynamicArrayToCopy = data.getDataAs<INeighborList>(dynamicArrayPath);
         auto* copyArray = data.getDataAs<IDataArray>(copyDataPath);
-        mapPointCloudDataByKernel(copyArray, dynamicArrayToCopy, uniformKernel, kernelNumVoxels, dims.data(), x, y, z, i);
+        //NO BOOL
+        ExecuteNeighborFunction(MapPointCloudDataByKernelFunctor{}, copyArray->getDataType(), copyArray, dynamicArrayToCopy, uniformKernel, kernelNumVoxels, dims.data(), x, y, z, i);
       }
     }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
@@ -28,7 +28,7 @@ constexpr int64 k_MissingImageGeom = -24501;
 struct MapPointCloudDataByKernelFunctor
 {
   template <typename T>
-  void operator()(IDataArray* source, INeighborList* dynamic, std::vector<float>& kernelVals, int64 kernel[3], usize dims[3], usize curX, usize curY, usize curZ, usize vertIdx)
+  void operator()(IDataArray* source, INeighborList* dynamic, std::vector<float>& kernelVals, const int64 kernel[3], const usize dims[3], usize curX, usize curY, usize curZ, usize vertIdx)
   {
     auto* inputDataArray = dynamic_cast<DataArray<T>*>(source);
     auto& inputData = inputDataArray->getDataStoreRef();
@@ -66,7 +66,7 @@ struct MapPointCloudDataByKernelFunctor
   }
 };
 
-void determineKernel(uint64 interpolationTechnique, const FloatVec3& sigmas, std::vector<float32>& kernel, int64 kernelNumVoxels[3])
+void determineKernel(uint64 interpolationTechnique, const FloatVec3& sigmas, std::vector<float32>& kernel, const int64 kernelNumVoxels[3])
 {
   usize counter = 0;
 
@@ -488,8 +488,15 @@ Result<> InterpolatePointCloudToRegularGridFilter::executeImpl(DataStructure& da
         auto dynamicArrayPath = parentPath.createChildPath(interpolatedDataPathItem.getTargetName() + "Neighbors");
         auto* dynamicArrayToInterpolate = data.getDataAs<INeighborList>(dynamicArrayPath);
         auto* interpolatedArray = data.getDataAs<IDataArray>(interpolatedDataPathItem);
+
+        const auto& type = interpolatedArray->getDataType();
+        if(type == DataType::boolean) // Cant be executed will throw error
+        {
+          continue;
+        }
+
         //NO BOOL
-        ExecuteNeighborFunction(MapPointCloudDataByKernelFunctor{}, interpolatedArray->getDataType(), interpolatedArray, dynamicArrayToInterpolate, kernel, kernelNumVoxels, dims.data(), x, y, z, i);
+        ExecuteNeighborFunction(MapPointCloudDataByKernelFunctor{}, type, interpolatedArray, dynamicArrayToInterpolate, kernel, kernelNumVoxels, dims.data(), x, y, z, i);
       }
     }
 
@@ -500,8 +507,15 @@ Result<> InterpolatePointCloudToRegularGridFilter::executeImpl(DataStructure& da
         auto dynamicArrayPath = interpolatedDataPath.createChildPath(copyDataPath.getTargetName() + " Neighbors");
         auto* dynamicArrayToCopy = data.getDataAs<INeighborList>(dynamicArrayPath);
         auto* copyArray = data.getDataAs<IDataArray>(copyDataPath);
+
+        const auto& type = copyArray->getDataType();
+        if(type == DataType::boolean) // Cant be executed will throw error
+        {
+          continue;
+        }
+
         //NO BOOL
-        ExecuteNeighborFunction(MapPointCloudDataByKernelFunctor{}, copyArray->getDataType(), copyArray, dynamicArrayToCopy, uniformKernel, kernelNumVoxels, dims.data(), x, y, z, i);
+        ExecuteNeighborFunction(MapPointCloudDataByKernelFunctor{}, type, copyArray, dynamicArrayToCopy, uniformKernel, kernelNumVoxels, dims.data(), x, y, z, i);
       }
     }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MultiThresholdObjects.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MultiThresholdObjects.cpp
@@ -5,6 +5,7 @@
 #include "complex/Parameters/ArrayCreationParameter.hpp"
 #include "complex/Parameters/ArrayThresholdsParameter.hpp"
 #include "complex/Utilities/ArrayThreshold.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 namespace complex
 {
@@ -109,67 +110,6 @@ public:
     }
   }
 
-  /**
-   * @brief execute
-   * @param input
-   * @param output
-   * @return
-   */
-  void execute(DataStructure& dataStructure, DataPath& inputArrayDataPath)
-  {
-    const auto& dataArray = dataStructure.getDataRefAs<IDataArray>(inputArrayDataPath);
-
-    DataType type = dataArray.getDataType();
-
-    switch(type)
-    {
-    case DataType::int8: {
-      filterData<int8>(dynamic_cast<const DataArray<int8>&>(dataArray));
-      break;
-    }
-    case DataType::uint8: {
-      filterData<uint8>(dynamic_cast<const DataArray<uint8>&>(dataArray));
-      break;
-    }
-    case DataType::int16: {
-      filterData<int16>(dynamic_cast<const DataArray<int16>&>(dataArray));
-      break;
-    }
-    case DataType::uint16: {
-      filterData<uint16>(dynamic_cast<const DataArray<uint16>&>(dataArray));
-      break;
-    }
-    case DataType::int32: {
-      filterData<int32>(dynamic_cast<const DataArray<int32>&>(dataArray));
-      break;
-    }
-    case DataType::uint32: {
-      filterData<uint32>(dynamic_cast<const DataArray<uint32>&>(dataArray));
-      break;
-    }
-    case DataType::int64: {
-      filterData<int64>(dynamic_cast<const DataArray<int64>&>(dataArray));
-      break;
-    }
-    case DataType::uint64: {
-      filterData<uint64>(dynamic_cast<const DataArray<uint64>&>(dataArray));
-      break;
-    }
-    case DataType::float32: {
-      filterData<float32>(dynamic_cast<const DataArray<float32>&>(dataArray));
-      break;
-    }
-    case DataType::float64: {
-      filterData<float64>(dynamic_cast<const DataArray<float64>&>(dataArray));
-      break;
-    }
-    case DataType::boolean: {
-      filterData<bool>(dynamic_cast<const DataArray<bool>&>(dataArray));
-      break;
-    }
-    }
-  }
-
 private:
   complex::ArrayThreshold::ComparisonType m_ComparisonOperator;
   complex::ArrayThreshold::ComparisonValue m_ComparisonValue;
@@ -182,6 +122,16 @@ public:
   ThresholdFilterHelper& operator=(ThresholdFilterHelper&&) = delete;      // Move Assignment Not Implemented
 };
 
+struct ExecuteThresholdHelper
+{
+  template <typename Type>
+  void operator()(ThresholdFilterHelper& helper, const IDataArray& iDataArray)
+  {
+    const auto& dataArray = dynamic_cast<const DataArray<Type>&>(iDataArray);
+    helper.filterData<Type>(dataArray);
+  }
+};
+
 /**
  * @brief InsertThreshold
  * @param numItems
@@ -190,10 +140,9 @@ public:
  * @param newArrayPtr
  * @param inverse
  */
-void InsertThreshold(int64_t numItems, BoolArray& currentArray, complex::IArrayThreshold::UnionOperator unionOperator, std::vector<bool>& newArrayPtr, bool inverse)
+void InsertThreshold(usize numItems, BoolArray& currentArray, complex::IArrayThreshold::UnionOperator unionOperator, std::vector<bool>& newArrayPtr, bool inverse)
 {
-
-  for(int64_t i = 0; i < numItems; i++)
+  for(usize i = 0; i < numItems; i++)
   {
     // invert the current comparison if necessary
     if(inverse)
@@ -230,7 +179,7 @@ void ThresholdValue(std::shared_ptr<ArrayThreshold>& comparisonValue, DataStruct
   }
   // Traditionally we would do a check to ensure we get a valid pointer, I'm forgoing that check because it
   // was essentially done in the preflight part.
-  BoolArray& outputResultArray = dataStructure.getDataRefAs<BoolArray>(outputResultArrayPath);
+  auto& outputResultArray = dataStructure.getDataRefAs<BoolArray>(outputResultArrayPath);
 
   // Get the total number of tuples, create and initialize an array with FALSE to use for these results
   size_t totalTuples = outputResultArray.getNumberOfTuples();
@@ -242,9 +191,11 @@ void ThresholdValue(std::shared_ptr<ArrayThreshold>& comparisonValue, DataStruct
 
   DataPath inputDataArrayPath = comparisonValue->getArrayPath();
 
-  ThresholdFilterHelper filter(compOperator, compValue, tempResultVector);
+  ThresholdFilterHelper helper(compOperator, compValue, tempResultVector);
 
-  filter.execute(dataStructure, inputDataArrayPath);
+  const auto& iDataArray = dataStructure.getDataRefAs<IDataArray>(inputDataArrayPath);
+
+  ExecuteDataFunction(ExecuteThresholdHelper{}, iDataArray.getDataType(), helper, iDataArray);
 
   if(replaceInput)
   {
@@ -272,18 +223,9 @@ void ThresholdSet(std::shared_ptr<ArrayThresholdSet>& inputComparisonSet, DataSt
     return;
   }
 
-  //  if(inverse)
-  //  {
-  //    inverse = !comparisonSet->getInvertComparison();
-  //  }
-  //  else
-  //  {
-  //    inverse = comparisonSet->getInvertComparison();
-  //  }
-
   // Traditionally we would do a check to ensure we get a valid pointer, I'm forgoing that check because it
   // was essentially done in the preflight part.
-  BoolArray& outputResultArray = dataStructure.getDataRefAs<BoolArray>(outputResultArrayPath);
+  auto& outputResultArray = dataStructure.getDataRefAs<BoolArray>(outputResultArrayPath);
 
   // Get the total number of tuples, create and initialize an array with FALSE to use for these results
   size_t totalTuples = outputResultArray.getNumberOfTuples();
@@ -335,21 +277,25 @@ std::string MultiThresholdObjects::name() const
   return FilterTraits<MultiThresholdObjects>::name;
 }
 
+// -----------------------------------------------------------------------------
 std::string MultiThresholdObjects::className() const
 {
   return FilterTraits<MultiThresholdObjects>::className;
 }
 
+// -----------------------------------------------------------------------------
 Uuid MultiThresholdObjects::uuid() const
 {
   return FilterTraits<MultiThresholdObjects>::uuid;
 }
 
+// -----------------------------------------------------------------------------
 std::string MultiThresholdObjects::humanName() const
 {
   return "Multi-Threshold Objects";
 }
 
+// -----------------------------------------------------------------------------
 Parameters MultiThresholdObjects::parameters() const
 {
   Parameters params;
@@ -361,35 +307,13 @@ Parameters MultiThresholdObjects::parameters() const
   return params;
 }
 
+// -----------------------------------------------------------------------------
 IFilter::UniquePointer MultiThresholdObjects::clone() const
 {
   return std::make_unique<MultiThresholdObjects>();
 }
 
-std::vector<usize> getDims(const DataStructure& data, const std::set<DataPath>& dataPaths)
-{
-  if(dataPaths.empty())
-  {
-    return {0};
-  }
-  std::vector<usize> dims;
-
-  DataPath firstDataPath = *(dataPaths.begin());
-  const IDataArray* dataArray = data.getDataAs<IDataArray>(firstDataPath);
-  size_t numTuples = dataArray->getNumberOfTuples();
-
-  for(const auto& dataPath : dataPaths)
-  {
-    const IDataArray* currentDataArray = data.getDataAs<IDataArray>(dataPath);
-    if(numTuples != dataArray->getNumberOfTuples())
-    {
-      return {};
-    }
-  }
-
-  return {0};
-}
-
+// -----------------------------------------------------------------------------
 IFilter::PreflightResult MultiThresholdObjects::preflightImpl(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   auto thresholdsObject = args.value<ArrayThresholdSet>(k_ArrayThresholds_Key);
@@ -414,7 +338,7 @@ IFilter::PreflightResult MultiThresholdObjects::preflightImpl(const DataStructur
   // Check for Scalar arrays
   for(const auto& dataPath : thresholdPaths)
   {
-    const IDataArray* currentDataArray = data.getDataAs<IDataArray>(dataPath);
+    const auto* currentDataArray = data.getDataAs<IDataArray>(dataPath);
     if(currentDataArray != nullptr && currentDataArray->getNumberOfComponents() != 1)
     {
       auto errorMessage = fmt::format("Data Array is not a Scalar Data Array. Data Arrays must only have a single component. '{}:{}'", dataPath.toString(), currentDataArray->getNumberOfComponents());
@@ -424,12 +348,12 @@ IFilter::PreflightResult MultiThresholdObjects::preflightImpl(const DataStructur
 
   // Check that all arrays the number of tuples match
   DataPath firstDataPath = *(thresholdPaths.begin());
-  const IDataArray* dataArray = data.getDataAs<IDataArray>(firstDataPath);
+  const auto* dataArray = data.getDataAs<IDataArray>(firstDataPath);
   size_t numTuples = dataArray->getNumberOfTuples();
 
   for(const auto& dataPath : thresholdPaths)
   {
-    const IDataArray* currentDataArray = data.getDataAs<IDataArray>(dataPath);
+    const auto* currentDataArray = data.getDataAs<IDataArray>(dataPath);
     if(numTuples != currentDataArray->getNumberOfTuples())
     {
       auto errorMessage =
@@ -473,8 +397,6 @@ Result<> MultiThresholdObjects::executeImpl(DataStructure& dataStructure, const 
       firstValueFound = true;
     }
   }
-
-  // thresholdsObject.applyMaskValues(data, maskArrayPath);
 
   return {};
 }


### PR DESCRIPTION
This PR removed DataType switches from the following filters:
- Multi-ThresholdObjects
- FindDifferencesMap
- InitializeData
- SplitAttributeArray
- CopyFeatureArraytoElementArray
- CreateFreatureArrayFromElementArray
- InterpolatePointCloudtoRegularGrid

Some of these filters were slightly rewritten to ensure the more efficient route was taken.

## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `complex/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `complex/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to complex!** -->
