### PR TITLE
ENH: Improved HDF5 Error messages

### DIFF
--- a/src/Plugins/ComplexCore/test/DREAM3DFileTest.cpp
+++ b/src/Plugins/ComplexCore/test/DREAM3DFileTest.cpp
@@ -280,8 +280,8 @@ TEST_CASE("DREAM3DFileTest:DREAM3D File IO Test")
     Result<HDF5::FileWriter> result = HDF5::FileWriter::CreateFile(GetIODataPath());
     REQUIRE(result.valid());
 
-    auto errorCode = DREAM3D::WriteFile(result.value(), fileData);
-    REQUIRE(errorCode >= 0);
+    auto writeResult = DREAM3D::WriteFile(result.value(), fileData);
+    COMPLEX_RESULT_REQUIRE_VALID(writeResult);
   }
 
   // Read .dream3d file

--- a/src/Plugins/ComplexCore/test/ImportHDF5DatasetTest.cpp
+++ b/src/Plugins/ComplexCore/test/ImportHDF5DatasetTest.cpp
@@ -23,10 +23,8 @@ std::string m_FilePath = unit_test::k_BinaryDir.str() + "/ImportHDF5DatasetTest.
 //  Uses Raw Pointers to save data to the data file
 // -----------------------------------------------------------------------------
 template <typename T>
-complex::HDF5::ErrorType writePointer1DArrayDataset(complex::HDF5::GroupWriter& ptrGroupWriter)
+Result<> writePointer1DArrayDataset(complex::HDF5::GroupWriter& ptrGroupWriter)
 {
-  complex::HDF5::ErrorType err = 1;
-
   // Create the Dimensions
   std::vector<hsize_t> dims(1);
   dims[0] = COMPDIMPROD * TUPLEDIMPROD;
@@ -42,20 +40,18 @@ complex::HDF5::ErrorType writePointer1DArrayDataset(complex::HDF5::GroupWriter& 
   std::string dsetName = complex::HDF5::Support::HdfTypeForPrimitiveAsStr<T>();
   dsetName = "Pointer1DArrayDataset<" + dsetName + ">";
   complex::HDF5::DatasetWriter dsetWriter = ptrGroupWriter.createDatasetWriter(dsetName);
-  err = dsetWriter.writeSpan(dims, nonstd::span<const T>{data});
-  REQUIRE(err >= 0);
+  auto result = dsetWriter.writeSpan(dims, nonstd::span<const T>{data});
+  COMPLEX_RESULT_REQUIRE_VALID(result);
 
-  return err;
+  return result;
 }
 
 // -----------------------------------------------------------------------------
 //  Uses Raw Pointers to save data to the data file
 // -----------------------------------------------------------------------------
 template <typename T>
-complex::HDF5::ErrorType writePointer2DArrayDataset(complex::HDF5::GroupWriter& ptrGroupWriter)
+Result<> writePointer2DArrayDataset(complex::HDF5::GroupWriter& ptrGroupWriter)
 {
-  complex::HDF5::ErrorType err = 1;
-
   // Create the Dimensions
   std::vector<hsize_t> dims(2);
   dims[0] = 10;
@@ -72,20 +68,18 @@ complex::HDF5::ErrorType writePointer2DArrayDataset(complex::HDF5::GroupWriter& 
   std::string dsetName = complex::HDF5::Support::HdfTypeForPrimitiveAsStr<T>();
   dsetName = "Pointer2DArrayDataset<" + dsetName + ">";
   complex::HDF5::DatasetWriter dsetWriter = ptrGroupWriter.createDatasetWriter(dsetName);
-  err = dsetWriter.writeSpan(dims, nonstd::span<const T>{data});
-  REQUIRE(err >= 0);
+  auto result = dsetWriter.writeSpan(dims, nonstd::span<const T>{data});
+  COMPLEX_RESULT_REQUIRE_VALID(result);
 
-  return err;
+  return result;
 }
 
 // -----------------------------------------------------------------------------
 //  Uses Raw Pointers to save data to the data file
 // -----------------------------------------------------------------------------
 template <typename T>
-complex::HDF5::ErrorType writePointer3DArrayDataset(complex::HDF5::GroupWriter& ptrGroupWriter)
+Result<> writePointer3DArrayDataset(complex::HDF5::GroupWriter& ptrGroupWriter)
 {
-  complex::HDF5::ErrorType err = 1;
-
   // Create the Dimensions
   std::vector<hsize_t> dims(3);
   dims[0] = 10;
@@ -103,20 +97,18 @@ complex::HDF5::ErrorType writePointer3DArrayDataset(complex::HDF5::GroupWriter& 
   std::string dsetName = complex::HDF5::Support::HdfTypeForPrimitiveAsStr<T>();
   dsetName = "Pointer3DArrayDataset<" + dsetName + ">";
   complex::HDF5::DatasetWriter dsetWriter = ptrGroupWriter.createDatasetWriter(dsetName);
-  err = dsetWriter.writeSpan(dims, nonstd::span<const T>{data});
-  REQUIRE(err >= 0);
+  auto result = dsetWriter.writeSpan(dims, nonstd::span<const T>{data});
+  COMPLEX_RESULT_REQUIRE_VALID(result);
 
-  return err;
+  return result;
 }
 
 // -----------------------------------------------------------------------------
 //  Uses Raw Pointers to save data to the data file
 // -----------------------------------------------------------------------------
 template <typename T>
-complex::HDF5::ErrorType writePointer4DArrayDataset(complex::HDF5::GroupWriter& ptrGroupWriter)
+Result<> writePointer4DArrayDataset(complex::HDF5::GroupWriter& ptrGroupWriter)
 {
-  complex::HDF5::ErrorType err = 1;
-
   // Create the Dimensions
   std::vector<hsize_t> dims(4);
   dims[0] = 10;
@@ -135,10 +127,10 @@ complex::HDF5::ErrorType writePointer4DArrayDataset(complex::HDF5::GroupWriter& 
   std::string dsetName = complex::HDF5::Support::HdfTypeForPrimitiveAsStr<T>();
   dsetName = "Pointer4DArrayDataset<" + dsetName + ">";
   complex::HDF5::DatasetWriter dsetWriter = ptrGroupWriter.createDatasetWriter(dsetName);
-  err = dsetWriter.writeSpan(dims, nonstd::span<const T>{data});
-  REQUIRE(err >= 0);
+  auto result = dsetWriter.writeSpan(dims, nonstd::span<const T>{data});
+  COMPLEX_RESULT_REQUIRE_VALID(result);
 
-  return err;
+  return result;
 }
 
 // -----------------------------------------------------------------------------
@@ -161,49 +153,49 @@ void writeHDF5File()
   complex::HDF5::GroupWriter ptrGroupWriter = fileWriter.createGroupWriter("Pointer");
   REQUIRE(ptrGroupWriter.isValid());
 
-  REQUIRE(writePointer1DArrayDataset<int8_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer1DArrayDataset<uint8_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer1DArrayDataset<int16_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer1DArrayDataset<uint16_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer1DArrayDataset<int32_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer1DArrayDataset<uint32_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer1DArrayDataset<int64_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer1DArrayDataset<uint64_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer1DArrayDataset<float32>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer1DArrayDataset<float64>(ptrGroupWriter) >= 0);
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer1DArrayDataset<int8_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer1DArrayDataset<uint8_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer1DArrayDataset<int16_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer1DArrayDataset<uint16_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer1DArrayDataset<int32_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer1DArrayDataset<uint32_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer1DArrayDataset<int64_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer1DArrayDataset<uint64_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer1DArrayDataset<float32>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer1DArrayDataset<float64>(ptrGroupWriter));
 
-  REQUIRE(writePointer2DArrayDataset<int8_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer2DArrayDataset<uint8_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer2DArrayDataset<int16_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer2DArrayDataset<uint16_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer2DArrayDataset<int32_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer2DArrayDataset<uint32_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer2DArrayDataset<int64_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer2DArrayDataset<uint64_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer2DArrayDataset<float32>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer2DArrayDataset<float64>(ptrGroupWriter) >= 0);
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer2DArrayDataset<int8_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer2DArrayDataset<uint8_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer2DArrayDataset<int16_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer2DArrayDataset<uint16_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer2DArrayDataset<int32_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer2DArrayDataset<uint32_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer2DArrayDataset<int64_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer2DArrayDataset<uint64_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer2DArrayDataset<float32>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer2DArrayDataset<float64>(ptrGroupWriter));
 
-  REQUIRE(writePointer3DArrayDataset<int8_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer3DArrayDataset<uint8_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer3DArrayDataset<int16_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer3DArrayDataset<uint16_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer3DArrayDataset<int32_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer3DArrayDataset<uint32_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer3DArrayDataset<int64_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer3DArrayDataset<uint64_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer3DArrayDataset<float32>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer3DArrayDataset<float64>(ptrGroupWriter) >= 0);
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer3DArrayDataset<int8_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer3DArrayDataset<uint8_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer3DArrayDataset<int16_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer3DArrayDataset<uint16_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer3DArrayDataset<int32_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer3DArrayDataset<uint32_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer3DArrayDataset<int64_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer3DArrayDataset<uint64_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer3DArrayDataset<float32>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer3DArrayDataset<float64>(ptrGroupWriter));
 
-  REQUIRE(writePointer4DArrayDataset<int8_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer4DArrayDataset<uint8_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer4DArrayDataset<int16_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer4DArrayDataset<uint16_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer4DArrayDataset<int32_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer4DArrayDataset<uint32_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer4DArrayDataset<int64_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer4DArrayDataset<uint64_t>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer4DArrayDataset<float32>(ptrGroupWriter) >= 0);
-  REQUIRE(writePointer4DArrayDataset<float64>(ptrGroupWriter) >= 0);
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer4DArrayDataset<int8_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer4DArrayDataset<uint8_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer4DArrayDataset<int16_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer4DArrayDataset<uint16_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer4DArrayDataset<int32_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer4DArrayDataset<uint32_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer4DArrayDataset<int64_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer4DArrayDataset<uint64_t>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer4DArrayDataset<float32>(ptrGroupWriter));
+  COMPLEX_RESULT_REQUIRE_VALID(writePointer4DArrayDataset<float64>(ptrGroupWriter));
 }
 
 // -----------------------------------------------------------------------------

--- a/src/complex/DataStructure/IO/HDF5/IDataIO.cpp
+++ b/src/complex/DataStructure/IO/HDF5/IDataIO.cpp
@@ -37,8 +37,8 @@ Result<> IDataIO::WriteDataId(object_writer_type& objectWriter, const std::optio
     return MakeErrorResult(-404, ss);
   }
   DataObject::IdType id = objectId.value();
-  auto error = attribute.writeValue<DataObject::IdType>(id);
-  if(error < 0)
+  auto result = attribute.writeValue<DataObject::IdType>(id);
+  if(result.invalid())
   {
     std::string ss = fmt::format("Failed to write DataObject ID, '{}' for tag '{}'", id, tag);
     return MakeErrorResult(405, ss);
@@ -52,27 +52,27 @@ Result<> IDataIO::WriteObjectAttributes(DataStructureWriter& dataStructureWriter
   dataStructureWriter.addWriter(objectWriter, dataObject.getId());
 
   auto typeAttributeWriter = objectWriter.createAttribute(Constants::k_ObjectTypeTag);
-  auto error = typeAttributeWriter.writeString(dataObject.getTypeName());
-  if(error < 0)
+  auto result = typeAttributeWriter.writeString(dataObject.getTypeName());
+  if(result.invalid())
   {
     std::string ss = fmt::format("Error writing DataObject attribute: {}", Constants::k_ObjectTypeTag);
-    return MakeErrorResult(error, ss);
+    return MakeErrorResult(result.errors()[0].code, ss);
   }
 
   auto idAttributeWriter = objectWriter.createAttribute(Constants::k_ObjectIdTag);
-  error = idAttributeWriter.writeValue(dataObject.getId());
-  if(error < 0)
+  result = idAttributeWriter.writeValue(dataObject.getId());
+  if(result.invalid())
   {
     std::string ss = fmt::format("Error writing DataObject attribute: {}", Constants::k_ObjectIdTag);
-    return MakeErrorResult(error, ss);
+    return MakeErrorResult(result.errors()[0].code, ss);
   }
 
   auto importableAttributeWriter = objectWriter.createAttribute(Constants::k_ImportableTag);
-  error = importableAttributeWriter.writeValue<int32>(importable ? 1 : 0);
-  if(error < 0)
+  result = importableAttributeWriter.writeValue<int32>(importable ? 1 : 0);
+  if(result.invalid())
   {
     std::string ss = fmt::format("Error writing DataObject attribute: {}", Constants::k_ImportableTag);
-    return MakeErrorResult(error, ss);
+    return MakeErrorResult(result.errors()[0].code, ss);
   }
 
   return {};

--- a/src/complex/DataStructure/IO/HDF5/INodeGeom0dIO.cpp
+++ b/src/complex/DataStructure/IO/HDF5/INodeGeom0dIO.cpp
@@ -52,12 +52,11 @@ Result<> INodeGeom0dIO::WriteNodeGeom0dData(DataStructureWriter& dataStructureWr
     {
       indices[i] = i;
     }
-    auto errorCode = datasetWriter.writeSpan(complex::HDF5::DatasetWriter::DimsType{numVerts, 1}, nonstd::span<const int64>{indices});
+    result = datasetWriter.writeSpan(complex::HDF5::DatasetWriter::DimsType{numVerts, 1}, nonstd::span<const int64>{indices});
     if(result.invalid())
     {
       std::string ss = "Failed to write indices to dataset";
-      return MakeErrorResult(errorCode, ss);
-      return result;
+      return MakeErrorResult(result.errors()[0].code, ss);
     }
   }
 

--- a/src/complex/DataStructure/IO/HDF5/IOUtilities.cpp
+++ b/src/complex/DataStructure/IO/HDF5/IOUtilities.cpp
@@ -22,27 +22,27 @@ Result<> HDF5::WriteObjectAttributes(DataStructureWriter& dataStructureWriter, c
   dataStructureWriter.addWriter(objectWriter, dataObject->getId());
 
   auto typeAttributeWriter = objectWriter.createAttribute(Constants::k_ObjectTypeTag);
-  complex::HDF5::ErrorType error = typeAttributeWriter.writeString(dataObject->getTypeName());
-  if(error < 0)
+  Result<> result = typeAttributeWriter.writeString(dataObject->getTypeName());
+  if(result.invalid())
   {
     std::string ss = fmt::format("Could not write to attribute {}", Constants::k_ObjectTypeTag);
-    return MakeErrorResult(error, ss);
+    return MakeErrorResult(result.errors()[0].code, ss);
   }
 
   auto idAttributeWriter = objectWriter.createAttribute(Constants::k_ObjectIdTag);
-  error = idAttributeWriter.writeValue(dataObject->getId());
-  if(error < 0)
+  result = idAttributeWriter.writeValue(dataObject->getId());
+  if(result.invalid())
   {
     std::string ss = fmt::format("Could not write to attribute {}", Constants::k_ObjectIdTag);
-    return MakeErrorResult(error, ss);
+    return MakeErrorResult(result.errors()[0].code, ss);
   }
 
   auto importableAttributeWriter = objectWriter.createAttribute(Constants::k_ImportableTag);
-  error = importableAttributeWriter.writeValue<int32>(importable ? 1 : 0);
-  if(error < 0)
+  result = importableAttributeWriter.writeValue<int32>(importable ? 1 : 0);
+  if(result.invalid())
   {
     std::string ss = fmt::format("Could not write to attribute {}", Constants::k_ImportableTag);
-    return MakeErrorResult(error, ss);
+    return MakeErrorResult(result.errors()[0].code, ss);
   }
 
   return {};

--- a/src/complex/DataStructure/IO/HDF5/ImageGeomIO.cpp
+++ b/src/complex/DataStructure/IO/HDF5/ImageGeomIO.cpp
@@ -2,6 +2,7 @@
 
 #include "DataStructureReader.hpp"
 #include "complex/Common/Array.hpp"
+#include "complex/Common/Result.hpp"
 #include "complex/DataStructure/Geometry/ImageGeom.hpp"
 #include "complex/DataStructure/IO/Generic/IOConstants.hpp"
 #include "complex/DataStructure/IO/HDF5/DataArrayIO.hpp"
@@ -116,24 +117,24 @@ Result<> ImageGeomIO::writeData(DataStructureWriter& dataStructureWriter, const 
   }
 
   auto dimensionAttr = groupWriter.createAttribute(IOConstants::k_H5_DIMENSIONS);
-  auto errorCode = dimensionAttr.writeVector(dims, volDimsVector);
-  if(errorCode < 0)
+  auto writeResult = dimensionAttr.writeVector(dims, volDimsVector);
+  if(writeResult.invalid())
   {
-    return MakeErrorResult(errorCode, "Failed to write volume dimensions");
+    return MakeErrorResult(writeResult.errors()[0].code, "Failed to write volume dimensions");
   }
 
   auto originAttr = groupWriter.createAttribute(IOConstants::k_H5_ORIGIN);
-  errorCode = originAttr.writeVector(dims, originVector);
-  if(errorCode < 0)
+  writeResult = originAttr.writeVector(dims, originVector);
+  if(writeResult.invalid())
   {
-    return MakeErrorResult(errorCode, "Failed to write volume origin");
+    return MakeErrorResult(writeResult.errors()[0].code, "Failed to write volume origin");
   }
 
   auto spacingAttr = groupWriter.createAttribute(IOConstants::k_H5_SPACING);
-  errorCode = spacingAttr.writeVector(dims, spacingVector);
-  if(errorCode < 0)
+  writeResult = spacingAttr.writeVector(dims, spacingVector);
+  if(writeResult.invalid())
   {
-    return MakeErrorResult(errorCode, "Failed to write volume spacing");
+    return MakeErrorResult(writeResult.errors()[0].code, "Failed to write volume spacing");
   }
 
   return {};

--- a/src/complex/DataStructure/IO/HDF5/NeighborListIO.hpp
+++ b/src/complex/DataStructure/IO/HDF5/NeighborListIO.hpp
@@ -150,11 +150,11 @@ public:
       return flattenedResult;
     }
     auto linkedDatasetAttribute = datasetWriter.createAttribute("Linked NumNeighbors Dataset");
-    auto err = linkedDatasetAttribute.writeString(neighborList.getNumNeighborsArrayName());
-    if(err < 0)
+    result = linkedDatasetAttribute.writeString(neighborList.getNumNeighborsArrayName());
+    if(result.invalid())
     {
       std::string ss = "Failed to write NeighborList dataset data name";
-      return MakeErrorResult(err, ss);
+      return MakeErrorResult(result.errors()[0].code, ss);
     }
     return WriteObjectAttributes(dataStructureWriter, neighborList, datasetWriter, importable);
   }

--- a/src/complex/DataStructure/IO/HDF5/RectGridGeomIO.cpp
+++ b/src/complex/DataStructure/IO/HDF5/RectGridGeomIO.cpp
@@ -75,11 +75,11 @@ Result<> RectGridGeomIO::writeData(DataStructureWriter& dataStructureWriter, con
   }
 
   auto dimensionAttr = groupWriter.createAttribute(IOConstants::k_DimensionsTag);
-  auto errorCode = dimensionAttr.writeVector(dims, dimsVector);
-  if(errorCode < 0)
+  auto writeResult = dimensionAttr.writeVector(dims, dimsVector);
+  if(writeResult.invalid())
   {
     std::string ss = "Failed to write dimensions attribute";
-    return MakeErrorResult(errorCode, ss);
+    return MakeErrorResult(writeResult.errors()[0].code, ss);
   }
 
   // Write DataObject IDs

--- a/src/complex/DataStructure/IO/HDF5/ScalarDataIO.hpp
+++ b/src/complex/DataStructure/IO/HDF5/ScalarDataIO.hpp
@@ -61,13 +61,12 @@ public:
 
     complex::HDF5::DatasetWriter::DimsType dims = {1};
     std::array<T, 1> dataVector = {scalarData.getValue()};
-    auto h5Error = datasetWriter.writeSpan(dims, nonstd::span<const T>{dataVector});
-    if(h5Error < 0)
+    Result<> h5Result = datasetWriter.writeSpan(dims, nonstd::span<const T>{dataVector});
+    if(h5Result.invalid())
     {
       return MakeErrorResult(-460, "Failed to write ScalarData");
     }
-    Result<> result = WriteObjectAttributes(dataStructureWriter, scalarData, datasetWriter, importable);
-    return result;
+    return WriteObjectAttributes(dataStructureWriter, scalarData, datasetWriter, importable);
   }
 
   /**

--- a/src/complex/DataStructure/IO/HDF5/StringArrayIO.cpp
+++ b/src/complex/DataStructure/IO/HDF5/StringArrayIO.cpp
@@ -51,11 +51,10 @@ Result<> StringArrayIO::writeData(DataStructureWriter& dataStructureWriter, cons
 
   // writeVectorOfStrings may resize the collection
   data_type::collection_type strings = dataArray.values();
-  const auto err = datasetWriter.writeVectorOfStrings(strings);
-  if(err < 0)
+  const auto result = datasetWriter.writeVectorOfStrings(strings);
+  if(result.invalid())
   {
-    std::string ss = "Failed to write StringArray text";
-    return MakeErrorResult(err, ss);
+    return result;
   }
   return WriteObjectAttributes(dataStructureWriter, dataArray, datasetWriter, importable);
 }

--- a/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.hpp
+++ b/src/complex/Utilities/Parsing/DREAM3D/Dream3dIO.hpp
@@ -70,17 +70,17 @@ COMPLEX_EXPORT Result<FileData> ReadFile(const std::filesystem::path& path);
  * @brief Writes a .dream3d file with the specified data.
  * @param fileWriter
  * @param fileData
- * @return complex::HDF5::ErrorType
+ * @return Result<>
  */
-COMPLEX_EXPORT complex::HDF5::ErrorType WriteFile(complex::HDF5::FileWriter& fileWriter, const FileData& fileData);
+COMPLEX_EXPORT Result<> WriteFile(complex::HDF5::FileWriter& fileWriter, const FileData& fileData);
 
 /**
  * @brief Writes a .dream3d file with the specified data.
  * @param fileWriter
  * @param fileData
- * @return complex::HDF5::ErrorType
+ * @return Result<>
  */
-COMPLEX_EXPORT complex::HDF5::ErrorType WriteFile(complex::HDF5::FileWriter& fileWriter, const Pipeline& pipeline, const DataStructure& dataStructure);
+COMPLEX_EXPORT Result<> WriteFile(complex::HDF5::FileWriter& fileWriter, const Pipeline& pipeline, const DataStructure& dataStructure);
 
 /**
  * @brief Writes a .dream3d file with the specified data.

--- a/src/complex/Utilities/Parsing/HDF5/H5Support.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5Support.hpp
@@ -39,7 +39,7 @@
   {                                                                                                                                                                                                    \
     std::cout << "File: " << __FILE__ << "(" << __LINE__ << "): "                                                                                                                                      \
               << "Error Closing Attribute." << std::endl;                                                                                                                                              \
-    returnError = error;                                                                                                                                                                               \
+    returnError = MakeErrorResult(error, "Error Closing Attribute");                                                                                                                                   \
   }
 
 #define H5S_CLOSE_H5_DATASPACE(dataspaceId, error, returnError)                                                                                                                                        \
@@ -48,7 +48,7 @@
   {                                                                                                                                                                                                    \
     std::cout << "File: " << __FILE__ << "(" << __LINE__ << "): "                                                                                                                                      \
               << "Error closing Dataspace." << std::endl;                                                                                                                                              \
-    returnError = error;                                                                                                                                                                               \
+    returnError = MakeErrorResult(error, "Error Closing Dataspace");                                                                                                                                   \
   }
 
 #define H5S_CLOSE_H5_TYPE(typeId, error, returnError)                                                                                                                                                  \
@@ -57,7 +57,7 @@
   {                                                                                                                                                                                                    \
     std::cout << "File: " << __FILE__ << "(" << __LINE__ << "): "                                                                                                                                      \
               << "Error closing DataType" << std::endl;                                                                                                                                                \
-    returnError = error;                                                                                                                                                                               \
+    returnError = MakeErrorResult(error, "Error closing DataType");                                                                                                                                    \
   }
 
 #define H5_CLOSE_H5_DATASET(datasetId, error, returnError, datasetName)                                                                                                                                \

--- a/src/complex/Utilities/Parsing/HDF5/IO/AttributeIO.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/IO/AttributeIO.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "complex/Common/Result.hpp"
 #include "complex/Utilities/Parsing/HDF5/H5.hpp"
 #include "complex/Utilities/Parsing/HDF5/H5Support.hpp"
 #include "complex/complex_export.hpp"
@@ -139,28 +140,29 @@ public:
    * @brief Writes the specified string to the HDF5 attribute.
    * Returns the resulting HDF5 error code if any occurred.
    * @param text
-   * @return ErrorType
+   * @return Result<>
    */
-  ErrorType writeString(const std::string& text);
+  Result<> writeString(const std::string& text);
 
   /**
    * @brief Writes the specified value to the HDF5 attribute.
    * Returns the resulting HDF5 error code, should an error occur.
    * @tparam T
    * @param value
-   * @return ErrorType
+   * @return Result<>
    */
   template <typename T>
-  ErrorType writeValue(T value);
+  Result<> writeValue(T value);
 
   /**
    * @brief Writes a vector of values to the HDF5 attribute.
    * @tparam T
    * @param dims HDF5 data dimensions
    * @param vector std::vector of data
+   * @return Result<>
    */
   template <typename T>
-  ErrorType writeVector(const DimsVector& dims, const std::vector<T>& vector);
+  Result<> writeVector(const DimsVector& dims, const std::vector<T>& vector);
 
 protected:
   /**
@@ -171,9 +173,9 @@ protected:
   /**
    * @brief Finds and deletes any existing attribute with the current name.
    * Returns any error that might occur when deleting the attribute.
-   * @return ErrorType
+   * @return Result<>
    */
-  ErrorType findAndDeleteAttribute();
+  Result<> findAndDeleteAttribute();
 
 private:
   IdType m_ObjectId = 0;
@@ -193,17 +195,17 @@ extern template COMPLEX_EXPORT float AttributeIO::readAsValue<float>() const;
 extern template COMPLEX_EXPORT double AttributeIO::readAsValue<double>() const;
 extern template COMPLEX_EXPORT bool AttributeIO::readAsValue<bool>() const;
 
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeValue<int8_t>(int8_t value);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeValue<int16_t>(int16_t value);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeValue<int32_t>(int32_t value);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeValue<int64_t>(int64_t value);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeValue<uint8_t>(uint8_t value);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeValue<uint16_t>(uint16_t value);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeValue<uint32_t>(uint32_t value);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeValue<uint64_t>(uint64_t value);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeValue<float>(float value);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeValue<double>(double value);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeValue<bool>(bool value);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeValue<int8_t>(int8_t value);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeValue<int16_t>(int16_t value);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeValue<int32_t>(int32_t value);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeValue<int64_t>(int64_t value);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeValue<uint8_t>(uint8_t value);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeValue<uint16_t>(uint16_t value);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeValue<uint32_t>(uint32_t value);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeValue<uint64_t>(uint64_t value);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeValue<float>(float value);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeValue<double>(double value);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeValue<bool>(bool value);
 
 extern template COMPLEX_EXPORT std::vector<int8_t> AttributeIO::readAsVector<int8_t>() const;
 extern template COMPLEX_EXPORT std::vector<int16_t> AttributeIO::readAsVector<int16_t>() const;
@@ -217,15 +219,15 @@ extern template COMPLEX_EXPORT std::vector<float> AttributeIO::readAsVector<floa
 extern template COMPLEX_EXPORT std::vector<double> AttributeIO::readAsVector<double>() const;
 extern template COMPLEX_EXPORT std::vector<bool> AttributeIO::readAsVector<bool>() const;
 
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeVector<int8_t>(const AttributeIO::DimsVector& dims, const std::vector<int8_t>& vector);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeVector<int16_t>(const AttributeIO::DimsVector& dims, const std::vector<int16_t>& vector);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeVector<int32_t>(const AttributeIO::DimsVector& dims, const std::vector<int32_t>& vector);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeVector<int64_t>(const AttributeIO::DimsVector& dims, const std::vector<int64_t>& vector);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeVector<uint8_t>(const AttributeIO::DimsVector& dims, const std::vector<uint8_t>& vector);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeVector<uint16_t>(const AttributeIO::DimsVector& dims, const std::vector<uint16_t>& vector);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeVector<uint32_t>(const AttributeIO::DimsVector& dims, const std::vector<uint32_t>& vector);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeVector<uint64_t>(const AttributeIO::DimsVector& dims, const std::vector<uint64_t>& vector);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeVector<float>(const AttributeIO::DimsVector& dims, const std::vector<float>& vector);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeVector<double>(const AttributeIO::DimsVector& dims, const std::vector<double>& vector);
-extern template COMPLEX_EXPORT ErrorType AttributeIO::writeVector<bool>(const AttributeIO::DimsVector& dims, const std::vector<bool>& vector);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeVector<int8_t>(const AttributeIO::DimsVector& dims, const std::vector<int8_t>& vector);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeVector<int16_t>(const AttributeIO::DimsVector& dims, const std::vector<int16_t>& vector);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeVector<int32_t>(const AttributeIO::DimsVector& dims, const std::vector<int32_t>& vector);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeVector<int64_t>(const AttributeIO::DimsVector& dims, const std::vector<int64_t>& vector);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeVector<uint8_t>(const AttributeIO::DimsVector& dims, const std::vector<uint8_t>& vector);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeVector<uint16_t>(const AttributeIO::DimsVector& dims, const std::vector<uint16_t>& vector);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeVector<uint32_t>(const AttributeIO::DimsVector& dims, const std::vector<uint32_t>& vector);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeVector<uint64_t>(const AttributeIO::DimsVector& dims, const std::vector<uint64_t>& vector);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeVector<float>(const AttributeIO::DimsVector& dims, const std::vector<float>& vector);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeVector<double>(const AttributeIO::DimsVector& dims, const std::vector<double>& vector);
+extern template COMPLEX_EXPORT Result<> AttributeIO::writeVector<bool>(const AttributeIO::DimsVector& dims, const std::vector<bool>& vector);
 } // namespace complex::HDF5

--- a/src/complex/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
@@ -184,9 +184,9 @@ public:
    * Any one of the write* methods must be called before adding attributes to
    * the HDF5 dataset.
    * @param text
-   * @return ErrorType
+   * @return Result<>
    */
-  ErrorType writeString(const std::string& text);
+  Result<> writeString(const std::string& text);
 
   /**
    * @brief Writes a vector of strings to the dataset. Returns the HDF5 error,
@@ -195,9 +195,9 @@ public:
    * Any one of the write* methods must be called before adding attributes to
    * the HDF5 dataset.
    * @param text
-   * @return ErrorType
+   * @return Result<>
    */
-  ErrorType writeVectorOfStrings(std::vector<std::string>& text);
+  Result<> writeVectorOfStrings(std::vector<std::string>& text);
 
   /**
    * @brief Writes a span of values to the dataset. Returns the HDF5 error,
@@ -208,10 +208,10 @@ public:
    * @tparam T
    * @param dims
    * @param values
-   * @return ErrorType
+   * @return Result<>
    */
   template <typename T>
-  ErrorType writeSpan(const DimsType& dims, nonstd::span<const T> values);
+  Result<> writeSpan(const DimsType& dims, nonstd::span<const T> values);
 
   /**
    * @brief Writes a span of values to the dataset. Returns the HDF5 error,
@@ -222,10 +222,10 @@ public:
    * @tparam T
    * @param dims
    * @param values
-   * @return ErrorType
+   * @return Result<>
    */
   template <typename T>
-  ErrorType writeChunk(const DimsType& dims, nonstd::span<const T> values, const DimsType& chunkDims, nonstd::span<const hsize_t> offset);
+  Result<> writeChunk(const DimsType& dims, nonstd::span<const T> values, const DimsType& chunkDims, nonstd::span<const hsize_t> offset);
 
   template <typename T>
   void createOrOpenDataset(const DimsType& dimensions, IdType propertiesId = 0)
@@ -270,9 +270,9 @@ protected:
   /**
    * @brief Finds and deletes any existing attribute with the current name.
    * Returns any error that might occur when deleting the attribute.
-   * @return ErrorType
+   * @return Result<>
    */
-  ErrorType findAndDeleteAttribute();
+  Result<> findAndDeleteAttribute();
 
   /**
    * @brief Opens the target HDF5 dataset or creates a new one using the given
@@ -321,27 +321,27 @@ extern template bool DatasetIO::readChunkIntoSpan<uint64_t>(nonstd::span<uint64_
 extern template bool DatasetIO::readChunkIntoSpan<float>(nonstd::span<float>, nonstd::span<const hsize_t>) const;
 extern template bool DatasetIO::readChunkIntoSpan<double>(nonstd::span<double>, nonstd::span<const hsize_t>) const;
 
-extern template ErrorType DatasetIO::writeSpan<int8_t>(const DimsType& dims, nonstd::span<const int8_t>);
-extern template ErrorType DatasetIO::writeSpan<int16_t>(const DimsType& dims, nonstd::span<const int16_t>);
-extern template ErrorType DatasetIO::writeSpan<int32_t>(const DimsType& dims, nonstd::span<const int32_t>);
-extern template ErrorType DatasetIO::writeSpan<int64_t>(const DimsType& dims, nonstd::span<const int64_t>);
-extern template ErrorType DatasetIO::writeSpan<uint8_t>(const DimsType& dims, nonstd::span<const uint8_t>);
-extern template ErrorType DatasetIO::writeSpan<uint16_t>(const DimsType& dims, nonstd::span<const uint16_t>);
-extern template ErrorType DatasetIO::writeSpan<uint32_t>(const DimsType& dims, nonstd::span<const uint32_t>);
-extern template ErrorType DatasetIO::writeSpan<uint64_t>(const DimsType& dims, nonstd::span<const uint64_t>);
-extern template ErrorType DatasetIO::writeSpan<float>(const DimsType& dims, nonstd::span<const float>);
-extern template ErrorType DatasetIO::writeSpan<double>(const DimsType& dims, nonstd::span<const double>);
+extern template Result<> DatasetIO::writeSpan<int8_t>(const DimsType& dims, nonstd::span<const int8_t>);
+extern template Result<> DatasetIO::writeSpan<int16_t>(const DimsType& dims, nonstd::span<const int16_t>);
+extern template Result<> DatasetIO::writeSpan<int32_t>(const DimsType& dims, nonstd::span<const int32_t>);
+extern template Result<> DatasetIO::writeSpan<int64_t>(const DimsType& dims, nonstd::span<const int64_t>);
+extern template Result<> DatasetIO::writeSpan<uint8_t>(const DimsType& dims, nonstd::span<const uint8_t>);
+extern template Result<> DatasetIO::writeSpan<uint16_t>(const DimsType& dims, nonstd::span<const uint16_t>);
+extern template Result<> DatasetIO::writeSpan<uint32_t>(const DimsType& dims, nonstd::span<const uint32_t>);
+extern template Result<> DatasetIO::writeSpan<uint64_t>(const DimsType& dims, nonstd::span<const uint64_t>);
+extern template Result<> DatasetIO::writeSpan<float>(const DimsType& dims, nonstd::span<const float>);
+extern template Result<> DatasetIO::writeSpan<double>(const DimsType& dims, nonstd::span<const double>);
 
-extern template ErrorType DatasetIO::writeChunk<int8_t>(const DimsType& dims, nonstd::span<const int8_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
-extern template ErrorType DatasetIO::writeChunk<int16_t>(const DimsType& dims, nonstd::span<const int16_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
-extern template ErrorType DatasetIO::writeChunk<int32_t>(const DimsType& dims, nonstd::span<const int32_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
-extern template ErrorType DatasetIO::writeChunk<int64_t>(const DimsType& dims, nonstd::span<const int64_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
-extern template ErrorType DatasetIO::writeChunk<uint8_t>(const DimsType& dims, nonstd::span<const uint8_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
-extern template ErrorType DatasetIO::writeChunk<uint16_t>(const DimsType& dims, nonstd::span<const uint16_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
-extern template ErrorType DatasetIO::writeChunk<uint32_t>(const DimsType& dims, nonstd::span<const uint32_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
-extern template ErrorType DatasetIO::writeChunk<uint64_t>(const DimsType& dims, nonstd::span<const uint64_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
-extern template ErrorType DatasetIO::writeChunk<float>(const DimsType& dims, nonstd::span<const float> values, const DimsType&, nonstd::span<const hsize_t> offset);
-extern template ErrorType DatasetIO::writeChunk<double>(const DimsType& dims, nonstd::span<const double> values, const DimsType&, nonstd::span<const hsize_t> offset);
-extern template ErrorType DatasetIO::writeChunk<bool>(const DimsType& dims, nonstd::span<const bool> values, const DimsType&, nonstd::span<const hsize_t> offset);
-extern template ErrorType DatasetIO::writeChunk<char>(const DimsType& dims, nonstd::span<const char> values, const DimsType&, nonstd::span<const hsize_t> offset);
+extern template Result<> DatasetIO::writeChunk<int8_t>(const DimsType& dims, nonstd::span<const int8_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
+extern template Result<> DatasetIO::writeChunk<int16_t>(const DimsType& dims, nonstd::span<const int16_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
+extern template Result<> DatasetIO::writeChunk<int32_t>(const DimsType& dims, nonstd::span<const int32_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
+extern template Result<> DatasetIO::writeChunk<int64_t>(const DimsType& dims, nonstd::span<const int64_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
+extern template Result<> DatasetIO::writeChunk<uint8_t>(const DimsType& dims, nonstd::span<const uint8_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
+extern template Result<> DatasetIO::writeChunk<uint16_t>(const DimsType& dims, nonstd::span<const uint16_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
+extern template Result<> DatasetIO::writeChunk<uint32_t>(const DimsType& dims, nonstd::span<const uint32_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
+extern template Result<> DatasetIO::writeChunk<uint64_t>(const DimsType& dims, nonstd::span<const uint64_t> values, const DimsType&, nonstd::span<const hsize_t> offset);
+extern template Result<> DatasetIO::writeChunk<float>(const DimsType& dims, nonstd::span<const float> values, const DimsType&, nonstd::span<const hsize_t> offset);
+extern template Result<> DatasetIO::writeChunk<double>(const DimsType& dims, nonstd::span<const double> values, const DimsType&, nonstd::span<const hsize_t> offset);
+extern template Result<> DatasetIO::writeChunk<bool>(const DimsType& dims, nonstd::span<const bool> values, const DimsType&, nonstd::span<const hsize_t> offset);
+extern template Result<> DatasetIO::writeChunk<char>(const DimsType& dims, nonstd::span<const char> values, const DimsType&, nonstd::span<const hsize_t> offset);
 } // namespace complex::HDF5

--- a/src/complex/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
@@ -234,10 +234,11 @@ public:
     hid_t dataspaceId = H5Screate_simple(dimensions.size(), dimensions.data(), nullptr);
     if(dataspaceId >= 0)
     {
-      herr_t error = findAndDeleteAttribute();
-      if(error < 0)
+      auto result = findAndDeleteAttribute();
+      if(result.invalid())
       {
         std::cout << "Error Removing Existing Attribute" << std::endl;
+        return;
       }
       else
       {
@@ -246,6 +247,7 @@ public:
         if(getId() < 0)
         {
           std::cout << "Error Creating or Opening Dataset" << std::endl;
+          return;
         }
       }
     }

--- a/src/complex/Utilities/Parsing/HDF5/IO/GroupIO.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/IO/GroupIO.cpp
@@ -2,6 +2,8 @@
 
 #include "complex/Utilities/Parsing/HDF5/H5Support.hpp"
 
+#include "fmt/format.h"
+
 #include <H5Gpublic.h>
 #include <H5Opublic.h>
 
@@ -267,11 +269,11 @@ std::shared_ptr<DatasetIO> GroupIO::createDatasetPtr(const std::string& childNam
   return std::make_shared<DatasetIO>(getId(), childName);
 }
 
-ErrorType GroupIO::createLink(const std::string& objectPath)
+Result<> GroupIO::createLink(const std::string& objectPath)
 {
   if(objectPath.empty())
   {
-    return -1;
+    return MakeErrorResult(-105, "Cannot create link with empty path");
   }
   size_t index = objectPath.find_last_of('/');
   if(index > 0)
@@ -281,7 +283,11 @@ ErrorType GroupIO::createLink(const std::string& objectPath)
   std::string objectName = objectPath.substr(index);
 
   herr_t errorCode = H5Lcreate_hard(getFileId(), objectPath.c_str(), getId(), objectName.c_str(), H5P_DEFAULT, H5P_DEFAULT);
-  return errorCode;
+  if(errorCode < 0)
+  {
+    return MakeErrorResult(errorCode, fmt::format("Failed to create link to path '{}'", objectPath));
+  }
+  return {};
 }
 
 // -----------------------------------------------------------------------------

--- a/src/complex/Utilities/Parsing/HDF5/IO/GroupIO.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/IO/GroupIO.hpp
@@ -95,9 +95,9 @@ public:
    * by an HDF5 object path.
    * Returns an error code if one occurs. Otherwise, this method returns 0.
    * @param objectPath
-   * @return ErrorType
+   * @return Result<>
    */
-  ErrorType createLink(const std::string& objectPath);
+  Result<> createLink(const std::string& objectPath);
 
   /**
    * @brief Returns the number of children objects within the group.

--- a/src/complex/Utilities/Parsing/HDF5/Writers/AttributeWriter.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/Writers/AttributeWriter.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "complex/Common/Result.hpp"
 #include "complex/Utilities/Parsing/HDF5/H5.hpp"
 #include "complex/Utilities/Parsing/HDF5/H5Support.hpp"
 
@@ -65,32 +66,32 @@ public:
    * @brief Writes the specified string to the HDF5 attribute.
    * Returns the resulting HDF5 error code if any occurred.
    * @param text
-   * @return ErrorType
+   * @return Result<>
    */
-  ErrorType writeString(const std::string& text);
+  Result<> writeString(const std::string& text);
 
   /**
    * @brief Writes the specified value to the HDF5 attribute.
    * Returns the resulting HDF5 error code, should an error occur.
    * @tparam T
    * @param value
-   * @return ErrorType
+   * @return Result<>
    */
   template <typename T>
-  ErrorType writeValue(T value)
+  Result<> writeValue(T value)
   {
     if(!isValid())
     {
-      return -1;
+      return MakeErrorResult(-100, "Cannot write to invalid AttributeWriter");
     }
 
     herr_t error = 0;
-    herr_t returnError = 0;
+    Result<> returnError = {};
 
     hid_t dataType = Support::HdfTypeForPrimitive<T>();
     if(dataType == -1)
     {
-      return -1;
+      return MakeErrorResult(-101, "Cannot write specified data type");
     }
 
     /* Create the data space for the attribute. */
@@ -100,8 +101,8 @@ public:
     if(dataspaceId >= 0)
     {
       // Delete existing attribute
-      error = findAndDeleteAttribute();
-      if(error >= 0)
+      auto result = findAndDeleteAttribute();
+      if(result.valid())
       {
         /* Create the attribute. */
         hid_t attributeId = H5Acreate(getObjectId(), getAttributeName().c_str(), dataType, dataspaceId, H5P_DEFAULT, H5P_DEFAULT);
@@ -111,29 +112,26 @@ public:
           error = H5Awrite(attributeId, dataType, &value);
           if(error < 0)
           {
-            std::cout << "Error Writing Attribute" << std::endl;
-            returnError = error;
+            returnError = MakeErrorResult(error, "Error Writing Attribute");
           }
         }
         /* Close the attribute. */
         error = H5Aclose(attributeId);
         if(error < 0)
         {
-          std::cout << "Error Closing Attribute" << std::endl;
-          returnError = error;
+          returnError = MakeErrorResult(error, "Error Closing Attribute");
         }
       }
       /* Close the dataspace. */
       error = H5Sclose(dataspaceId);
       if(error < 0)
       {
-        std::cout << "Error Closing Dataspace" << std::endl;
-        returnError = error;
+        returnError = MakeErrorResult(error, "Error Closing Dataspace");
       }
     }
     else
     {
-      returnError = static_cast<herr_t>(dataspaceId);
+      returnError = MakeErrorResult(dataspaceId, "Invalid Dataspace ID");
     }
 
     return returnError;
@@ -144,32 +142,32 @@ public:
    * @tparam T
    * @param dims HDF5 data dimensions
    * @param vector std::vector of data
+   * @return Result<>
    */
   template <typename T>
-  ErrorType writeVector(const DimsVector& dims, const std::vector<T>& vector)
+  Result<> writeVector(const DimsVector& dims, const std::vector<T>& vector)
   {
     if(!isValid())
     {
-      return -1;
+      return MakeErrorResult(-100, "Cannot write to invalid AttributeWriter");
     }
 
-    herr_t returnError = 0;
+    Result<> returnError = {};
+    ErrorType error = 0;
     int32_t rank = static_cast<int32_t>(dims.size());
 
     hid_t dataType = Support::HdfTypeForPrimitive<T>();
     if(dataType == -1)
     {
-      std::cout << "dataType was unknown" << std::endl;
-      return -1;
+      return MakeErrorResult(-101, "Unknown data type");
     }
 
     hid_t dataspaceId = H5Screate_simple(rank, dims.data(), nullptr);
     if(dataspaceId >= 0)
     {
       // Delete any existing attribute
-      herr_t error = findAndDeleteAttribute();
-
-      if(error >= 0)
+      auto result = findAndDeleteAttribute();
+      if(result.valid())
       {
         /* Create the attribute. */
         hid_t attributeId = H5Acreate(getObjectId(), getAttributeName().c_str(), dataType, dataspaceId, H5P_DEFAULT, H5P_DEFAULT);
@@ -179,29 +177,26 @@ public:
           error = H5Awrite(attributeId, dataType, static_cast<const void*>(vector.data()));
           if(error < 0)
           {
-            std::cout << "Error Writing Attribute" << std::endl;
-            returnError = error;
+            returnError = MakeErrorResult(error, "Error Writing Attribute");
           }
         }
         /* Close the attribute. */
         error = H5Aclose(attributeId);
         if(error < 0)
         {
-          std::cout << "Error Closing Attribute" << std::endl;
-          returnError = error;
+          returnError = MakeErrorResult(error, "Error Closing Attribute");
         }
       }
       /* Close the dataspace. */
       error = H5Sclose(dataspaceId);
       if(error < 0)
       {
-        std::cout << "Error Closing Dataspace" << std::endl;
-        returnError = error;
+        returnError = MakeErrorResult(error, "Error Closing Dataspace");
       }
     }
     else
     {
-      returnError = static_cast<herr_t>(dataspaceId);
+      returnError = MakeErrorResult(dataspaceId, "Error Opening Dataspace ID");
     }
 
     return returnError;
@@ -211,9 +206,9 @@ protected:
   /**
    * @brief Finds and deletes any existing attribute with the current name.
    * Returns any error that might occur when deleting the attribute.
-   * @return ErrorType
+   * @return Result<>
    */
-  ErrorType findAndDeleteAttribute();
+  Result<> findAndDeleteAttribute();
 
 private:
   const IdType m_ObjectId = 0;

--- a/src/complex/Utilities/Parsing/HDF5/Writers/GroupWriter.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/Writers/GroupWriter.cpp
@@ -2,6 +2,8 @@
 
 #include "complex/Utilities/Parsing/HDF5/H5Support.hpp"
 
+#include "fmt/format.h"
+
 #include <H5Gpublic.h>
 
 namespace complex::HDF5
@@ -73,11 +75,11 @@ DatasetWriter GroupWriter::createDatasetWriter(const std::string& childName)
   return DatasetWriter(getId(), childName);
 }
 
-ErrorType GroupWriter::createLink(const std::string& objectPath)
+Result<> GroupWriter::createLink(const std::string& objectPath)
 {
   if(objectPath.empty())
   {
-    return -1;
+    return MakeErrorResult(-102, "Cannot link to an empty path");
   }
   size_t index = objectPath.find_last_of('/');
   if(index > 0)
@@ -87,6 +89,10 @@ ErrorType GroupWriter::createLink(const std::string& objectPath)
   std::string objectName = objectPath.substr(index);
 
   herr_t errorCode = H5Lcreate_hard(getFileId(), objectPath.c_str(), getId(), objectName.c_str(), H5P_DEFAULT, H5P_DEFAULT);
-  return errorCode;
+  if(errorCode < 0)
+  {
+    return MakeErrorResult(errorCode, fmt::format("Error Creating Link to path {}", objectPath));
+  }
+  return {};
 }
 } // namespace complex::HDF5

--- a/src/complex/Utilities/Parsing/HDF5/Writers/GroupWriter.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/Writers/GroupWriter.hpp
@@ -58,9 +58,9 @@ public:
    * by an HDF5 object path.
    * Returns an error code if one occurs. Otherwise, this method returns 0.
    * @param objectPath
-   * @return ErrorType
+   * @return Result<>
    */
-  ErrorType createLink(const std::string& objectPath);
+  Result<> createLink(const std::string& objectPath);
 
 protected:
   /**


### PR DESCRIPTION
Replaced ErrorType return type with Result<> within HDF5 utility classes.

Fixes #519.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `complex/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `complex/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [ ] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [ ] Classes and methods are properly documented


<!-- **Thanks for contributing to complex!** -->
