### PR TITLE
BUG: Fix Resizing Misnomer and Move Resize Into AttributeMatrix API

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ComputeFeatureRect.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ComputeFeatureRect.cpp
@@ -40,7 +40,7 @@ Result<> ComputeFeatureRect::operator()()
   if(corners.getNumberOfTuples() == 0)
   {
     usize maxElement = static_cast<usize>(*std::max_element(featureIds.begin(), featureIds.end()));
-    corners.reshapeTuples(std::vector<usize>{maxElement + 1});
+    corners.resizeTuples(std::vector<usize>{maxElement + 1});
   }
 
   auto& cornersDataStore = corners.getIDataStoreRefAs<UInt32DataStore>();

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ExtractVertexGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ExtractVertexGeometry.cpp
@@ -121,7 +121,7 @@ Result<> ExtractVertexGeometry::operator()()
         DataPath destDataArrayPath = vertexAttrMatrixPath.createChildPath(srcDataArrayPath.getTargetName());
         IDataArray& destDataArray = m_DataStructure.getDataRefAs<IDataArray>(destDataArrayPath);
         auto& destDataArrayStore = destDataArray.getIDataStoreRef();
-        destDataArrayStore.reshapeTuples({cellCount});
+        destDataArrayStore.resizeTuples({cellCount});
       }
 
       maskArray = maskArrayPtr;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ExtractVertexGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ExtractVertexGeometry.cpp
@@ -114,7 +114,7 @@ Result<> ExtractVertexGeometry::operator()()
     {
       const BoolArray* maskArrayPtr = m_DataStructure.getDataAs<BoolArray>(m_InputValues->MaskArrayPath);
       cellCount = std::count(maskArrayPtr->begin(), maskArrayPtr->end(), true);
-      vertexAttrMatrix.setShape({cellCount});
+      vertexAttrMatrix.resizeTuples({cellCount});
 
       for(const auto& srcDataArrayPath : m_InputValues->IncludedDataArrayPaths)
       {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindArrayStatistics.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindArrayStatistics.cpp
@@ -785,7 +785,7 @@ Result<> FindArrayStatistics::operator()()
     {
       if(array != nullptr)
       {
-        array->reshapeTuples({numFeatures});
+        array->resizeTuples({numFeatures});
       }
     }
   }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindArrayStatistics.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindArrayStatistics.cpp
@@ -779,7 +779,7 @@ Result<> FindArrayStatistics::operator()()
     numFeatures = findNumFeatures(featureIds);
 
     auto* destAttrMatPtr = m_DataStructure.getDataAs<AttributeMatrix>(m_InputValues->DestinationAttributeMatrix);
-    destAttrMatPtr->setShape({numFeatures});
+    destAttrMatPtr->resizeTuples({numFeatures});
 
     for(const auto& array : arrays)
     {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindTriangleGeomSizes.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindTriangleGeomSizes.cpp
@@ -84,8 +84,7 @@ Result<> FindTriangleGeomSizes::operator()()
 
   AttributeMatrix::ShapeType tDims = {featureSet.size() + 1};
   auto& featAttrMat = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->FeatureAttributeMatrixPath);
-  featAttrMat.setShape(tDims);
-  ResizeAttributeMatrix(featAttrMat, tDims);
+  featAttrMat.resizeTuples(tDims);
   auto& volumes = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->VolumesArrayPath);
 
   std::array<usize, 3> faceVertexIndices = {0, 0, 0};

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ImageContouring.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ImageContouring.cpp
@@ -18,7 +18,7 @@ struct ExecuteFlyingEdgesFunctor
     flyingEdges.pass3();
 
     // pass 3 resized normals so be sure to resize parent AM
-    normAM.setShape(normals.getTupleShape());
+    normAM.resizeTuples(normals.getTupleShape());
 
     flyingEdges.pass4();
   }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/PointSampleTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/PointSampleTriangleGeometry.cpp
@@ -65,7 +65,7 @@ Result<> PointSampleTriangleGeometry::operator()()
   VertexGeom& vertex = m_DataStructure.getDataRefAs<VertexGeom>(m_Inputs->pVertexGeometryPath);
   vertex.resizeVertexList(m_Inputs->pNumberOfSamples);
   auto tupleShape = {static_cast<usize>(m_Inputs->pNumberOfSamples)};
-  ResizeAttributeMatrix(*vertex.getVertexAttributeMatrix(), tupleShape);
+  vertex.getVertexAttributeMatrix()->resizeTuples(tupleShape);
 
   std::mt19937_64::result_type seed = static_cast<std::mt19937_64::result_type>(std::chrono::steady_clock::now().time_since_epoch().count());
   std::mt19937_64 generator(seed);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/QuickSurfaceMesh.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/QuickSurfaceMesh.cpp
@@ -102,8 +102,8 @@ Result<> QuickSurfaceMesh::operator()()
   std::vector<usize> tupleShape = {triangleCount};
   triangleGeom.resizeFaceList(triangleCount);
   triangleGeom.resizeVertexList(nodeCount);
-  ResizeAttributeMatrix(*triangleGeom.getFaceAttributeMatrix(), tupleShape);
-  ResizeAttributeMatrix(*triangleGeom.getVertexAttributeMatrix(), {nodeCount});
+  triangleGeom.getFaceAttributeMatrix()->resizeTuples(tupleShape);
+  triangleGeom.getVertexAttributeMatrix()->resizeTuples({nodeCount});
 
   // Resize the Face Arrays that are being copied over from the ImageGeom Cell Data
   for(const auto& dataPath : m_Inputs->pCreatedDataArrayPaths)
@@ -807,8 +807,8 @@ void QuickSurfaceMesh::createNodesAndTriangles(std::vector<MeshIndexType>& m_Nod
   std::vector<size_t> tDims = {nodeCount};
   triangleGeom->resizeVertexList(nodeCount);
   triangleGeom->resizeFaceList(triangleCount);
-  ResizeAttributeMatrix(*triangleGeom->getFaceAttributeMatrix(), {triangleCount});
-  ResizeAttributeMatrix(*triangleGeom->getVertexAttributeMatrix(), tDims);
+  triangleGeom->getFaceAttributeMatrix()->resizeTuples({triangleCount});
+  triangleGeom->getVertexAttributeMatrix()->resizeTuples(tDims);
 
   // Remove and then insert a properly sized Int32Array for the FaceLabels
   m_DataStructure.removeData(m_Inputs->pFaceLabelsDataPath);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
@@ -281,7 +281,7 @@ int64_t ScalarSegmentFeatures::getSeed(int32 gnum, int64 nextSeed) const
     featureIds->setValue(static_cast<usize>(seed), gnum);
     std::vector<usize> tDims = {static_cast<usize>(gnum) + 1};
     auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->pCellFeaturesPath);
-    ResizeAttributeMatrix(cellFeaturesAM, tDims); // This will resize the active array
+    cellFeaturesAM.resizeTuples(tDims); // This will resize the active array
   }
   return seed;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/SharedFeatureFace.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/SharedFeatureFace.cpp
@@ -138,13 +138,12 @@ Result<> SharedFeatureFace::operator()()
   // Grain Boundary Attribute Matrix
   auto& faceFeatureAttrMat = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->GrainBoundaryAttributeMatrixPath);
   std::vector<usize> tDims = {static_cast<usize>(index)};
-  faceFeatureAttrMat.setShape(tDims);
-  ResizeAttributeMatrix(faceFeatureAttrMat, tDims);
+  faceFeatureAttrMat.resizeTuples(tDims);
 
   auto& surfaceMeshFeatureFaceLabels = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->FeatureFaceLabelsArrayPath);
   auto& surfaceMeshFeatureFaceNumTriangles = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->FeatureFaceNumTrianglesArrayPath);
-  surfaceMeshFeatureFaceLabels.getDataStore()->reshapeTuples(tDims);
-  surfaceMeshFeatureFaceNumTriangles.getDataStore()->reshapeTuples(tDims);
+  surfaceMeshFeatureFaceLabels.getDataStore()->resizeTuples(tDims);
+  surfaceMeshFeatureFaceNumTriangles.getDataStore()->resizeTuples(tDims);
 
   // For smaller data sets having data parallelization ON actually runs slower due to
   // all the overhead of the threads. We are just going to turn this off for

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/StlFileReader.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/StlFileReader.cpp
@@ -386,8 +386,8 @@ Result<> StlFileReader::eliminate_duplicate_nodes()
     triangles[i * 3 + 2] = uniqueIds[node3];
   }
 
-  ResizeAttributeMatrix(*triangleGeom.getFaceAttributeMatrix(), {triangleGeom.getNumberOfFaces()});
-  ResizeAttributeMatrix(*triangleGeom.getVertexAttributeMatrix(), {triangleGeom.getNumberOfVertices()});
+  triangleGeom.getFaceAttributeMatrix()->resizeTuples({triangleGeom.getNumberOfFaces()});
+  triangleGeom.getVertexAttributeMatrix()->resizeTuples({triangleGeom.getNumberOfVertices()});
 
   return {};
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateFeatureArrayFromElementArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateFeatureArrayFromElementArray.cpp
@@ -177,7 +177,7 @@ Result<> CreateFeatureArrayFromElementArray::executeImpl(DataStructure& dataStru
   usize maxValue = featureIds[featureIdsMaxIdx];
 
   auto& createdArrayStore = createdArray.getIDataStoreRefAs<IDataStore>();
-  createdArrayStore.reshapeTuples(std::vector<usize>{maxValue + 1});
+  createdArrayStore.resizeTuples(std::vector<usize>{maxValue + 1});
 
   return ExecuteDataFunction(CopyCellDataFunctor{}, selectedCellArray.getDataType(), dataStructure, pSelectedCellArrayPathValue, pFeatureIdsArrayPathValue, pCreatedArrayNameValue, shouldCancel);
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CropVertexGeometry.cpp
@@ -211,7 +211,7 @@ Result<> CropVertexGeometry::executeImpl(DataStructure& dataStructure, const Arg
 
   DataPath croppedVertexDataPath = croppedGeomPath.createChildPath(vertexDataName);
   auto& vertedDataAttMatrix = dataStructure.getDataRefAs<AttributeMatrix>(croppedVertexDataPath);
-  ResizeAttributeMatrix(vertedDataAttMatrix, tDims);
+  vertedDataAttMatrix.resizeTuples(tDims);
 
   for(usize i = 0; i < numTuples; i++)
   {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -325,8 +325,8 @@ Result<> ExtractInternalSurfacesFromTriangleGeometry::executeImpl(DataStructure&
   // Resize the vertex and triangle arrays
   internalTriangleGeom.resizeVertexList(currentNewVertIndex);
   internalTriangleGeom.resizeFaceList(currentNewTriIndex);
-  ResizeAttributeMatrix(*internalTriangleGeom.getVertexAttributeMatrix(), {currentNewVertIndex});
-  ResizeAttributeMatrix(*internalTriangleGeom.getFaceAttributeMatrix(), {currentNewTriIndex});
+  internalTriangleGeom.getVertexAttributeMatrix()->resizeTuples({currentNewVertIndex});
+  internalTriangleGeom.getFaceAttributeMatrix()->resizeTuples({currentNewTriIndex});
 
   IGeometry::SharedVertexList* internalVerts = internalTriangleGeom.getVertices();
   IGeometry::SharedFaceList* internalTriangles = internalTriangleGeom.getFaces();
@@ -384,7 +384,7 @@ Result<> ExtractInternalSurfacesFromTriangleGeometry::executeImpl(DataStructure&
     DataPath destinationPath = internalTrianglesPath.createChildPath(faceDataName).createChildPath(targetArrayPath.getTargetName());
     auto& src = data.getDataRefAs<IDataArray>(targetArrayPath);
     auto& dest = data.getDataRefAs<IDataArray>(destinationPath);
-    dest.getIDataStore()->reshapeTuples({currentNewTriIndex});
+    dest.getIDataStore()->resizeTuples({currentNewTriIndex});
 
     ExecuteDataFunction(RemoveFlaggedVerticesFunctor{}, src.getDataType(), src, dest, triNewIndex);
   }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedVertices.cpp
@@ -33,7 +33,7 @@ struct RemoveFlaggedVerticesFunctor
   {
     auto& inputData = dynamic_cast<DataArray<T>&>(inputDataPtr);
     auto& maskedData = dynamic_cast<DataArray<T>&>(maskedDataPtr);
-    maskedData.getDataStore()->reshapeTuples({maskPoints.size()});
+    maskedData.getDataStore()->resizeTuples({maskPoints.size()});
     usize nComps = inputData.getNumberOfComponents();
 
     for(usize i = 0; i < maskPoints.size(); i++)
@@ -196,7 +196,7 @@ Result<> RemoveFlaggedVertices::executeImpl(DataStructure& data, const Arguments
 
   VertexGeom& reducedVertex = data.getDataRefAs<VertexGeom>(reducedVertexPath);
   reducedVertex.resizeVertexList(trueCount);
-  ResizeAttributeMatrix(*reducedVertex.getVertexAttributeMatrix(), tDims);
+  reducedVertex.getVertexAttributeMatrix()->resizeTuples(tDims);
 
   for(size_t i = 0; i < trueCount; i++)
   {

--- a/src/Plugins/ComplexCore/test/ArrayCalculatorTest.cpp
+++ b/src/Plugins/ComplexCore/test/ArrayCalculatorTest.cpp
@@ -46,11 +46,9 @@ const std::string k_Pi_Str = StringUtilities::number(numbers::pi);
 DataStructure createDataStructure()
 {
   DataStructure dataStructure;
-  AttributeMatrix* am1 = AttributeMatrix::Create(dataStructure, k_AttributeMatrix);
-  am1->setShape(std::vector<size_t>(1, 10));
+  AttributeMatrix* am1 = AttributeMatrix::Create(dataStructure, k_AttributeMatrix, {10ULL});
   const auto am1Id = am1->getId();
-  AttributeMatrix* am2 = AttributeMatrix::Create(dataStructure, k_NumericMatrix);
-  am2->setShape(std::vector<size_t>(1, 1));
+  AttributeMatrix* am2 = AttributeMatrix::Create(dataStructure, k_NumericMatrix, {1ULL});
   Float32Array* array1 = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, k_InputArray1, {10}, {1}, am1Id);
   array1->fill(-12);
   UInt32Array* array2 = UInt32Array::CreateWithStore<UInt32DataStore>(dataStructure, k_InputArray2, {10}, {1}, am1Id);

--- a/src/Plugins/ComplexCore/test/ComputeFeatureRectTest.cpp
+++ b/src/Plugins/ComplexCore/test/ComputeFeatureRectTest.cpp
@@ -24,8 +24,7 @@ DataStructure CreateTestData()
   ImageGeom* iGeom = ImageGeom::Create(dataStructure, k_ImageGeometryName);
   std::vector<usize> dims = {5, 5, 5};
   iGeom->setDimensions(dims);
-  AttributeMatrix* cellAM = AttributeMatrix::Create(dataStructure, k_CellAttrMatrixName, iGeom->getId());
-  cellAM->setShape({dims[2], dims[1], dims[0]});
+  AttributeMatrix* cellAM = AttributeMatrix::Create(dataStructure, k_CellAttrMatrixName, {dims[2], dims[1], dims[0]}, iGeom->getId());
 
   Int32Array* featureIds = Int32Array::CreateWithStore<Int32DataStore>(dataStructure, k_FeatureIdsArrayName, {dims[2], dims[1], dims[0]}, {1}, cellAM->getId());
   featureIds->fill(0);
@@ -67,8 +66,7 @@ DataStructure CreateTestData()
   featureIdsStore[67] = 3;
   featureIdsStore[68] = 3;
 
-  AttributeMatrix* featureAM = AttributeMatrix::Create(dataStructure, k_FeatureAttrMatrixName, iGeom->getId());
-  featureAM->setShape({4});
+  AttributeMatrix* featureAM = AttributeMatrix::Create(dataStructure, k_FeatureAttrMatrixName, {4}, iGeom->getId());
 
   std::vector<usize> compDims = {6};
   UInt32Array* rect = UInt32Array::CreateWithStore<UInt32DataStore>(dataStructure, k_RectCoordsExemplaryArrayName, {4}, {6}, featureAM->getId());

--- a/src/Plugins/ComplexCore/test/ComputeMomentInvariants2DTest.cpp
+++ b/src/Plugins/ComplexCore/test/ComputeMomentInvariants2DTest.cpp
@@ -100,8 +100,7 @@ DataStructure CreateInvalidTestData()
   dims[0] = 5;
   dims[1] = 5;
   dims[2] = 5;
-  AttributeMatrix* cellAm = AttributeMatrix::Create(dataStructure, k_CellData, imageGeom->getId());
-  cellAm->setShape(dims);
+  AttributeMatrix* cellAm = AttributeMatrix::Create(dataStructure, k_CellData, dims, imageGeom->getId());
 
   Int32Array* featureIds = Int32Array::CreateWithStore<DataStore<int32>>(dataStructure, k_FeatureIds, dims, std::vector<usize>{1}, cellAm->getId());
   featureIds->fill(0);
@@ -117,8 +116,7 @@ DataStructure CreateInvalidTestData()
 
   dims.resize(1);
   dims[0] = 2;
-  AttributeMatrix* featureAm = AttributeMatrix::Create(dataStructure, k_FeatureData, imageGeom->getId());
-  featureAm->setShape(dims);
+  AttributeMatrix* featureAm = AttributeMatrix::Create(dataStructure, k_FeatureData, dims, imageGeom->getId());
 
 #if 0
       0, 0, 0, 0, 0,
@@ -154,8 +152,7 @@ DataStructure CreateTestData()
   dims[0] = 1;
   dims[1] = 5;
   dims[2] = 5;
-  AttributeMatrix* cellAm = AttributeMatrix::Create(dataStructure, k_CellData, imageGeom->getId());
-  cellAm->setShape(dims);
+  AttributeMatrix* cellAm = AttributeMatrix::Create(dataStructure, k_CellData, dims, imageGeom->getId());
 
   Int32Array* featureIds = Int32Array::CreateWithStore<DataStore<int32>>(dataStructure, k_FeatureIds, dims, std::vector<usize>{1}, cellAm->getId());
   featureIds->fill(0);
@@ -171,8 +168,7 @@ DataStructure CreateTestData()
 
   dims.resize(1);
   dims[0] = 2;
-  AttributeMatrix* featureAm = AttributeMatrix::Create(dataStructure, k_FeatureData, imageGeom->getId());
-  featureAm->setShape(dims);
+  AttributeMatrix* featureAm = AttributeMatrix::Create(dataStructure, k_FeatureData, dims, imageGeom->getId());
 
 #if 0
       0, 0, 0, 0, 0,

--- a/src/Plugins/ComplexCore/test/ConvertDataTest.cpp
+++ b/src/Plugins/ComplexCore/test/ConvertDataTest.cpp
@@ -10,8 +10,6 @@
 
 #include <catch2/catch.hpp>
 
-#include <cassert>
-#include <memory>
 #include <vector>
 
 using namespace complex;
@@ -27,9 +25,8 @@ const size_t COMPONENT_DIM = 2;
 template <typename T>
 void createDataStructure(DataStructure& dataStructure)
 {
-  std::vector<size_t> tdims = {TUPLE_DIM};
-  AttributeMatrix* am = AttributeMatrix::Create(dataStructure, AttributeMatrixName);
-  am->setShape(tdims);
+  const std::vector<size_t> tdims = {TUPLE_DIM};
+  AttributeMatrix* am = AttributeMatrix::Create(dataStructure, AttributeMatrixName, tdims);
   std::vector<size_t> cdims = {COMPONENT_DIM};
   DataArray<T>* da = DataArray<T>::template CreateWithStore<DataStore<T>>(dataStructure, DataArrayName, tdims, cdims, am->getId());
   da->fill(static_cast<T>(0.0));

--- a/src/Plugins/ComplexCore/test/CopyDataObjectTest.cpp
+++ b/src/Plugins/ComplexCore/test/CopyDataObjectTest.cpp
@@ -85,8 +85,7 @@ TEST_CASE("ComplexCore::CopyDataObjectFilter(Invalid Parameters)", "[ComplexCore
   }
   SECTION("Copy data new parent tuple mimatch")
   {
-    auto* attributeMatrix = AttributeMatrix::Create(dataStructure, "TestAttributeMatrix");
-    attributeMatrix->setShape({10, 5, 1});
+    auto* attributeMatrix = AttributeMatrix::Create(dataStructure, "TestAttributeMatrix", {10, 5, 1});
 
     const DataPath dataPath({Constants::k_SmallIN100, Constants::k_EbsdScanData, "Phases"});
     const DataPath copyPath({"TestAttributeMatrix"});

--- a/src/Plugins/ComplexCore/test/CreateAttributeMatrixTest.cpp
+++ b/src/Plugins/ComplexCore/test/CreateAttributeMatrixTest.cpp
@@ -45,7 +45,7 @@ TEST_CASE("ComplexCore::CreateAttributeMatrixFilter(Invalid Parameters)", "[Comp
 
   SECTION("Section 2")
   {
-    AttributeMatrix* attMat1 = AttributeMatrix::Create(dataStructure, "AttributeMatrix1");
+    AttributeMatrix* attMat1 = AttributeMatrix::Create(dataStructure, "AttributeMatrix1", {1ULL});
     args.insert(CreateAttributeMatrixFilter::k_DataObjectPath, std::make_any<DataPath>(DataPath({"AttributeMatrix1", "AttributeMatrix2"})));
     args.insert(CreateAttributeMatrixFilter::k_TupleDims_Key, std::make_any<DynamicTableParameter::ValueType>(k_TupleDims));
   }

--- a/src/Plugins/ComplexCore/test/CropImageGeometryTest.cpp
+++ b/src/Plugins/ComplexCore/test/CropImageGeometryTest.cpp
@@ -36,13 +36,13 @@ DataStructure CreateDataStructure()
   imageGeom->setOrigin({0.0f, 20.0f, 66.0f});
   SizeVec3 imageGeomDims = {40, 60, 80};
   imageGeom->setDimensions(imageGeomDims); // Listed from slowest to fastest (Z, Y, X)
-  auto* cellData = AttributeMatrix::Create(dataStructure, ImageGeom::k_CellDataName, imageGeom->getId());
+
   auto imageDimsArray = imageGeomDims.toArray();
   AttributeMatrix::ShapeType cellDataDims{imageDimsArray.crbegin(), imageDimsArray.crend()};
-  cellData->setShape(cellDataDims);
-  imageGeom->setCellData(*cellData);
+  auto* cellDataPtr = AttributeMatrix::Create(dataStructure, ImageGeom::k_CellDataName, cellDataDims, imageGeom->getId());
+  imageGeom->setCellData(*cellDataPtr);
 
-  Int32Array* phases_data = UnitTest::CreateTestDataArray<int32>(dataStructure, "Phases", cellDataDims, {1}, cellData->getId());
+  Int32Array* phases_data = UnitTest::CreateTestDataArray<int32>(dataStructure, "Phases", cellDataDims, {1}, cellDataPtr->getId());
 
   return dataStructure;
 }

--- a/src/Plugins/ComplexCore/test/CropVertexGeometryTest.cpp
+++ b/src/Plugins/ComplexCore/test/CropVertexGeometryTest.cpp
@@ -23,8 +23,7 @@ DataStructure createTestData()
   auto* vertexArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "Vertices", {k_TupleCount}, {3}, vertexGeom->getId());
   vertexGeom->setVertices(*vertexArray);
 
-  auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, k_VertexDataName, vertexGeom->getId());
-  vertexAttributeMatrix->setShape({k_TupleCount});
+  auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, k_VertexDataName, {k_TupleCount}, vertexGeom->getId());
   vertexGeom->setVertexAttributeMatrix(*vertexAttributeMatrix);
 
   auto* dataArray = Int32Array::CreateWithStore<Int32DataStore>(dataStructure, "DataArray", {k_TupleCount}, {1}, vertexAttributeMatrix->getId());

--- a/src/Plugins/ComplexCore/test/DREAM3DFileTest.cpp
+++ b/src/Plugins/ComplexCore/test/DREAM3DFileTest.cpp
@@ -136,9 +136,10 @@ DataStructure CreateTestDataStructure()
   auto group1 = DataGroup::Create(dataStructure, DataNames::k_Group1Name);
   auto group2 = DataGroup::Create(dataStructure, DataNames::k_Group2Name, group1->getId());
   auto group3 = DataGroup::Create(dataStructure, DataNames::k_Group3Name, group2->getId());
-  auto attributeMatrix = AttributeMatrix::Create(dataStructure, DataNames::k_AttributeMatrixName, group1->getId());
+
   std::vector<usize> tupleShape = {10};
-  attributeMatrix->setShape(tupleShape);
+  auto* attributeMatrix = AttributeMatrix::Create(dataStructure, DataNames::k_AttributeMatrixName, tupleShape, group1->getId());
+
   Result<> arrayCreationResults =
       CreateArray<int8>(dataStructure, tupleShape, std::vector<usize>{1}, DataPath({DataNames::k_Group1Name, DataNames::k_AttributeMatrixName, DataNames::k_Array2Name}), IDataAction::Mode::Execute);
   auto& dataArray = dataStructure.getDataRefAs<Int8Array>(DataPath({DataNames::k_Group1Name, DataNames::k_AttributeMatrixName, DataNames::k_Array2Name}));

--- a/src/Plugins/ComplexCore/test/ExtractVertexGeometryTest.cpp
+++ b/src/Plugins/ComplexCore/test/ExtractVertexGeometryTest.cpp
@@ -44,8 +44,7 @@ DataStructure CreateDataStructure()
   TriangleGeom::Create(dataStructure, k_WrongGeometryName);
 
   // Create the Cell AttributeMatrix
-  AttributeMatrix* cellAttrMat = AttributeMatrix::Create(dataStructure, k_CellAttrMatName, imageGeom->getId());
-  cellAttrMat->setShape(dims);
+  AttributeMatrix* cellAttrMat = AttributeMatrix::Create(dataStructure, k_CellAttrMatName, dims, imageGeom->getId());
 
   // Generate a "mask"
   BoolArray* maskData = BoolArray::CreateWithStore<BoolDataStore>(dataStructure, k_MaskArrayName, {cellCount}, {1}, cellAttrMat->getId());
@@ -56,8 +55,7 @@ DataStructure CreateDataStructure()
   (*maskData)[13] = false;
   (*maskData)[14] = false;
 
-  AttributeMatrix* cellAttrMat2 = AttributeMatrix::Create(dataStructure, k_CellAttrMat2Name, imageGeom->getId());
-  cellAttrMat2->setShape(dims);
+  AttributeMatrix* cellAttrMat2 = AttributeMatrix::Create(dataStructure, k_CellAttrMat2Name, dims, imageGeom->getId());
 
   // Create a cell attribute array
   Float32Array* f32Data = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, k_FloatArrayName, {cellCount}, {1}, cellAttrMat->getId());
@@ -66,8 +64,7 @@ DataStructure CreateDataStructure()
   Float32Array* f32Data2 = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, k_FloatArrayName, {cellCount}, {1}, cellAttrMat2->getId());
   f32Data2->fill(45.243f);
 
-  AttributeMatrix* wrongTuplesAttrMatrix = AttributeMatrix::Create(dataStructure, k_WrongAttrMatName, imageGeom->getId());
-  wrongTuplesAttrMatrix->setShape({3});
+  AttributeMatrix* wrongTuplesAttrMatrix = AttributeMatrix::Create(dataStructure, k_WrongAttrMatName, {3}, imageGeom->getId());
 
   Float32Array::CreateWithStore<Float32DataStore>(dataStructure, k_FloatArrayName, {3}, {1}, wrongTuplesAttrMatrix->getId());
 

--- a/src/Plugins/ComplexCore/test/FeatureDataCSVWriterTest.cpp
+++ b/src/Plugins/ComplexCore/test/FeatureDataCSVWriterTest.cpp
@@ -52,8 +52,7 @@ TEST_CASE("ComplexCore::FeatureDataCSVWriterFilter: Test Algorithm", "[FeatureDa
 {
   FeatureDataCSVWriterFilter filter;
   DataStructure dataStructure;
-  AttributeMatrix& topLevelGroup = *AttributeMatrix::Create(dataStructure, "TestData");
-  topLevelGroup.setShape(k_VertexTupleDims);
+  AttributeMatrix& topLevelGroup = *AttributeMatrix::Create(dataStructure, "TestData", k_VertexTupleDims);
   auto path = dataStructure.getAllDataPaths()[0];
 
   auto* neighborList = NeighborList<float32>::Create(dataStructure, "Neighbor List", k_NumTuples, topLevelGroup.getId());

--- a/src/Plugins/ComplexCore/test/FindLargestCrossSectionsTest.cpp
+++ b/src/Plugins/ComplexCore/test/FindLargestCrossSectionsTest.cpp
@@ -23,10 +23,8 @@ DataStructure CreateValidTestDataStructure()
   std::vector<usize> dims = {6, 6, 6};
   imageGeom->setDimensions(dims);
 
-  auto* cellAM = AttributeMatrix::Create(ds, k_CellData, imageGeom->getId());
-  cellAM->setShape(dims);
-  auto* cellFeatureAM = AttributeMatrix::Create(ds, k_CellFeatureData, imageGeom->getId());
-  cellFeatureAM->setShape({6});
+  auto* cellAM = AttributeMatrix::Create(ds, k_CellData, dims, imageGeom->getId());
+  auto* cellFeatureAM = AttributeMatrix::Create(ds, k_CellFeatureData, {6}, imageGeom->getId());
 
   auto* featureIds = Int32Array::CreateWithStore<Int32DataStore>(ds, k_FeatureIds, dims, {1}, cellAM->getId());
   auto& featureIdsDataStore = featureIds->getDataStoreRef();
@@ -263,12 +261,9 @@ DataStructure CreateInvalidTestDataStructure(bool geomIs3d)
   }
   imageGeom->setDimensions(dims);
 
-  auto* cellAM = AttributeMatrix::Create(ds, k_CellData, imageGeom->getId());
-  cellAM->setShape(dims);
-  auto* cellFeatureAM = AttributeMatrix::Create(ds, k_CellFeatureData, imageGeom->getId());
-  cellFeatureAM->setShape({6});
-  auto* testAM = AttributeMatrix::Create(ds, k_CellEnsembleData, imageGeom->getId());
-  testAM->setShape({2});
+  auto* cellAM = AttributeMatrix::Create(ds, k_CellData, dims, imageGeom->getId());
+  auto* cellFeatureAM = AttributeMatrix::Create(ds, k_CellFeatureData, {6}, imageGeom->getId());
+  auto* testAM = AttributeMatrix::Create(ds, k_CellEnsembleData, {2}, imageGeom->getId());
 
   auto* featureIds = Int32Array::CreateWithStore<Int32DataStore>(ds, k_FeatureIds, dims, {1}, cellAM->getId());
   auto& featureIdsDataStore = featureIds->getDataStoreRef();

--- a/src/Plugins/ComplexCore/test/ImportHDF5DatasetTest.cpp
+++ b/src/Plugins/ComplexCore/test/ImportHDF5DatasetTest.cpp
@@ -205,8 +205,7 @@ void testFilterPreflight(ImportHDF5Dataset& filter)
   DataStructure dataStructure;
   DataGroup* levelZeroGroup = DataGroup::Create(dataStructure, Constants::k_LevelZero);
   std::string levelZeroAMName = Constants::k_LevelZero.str() + "AM";
-  AttributeMatrix* levelZeroAttributeMatrix = AttributeMatrix::Create(dataStructure, levelZeroAMName);
-  levelZeroAttributeMatrix->setShape({COMPDIMPROD * TUPLEDIMPROD});
+  AttributeMatrix* levelZeroAttributeMatrix = AttributeMatrix::Create(dataStructure, levelZeroAMName, {COMPDIMPROD * TUPLEDIMPROD});
   std::optional<DataPath> levelZeroPath = {DataPath::FromString(Constants::k_LevelZero.view()).value()};
 
   ImportHDF5DatasetParameter::ValueType val = {levelZeroPath, "", {}};

--- a/src/Plugins/ComplexCore/test/RemoveFlaggedFeaturesTest.cpp
+++ b/src/Plugins/ComplexCore/test/RemoveFlaggedFeaturesTest.cpp
@@ -31,9 +31,9 @@ void FillDataStructure(DataStructure& dataStructure)
   imageGeom->setOrigin(std::vector<float>{0, 0, 0});
   imageGeom->setSpacing(std::vector<float>{1, 1, 1});
 
-  auto* attributeMatrix = AttributeMatrix::Create(dataStructure, k_CellData, imageGeom->getId());
   std::vector<size_t> tupleDims(dims.rbegin(), dims.rend());
-  attributeMatrix->setShape(tupleDims);
+  auto* attributeMatrix = AttributeMatrix::Create(dataStructure, k_CellData, tupleDims, imageGeom->getId());
+
   imageGeom->setCellData(*attributeMatrix);
 
   Int32Array* featureIds = UnitTest::CreateTestDataArray<int32>(dataStructure, k_FeatureIds, tupleDims, {1}, attributeMatrix->getId());
@@ -55,8 +55,7 @@ void FillDataStructure(DataStructure& dataStructure)
   testFeatIdsDataStore[14] = 3;
   testFeatIdsDataStore[15] = 0;
 
-  auto* featureAttributeMatrix = AttributeMatrix::Create(dataStructure, k_CellFeatureData, imageGeom->getId());
-  featureAttributeMatrix->setShape({4});
+  auto* featureAttributeMatrix = AttributeMatrix::Create(dataStructure, k_CellFeatureData, {4ULL}, imageGeom->getId());
   BoolArray* maskArray = BoolArray::CreateWithStore<DataStore<bool>>(dataStructure, k_ActiveName, {4}, {1}, featureAttributeMatrix->getId());
   auto& maskDataStore = maskArray->getDataStoreRef();
   maskDataStore[0] = false;

--- a/src/Plugins/ComplexCore/test/RemoveFlaggedVerticesTest.cpp
+++ b/src/Plugins/ComplexCore/test/RemoveFlaggedVerticesTest.cpp
@@ -42,8 +42,7 @@ TEST_CASE("ComplexCore::RemoveFlaggedVertices: Test Algorithm", "[ComplexCore][R
   Float32Array* coords = UnitTest::CreateTestDataArray<float>(dataStructure, "coords", vertexTupleDims, vertexCompDims, vertexGeom->getId());
   vertexGeom->setVertices(*coords); // Add the vertices to the VertexGeom object
 
-  auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, Constants::k_VertexDataGroupName, vertexGeom->getId());
-  vertexAttributeMatrix->setShape(vertexTupleDims);
+  auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, Constants::k_VertexDataGroupName, vertexTupleDims, vertexGeom->getId());
   vertexGeom->setVertexAttributeMatrix(*vertexAttributeMatrix);
 
   Int32Array* slipVector = UnitTest::CreateTestDataArray<int32>(dataStructure, Constants::k_SlipVector, vertexTupleDims, vertexCompDims, vertexAttributeMatrix->getId());

--- a/src/Plugins/ComplexCore/test/SplitAttributeArrayTest.cpp
+++ b/src/Plugins/ComplexCore/test/SplitAttributeArrayTest.cpp
@@ -56,8 +56,7 @@ void fillDataArray(DataArray<T>* inputArray)
 DataStructure createDataStructure()
 {
   DataStructure dataStructure;
-  AttributeMatrix* am1 = AttributeMatrix::Create(dataStructure, "AttributeMatrix");
-  am1->setShape(std::vector<size_t>(1, 10));
+  AttributeMatrix* am1 = AttributeMatrix::Create(dataStructure, "AttributeMatrix", {10});
 
   UInt32Array* mcArray1 = UInt32Array::CreateWithStore<DataStore<uint32>>(dataStructure, "MultiComponent Array uint32", std::vector<size_t>(1, 10), std::vector<size_t>(1, 5), am1->getId());
   fillDataArray<uint32>(mcArray1);

--- a/src/Plugins/ComplexCore/test/TriangleCentroidTest.cpp
+++ b/src/Plugins/ComplexCore/test/TriangleCentroidTest.cpp
@@ -48,11 +48,9 @@ TEST_CASE("ComplexCore::TriangleCentroidFilter", "[ComplexCore][TriangleCentroid
 {
   DataStructure dataStructure;
   TriangleGeom& acuteTriangle = *TriangleGeom::Create(dataStructure, k_TriangleGeometryName);
-  AttributeMatrix* faceData = AttributeMatrix::Create(dataStructure, INodeGeometry2D::k_FaceDataName, acuteTriangle.getId());
-  faceData->setShape({k_FaceTupleCount});
+  AttributeMatrix* faceData = AttributeMatrix::Create(dataStructure, INodeGeometry2D::k_FaceDataName, {k_FaceTupleCount}, acuteTriangle.getId());
   acuteTriangle.setFaceAttributeMatrix(*faceData);
-  AttributeMatrix* vertData = AttributeMatrix::Create(dataStructure, INodeGeometry0D::k_VertexDataName, acuteTriangle.getId());
-  vertData->setShape({k_VertexTupleCount});
+  AttributeMatrix* vertData = AttributeMatrix::Create(dataStructure, INodeGeometry0D::k_VertexDataName, {k_VertexTupleCount}, acuteTriangle.getId());
   acuteTriangle.setVertexAttributeMatrix(*vertData);
   auto vertexList = CreateVertexList(acuteTriangle, vertData->getId());
   auto facesList = CreateFaceList(acuteTriangle, faceData->getId());

--- a/src/Plugins/ComplexCore/test/TriangleDihedralAngleFilterTest.cpp
+++ b/src/Plugins/ComplexCore/test/TriangleDihedralAngleFilterTest.cpp
@@ -50,11 +50,9 @@ TEST_CASE("ComplexCore::TriangleDihedralAngleFilter[valid results]", "[ComplexCo
   std::string dihedralAnglesDataArrayName = "DihedralAngles";
   DataStructure dataStructure;
   TriangleGeom& acuteTriangle = *TriangleGeom::Create(dataStructure, triangleGeometryName);
-  AttributeMatrix* faceData = AttributeMatrix::Create(dataStructure, INodeGeometry2D::k_FaceDataName, acuteTriangle.getId());
-  faceData->setShape({k_FaceTupleCount});
+  AttributeMatrix* faceData = AttributeMatrix::Create(dataStructure, INodeGeometry2D::k_FaceDataName, {k_FaceTupleCount}, acuteTriangle.getId());
   acuteTriangle.setFaceAttributeMatrix(*faceData);
-  AttributeMatrix* vertData = AttributeMatrix::Create(dataStructure, INodeGeometry0D::k_VertexDataName, acuteTriangle.getId());
-  vertData->setShape({k_VertexTupleCount});
+  AttributeMatrix* vertData = AttributeMatrix::Create(dataStructure, INodeGeometry0D::k_VertexDataName, {k_VertexTupleCount}, acuteTriangle.getId());
   acuteTriangle.setVertexAttributeMatrix(*vertData);
   auto vertexList = createVertexList(acuteTriangle, vertData->getId());
   auto facesList = createFaceList(acuteTriangle, faceData->getId());

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
@@ -105,7 +105,7 @@ int64_t EBSDSegmentFeatures::getSeed(int32 gnum, int64 nextSeed) const
     AttributeMatrix& cellFeatureAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->cellFeatureAttributeMatrixPath);
     featureIds->setValue(static_cast<usize>(seed), gnum);
     std::vector<usize> tDims = {static_cast<usize>(gnum) + 1};
-    ResizeAttributeMatrix(cellFeatureAM, tDims); // This will resize the actives array
+    cellFeatureAM.resizeTuples(tDims); // This will resize the actives array
   }
   return seed;
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/MergeTwins.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/MergeTwins.cpp
@@ -74,7 +74,7 @@ int MergeTwins::getSeed(int32 newFid)
   {
     featureParentIds[seed] = newFid;
     std::vector<size_t> tDims(1, newFid + 1);
-    ResizeAttributeMatrix(cellFeaturesAttMatrix, tDims); // this will resize the active array as well
+    cellFeaturesAttMatrix.resizeTuples(tDims); // this will resize the active array as well
   }
   return seed;
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadH5Ebsd.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadH5Ebsd.cpp
@@ -84,11 +84,11 @@ complex::Result<> LoadInfo(const complex::ReadH5EbsdInputValues* mInputValues, c
 
   complex::DataPath xtalDataPath = cellEnsembleMatrixPath.createChildPath(EbsdLib::EnsembleData::CrystalStructures);
   complex::UInt32Array& xtalData = mDataStructure.getDataRefAs<complex::UInt32Array>(xtalDataPath);
-  xtalData.getIDataStore()->reshapeTuples(tDims);
+  xtalData.getIDataStore()->resizeTuples(tDims);
 
   complex::DataPath latticeDataPath = cellEnsembleMatrixPath.createChildPath(EbsdLib::EnsembleData::LatticeConstants);
   complex::Float32Array& latticData = mDataStructure.getDataRefAs<complex::Float32Array>(latticeDataPath);
-  latticData.getIDataStore()->reshapeTuples(tDims);
+  latticData.getIDataStore()->resizeTuples(tDims);
 
   // Reshape the Material Names here also.
 

--- a/src/Plugins/OrientationAnalysis/test/FindAvgOrientationsTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/FindAvgOrientationsTest.cpp
@@ -139,8 +139,7 @@ TEST_CASE("OrientationAnalysis::FindAvgOrientations", "[OrientationAnalysis][Fin
       largestFeature = featureId;
     }
   }
-  AttributeMatrix* cellFeatureData = AttributeMatrix::Create(dataStructure, k_Grain_Data);
-  cellFeatureData->setShape({largestFeature + 1});
+  AttributeMatrix* cellFeatureData = AttributeMatrix::Create(dataStructure, k_Grain_Data, {largestFeature + 1});
 
   // Run the FindAvgOrientationsFilter
   {

--- a/src/complex/DataStructure/AttributeMatrix.cpp
+++ b/src/complex/DataStructure/AttributeMatrix.cpp
@@ -7,13 +7,15 @@
 
 using namespace complex;
 
-AttributeMatrix::AttributeMatrix(DataStructure& dataStructure, std::string name)
+AttributeMatrix::AttributeMatrix(DataStructure& dataStructure, std::string name, ShapeType tupleShape)
 : BaseGroup(dataStructure, std::move(name))
+, m_TupleShape(std::move(tupleShape))
 {
 }
 
-AttributeMatrix::AttributeMatrix(DataStructure& dataStructure, std::string name, IdType importId)
+AttributeMatrix::AttributeMatrix(DataStructure& dataStructure, std::string name, ShapeType tupleShape, IdType importId)
 : BaseGroup(dataStructure, std::move(name), importId)
+, m_TupleShape(std::move(tupleShape))
 {
 }
 
@@ -33,9 +35,9 @@ BaseGroup::GroupType AttributeMatrix::getGroupType() const
   return GroupType::AttributeMatrix;
 }
 
-AttributeMatrix* AttributeMatrix::Create(DataStructure& dataStructure, std::string name, const std::optional<IdType>& parentId)
+AttributeMatrix* AttributeMatrix::Create(DataStructure& dataStructure, std::string name, ShapeType tupleShape, const std::optional<IdType>& parentId)
 {
-  auto data = std::shared_ptr<AttributeMatrix>(new AttributeMatrix(dataStructure, std::move(name)));
+  auto data = std::shared_ptr<AttributeMatrix>(new AttributeMatrix(dataStructure, std::move(name), std::move(tupleShape)));
   if(!AttemptToAddObject(dataStructure, data, parentId))
   {
     return nullptr;
@@ -43,9 +45,9 @@ AttributeMatrix* AttributeMatrix::Create(DataStructure& dataStructure, std::stri
   return data.get();
 }
 
-AttributeMatrix* AttributeMatrix::Import(DataStructure& dataStructure, std::string name, IdType importId, const std::optional<IdType>& parentId)
+AttributeMatrix* AttributeMatrix::Import(DataStructure& dataStructure, std::string name, ShapeType tupleShape, IdType importId, const std::optional<IdType>& parentId)
 {
-  auto data = std::shared_ptr<AttributeMatrix>(new AttributeMatrix(dataStructure, std::move(name), importId));
+  auto data = std::shared_ptr<AttributeMatrix>(new AttributeMatrix(dataStructure, std::move(name), std::move(tupleShape), importId));
   if(!AttemptToAddObject(dataStructure, data, parentId))
   {
     return nullptr;
@@ -57,8 +59,7 @@ std::shared_ptr<DataObject> AttributeMatrix::deepCopy(const DataPath& copyPath)
 {
   auto& dataStruct = getDataStructureRef();
   // Don't construct with identifier since it will get created when inserting into data structure
-  auto copy = std::shared_ptr<AttributeMatrix>(new AttributeMatrix(dataStruct, copyPath.getTargetName()));
-  copy->setShape(m_TupleShape);
+  auto copy = std::shared_ptr<AttributeMatrix>(new AttributeMatrix(dataStruct, copyPath.getTargetName(), m_TupleShape));
   if(!dataStruct.containsData(copyPath) && dataStruct.insert(copy, copyPath.getParent()))
   {
     auto dataMapCopy = getDataMap().deepCopy(copyPath);
@@ -104,22 +105,17 @@ const AttributeMatrix::ShapeType& AttributeMatrix::getShape() const
   return m_TupleShape;
 }
 
-void AttributeMatrix::setShape(ShapeType shape)
-{
-  m_TupleShape = std::move(shape);
-}
-
 usize AttributeMatrix::getNumTuples() const
 {
   return std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
 }
 
-void AttributeMatrix::resizeTuples(ShapeType tupShape)
+void AttributeMatrix::resizeTuples(ShapeType tupleShape)
 {
-  setShape(tupShape);
+  m_TupleShape = std::move(tupleShape);
   auto childArrays = findAllChildrenOfType<IArray>();
   for(const auto& array : childArrays)
   {
-    array->resizeTuples(tupShape);
+    array->resizeTuples(m_TupleShape);
   }
 }

--- a/src/complex/DataStructure/AttributeMatrix.cpp
+++ b/src/complex/DataStructure/AttributeMatrix.cpp
@@ -4,7 +4,6 @@
 #include "complex/DataStructure/IArray.hpp"
 
 #include <exception>
-#include <stdexcept>
 
 using namespace complex;
 
@@ -85,17 +84,17 @@ bool AttributeMatrix::canInsert(const DataObject* obj) const
     return false;
   }
 
-  const auto* arrayObject = dynamic_cast<const IArray*>(obj);
+  const auto* arrayObjectPtr = dynamic_cast<const IArray*>(obj);
 
-  if(arrayObject == nullptr)
+  if(arrayObjectPtr == nullptr)
   {
     return false;
   }
 
-  IArray::ShapeType arrayTupleShape = arrayObject->getTupleShape();
+  const IArray::ShapeType arrayTupleShape = arrayObjectPtr->getTupleShape();
 
-  usize totalTuples = std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
-  usize incomingTupleCount = std::accumulate(arrayTupleShape.cbegin(), arrayTupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
+  const usize totalTuples = std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
+  const usize incomingTupleCount = std::accumulate(arrayTupleShape.cbegin(), arrayTupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
 
   return (totalTuples == incomingTupleCount);
 }

--- a/src/complex/DataStructure/AttributeMatrix.cpp
+++ b/src/complex/DataStructure/AttributeMatrix.cpp
@@ -114,3 +114,13 @@ usize AttributeMatrix::getNumTuples() const
 {
   return std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
 }
+
+void AttributeMatrix::resizeTuples(ShapeType tupShape)
+{
+  setShape(tupShape);
+  auto childArrays = findAllChildrenOfType<IArray>();
+  for(const auto& array : childArrays)
+  {
+    array->resizeTuples(tupShape);
+  }
+}

--- a/src/complex/DataStructure/AttributeMatrix.hpp
+++ b/src/complex/DataStructure/AttributeMatrix.hpp
@@ -28,11 +28,12 @@ public:
    * Returns a pointer to the AttributeMatrix if the process succeeds. Returns
    * nullptr otherwise.
    * @param dataStructure
-   * @param name
+   * @param name The name of the AttributeMatrix
+   * @param tupleShape The Tuple Shape (Dimensions) of the AttributeMatrix
    * @param parentId = {}
    * @return AttributeMatrix*
    */
-  static AttributeMatrix* Create(DataStructure& dataStructure, std::string name, const std::optional<IdType>& parentId = {});
+  static AttributeMatrix* Create(DataStructure& dataStructure, std::string name, ShapeType tupleShape, const std::optional<IdType>& parentId = {});
 
   /**
    * @brief Attempts to construct and insert a AttributeMatrix into the DataStructure.
@@ -47,12 +48,13 @@ public:
    * Returns a pointer to the AttributeMatrix if the process succeeds. Returns
    * nullptr otherwise.
    * @param dataStructure
-   * @param name
+   * @param name The name of the AttributeMatrix
+   * @param tupleShape The Tuple Shape (Dimensions) of the AttributeMatrix
    * @param importId
    * @param parentId = {}
    * @return AttributeMatrix*
    */
-  static AttributeMatrix* Import(DataStructure& dataStructure, std::string name, IdType importId, const std::optional<IdType>& parentId = {});
+  static AttributeMatrix* Import(DataStructure& dataStructure, std::string name, ShapeType tupleShape, IdType importId, const std::optional<IdType>& parentId = {});
 
   /**
    * @brief Constructs a shallow copy of the AttributeMatrix. This copy is not added
@@ -113,12 +115,6 @@ public:
   const ShapeType& getShape() const;
 
   /**
-   * @brief Sets the tuple shape.
-   * @param shape
-   */
-  void setShape(ShapeType shape);
-
-  /**
    * @brief Returns the total number of tuples.
    * @return
    */
@@ -136,10 +132,10 @@ public:
    * its Tuple Shape changed to be [4][5]. Since the total number of tuples remain
    * the same no data loss or memory allocation will take place.
    *
-   * @param tupShape the new tuple shape
+   * @param tupleShape the new tuple shape
    * @return
    */
-  void resizeTuples(ShapeType tupShape);
+  void resizeTuples(ShapeType tupleShape);
 
 protected:
   /**
@@ -147,17 +143,19 @@ protected:
    * specified name.
    * @param dataStructure
    * @param name
+   * @param tupleShape
    */
-  AttributeMatrix(DataStructure& dataStructure, std::string name);
+  AttributeMatrix(DataStructure& dataStructure, std::string name, ShapeType tupleShape);
 
   /**
    * @brief Creates the AttributeMatrix for the target DataStructure and with the
    * specified name.
    * @param dataStructure
    * @param name
+   * @param tupleShape
    * @param importId
    */
-  AttributeMatrix(DataStructure& dataStructure, std::string name, IdType importId);
+  AttributeMatrix(DataStructure& dataStructure, std::string name, ShapeType tupleShape, IdType importId);
 
   /**
    * @brief Checks if the provided DataObject can be added to the container.

--- a/src/complex/DataStructure/AttributeMatrix.hpp
+++ b/src/complex/DataStructure/AttributeMatrix.hpp
@@ -21,7 +21,7 @@ public:
   /**
    * @brief Attempts to construct and insert a AttributeMatrix into the DataStructure.
    * If a parentId is provided, then the AttributeMatrix is created with the
-   * corresponding BaseGroup as its parent. Otherwise, the DataStucture will be
+   * corresponding BaseGroup as its parent. Otherwise, the DataStructure will be
    * used as the parent object. In either case, the DataStructure will take
    * ownership of the AttributeMatrix.
    *
@@ -37,7 +37,7 @@ public:
   /**
    * @brief Attempts to construct and insert a AttributeMatrix into the DataStructure.
    * If a parentId is provided, then the AttributeMatrix is created with the
-   * corresponding BaseGroup as its parent. Otherwise, the DataStucture will be
+   * corresponding BaseGroup as its parent. Otherwise, the DataStructure will be
    * used as the parent object. In either case, the DataStructure will take
    * ownership of the AttributeMatrix.
    *
@@ -125,8 +125,18 @@ public:
   usize getNumTuples() const;
 
   /**
-   * @brief Changes sets tuple Shape and resizes all child arrays.
-   * @param tupShape this si the new tuple shape
+   * @brief Sets the tuple Shape and resizes all child arrays.
+   *
+   * <b>This may result in loss of data if the over all number of tuples is less
+   * than the original number</b>. This action will <b>OVERWRITE</b> any existing
+   * tuple shape that DataArrays contained in this AttributeMatrix currently have.
+   *
+   * For example: If an underlying array has a Tuple Shape of [4][5] and this
+   * method is called with a Tuple Shape of [2][10], the underlying array will have
+   * its Tuple Shape changed to be [4][5]. Since the total number of tuples remain
+   * the same no data loss or memory allocation will take place.
+   *
+   * @param tupShape the new tuple shape
    * @return
    */
   void resizeTuples(ShapeType tupShape);

--- a/src/complex/DataStructure/AttributeMatrix.hpp
+++ b/src/complex/DataStructure/AttributeMatrix.hpp
@@ -124,6 +124,13 @@ public:
    */
   usize getNumTuples() const;
 
+  /**
+   * @brief Changes sets tuple Shape and resizes all child arrays.
+   * @param tupShape this si the new tuple shape
+   * @return
+   */
+  void resizeTuples(ShapeType tupShape);
+
 protected:
   /**
    * @brief Creates the AttributeMatrix for the target DataStructure and with the

--- a/src/complex/DataStructure/DataStore.hpp
+++ b/src/complex/DataStructure/DataStore.hpp
@@ -61,7 +61,7 @@ public:
   , m_NumComponents(std::accumulate(m_ComponentShape.cbegin(), m_ComponentShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
   , m_NumTuples(std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
   {
-    reshapeTuples(m_TupleShape);
+    resizeTuples(m_TupleShape);
     if(initValue.has_value())
     {
       std::fill_n(data(), this->getSize(), *initValue);
@@ -198,7 +198,7 @@ public:
    * @brief
    * @param tupleShape
    */
-  void reshapeTuples(const std::vector<usize>& tupleShape) override
+  void resizeTuples(const std::vector<usize>& tupleShape) override
   {
     auto oldSize = this->getSize();
     // Calculate the total number of values in the new array

--- a/src/complex/DataStructure/DataStore.hpp
+++ b/src/complex/DataStructure/DataStore.hpp
@@ -96,7 +96,7 @@ public:
   , m_NumTuples(other.m_NumTuples)
   {
     const usize count = other.getSize();
-    auto data = new value_type[count];
+    auto* data = new value_type[count];
     std::memcpy(data, other.m_Data.get(), count * sizeof(T));
     m_Data.reset(data);
   }
@@ -195,8 +195,23 @@ public:
   }
 
   /**
-   * @brief
-   * @param tupleShape
+   * @brief This method sets the shape of the dimensions to `tupleShape`.
+   *
+   * There are 3 possibilities when using this function:
+   * [1] The number of tuples of the new shape is *LESS* than the original. In this
+   * case a memory allocation will take place and the first 'N' elements of data
+   * will be copied into the new array. The remaining data is *LOST*
+   *
+   * [2] The number of tuples of the new shape is *EQUAL* to the original. In this
+   * case the shape is set and the function returns.
+   *
+   * [3] The number of tuples of the new shape is *GREATER* than the original. In
+   * this case a new array is allocated and all the data from the original array
+   * is copied into the new array and the remaining elements are initialized to
+   * the default initialization value.
+   *
+   * @param tupleShape The new shape of the data where the dimensions are "C" ordered
+   * from *slowest* to *fastest*.
    */
   void resizeTuples(const std::vector<usize>& tupleShape) override
   {

--- a/src/complex/DataStructure/EmptyDataStore.hpp
+++ b/src/complex/DataStructure/EmptyDataStore.hpp
@@ -133,7 +133,7 @@ public:
    * EmptyDataStore class contains no data other than its target size.
    * @param tupleShape
    */
-  void reshapeTuples(const ShapeType& tupleShape) override
+  void resizeTuples(const ShapeType& tupleShape) override
   {
     throw std::runtime_error("");
   }

--- a/src/complex/DataStructure/Geometry/INodeGeometry0D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry0D.cpp
@@ -54,7 +54,7 @@ void INodeGeometry0D::setVertexListId(const std::optional<IdType>& vertices)
 
 void INodeGeometry0D::resizeVertexList(usize size)
 {
-  getVerticesRef().getIDataStoreRef().reshapeTuples({size});
+  getVerticesRef().getIDataStoreRef().resizeTuples({size});
 }
 
 usize INodeGeometry0D::getNumberOfVertices() const

--- a/src/complex/DataStructure/Geometry/INodeGeometry1D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry1D.cpp
@@ -54,7 +54,7 @@ void INodeGeometry1D::setEdgeListId(const std::optional<IdType>& edgeList)
 
 void INodeGeometry1D::resizeEdgeList(usize size)
 {
-  getEdgesRef().getIDataStoreRef().reshapeTuples({size});
+  getEdgesRef().getIDataStoreRef().resizeTuples({size});
 }
 
 usize INodeGeometry1D::getNumberOfCells() const

--- a/src/complex/DataStructure/Geometry/INodeGeometry2D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry2D.cpp
@@ -54,7 +54,7 @@ void INodeGeometry2D::setFaceList(const SharedFaceList& faces)
 
 void INodeGeometry2D::resizeFaceList(usize size)
 {
-  getFacesRef().getIDataStoreRef().reshapeTuples({size});
+  getFacesRef().getIDataStoreRef().resizeTuples({size});
 }
 
 usize INodeGeometry2D::getNumberOfFaces() const

--- a/src/complex/DataStructure/Geometry/INodeGeometry3D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry3D.cpp
@@ -54,7 +54,7 @@ void INodeGeometry3D::setPolyhedraList(const SharedFaceList& polyhedra)
 
 void INodeGeometry3D::resizePolyhedraList(usize size)
 {
-  getPolyhedraRef().getIDataStoreRef().reshapeTuples({size});
+  getPolyhedraRef().getIDataStoreRef().resizeTuples({size});
 }
 
 usize INodeGeometry3D::getNumberOfPolyhedra() const

--- a/src/complex/DataStructure/IArray.hpp
+++ b/src/complex/DataStructure/IArray.hpp
@@ -72,7 +72,7 @@ public:
   /**
    * @brief Resizes the internal array to accomondate
    */
-  virtual void reshapeTuples(const std::vector<usize>& tupleShape) = 0;
+  virtual void resizeTuples(const std::vector<usize>& tupleShape) = 0;
 
   static std::set<std::string> StringListFromArrayType(const std::set<ArrayType>& arrayTypes)
   {

--- a/src/complex/DataStructure/IArray.hpp
+++ b/src/complex/DataStructure/IArray.hpp
@@ -21,6 +21,13 @@ public:
 
   ~IArray() override = default;
 
+  IArray() = delete;
+  IArray(const IArray&) = default;
+  IArray(IArray&&) = default;
+
+  IArray& operator=(const IArray&) = delete;
+  IArray& operator=(IArray&&) noexcept = delete;
+
   /**
    * @brief Returns an enumeration of the class or subclass. Used for quick comparison or type deduction
    * @return
@@ -70,7 +77,23 @@ public:
   virtual usize getNumberOfComponents() const = 0;
 
   /**
-   * @brief Resizes the internal array to accomondate
+   * @brief This method sets the shape of the dimensions to `tupleShape`.
+   *
+   * There are 3 possibilities when using this function:
+   * [1] The number of tuples of the new shape is *LESS* than the original. In this
+   * case a memory allocation will take place and the first 'N' elements of data
+   * will be copied into the new array. The remaining data is *LOST*
+   *
+   * [2] The number of tuples of the new shape is *EQUAL* to the original. In this
+   * case the shape is set and the function returns.
+   *
+   * [3] The number of tuples of the new shape is *GREATER* than the original. In
+   * this case a new array is allocated and all the data from the original array
+   * is copied into the new array and the remaining elements are initialized to
+   * the default initialization value.
+   *
+   * @param tupleShape The new shape of the data where the dimensions are "C" ordered
+   * from *slowest* to *fastest*.
    */
   virtual void resizeTuples(const std::vector<usize>& tupleShape) = 0;
 
@@ -88,8 +111,6 @@ public:
   }
 
 protected:
-  IArray() = delete;
-
   IArray(DataStructure& dataStructure, std::string name)
   : DataObject(dataStructure, std::move(name))
   {
@@ -99,11 +120,5 @@ protected:
   : DataObject(dataStructure, std::move(name), importId)
   {
   }
-
-  IArray(const IArray&) = default;
-  IArray(IArray&&) = default;
-
-  IArray& operator=(const IArray&) = delete;
-  IArray& operator=(IArray&&) noexcept = delete;
 };
 } // namespace complex

--- a/src/complex/DataStructure/IDataArray.hpp
+++ b/src/complex/DataStructure/IDataArray.hpp
@@ -137,9 +137,9 @@ public:
   /**
    * @brief Resizes the internal array to accomondate
    */
-  void reshapeTuples(const std::vector<usize>& tupleShape) override
+  void resizeTuples(const std::vector<usize>& tupleShape) override
   {
-    getIDataStoreRef().reshapeTuples(tupleShape);
+    getIDataStoreRef().resizeTuples(tupleShape);
   }
 
   /**

--- a/src/complex/DataStructure/IDataStore.hpp
+++ b/src/complex/DataStructure/IDataStore.hpp
@@ -76,7 +76,7 @@ public:
    * @brief Resizes the DataStore to handle the specified number of tuples.
    * @param numTuples
    */
-  virtual void reshapeTuples(const ShapeType& tupleShape) = 0;
+  virtual void resizeTuples(const ShapeType& tupleShape) = 0;
 
   /**
    * @brief Returns the DataStore's DataType as an enum

--- a/src/complex/DataStructure/INeighborList.cpp
+++ b/src/complex/DataStructure/INeighborList.cpp
@@ -16,7 +16,7 @@ INeighborList::INeighborList(DataStructure& dataStructure, const std::string& na
 {
 }
 
-INeighborList::~INeighborList() = default;
+INeighborList::~INeighborList() noexcept = default;
 
 std::string INeighborList::getTypeName() const
 {

--- a/src/complex/DataStructure/INeighborList.hpp
+++ b/src/complex/DataStructure/INeighborList.hpp
@@ -12,7 +12,7 @@ class COMPLEX_EXPORT INeighborList : public IArray
 public:
   static inline constexpr StringLiteral k_TypeName = "INeighborList";
 
-  virtual ~INeighborList();
+  ~INeighborList() noexcept override;
 
   /**
    * @brief Returns typename of the DataObject as a std::string.

--- a/src/complex/DataStructure/IO/HDF5/AttributeMatrixIO.cpp
+++ b/src/complex/DataStructure/IO/HDF5/AttributeMatrixIO.cpp
@@ -25,7 +25,6 @@ std::string AttributeMatrixIO::getTypeName() const
 Result<> AttributeMatrixIO::readData(DataStructureReader& structureReader, const group_reader_type& parentGroup, const std::string& objectName, DataObject::IdType importId,
                                      const std::optional<DataObject::IdType>& parentId, bool useEmptyDataStore) const
 {
-  auto* dataObject = data_type::Import(structureReader.getDataStructure(), objectName, importId, parentId);
 
   auto groupReader = parentGroup.openGroup(objectName);
   auto attribute = groupReader.getAttribute(IOConstants::k_TupleDims);
@@ -33,11 +32,10 @@ Result<> AttributeMatrixIO::readData(DataStructureReader& structureReader, const
 
   if(tupleShape.empty())
   {
-    std::string ss = "Failed to read AttributeMatrix tuple shape";
-    return MakeErrorResult(-1, ss);
+    return MakeErrorResult(-1550, fmt::format("Failed to read AttributeMatrix tuple shape"));
   }
+  auto* dataObject = data_type::Import(structureReader.getDataStructure(), objectName, tupleShape, importId, parentId);
 
-  dataObject->setShape(tupleShape);
   Result<> result = BaseGroupIO::ReadBaseGroupData(structureReader, *dataObject, parentGroup, objectName, importId, parentId, useEmptyDataStore);
   if(result.invalid())
   {

--- a/src/complex/DataStructure/NeighborList.cpp
+++ b/src/complex/DataStructure/NeighborList.cpp
@@ -316,7 +316,7 @@ DataObject::Type NeighborList<T>::getDataObjectType() const
 }
 
 template <typename T>
-void NeighborList<T>::reshapeTuples(const std::vector<usize>& tupleShape)
+void NeighborList<T>::resizeTuples(const std::vector<usize>& tupleShape)
 {
   auto numTuples = std::accumulate(tupleShape.cbegin(), tupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
   resizeTotalElements(numTuples);

--- a/src/complex/DataStructure/NeighborList.hpp
+++ b/src/complex/DataStructure/NeighborList.hpp
@@ -300,7 +300,7 @@ public:
   /**
    * @brief Resizes the internal array to accomondate
    */
-  void reshapeTuples(const std::vector<usize>& tupleShape) override;
+  void resizeTuples(const std::vector<usize>& tupleShape) override;
 
   const std::vector<SharedVectorType>& getValues() const;
 

--- a/src/complex/DataStructure/NeighborList.hpp
+++ b/src/complex/DataStructure/NeighborList.hpp
@@ -134,8 +134,23 @@ public:
   int32 resizeTotalElements(usize size);
 
   /**
-   * @brief Resizes the internal array to accomondate numTuples
-   * @param numTuples
+   * @brief This method sets the shape of the dimensions to `tupleShape`.
+   *
+   * There are 3 possibilities when using this function:
+   * [1] The number of tuples of the new shape is *LESS* than the original. In this
+   * case a memory allocation will take place and the first 'N' elements of data
+   * will be copied into the new array. The remaining data is *LOST*
+   *
+   * [2] The number of tuples of the new shape is *EQUAL* to the original. In this
+   * case the shape is set and the function returns.
+   *
+   * [3] The number of tuples of the new shape is *GREATER* than the original. In
+   * this case a new array is allocated and all the data from the original array
+   * is copied into the new array and the remaining elements are initialized to
+   * the default initialization value.
+   *
+   * @param tupleShape The new shape of the data where the dimensions are "C" ordered
+   * from *slowest* to *fastest*.
    */
   void resizeTuples(usize numTuples);
 

--- a/src/complex/DataStructure/StringArray.cpp
+++ b/src/complex/DataStructure/StringArray.cpp
@@ -202,7 +202,7 @@ usize StringArray::getNumberOfComponents() const
   return 1;
 }
 
-void StringArray::reshapeTuples(const std::vector<usize>& tupleShape)
+void StringArray::resizeTuples(const std::vector<usize>& tupleShape)
 {
   auto numTuples = std::accumulate(tupleShape.cbegin(), tupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
   if(numTuples != size())

--- a/src/complex/DataStructure/StringArray.hpp
+++ b/src/complex/DataStructure/StringArray.hpp
@@ -92,7 +92,23 @@ public:
   usize getNumberOfComponents() const override;
 
   /**
-   * @brief Resizes the internal array to accomondate
+   * @brief This method sets the shape of the dimensions to `tupleShape`.
+   *
+   * There are 3 possibilities when using this function:
+   * [1] The number of tuples of the new shape is *LESS* than the original. In this
+   * case a memory allocation will take place and the first 'N' elements of data
+   * will be copied into the new array. The remaining data is *LOST*
+   *
+   * [2] The number of tuples of the new shape is *EQUAL* to the original. In this
+   * case the shape is set and the function returns.
+   *
+   * [3] The number of tuples of the new shape is *GREATER* than the original. In
+   * this case a new array is allocated and all the data from the original array
+   * is copied into the new array and the remaining elements are initialized to
+   * the default initialization value.
+   *
+   * @param tupleShape The new shape of the data where the dimensions are "C" ordered
+   * from *slowest* to *fastest*.
    */
   void resizeTuples(const std::vector<usize>& tupleShape) override;
 

--- a/src/complex/DataStructure/StringArray.hpp
+++ b/src/complex/DataStructure/StringArray.hpp
@@ -94,7 +94,7 @@ public:
   /**
    * @brief Resizes the internal array to accomondate
    */
-  void reshapeTuples(const std::vector<usize>& tupleShape) override;
+  void resizeTuples(const std::vector<usize>& tupleShape) override;
 
 protected:
   StringArray(DataStructure& dataStructure, std::string name);

--- a/src/complex/Filter/Actions/CreateAttributeMatrixAction.cpp
+++ b/src/complex/Filter/Actions/CreateAttributeMatrixAction.cpp
@@ -46,12 +46,11 @@ Result<> CreateAttributeMatrixAction::apply(DataStructure& dataStructure, Mode m
     return MakeErrorResult(-5205, fmt::format("{}CreateAttributeMatrixAction: Parent Id was not available for path:'{}'", prefix, parentPath.toString()));
   }
 
-  auto* attributeMatrix = AttributeMatrix::Create(dataStructure, createdAttributeMatrixPath.getTargetName(), dataStructure.getId(parentPath).value());
+  auto* attributeMatrix = AttributeMatrix::Create(dataStructure, createdAttributeMatrixPath.getTargetName(), m_TupleShape, dataStructure.getId(parentPath).value());
   if(attributeMatrix == nullptr)
   {
     return MakeErrorResult(-5206, fmt::format("{}CreateAttributeMatrixAction: Failed to create AttributeMatrix: '{}'", prefix, createdAttributeMatrixPath.toString()));
   }
-  attributeMatrix->setShape(m_TupleShape);
 
   return {};
 }

--- a/src/complex/Filter/Actions/CreateGeometry1DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry1DAction.hpp
@@ -221,20 +221,18 @@ public:
     }
 
     // Create the vertex and edge AttributeMatrix
-    auto* edgeAttributeMatrix = AttributeMatrix::Create(dataStructure, m_EdgeDataName, geometry1d->getId());
+    auto* edgeAttributeMatrix = AttributeMatrix::Create(dataStructure, m_EdgeDataName, edgeTupleShape, geometry1d->getId());
     if(edgeAttributeMatrix == nullptr)
     {
       return MakeErrorResult(-5411, fmt::format("{}CreateGeometry1DAction: Failed to create attribute matrix: '{}'", prefix, edgeDataPath.toString()));
     }
-    edgeAttributeMatrix->setShape(edgeTupleShape);
     geometry1d->setEdgeAttributeMatrix(*edgeAttributeMatrix);
 
-    auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, geometry1d->getId());
+    auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, vertexTupleShape, geometry1d->getId());
     if(vertexAttributeMatrix == nullptr)
     {
       return MakeErrorResult(-5412, fmt::format("{}CreateGeometry1DAction: Failed to create attribute matrix: '{}'", prefix, vertexDataPath.toString()));
     }
-    vertexAttributeMatrix->setShape(vertexTupleShape);
     geometry1d->setVertexAttributeMatrix(*vertexAttributeMatrix);
 
     return {};

--- a/src/complex/Filter/Actions/CreateGeometry2DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry2DAction.hpp
@@ -221,20 +221,18 @@ public:
     }
 
     // Create the vertex and face AttributeMatrix
-    auto* faceAttributeMatrix = AttributeMatrix::Create(dataStructure, m_FaceDataName, geometry2d->getId());
+    auto* faceAttributeMatrix = AttributeMatrix::Create(dataStructure, m_FaceDataName, faceTupleShape, geometry2d->getId());
     if(faceAttributeMatrix == nullptr)
     {
       return MakeErrorResult(-5511, fmt::format("{}CreateGeometry2DAction: Failed to create attribute matrix: '{}'", prefix, faceDataPath.toString()));
     }
-    faceAttributeMatrix->setShape(faceTupleShape);
     geometry2d->setFaceAttributeMatrix(*faceAttributeMatrix);
 
-    auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, geometry2d->getId());
+    auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, vertexTupleShape, geometry2d->getId());
     if(vertexAttributeMatrix == nullptr)
     {
       return MakeErrorResult(-5512, fmt::format("CreateGeometry2DAction: Failed to create attribute matrix: '{}'", prefix, vertexDataPath.toString()));
     }
-    vertexAttributeMatrix->setShape(vertexTupleShape);
     geometry2d->setVertexAttributeMatrix(*vertexAttributeMatrix);
 
     return {};

--- a/src/complex/Filter/Actions/CreateGeometry3DAction.hpp
+++ b/src/complex/Filter/Actions/CreateGeometry3DAction.hpp
@@ -220,20 +220,18 @@ public:
     }
 
     // Create the vertex and cell AttributeMatrix
-    auto* cellAttributeMatrix = AttributeMatrix::Create(dataStructure, m_CellDataName, geometry3d->getId());
+    auto* cellAttributeMatrix = AttributeMatrix::Create(dataStructure, m_CellDataName, cellTupleShape, geometry3d->getId());
     if(cellAttributeMatrix == nullptr)
     {
       return MakeErrorResult(-5611, fmt::format("{}CreateGeometry3DAction: Failed to create attribute matrix: '{}'", prefix, cellDataPath.toString()));
     }
-    cellAttributeMatrix->setShape(cellTupleShape);
     geometry3d->setPolyhedraAttributeMatrix(*cellAttributeMatrix);
 
-    auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, geometry3d->getId());
+    auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, vertexTupleShape, geometry3d->getId());
     if(vertexAttributeMatrix == nullptr)
     {
       return MakeErrorResult(-5612, fmt::format("{}CreateGeometry3DAction: Failed to create attribute matrix: '{}'", prefix, vertexDataPath.toString()));
     }
-    vertexAttributeMatrix->setShape(vertexTupleShape);
     geometry3d->setVertexAttributeMatrix(*vertexAttributeMatrix);
 
     return {};

--- a/src/complex/Filter/Actions/CreateImageGeometryAction.cpp
+++ b/src/complex/Filter/Actions/CreateImageGeometryAction.cpp
@@ -57,13 +57,12 @@ Result<> CreateImageGeometryAction::apply(DataStructure& dataStructure, Mode mod
   imageGeom->setOrigin(m_Origin);
   imageGeom->setSpacing(m_Spacing);
 
-  auto* attributeMatrix = AttributeMatrix::Create(dataStructure, m_CellDataName, imageGeom->getId());
+  const DimensionType reversedDims(m_Dims.rbegin(), m_Dims.rend());
+  auto* attributeMatrix = AttributeMatrix::Create(dataStructure, m_CellDataName, reversedDims, imageGeom->getId());
   if(attributeMatrix == nullptr)
   {
     return MakeErrorResult(-5706, fmt::format("{}Failed to create ImageGeometry: '{}'", prefix, getCreatedPath().createChildPath(m_CellDataName).toString()));
   }
-  DimensionType reversedDims(m_Dims.rbegin(), m_Dims.rend());
-  attributeMatrix->setShape(std::move(reversedDims));
 
   imageGeom->setCellData(*attributeMatrix);
 

--- a/src/complex/Filter/Actions/CreateRectGridGeometryAction.cpp
+++ b/src/complex/Filter/Actions/CreateRectGridGeometryAction.cpp
@@ -96,12 +96,11 @@ Result<> CreateRectGridGeometryAction::apply(DataStructure& dataStructure, Mode 
   }
   rectGridGeom->setDimensions(dims);
 
-  auto* attributeMatrix = AttributeMatrix::Create(dataStructure, m_CellDataName, rectGridGeom->getId());
+  auto* attributeMatrix = AttributeMatrix::Create(dataStructure, m_CellDataName, dims, rectGridGeom->getId());
   if(attributeMatrix == nullptr)
   {
     return MakeErrorResult(-5909, fmt::format("{}CreateRectGridGeometryAction: Failed to create RectGridGeometry: '{}'", prefix, getCreatedPath().createChildPath(m_CellDataName).toString()));
   }
-  attributeMatrix->setShape(std::move(dims));
 
   rectGridGeom->setCellData(*attributeMatrix);
 

--- a/src/complex/Filter/Actions/CreateVertexGeometryAction.hpp
+++ b/src/complex/Filter/Actions/CreateVertexGeometryAction.hpp
@@ -161,12 +161,11 @@ public:
     }
 
     // Create the Vertex AttributeMatrix
-    auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, vertexGeom->getId());
+    auto* vertexAttributeMatrix = AttributeMatrix::Create(dataStructure, m_VertexDataName, tupleShape, vertexGeom->getId());
     if(vertexAttributeMatrix == nullptr)
     {
       return MakeErrorResult(-6107, fmt::format("{}Failed to create attribute matrix: '{}'", prefix, getVertexDataPath().toString()));
     }
-    vertexAttributeMatrix->setShape(tupleShape);
     vertexGeom->setVertexAttributeMatrix(*vertexAttributeMatrix);
 
     return {};

--- a/src/complex/Utilities/DataArrayUtilities.cpp
+++ b/src/complex/Utilities/DataArrayUtilities.cpp
@@ -230,17 +230,6 @@ Result<> ResizeAndReplaceDataArray(DataStructure& dataStructure, const DataPath&
 }
 
 //-----------------------------------------------------------------------------
-void ResizeAttributeMatrix(AttributeMatrix& attributeMatrix, const std::vector<usize>& newShape)
-{
-  attributeMatrix.setShape(newShape);
-  auto childArrays = attributeMatrix.findAllChildrenOfType<IArray>();
-  for(const auto& array : childArrays)
-  {
-    array->reshapeTuples(newShape);
-  }
-}
-
-//-----------------------------------------------------------------------------
 Result<> ValidateNumFeaturesInArray(const DataStructure& dataStructure, const DataPath& arrayPath, const Int32Array& featureIds)
 {
   const auto* featureArray = dataStructure.getDataAs<IDataArray>(arrayPath);

--- a/src/complex/Utilities/DataArrayUtilities.hpp
+++ b/src/complex/Utilities/DataArrayUtilities.hpp
@@ -660,16 +660,6 @@ COMPLEX_EXPORT bool CheckArraysAreSameType(const DataStructure& dataStructure, c
 COMPLEX_EXPORT bool CheckArraysHaveSameTupleCount(const DataStructure& dataStructure, const std::vector<DataPath>& dataArrayPaths);
 
 /**
- * @brief This function will ensure that a user entered numeric value can correctly be parsed into the selected DataArray
- *
- * @param value The string value that is to be parsed
- * @param inputDataArray The DataArray that the value would be inserted into.
- * @return
- */
-
-COMPLEX_EXPORT void ResizeAttributeMatrix(AttributeMatrix& attributeMatrix, const std::vector<usize>& newShape);
-
-/**
  * @brief Validates that the number of features in the array are equivalent
  * @param dataStructure the DataStructure containing the array
  * @param arrayPath the DataPath to the array in the dataStructure
@@ -706,7 +696,7 @@ Result<> ResizeDataArray(DataStructure& dataStructure, const DataPath& arrayPath
   }
 
   // the array's parent is not in an Attribute Matrix so we can safely reshape to the new tuple shape
-  dataArray->template getIDataStoreRefAs<DataStore<T>>().reshapeTuples(newShape);
+  dataArray->template getIDataStoreRefAs<DataStore<T>>().resizeTuples(newShape);
   return {};
 }
 

--- a/src/complex/Utilities/DataArrayUtilities.hpp
+++ b/src/complex/Utilities/DataArrayUtilities.hpp
@@ -350,7 +350,6 @@ std::shared_ptr<AbstractDataStore<T>> CreateDataStore(const typename IDataStore:
 template <class T>
 Result<> CreateArray(DataStructure& dataStructure, const std::vector<usize>& tupleShape, const std::vector<usize>& compShape, const DataPath& path, IDataAction::Mode mode, std::string dataFormat = "")
 {
-
   auto parentPath = path.getParent();
 
   std::optional<DataObject::IdType> dataObjectId;

--- a/src/complex/Utilities/DataGroupUtilities.cpp
+++ b/src/complex/Utilities/DataGroupUtilities.cpp
@@ -87,7 +87,7 @@ bool RemoveInactiveObjects(DataStructure& dataStructure, const DataPath& feature
           destIdx++;
         }
         // Now chop off the end of the copy and modified array
-        dataArray->getIDataStore()->reshapeTuples(newShape);
+        dataArray->getIDataStore()->resizeTuples(newShape);
       }
 
       // Loop over all the points and correct all the feature names

--- a/src/complex/Utilities/FlyingEdges.hpp
+++ b/src/complex/Utilities/FlyingEdges.hpp
@@ -887,7 +887,7 @@ public:
 
     m_TriangleGeom.resizeFaceList(triAccum);
     m_TriangleGeom.resizeVertexList(pointAccum);
-    m_Normals.getIDataStoreRef().reshapeTuples({pointAccum});
+    m_Normals.getIDataStoreRef().resizeTuples({pointAccum});
   }
   ///////////////////////////////////////////////////////////////////////////////
 

--- a/src/complex/Utilities/GeometryHelpers.hpp
+++ b/src/complex/Utilities/GeometryHelpers.hpp
@@ -252,7 +252,7 @@ void FindTetEdges(const DataArray<T>* tetList, DataArray<T>* edgeList)
     }
   }
 
-  edgeList->getDataStore()->reshapeTuples({edgeSet.size()});
+  edgeList->getDataStore()->resizeTuples({edgeSet.size()});
   auto& uEdges = *edgeList;
   T index = 0;
 
@@ -310,7 +310,7 @@ void FindHexEdges(const DataArray<T>* hexList, DataArray<T>* edge_List)
   }
 
   typename std::set<std::pair<T, T>>::iterator setIter;
-  edge_List->getDataStore()->reshapeTuples({edgeSet.size()});
+  edge_List->getDataStore()->resizeTuples({edgeSet.size()});
   auto& uEdges = *edge_List;
   T index = 0;
 
@@ -355,7 +355,7 @@ void FindTetFaces(const DataArray<T>* tetList, DataArray<T>* faceList)
     }
   }
 
-  faceList->getDataStore()->reshapeTuples({faceSet.size()});
+  faceList->getDataStore()->resizeTuples({faceSet.size()});
   auto& uFaces = *faceList;
   T index = 0;
 
@@ -404,7 +404,7 @@ void FindHexFaces(const DataArray<T>* hexList, DataArray<T>* faceList)
     }
   }
 
-  faceList->getDataStore()->reshapeTuples({faceSet.size()});
+  faceList->getDataStore()->resizeTuples({faceSet.size()});
   auto& uFaces = *faceList;
   T index = 0;
 
@@ -467,7 +467,7 @@ void FindUnsharedTetEdges(const DataArray<T>* tetList, DataArray<T>* edgeList)
     }
   }
 
-  edgeList->getDataStore()->reshapeTuples({edgeMap.size()});
+  edgeList->getDataStore()->resizeTuples({edgeMap.size()});
   auto& bEdges = *edgeList;
   T index = 0;
 
@@ -538,7 +538,7 @@ void FindUnsharedHexEdges(const DataArray<T>* hexList, DataArray<T>* edge_List)
     }
   }
 
-  edge_List->getDataStore()->reshapeTuples({edgeMap.size()});
+  edge_List->getDataStore()->resizeTuples({edgeMap.size()});
   auto& bEdges = *edge_List;
   T index = 0;
 
@@ -598,7 +598,7 @@ void FindUnsharedTetFaces(const DataArray<T>* tetList, DataArray<T>* faceList)
     }
   }
 
-  faceList->getDataStore()->reshapeTuples({faceMap.size()});
+  faceList->getDataStore()->resizeTuples({faceMap.size()});
   auto& uFaces = *faceList;
   T index = 0;
 
@@ -662,7 +662,7 @@ void FindUnsharedHexFaces(const DataArray<T>* hexList, DataArray<T>* faceList)
     }
   }
 
-  faceList->getDataStore()->reshapeTuples({faceMap.size()});
+  faceList->getDataStore()->resizeTuples({faceMap.size()});
   auto& uFaces = *faceList;
   T index = 0;
 
@@ -731,7 +731,7 @@ void Find2DElementEdges(const DataArray<T>* elemList, DataArray<T>* edgeList)
   }
 
   typename std::set<std::pair<T, T>>::iterator setIter;
-  edgeList->getDataStore()->reshapeTuples({edgeSet.size()});
+  edgeList->getDataStore()->resizeTuples({edgeSet.size()});
   auto& uEdges = *edgeList;
   T index = 0;
 
@@ -811,7 +811,7 @@ void Find2DUnsharedEdges(const DataArray<T>* elemList, DataArray<T>* edgeList)
     }
   }
 
-  edgeList->getDataStore()->reshapeTuples({edgeMap.size()});
+  edgeList->getDataStore()->resizeTuples({edgeMap.size()});
   auto& bEdges = *edgeList;
   T index = 0;
 

--- a/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -1001,13 +1001,12 @@ void readLegacyAttributeMatrix(DataStructure& dataStructure, const complex::HDF5
 {
   DataObject::IdType parentId = parent.getId();
   const std::string amName = amGroupReader.getName();
-  auto* attributeMatrix = AttributeMatrix::Create(dataStructure, amName, parentId);
 
   auto tDimsReader = amGroupReader.getAttribute("TupleDimensions");
   auto tDims = tDimsReader.readAsVector<uint64>();
   auto reversedTDims = AttributeMatrix::ShapeType(tDims.crbegin(), tDims.crend());
 
-  attributeMatrix->setShape(reversedTDims);
+  auto* attributeMatrix = AttributeMatrix::Create(dataStructure, amName, reversedTDims, parentId);
 
   auto dataArrayNames = amGroupReader.getChildNames();
   for(const auto& daName : dataArrayNames)

--- a/src/complex/Utilities/SamplingUtils.hpp
+++ b/src/complex/Utilities/SamplingUtils.hpp
@@ -60,7 +60,7 @@ inline Result<> RenumberFeatures(DataStructure& dataStructure, const DataPath& n
 
   if(!RemoveInactiveObjects(dataStructure, destCellFeatAttributeMatrixPath, activeObjects, destFeatureIdsRef, totalFeatures))
   {
-    std::string ss = fmt::format("An error occured while trying to remove the inactive objects from Attribute Matrix '{}'", destCellFeatAttributeMatrixPath.toString());
+    std::string ss = fmt::format("An error occurred while trying to remove the inactive objects from Attribute Matrix '{}'", destCellFeatAttributeMatrixPath.toString());
     return MakeErrorResult(-606, ss);
   }
   return {};

--- a/test/DataStructTest.cpp
+++ b/test/DataStructTest.cpp
@@ -73,9 +73,8 @@ DataStructure createTestDataStructure()
     (*testIntArray)[3] = 15;
     (*testIntArray)[4] = 20;
 
-    AttributeMatrix* levelOneAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_CellData, imageGeom->getId());
     const std::vector<usize> reversedDims(imageGeomDims.rbegin(), imageGeomDims.rend());
-    levelOneAttMatrix->setShape(reversedDims);
+    AttributeMatrix* levelOneAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_CellData, reversedDims, imageGeom->getId());
     imageGeom->setCellData(*levelOneAttMatrix);
 
     BoolArray* testBoolArray = UnitTest::CreateTestDataArray<bool>(dataStruct, Constants::k_ConditionalArray, reversedDims, {1}, levelOneAttMatrix->getId());
@@ -147,9 +146,8 @@ DataStructure createTestDataStructure()
   {
     VertexGeom* vertexGeom = VertexGeom::Create(dataStruct, Constants::k_VertexGeometry);
 
-    AttributeMatrix* vertAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_VertexDataGroupName, vertexGeom->getId());
     std::vector<usize> vertTupleShape = {4};
-    vertAttMatrix->setShape(vertTupleShape);
+    AttributeMatrix* vertAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_VertexDataGroupName, vertTupleShape, vertexGeom->getId());
     vertexGeom->setVertexAttributeMatrix(*vertAttMatrix);
     StringArray* testStringArray = StringArray::CreateWithValues(dataStruct, k_StringArray, {"stringone", "stringtwo", "stringthree", "stringfour"}, vertAttMatrix->getId());
     Float32Array* vertListArray = UnitTest::CreateTestDataArray<float32>(dataStruct, Constants::k_Float32DataSet, vertTupleShape, {3}, vertexGeom->getId());
@@ -175,13 +173,12 @@ DataStructure createTestDataStructure()
     EdgeGeom* edgeGeom = EdgeGeom::Create(dataStruct, k_EdgeGeo);
 
     auto scalar = ScalarData<int64>::Create(dataStruct, k_ScalarData, 60, edgeGeom->getId());
-    AttributeMatrix* edgeAttMatrix = AttributeMatrix::Create(dataStruct, INodeGeometry1D::k_EdgeDataName, edgeGeom->getId());
     std::vector<usize> edgeTupleShape = {4};
-    edgeAttMatrix->setShape(edgeTupleShape);
+    AttributeMatrix* edgeAttMatrix = AttributeMatrix::Create(dataStruct, INodeGeometry1D::k_EdgeDataName, edgeTupleShape, edgeGeom->getId());
     edgeGeom->setEdgeAttributeMatrix(*edgeAttMatrix);
-    AttributeMatrix* edgeVertAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_VertexDataGroupName, edgeGeom->getId());
+
     std::vector<usize> edgeVertTupleShape = {5};
-    edgeVertAttMatrix->setShape(edgeVertTupleShape);
+    AttributeMatrix* edgeVertAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_VertexDataGroupName, edgeVertTupleShape, edgeGeom->getId());
     edgeGeom->setVertexAttributeMatrix(*edgeVertAttMatrix);
     Float32Array* edgeVertListArray = UnitTest::CreateTestDataArray<float32>(dataStruct, Constants::k_Float32DataSet, edgeVertTupleShape, {3}, edgeGeom->getId());
     (*edgeVertListArray)[0] = 0;
@@ -221,13 +218,12 @@ DataStructure createTestDataStructure()
   {
     TriangleGeom* triangleGeom = TriangleGeom::Create(dataStruct, Constants::k_TriangleGeometryName);
 
-    AttributeMatrix* faceAttMatrix = AttributeMatrix::Create(dataStruct, INodeGeometry2D::k_FaceDataName, triangleGeom->getId());
     std::vector<usize> faceTupleShape = {5};
-    faceAttMatrix->setShape(faceTupleShape);
+    AttributeMatrix* faceAttMatrix = AttributeMatrix::Create(dataStruct, INodeGeometry2D::k_FaceDataName, faceTupleShape, triangleGeom->getId());
     triangleGeom->setFaceAttributeMatrix(*faceAttMatrix);
-    AttributeMatrix* faceVertAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_VertexDataGroupName, triangleGeom->getId());
+
     std::vector<usize> faceVertTupleShape = {6};
-    faceVertAttMatrix->setShape(faceVertTupleShape);
+    AttributeMatrix* faceVertAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_VertexDataGroupName, faceVertTupleShape, triangleGeom->getId());
     triangleGeom->setVertexAttributeMatrix(*faceVertAttMatrix);
     Float32Array* faceVertListArray = UnitTest::CreateTestDataArray<float32>(dataStruct, Constants::k_Float32DataSet, faceVertTupleShape, {3}, triangleGeom->getId());
     (*faceVertListArray)[0] = 0;
@@ -279,13 +275,11 @@ DataStructure createTestDataStructure()
   {
     QuadGeom* quadGeom = QuadGeom::Create(dataStruct, k_QuadGeo);
 
-    AttributeMatrix* faceAttMatrix = AttributeMatrix::Create(dataStruct, INodeGeometry2D::k_FaceDataName, quadGeom->getId());
     std::vector<usize> faceTupleShape = {2};
-    faceAttMatrix->setShape(faceTupleShape);
+    AttributeMatrix* faceAttMatrix = AttributeMatrix::Create(dataStruct, INodeGeometry2D::k_FaceDataName, faceTupleShape, quadGeom->getId());
     quadGeom->setFaceAttributeMatrix(*faceAttMatrix);
-    AttributeMatrix* faceVertAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_VertexDataGroupName, quadGeom->getId());
     std::vector<usize> faceVertTupleShape = {6};
-    faceVertAttMatrix->setShape(faceVertTupleShape);
+    AttributeMatrix* faceVertAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_VertexDataGroupName, faceVertTupleShape, quadGeom->getId());
     quadGeom->setVertexAttributeMatrix(*faceVertAttMatrix);
     Float32Array* faceVertListArray = UnitTest::CreateTestDataArray<float32>(dataStruct, Constants::k_Float32DataSet, faceVertTupleShape, {3}, quadGeom->getId());
     (*faceVertListArray)[0] = -1;
@@ -330,13 +324,11 @@ DataStructure createTestDataStructure()
   {
     TetrahedralGeom* tetGeom = TetrahedralGeom::Create(dataStruct, k_TetGeo);
 
-    AttributeMatrix* polyAttMatrix = AttributeMatrix::Create(dataStruct, INodeGeometry3D::k_PolyhedronDataName, tetGeom->getId());
     std::vector<usize> cellTupleShape = {2};
-    polyAttMatrix->setShape(cellTupleShape);
+    AttributeMatrix* polyAttMatrix = AttributeMatrix::Create(dataStruct, INodeGeometry3D::k_PolyhedronDataName, cellTupleShape, tetGeom->getId());
     tetGeom->setPolyhedraAttributeMatrix(*polyAttMatrix);
-    AttributeMatrix* cellVertAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_VertexDataGroupName, tetGeom->getId());
     std::vector<usize> vertTupleShape = {5};
-    cellVertAttMatrix->setShape(vertTupleShape);
+    AttributeMatrix* cellVertAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_VertexDataGroupName, vertTupleShape, tetGeom->getId());
     tetGeom->setVertexAttributeMatrix(*cellVertAttMatrix);
     Float32Array* vertListArray = UnitTest::CreateTestDataArray<float32>(dataStruct, Constants::k_Float32DataSet, vertTupleShape, {3}, tetGeom->getId());
     (*vertListArray)[0] = -1;
@@ -380,13 +372,11 @@ DataStructure createTestDataStructure()
   {
     HexahedralGeom* hexGeom = HexahedralGeom::Create(dataStruct, k_HexGeo);
 
-    AttributeMatrix* polyAttMatrix = AttributeMatrix::Create(dataStruct, INodeGeometry3D::k_PolyhedronDataName, hexGeom->getId());
     std::vector<usize> cellTupleShape = {2};
-    polyAttMatrix->setShape(cellTupleShape);
+    AttributeMatrix* polyAttMatrix = AttributeMatrix::Create(dataStruct, INodeGeometry3D::k_PolyhedronDataName, cellTupleShape, hexGeom->getId());
     hexGeom->setPolyhedraAttributeMatrix(*polyAttMatrix);
-    AttributeMatrix* cellVertAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_VertexDataGroupName, hexGeom->getId());
     std::vector<usize> vertTupleShape = {12};
-    cellVertAttMatrix->setShape(vertTupleShape);
+    AttributeMatrix* cellVertAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_VertexDataGroupName, vertTupleShape, hexGeom->getId());
     hexGeom->setVertexAttributeMatrix(*cellVertAttMatrix);
     Float32Array* vertListArray = UnitTest::CreateTestDataArray<float32>(dataStruct, Constants::k_Float32DataSet, vertTupleShape, {3}, hexGeom->getId());
     (*vertListArray)[0] = -1;

--- a/test/H5Test.cpp
+++ b/test/H5Test.cpp
@@ -740,7 +740,7 @@ TEST_CASE("DataArray<bool> IO")
   }
 }
 
-TEST_CASE("xmdf")
+TEST_CASE("xdmf")
 {
   DataStructure dataStructure;
   auto* vertexGeom = VertexGeom::Create(dataStructure, "VertexGeom");
@@ -756,8 +756,7 @@ TEST_CASE("xmdf")
     item = realDistribution(generator);
   }
   auto* verts = DataArray<float32>::Create(dataStructure, "Verts", std::move(vertsDataStore), geomId);
-  auto* vertexData = AttributeMatrix::Create(dataStructure, "VertexData", geomId);
-  vertexData->setShape({numVerts});
+  auto* vertexData = AttributeMatrix::Create(dataStructure, "VertexData", {numVerts}, geomId);
   vertexGeom->setVertexAttributeMatrix(*vertexData);
   vertexGeom->setVertices(*verts);
   auto vertexAssociatedData = std::make_unique<DataStore<int32>>(numVerts, 0);


### PR DESCRIPTION
## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented
