### PR TITLE
FILTER: Nearest Point Fuse Regular Grids

### DIFF
--- a/src/Plugins/ComplexCore/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/CMakeLists.txt
@@ -83,6 +83,7 @@ set(FilterList
   MinNeighbors
   MoveData
   MultiThresholdObjects
+  NearestPointFuseRegularGridsFilter
   PartitionGeometryFilter
   PointSampleTriangleGeometryFilter
   QuickSurfaceMeshFilter
@@ -149,6 +150,7 @@ set(AlgorithmList
   ImportVolumeGraphicsFile
   ImportBinaryCTNorthstar
   LaplacianSmoothing
+  NearestPointFuseRegularGrids
   PartitionGeometry
   PointSampleTriangleGeometry
   QuickSurfaceMesh

--- a/src/Plugins/ComplexCore/docs/NearestPointFuseRegularGridsFilter.md
+++ b/src/Plugins/ComplexCore/docs/NearestPointFuseRegularGridsFilter.md
@@ -1,0 +1,38 @@
+# Fuse Regular Grids (Nearest Points)
+
+## Group (Subgroup)
+
+Sampling (Resolution)
+
+## Description
+
+This **Filter** fuses two **Image Geometry** data sets together. The grid of **Cells** in the *Reference* **Data Container** is overlaid on the grid of **Cells** in the *Sampling* **Data Container**.  Each **Cell** in the *Reference* **Data Container** is associated with the nearest point in the *Sampling* **Data Container** (i.e., no *interpolation* is performed).  All the attributes of the **Cell** in the *Sampling* **Data Container** are then assigned to the **Cell** in the *Reference* **Data Container**.  Additional to the **Cell** attributes being copied, all **Feature and Ensemble Attribute Matrices** from the *Sampling* **Data Container** are copied to the *Reference* **Data Container**.
+
+*Note:* The *Sampling* **Data Container** remains identical after this **Filter**, but the *Reference* **Data Container**, while "geometrically identical", gains all the attribute arrays from the *Sampling* **Data Container**.
+
+## Parameters
+
+None
+
+## Required Geometry
+
+Image
+
+## Required Objects
+
+None
+
+## Created Objects
+
+| Kind | Default Name | Type | Component Dimensions | Description |
+|------|--------------|------|----------------------|-------------|
+| **Attribute Matrix** | CellData | Cell | N/A | *Reference* **Cell** data to use for fusion |
+| **Attribute Matrix** | CellData | Cell | N/A | *Sampling* **Cell** data to use for fusion |
+
+## License & Copyright
+
+Please see the description file distributed with this **Plugin**
+
+## DREAM.3D Mailing Lists
+
+If you need more help with a **Filter**, please consider asking your question on the [DREAM.3D Users Google group!](https://groups.google.com/forum/?hl=en#!forum/dream3d-users)

--- a/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/ComplexCoreLegacyUUIDMapping.hpp
@@ -97,6 +97,7 @@
 #include "ComplexCore/Filters/AppendImageGeometryZSliceFilter.hpp"
 #include "ComplexCore/Filters/FindFeatureClusteringFilter.hpp"
 #include "ComplexCore/Filters/AbaqusHexahedronWriterFilter.hpp"
+#include "ComplexCore/Filters/NearestPointFuseRegularGridsFilter.hpp"
 // @@__HEADER__TOKEN__DO__NOT__DELETE__@@
 
 namespace complex
@@ -194,7 +195,7 @@ namespace complex
     {complex::Uuid::FromString("a8463056-3fa7-530b-847f-7f4cb78b8602").value(), complex::FilterTraits<RemoveFlaggedFeaturesFilter>::uuid}, // RemoveFlaggedFeatures
     {complex::Uuid::FromString("e0555de5-bdc6-5bea-ba2f-aacfbec0a022").value(), complex::FilterTraits<RemoveFlaggedFeaturesFilter>::uuid}, // ExtractFlaggedFeatures
     {complex::Uuid::FromString("27a132b2-a592-519a-8cb7-38599a7f28ec").value(), complex::FilterTraits<ComputeMomentInvariants2DFilter>::uuid}, // ComputeMomentInvariants2D
-	  {complex::Uuid::FromString("fcdde553-36b4-5731-bc88-fc499806cb4e").value(), complex::FilterTraits<FindVertexToTriangleDistancesFilter>::uuid}, // FindVertexToTriangleDistances
+	{complex::Uuid::FromString("fcdde553-36b4-5731-bc88-fc499806cb4e").value(), complex::FilterTraits<FindVertexToTriangleDistancesFilter>::uuid}, // FindVertexToTriangleDistances
     {complex::Uuid::FromString("c681caf4-22f2-5885-bbc9-a0476abc72eb").value(), complex::FilterTraits<ApplyTransformationToGeometryFilter>::uuid}, // ApplyTransformationToGeometry
     {complex::Uuid::FromString("6eda8dbf-dbd8-562a-ae1a-f2904157c189").value(), complex::FilterTraits<ComputeFeatureRectFilter>::uuid}, // ComputeFeatureRect
     {complex::Uuid::FromString("9f77b4a9-6416-5220-a688-115f4e14c90d").value(), complex::FilterTraits<FindLargestCrossSectionsFilter>::uuid}, // FindLargestCrossSections
@@ -203,6 +204,7 @@ namespace complex
     {complex::Uuid::FromString("52b2918a-4fb5-57aa-97d4-ccc084b89572").value(), complex::FilterTraits<AppendImageGeometryZSliceFilter>::uuid}, // AppendImageGeometryZSlice
     {complex::Uuid::FromString("a1e9cf6d-2d1b-573e-98b8-0314c993d2b6").value(), complex::FilterTraits<FindFeatureClusteringFilter>::uuid}, // FindFeatureClustering
     {complex::Uuid::FromString("0559aa37-c5ad-549a-82d4-bff4bfcb6cc6").value(), complex::FilterTraits<AbaqusHexahedronWriterFilter>::uuid}, // AbaqusHexahedronWriter
+    {complex::Uuid::FromString("cbaf9e68-5ded-560c-9440-509289100ea8").value(), complex::FilterTraits<NearestPointFuseRegularGridsFilter>::uuid}, // NearestPointFuseRegularGrids
     // @@__MAP__UPDATE__TOKEN__DO__NOT__DELETE__@@
   };
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/NearestPointFuseRegularGrids.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/NearestPointFuseRegularGrids.cpp
@@ -1,0 +1,48 @@
+#include "NearestPointFuseRegularGrids.hpp"
+
+#include "complex/DataStructure/DataArray.hpp"
+#include "complex/DataStructure/DataGroup.hpp"
+
+using namespace complex;
+
+// -----------------------------------------------------------------------------
+NearestPointFuseRegularGrids::NearestPointFuseRegularGrids(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, NearestPointFuseRegularGridsInputValues* inputValues)
+: m_DataStructure(dataStructure)
+, m_InputValues(inputValues)
+, m_ShouldCancel(shouldCancel)
+, m_MessageHandler(mesgHandler)
+{
+}
+
+// -----------------------------------------------------------------------------
+NearestPointFuseRegularGrids::~NearestPointFuseRegularGrids() noexcept = default;
+
+// -----------------------------------------------------------------------------
+const std::atomic_bool& NearestPointFuseRegularGrids::getCancel()
+{
+  return m_ShouldCancel;
+}
+
+// -----------------------------------------------------------------------------
+Result<> NearestPointFuseRegularGrids::operator()()
+{
+  /**
+  * This section of the code should contain the actual algorithmic codes that
+  * will accomplish the goal of the file.
+  *
+  * If you can parallelize the code there are a number of examples on how to do that.
+  *    GenerateIPFColors is one example
+  *
+  * If you need to determine what kind of array you have (Int32Array, Float32Array, etc)
+  * look to the ExecuteDataFunction() in complex/Utilities/FilterUtilities.hpp template 
+  * function to help with that code.
+  *   An Example algorithm class is `CombineAttributeArrays` and `RemoveFlaggedVertices`
+  * 
+  * There are other utility classes that can help alleviate the amount of code that needs
+  * to be written.
+  *
+  * REMOVE THIS COMMENT BLOCK WHEN YOU ARE FINISHED WITH THE FILTER_HUMAN_NAME
+  */
+
+  return {};
+}

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/NearestPointFuseRegularGrids.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/NearestPointFuseRegularGrids.cpp
@@ -2,11 +2,55 @@
 
 #include "complex/DataStructure/DataArray.hpp"
 #include "complex/DataStructure/DataGroup.hpp"
+#include "complex/DataStructure/Geometry/ImageGeom.hpp"
+#include "complex/Utilities/ParallelAlgorithmUtilities.hpp"
+#include "complex/Utilities/ParallelTaskAlgorithm.hpp"
 
 using namespace complex;
 
+namespace
+{
+template <typename T>
+class CopyFromIndicesListImpl
+{
+public:
+  CopyFromIndicesListImpl(const IDataArray& sourceArray, IDataArray& destArray, const std::vector<std::pair<usize, usize>>& sourceToDest)
+  : m_SourceArray(dynamic_cast<const DataArray<T>&>(sourceArray))
+  , m_DestArray(dynamic_cast<DataArray<T>&>(destArray))
+  , m_IndicesList(sourceToDest)
+  {
+  }
+  ~CopyFromIndicesListImpl() = default;
+
+  CopyFromIndicesListImpl(const CopyFromIndicesListImpl&) = default;
+  CopyFromIndicesListImpl(CopyFromIndicesListImpl&&) noexcept = default;
+  CopyFromIndicesListImpl& operator=(const CopyFromIndicesListImpl&) = delete;
+  CopyFromIndicesListImpl& operator=(CopyFromIndicesListImpl&&) noexcept = delete;
+
+  void operator()() const
+  {
+    usize numComps = m_SourceArray.getNumberOfComponents();
+    for(const auto& [source, dest] : m_IndicesList)
+    {
+      usize sourceIndex = source * numComps;
+      usize destIndex = dest * numComps;
+      for(usize i = 0; i < numComps; i++)
+      {
+        m_DestArray[destIndex + i] = m_SourceArray[destIndex + i];
+      }
+    }
+  }
+
+private:
+  const DataArray<T>& m_SourceArray;
+  DataArray<T>& m_DestArray;
+  const std::vector<std::pair<usize, usize>>& m_IndicesList;
+};
+} // namespace
+
 // -----------------------------------------------------------------------------
-NearestPointFuseRegularGrids::NearestPointFuseRegularGrids(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, NearestPointFuseRegularGridsInputValues* inputValues)
+NearestPointFuseRegularGrids::NearestPointFuseRegularGrids(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel,
+                                                           NearestPointFuseRegularGridsInputValues* inputValues)
 : m_DataStructure(dataStructure)
 , m_InputValues(inputValues)
 , m_ShouldCancel(shouldCancel)
@@ -26,23 +70,99 @@ const std::atomic_bool& NearestPointFuseRegularGrids::getCancel()
 // -----------------------------------------------------------------------------
 Result<> NearestPointFuseRegularGrids::operator()()
 {
-  /**
-  * This section of the code should contain the actual algorithmic codes that
-  * will accomplish the goal of the file.
-  *
-  * If you can parallelize the code there are a number of examples on how to do that.
-  *    GenerateIPFColors is one example
-  *
-  * If you need to determine what kind of array you have (Int32Array, Float32Array, etc)
-  * look to the ExecuteDataFunction() in complex/Utilities/FilterUtilities.hpp template 
-  * function to help with that code.
-  *   An Example algorithm class is `CombineAttributeArrays` and `RemoveFlaggedVertices`
-  * 
-  * There are other utility classes that can help alleviate the amount of code that needs
-  * to be written.
-  *
-  * REMOVE THIS COMMENT BLOCK WHEN YOU ARE FINISHED WITH THE FILTER_HUMAN_NAME
-  */
+  auto& refAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->ReferenceCellAttributeMatrixPath);
+  auto& sampleAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->SamplingCellAttributeMatrixPath);
+
+  std::vector<std::pair<usize, usize>> sourceAndDestIndices = {};
+  sourceAndDestIndices.reserve(refAM.getNumTuples());
+
+  { // scoped to ensure mem and namespace is cleaner
+    auto& refImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ReferenceGeometryPath);
+    auto& sampleImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->SamplingGeometryPath);
+
+    // Get dimensions and resolutions of two grids
+    Vec3<float32> refRes = refImageGeom.getSpacing();
+    Vec3<float32> sampleRes = sampleImageGeom.getSpacing();
+    Vec3<float32> refOrigin = refImageGeom.getOrigin();
+    Vec3<float32> sampleOrigin = sampleImageGeom.getOrigin();
+    Vec3<usize> refDims = refImageGeom.getDimensions();
+    Vec3<usize> sampleDims = sampleImageGeom.getDimensions();
+
+    // Further down we divide by sampleRes, so here check to make sure that no components of the resolution are 0
+    // This would be incredible unusual behavior if it were to occur.
+    bool resHasZero = std::find(sampleRes.begin(), sampleRes.end(), 0.0f) != std::end(sampleRes) ? true : false;
+    if(resHasZero)
+    {
+      return MakeErrorResult(-5555, fmt::format("A component of the resolution for the Image Geometry associated with DataContainer '{}' is 0. This would result in a division by 0 operation",
+                                                m_InputValues->SamplingGeometryPath.toString()));
+    }
+
+    float32 x = 0.0f, y = 0.0f, z = 0.0f;
+    usize col = 0, row = 0, plane = 0;
+    usize refIndex = 0;
+    usize sampleIndex = 0;
+    usize planeComp = 0, rowComp = 0;
+
+    for(usize i = 0; i < refDims[2]; i++)
+    {
+      if(getCancel())
+      {
+        return {};
+      }
+
+      planeComp = i * refDims[0] * refDims[1];
+      for(usize j = 0; j < refDims[1]; j++)
+      {
+        rowComp = j * refDims[0];
+        for(usize k = 0; k < refDims[0]; k++)
+        {
+          x = (k * refRes[0] + refOrigin[0]);
+          y = (j * refRes[1] + refOrigin[1]);
+          z = (i * refRes[2] + refOrigin[2]);
+          if((x - sampleOrigin[0]) < 0)
+          {
+            continue;
+          }
+          if((y - sampleOrigin[1]) < 0)
+          {
+            continue;
+          }
+          if((z - sampleOrigin[2]) < 0)
+          {
+            continue;
+          }
+
+          col = usize((x - sampleOrigin[0]) / sampleRes[0]);
+          row = usize((y - sampleOrigin[1]) / sampleRes[1]);
+          plane = usize((z - sampleOrigin[2]) / sampleRes[2]);
+          if(col >= sampleDims[0] || row >= sampleDims[1] || plane >= sampleDims[2])
+          {
+            continue;
+          }
+
+          sampleIndex = (plane * sampleDims[0] * sampleDims[1]) + (row * sampleDims[0]) + col;
+          refIndex = planeComp + rowComp + k;
+
+          sourceAndDestIndices.emplace_back(sampleIndex, refIndex); // no need for std::move trivial copy
+        }
+      }
+    }
+  }
+
+  sourceAndDestIndices.shrink_to_fit();
+
+  // Copy according to  calculated values
+  ParallelTaskAlgorithm taskRunner;
+  auto sampleVoxelArrays = sampleAM.findAllChildrenOfType<IDataArray>();
+  for(const auto& array : sampleVoxelArrays)
+  {
+    // this path was created in preflight
+    DataPath createdArrayPath = m_InputValues->ReferenceCellAttributeMatrixPath.createChildPath(array->getName());
+    auto& refAMArray = m_DataStructure.getDataRefAs<IDataArray>(createdArrayPath);
+
+    ExecuteParallelFunction<CopyFromIndicesListImpl>(array->getDataType(), taskRunner, *array, refAMArray, sourceAndDestIndices);
+  }
+  taskRunner.wait();
 
   return {};
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/NearestPointFuseRegularGrids.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/NearestPointFuseRegularGrids.cpp
@@ -1,8 +1,9 @@
 #include "NearestPointFuseRegularGrids.hpp"
 
 #include "complex/DataStructure/DataArray.hpp"
-#include "complex/DataStructure/DataGroup.hpp"
 #include "complex/DataStructure/Geometry/ImageGeom.hpp"
+#include "complex/DataStructure/StringArray.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 #include "complex/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "complex/Utilities/ParallelTaskAlgorithm.hpp"
 
@@ -10,14 +11,86 @@ using namespace complex;
 
 namespace
 {
+template <class K>
+void CopyData(const K& inputArray, K& destArray, const ImageGeom& sampleImageGeom, const ImageGeom& refImageGeom, const std::atomic_bool& shouldCancel)
+{
+  // Get dimensions and resolutions of two grids
+  Vec3<float32> sampleRes = sampleImageGeom.getSpacing();
+  Vec3<float32> refRes = refImageGeom.getSpacing();
+  Vec3<float32> refOrigin = refImageGeom.getOrigin();
+  Vec3<float32> sampleOrigin = sampleImageGeom.getOrigin();
+  Vec3<usize> refDims = refImageGeom.getDimensions();
+  Vec3<usize> sampleDims = sampleImageGeom.getDimensions();
+
+  float32 x = 0.0f, y = 0.0f, z = 0.0f;
+  usize col = 0, row = 0, plane = 0;
+  usize refIndex = 0;
+  usize sampleIndex = 0;
+  usize planeComp = 0, rowComp = 0;
+  for(usize i = 0; i < refDims[2]; i++)
+  {
+    if(shouldCancel)
+    {
+      return;
+    }
+
+    planeComp = i * refDims[0] * refDims[1];
+    for(usize j = 0; j < refDims[1]; j++)
+    {
+      rowComp = j * refDims[0];
+      for(usize k = 0; k < refDims[0]; k++)
+      {
+        x = (k * refRes[0] + refOrigin[0]);
+        y = (j * refRes[1] + refOrigin[1]);
+        z = (i * refRes[2] + refOrigin[2]);
+        if((x - sampleOrigin[0]) < 0)
+        {
+          continue;
+        }
+        if((y - sampleOrigin[1]) < 0)
+        {
+          continue;
+        }
+        if((z - sampleOrigin[2]) < 0)
+        {
+          continue;
+        }
+
+        col = usize((x - sampleOrigin[0]) / sampleRes[0]);
+        row = usize((y - sampleOrigin[1]) / sampleRes[1]);
+        plane = usize((z - sampleOrigin[2]) / sampleRes[2]);
+        if(col >= sampleDims[0] || row >= sampleDims[1] || plane >= sampleDims[2])
+        {
+          continue;
+        }
+
+        sampleIndex = (plane * sampleDims[0] * sampleDims[1]) + (row * sampleDims[0]) + col;
+        refIndex = planeComp + rowComp + k;
+
+        usize numComps = destArray.getNumberOfComponents();
+        usize sourceIndex = sampleIndex * inputArray.getNumberOfComponents();
+        usize destIndex = refIndex * numComps;
+        for(usize offset = 0; offset < numComps; ++offset)
+        {
+          destArray[destIndex + offset] = inputArray.at(sourceIndex + offset);
+        }
+      }
+    }
+  }
+}
+
 template <typename T>
 class CopyFromIndicesListImpl
 {
 public:
-  CopyFromIndicesListImpl(const IDataArray& sourceArray, IDataArray& destArray, const std::vector<std::pair<usize, usize>>& sourceToDest)
-  : m_SourceArray(dynamic_cast<const DataArray<T>&>(sourceArray))
-  , m_DestArray(dynamic_cast<DataArray<T>&>(destArray))
-  , m_IndicesList(sourceToDest)
+  CopyFromIndicesListImpl(const IArray& sourceArray, IArray& destArray, const ImageGeom& sampleImageGeom, const ImageGeom& refImageGeom, float64 fillValue, const std::atomic_bool& shouldCancel)
+  : m_SourceArray(sourceArray)
+  , m_DestArray(destArray)
+  , m_ArrayType(destArray.getArrayType())
+  , m_SampleGeom(sampleImageGeom)
+  , m_RefGeom(refImageGeom)
+  , m_FillValue(fillValue)
+  , m_ShouldCancel(shouldCancel)
   {
   }
   ~CopyFromIndicesListImpl() = default;
@@ -29,22 +102,39 @@ public:
 
   void operator()() const
   {
-    usize numComps = m_SourceArray.getNumberOfComponents();
-    for(const auto& [source, dest] : m_IndicesList)
+    if(m_ArrayType == IArray::ArrayType::NeighborListArray)
     {
-      usize sourceIndex = source * numComps;
-      usize destIndex = dest * numComps;
-      for(usize i = 0; i < numComps; i++)
-      {
-        m_DestArray[destIndex + i] = m_SourceArray[destIndex + i];
-      }
+      return;
+      //      using NeighborListT = NeighborList<T>;
+      //      auto& destArray = dynamic_cast<NeighborListT&>(m_DestArray);
+      //      // Make sure the destination array is allocated AND each tuple list is initialized, so we can use the [] operator to copy over the data
+      //      if(destArray.getValues().empty() || destArray.getList(0) == nullptr)
+      //      {
+      //        destArray.addEntry(destArray.getNumberOfTuples() - 1, 0);
+      //      }
+      //      CopyData<NeighborListT>(dynamic_cast<const NeighborListT&>(m_SourceArray1), destArray);
+    }
+    else if(m_ArrayType == IArray::ArrayType::DataArray)
+    {
+      using DataArrayT = DataArray<T>;
+      auto destArray = dynamic_cast<DataArrayT&>(m_DestArray);
+      destArray.fill(static_cast<T>(m_FillValue));
+      CopyData<DataArrayT>(dynamic_cast<const DataArrayT&>(m_SourceArray), destArray, m_SampleGeom, m_RefGeom, m_ShouldCancel);
+    }
+    else if(m_ArrayType == IArray::ArrayType::StringArray)
+    {
+      CopyData<StringArray>(dynamic_cast<const StringArray&>(m_SourceArray), dynamic_cast<StringArray&>(m_DestArray), m_SampleGeom, m_RefGeom, m_ShouldCancel);
     }
   }
 
 private:
-  const DataArray<T>& m_SourceArray;
-  DataArray<T>& m_DestArray;
-  const std::vector<std::pair<usize, usize>>& m_IndicesList;
+  const IArray& m_SourceArray;
+  IArray& m_DestArray;
+  IArray::ArrayType m_ArrayType = IArray::ArrayType::Any;
+  const ImageGeom& m_SampleGeom;
+  const ImageGeom& m_RefGeom;
+  float64 m_FillValue;
+  const std::atomic_bool& m_ShouldCancel;
 };
 } // namespace
 
@@ -70,97 +160,37 @@ const std::atomic_bool& NearestPointFuseRegularGrids::getCancel()
 // -----------------------------------------------------------------------------
 Result<> NearestPointFuseRegularGrids::operator()()
 {
+  auto& refImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ReferenceGeometryPath);
+  auto& sampleImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->SamplingGeometryPath);
   auto& refAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->ReferenceCellAttributeMatrixPath);
   auto& sampleAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->SamplingCellAttributeMatrixPath);
+  Vec3<float32> sampleRes = sampleImageGeom.getSpacing();
 
-  std::vector<std::pair<usize, usize>> sourceAndDestIndices = {};
-  sourceAndDestIndices.reserve(refAM.getNumTuples());
-
-  { // scoped to ensure mem and namespace is cleaner
-    auto& refImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ReferenceGeometryPath);
-    auto& sampleImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->SamplingGeometryPath);
-
-    // Get dimensions and resolutions of two grids
-    Vec3<float32> refRes = refImageGeom.getSpacing();
-    Vec3<float32> sampleRes = sampleImageGeom.getSpacing();
-    Vec3<float32> refOrigin = refImageGeom.getOrigin();
-    Vec3<float32> sampleOrigin = sampleImageGeom.getOrigin();
-    Vec3<usize> refDims = refImageGeom.getDimensions();
-    Vec3<usize> sampleDims = sampleImageGeom.getDimensions();
-
-    // Further down we divide by sampleRes, so here check to make sure that no components of the resolution are 0
-    // This would be incredible unusual behavior if it were to occur.
-    bool resHasZero = std::find(sampleRes.begin(), sampleRes.end(), 0.0f) != std::end(sampleRes) ? true : false;
-    if(resHasZero)
-    {
-      return MakeErrorResult(-5555, fmt::format("A component of the resolution for the Image Geometry associated with DataContainer '{}' is 0. This would result in a division by 0 operation",
-                                                m_InputValues->SamplingGeometryPath.toString()));
-    }
-
-    float32 x = 0.0f, y = 0.0f, z = 0.0f;
-    usize col = 0, row = 0, plane = 0;
-    usize refIndex = 0;
-    usize sampleIndex = 0;
-    usize planeComp = 0, rowComp = 0;
-
-    for(usize i = 0; i < refDims[2]; i++)
-    {
-      if(getCancel())
-      {
-        return {};
-      }
-
-      planeComp = i * refDims[0] * refDims[1];
-      for(usize j = 0; j < refDims[1]; j++)
-      {
-        rowComp = j * refDims[0];
-        for(usize k = 0; k < refDims[0]; k++)
-        {
-          x = (k * refRes[0] + refOrigin[0]);
-          y = (j * refRes[1] + refOrigin[1]);
-          z = (i * refRes[2] + refOrigin[2]);
-          if((x - sampleOrigin[0]) < 0)
-          {
-            continue;
-          }
-          if((y - sampleOrigin[1]) < 0)
-          {
-            continue;
-          }
-          if((z - sampleOrigin[2]) < 0)
-          {
-            continue;
-          }
-
-          col = usize((x - sampleOrigin[0]) / sampleRes[0]);
-          row = usize((y - sampleOrigin[1]) / sampleRes[1]);
-          plane = usize((z - sampleOrigin[2]) / sampleRes[2]);
-          if(col >= sampleDims[0] || row >= sampleDims[1] || plane >= sampleDims[2])
-          {
-            continue;
-          }
-
-          sampleIndex = (plane * sampleDims[0] * sampleDims[1]) + (row * sampleDims[0]) + col;
-          refIndex = planeComp + rowComp + k;
-
-          sourceAndDestIndices.emplace_back(sampleIndex, refIndex); // no need for std::move trivial copy
-        }
-      }
-    }
+  // Further down we divide by sampleRes, so here check to make sure that no components of the resolution are 0
+  // This would be incredible unusual behavior if it were to occur.
+  bool resHasZero = std::find(sampleRes.begin(), sampleRes.end(), 0.0f) != std::end(sampleRes) ? true : false;
+  if(resHasZero)
+  {
+    return MakeErrorResult(-5555, fmt::format("A component of the resolution for the Image Geometry associated with DataContainer '{}' is 0. This would result in a division by 0 operation",
+                                              m_InputValues->SamplingGeometryPath.toString()));
   }
-
-  sourceAndDestIndices.shrink_to_fit();
 
   // Copy according to  calculated values
   ParallelTaskAlgorithm taskRunner;
-  auto sampleVoxelArrays = sampleAM.findAllChildrenOfType<IDataArray>();
+  auto sampleVoxelArrays = sampleAM.findAllChildrenOfType<IArray>();
   for(const auto& array : sampleVoxelArrays)
   {
     // this path was created in preflight
     DataPath createdArrayPath = m_InputValues->ReferenceCellAttributeMatrixPath.createChildPath(array->getName());
-    auto& refAMArray = m_DataStructure.getDataRefAs<IDataArray>(createdArrayPath);
+    auto& refAMArray = m_DataStructure.getDataRefAs<IArray>(createdArrayPath);
 
-    ExecuteParallelFunction<CopyFromIndicesListImpl>(array->getDataType(), taskRunner, *array, refAMArray, sourceAndDestIndices);
+    DataType dataType = DataType::int32;
+    if(refAMArray.getArrayType() == IArray::ArrayType::DataArray)
+    {
+      dataType = dynamic_cast<IDataArray&>(refAMArray).getDataType();
+    }
+
+    ExecuteParallelFunction<CopyFromIndicesListImpl>(dataType, taskRunner, *array, refAMArray, sampleImageGeom, refImageGeom, m_InputValues->fillValue, getCancel());
   }
   taskRunner.wait();
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/NearestPointFuseRegularGrids.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/NearestPointFuseRegularGrids.hpp
@@ -16,6 +16,7 @@ struct COMPLEXCORE_EXPORT NearestPointFuseRegularGridsInputValues
   DataPath SamplingGeometryPath;
   DataPath ReferenceCellAttributeMatrixPath;
   DataPath SamplingCellAttributeMatrixPath;
+  float64 fillValue;
 };
 
 /**

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/NearestPointFuseRegularGrids.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/NearestPointFuseRegularGrids.hpp
@@ -6,27 +6,16 @@
 #include "complex/DataStructure/DataStructure.hpp"
 #include "complex/Filter/IFilter.hpp"
 #include "complex/Parameters/DataGroupSelectionParameter.hpp"
-#include "complex/Parameters/DataGroupSelectionParameter.hpp"
-
-
-/**
-* This is example code to put in the Execute Method of the filter.
-  NearestPointFuseRegularGridsInputValues inputValues;
-
-  inputValues.ReferenceCellAttributeMatrixPath = filterArgs.value<DataPath>(k_ReferenceCellAttributeMatrixPath_Key);
-  inputValues.SamplingCellAttributeMatrixPath = filterArgs.value<DataPath>(k_SamplingCellAttributeMatrixPath_Key);
-
-  return NearestPointFuseRegularGrids(dataStructure, messageHandler, shouldCancel, &inputValues)();
-*/
 
 namespace complex
 {
 
 struct COMPLEXCORE_EXPORT NearestPointFuseRegularGridsInputValues
 {
+  DataPath ReferenceGeometryPath;
+  DataPath SamplingGeometryPath;
   DataPath ReferenceCellAttributeMatrixPath;
   DataPath SamplingCellAttributeMatrixPath;
-
 };
 
 /**

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/NearestPointFuseRegularGrids.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/NearestPointFuseRegularGrids.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "ComplexCore/ComplexCore_export.hpp"
+
+#include "complex/DataStructure/DataPath.hpp"
+#include "complex/DataStructure/DataStructure.hpp"
+#include "complex/Filter/IFilter.hpp"
+#include "complex/Parameters/DataGroupSelectionParameter.hpp"
+#include "complex/Parameters/DataGroupSelectionParameter.hpp"
+
+
+/**
+* This is example code to put in the Execute Method of the filter.
+  NearestPointFuseRegularGridsInputValues inputValues;
+
+  inputValues.ReferenceCellAttributeMatrixPath = filterArgs.value<DataPath>(k_ReferenceCellAttributeMatrixPath_Key);
+  inputValues.SamplingCellAttributeMatrixPath = filterArgs.value<DataPath>(k_SamplingCellAttributeMatrixPath_Key);
+
+  return NearestPointFuseRegularGrids(dataStructure, messageHandler, shouldCancel, &inputValues)();
+*/
+
+namespace complex
+{
+
+struct COMPLEXCORE_EXPORT NearestPointFuseRegularGridsInputValues
+{
+  DataPath ReferenceCellAttributeMatrixPath;
+  DataPath SamplingCellAttributeMatrixPath;
+
+};
+
+/**
+ * @class ConditionalSetValue
+ * @brief This filter replaces values in the target array with a user specified value
+ * where a bool mask array specifies.
+ */
+
+class COMPLEXCORE_EXPORT NearestPointFuseRegularGrids
+{
+public:
+  NearestPointFuseRegularGrids(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, NearestPointFuseRegularGridsInputValues* inputValues);
+  ~NearestPointFuseRegularGrids() noexcept;
+
+  NearestPointFuseRegularGrids(const NearestPointFuseRegularGrids&) = delete;
+  NearestPointFuseRegularGrids(NearestPointFuseRegularGrids&&) noexcept = delete;
+  NearestPointFuseRegularGrids& operator=(const NearestPointFuseRegularGrids&) = delete;
+  NearestPointFuseRegularGrids& operator=(NearestPointFuseRegularGrids&&) noexcept = delete;
+
+  Result<> operator()();
+
+  const std::atomic_bool& getCancel();
+
+private:
+  DataStructure& m_DataStructure;
+  const NearestPointFuseRegularGridsInputValues* m_InputValues = nullptr;
+  const std::atomic_bool& m_ShouldCancel;
+  const IFilter::MessageHandler& m_MessageHandler;
+};
+
+} // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/NearestPointFuseRegularGridsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/NearestPointFuseRegularGridsFilter.cpp
@@ -3,8 +3,10 @@
 #include "ComplexCore/Filters/Algorithms/NearestPointFuseRegularGrids.hpp"
 
 #include "complex/DataStructure/DataPath.hpp"
-#include "complex/Filter/Actions/EmptyAction.hpp"
+#include "complex/DataStructure/Geometry/ImageGeom.hpp"
+#include "complex/Filter/Actions/CreateArrayAction.hpp"
 #include "complex/Parameters/DataGroupSelectionParameter.hpp"
+#include "complex/Parameters/GeometrySelectionParameter.hpp"
 
 using namespace complex;
 
@@ -45,23 +47,17 @@ Parameters NearestPointFuseRegularGridsFilter::parameters() const
 {
   Parameters params;
 
-  /**
-   * Please separate the parameters into groups generally of the following:
-   *
-   * params.insertSeparator(Parameters::Separator{"Input Parameters"});
-   * params.insertSeparator(Parameters::Separator{"Required Input Cell Data"});
-   * params.insertSeparator(Parameters::Separator{"Required Input Feature Data"});
-   * params.insertSeparator(Parameters::Separator{"Created Cell Data"});
-   * params.insertSeparator(Parameters::Separator{"Created Cell Feature Data"});
-   *
-   * .. or create appropriate separators as needed. The UI in COMPLEX no longer
-   * does this for the developer by using catgories as in SIMPL
-   */
-
   // Create the parameter descriptors that are needed for this filter
-  params.insertSeparator(Parameters::Separator{"Cell Data"});
-  params.insert(std::make_unique<DataGroupSelectionParameter>(k_ReferenceCellAttributeMatrixPath_Key, "Reference Cell Attribute Matrix", "", DataPath{}));
-  params.insert(std::make_unique<DataGroupSelectionParameter>(k_SamplingCellAttributeMatrixPath_Key, "Sampling Cell Attribute Matrix", "", DataPath{}));
+  params.insertSeparator(Parameters::Separator{"Required Geometry"});
+  params.insert(std::make_unique<GeometrySelectionParameter>(k_SamplingGeometryPath_Key, "Sampling Image Geometry", "", DataPath{}, GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image}));
+  params.insert(
+      std::make_unique<GeometrySelectionParameter>(k_ReferenceGeometryPath_Key, "Reference Image Geometry", "", DataPath{}, GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image}));
+
+  params.insertSeparator(Parameters::Separator{"Required Cell Data"});
+  params.insert(std::make_unique<DataGroupSelectionParameter>(k_SamplingCellAttributeMatrixPath_Key, "Sampling Cell Attribute Matrix", "", DataPath{},
+                                                              DataGroupSelectionParameter::AllowedTypes{BaseGroup::GroupType::AttributeMatrix}));
+  params.insert(std::make_unique<DataGroupSelectionParameter>(k_ReferenceCellAttributeMatrixPath_Key, "Reference Cell Attribute Matrix", "", DataPath{},
+                                                              DataGroupSelectionParameter::AllowedTypes{BaseGroup::GroupType::AttributeMatrix}));
 
   return params;
 }
@@ -73,73 +69,44 @@ IFilter::UniquePointer NearestPointFuseRegularGridsFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult NearestPointFuseRegularGridsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult NearestPointFuseRegularGridsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
+                                                                           const std::atomic_bool& shouldCancel) const
 {
-  /****************************************************************************
-   * Write any preflight sanity checking codes in this function
-   ***************************************************************************/
-
-  /**
-   * These are the values that were gathered from the UI or the pipeline file or
-   * otherwise passed into the filter. These are here for your convenience. If you
-   * do not need some of them remove them.
-   */
-  auto pReferenceCellAttributeMatrixPathValue = filterArgs.value<DataPath>(k_ReferenceCellAttributeMatrixPath_Key);
+  auto pSamplingGeometryPathValue = filterArgs.value<DataPath>(k_SamplingGeometryPath_Key);
+  auto pReferenceGeometryPathValue = filterArgs.value<DataPath>(k_ReferenceGeometryPath_Key);
   auto pSamplingCellAttributeMatrixPathValue = filterArgs.value<DataPath>(k_SamplingCellAttributeMatrixPath_Key);
+  auto pReferenceCellAttributeMatrixPathValue = filterArgs.value<DataPath>(k_ReferenceCellAttributeMatrixPath_Key);
 
-
-
-  // Declare the preflightResult variable that will be populated with the results
-  // of the preflight. The PreflightResult type contains the output Actions and
-  // any preflight updated values that you want to be displayed to the user, typically
-  // through a user interface (UI).
   PreflightResult preflightResult;
-
-  // If your filter is making structural changes to the DataStructure then the filter
-  // is going to create OutputActions subclasses that need to be returned. This will
-  // store those actions.
   complex::Result<OutputActions> resultOutputActions;
-
-  // If your filter is going to pass back some `preflight updated values` then this is where you
-  // would create the code to store those values in the appropriate object. Note that we
-  // in line creating the pair (NOT a std::pair<>) of Key:Value that will get stored in
-  // the std::vector<PreflightValue> object.
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  // If the filter needs to pass back some updated values via a key:value string:string set of values
-  // you can declare and update that string here.
-  // None found in this filter based on the filter parameters
+  auto* sampleAM = dataStructure.getDataAs<AttributeMatrix>(pSamplingCellAttributeMatrixPathValue);
+  auto* refAM = dataStructure.getDataAs<AttributeMatrix>(pReferenceCellAttributeMatrixPathValue);
 
-  // If this filter makes changes to the DataStructure in the form of
-  // creating/deleting/moving/renaming DataGroups, Geometries, DataArrays then you
-  // will need to use one of the `*Actions` classes located in complex/Filter/Actions
-  // to relay that information to the preflight and execute methods. This is done by
-  // creating an instance of the Action class and then storing it in the resultOutputActions variable.
-  // This is done through a `push_back()` method combined with a `std::move()`. For the
-  // newly initiated to `std::move` once that code is executed what was once inside the Action class
-  // instance variable is *no longer there*. The memory has been moved. If you try to access that
-  // variable after this line you will probably get a crash or have subtle bugs. To ensure that this
-  // does not happen we suggest using braces `{}` to scope each of the action's declaration and store
-  // so that the programmer is not tempted to use the action instance past where it should be used.
-  // You have to create your own Actions class if there isn't something specific for your filter's needs
-
-  // Store the preflight updated value(s) into the preflightUpdatedValues vector using
-  // the appropriate methods.
-  // None found based on the filter parameters
+  // Create arrays on the reference grid to hold data present on the sampling grid
+  auto sampleVoxelArrays = sampleAM->findAllChildrenOfType<IDataArray>();
+  for(const auto& array : sampleVoxelArrays)
+  {
+    DataPath createdArrayPath = pReferenceCellAttributeMatrixPathValue.createChildPath(array->getName());
+    auto createArrayAction = std::make_unique<CreateArrayAction>(array->getDataType(), refAM->getShape(), array->getComponentShape(), createdArrayPath);
+    resultOutputActions.value().actions.push_back(std::move(createArrayAction));
+  }
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
 }
 
 //------------------------------------------------------------------------------
-Result<> NearestPointFuseRegularGridsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+Result<> NearestPointFuseRegularGridsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                                                         const std::atomic_bool& shouldCancel) const
 {
-
   NearestPointFuseRegularGridsInputValues inputValues;
 
-    inputValues.ReferenceCellAttributeMatrixPath = filterArgs.value<DataPath>(k_ReferenceCellAttributeMatrixPath_Key);
+  inputValues.SamplingGeometryPath = filterArgs.value<DataPath>(k_SamplingGeometryPath_Key);
+  inputValues.ReferenceGeometryPath = filterArgs.value<DataPath>(k_ReferenceGeometryPath_Key);
   inputValues.SamplingCellAttributeMatrixPath = filterArgs.value<DataPath>(k_SamplingCellAttributeMatrixPath_Key);
-
+  inputValues.ReferenceCellAttributeMatrixPath = filterArgs.value<DataPath>(k_ReferenceCellAttributeMatrixPath_Key);
 
   return NearestPointFuseRegularGrids(dataStructure, messageHandler, shouldCancel, &inputValues)();
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/NearestPointFuseRegularGridsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/NearestPointFuseRegularGridsFilter.cpp
@@ -1,0 +1,146 @@
+#include "NearestPointFuseRegularGridsFilter.hpp"
+
+#include "ComplexCore/Filters/Algorithms/NearestPointFuseRegularGrids.hpp"
+
+#include "complex/DataStructure/DataPath.hpp"
+#include "complex/Filter/Actions/EmptyAction.hpp"
+#include "complex/Parameters/DataGroupSelectionParameter.hpp"
+
+using namespace complex;
+
+namespace complex
+{
+//------------------------------------------------------------------------------
+std::string NearestPointFuseRegularGridsFilter::name() const
+{
+  return FilterTraits<NearestPointFuseRegularGridsFilter>::name.str();
+}
+
+//------------------------------------------------------------------------------
+std::string NearestPointFuseRegularGridsFilter::className() const
+{
+  return FilterTraits<NearestPointFuseRegularGridsFilter>::className;
+}
+
+//------------------------------------------------------------------------------
+Uuid NearestPointFuseRegularGridsFilter::uuid() const
+{
+  return FilterTraits<NearestPointFuseRegularGridsFilter>::uuid;
+}
+
+//------------------------------------------------------------------------------
+std::string NearestPointFuseRegularGridsFilter::humanName() const
+{
+  return "Fuse Regular Grids (Nearest Point)";
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> NearestPointFuseRegularGridsFilter::defaultTags() const
+{
+  return {"Sampling", "Spacing"};
+}
+
+//------------------------------------------------------------------------------
+Parameters NearestPointFuseRegularGridsFilter::parameters() const
+{
+  Parameters params;
+
+  /**
+   * Please separate the parameters into groups generally of the following:
+   *
+   * params.insertSeparator(Parameters::Separator{"Input Parameters"});
+   * params.insertSeparator(Parameters::Separator{"Required Input Cell Data"});
+   * params.insertSeparator(Parameters::Separator{"Required Input Feature Data"});
+   * params.insertSeparator(Parameters::Separator{"Created Cell Data"});
+   * params.insertSeparator(Parameters::Separator{"Created Cell Feature Data"});
+   *
+   * .. or create appropriate separators as needed. The UI in COMPLEX no longer
+   * does this for the developer by using catgories as in SIMPL
+   */
+
+  // Create the parameter descriptors that are needed for this filter
+  params.insertSeparator(Parameters::Separator{"Cell Data"});
+  params.insert(std::make_unique<DataGroupSelectionParameter>(k_ReferenceCellAttributeMatrixPath_Key, "Reference Cell Attribute Matrix", "", DataPath{}));
+  params.insert(std::make_unique<DataGroupSelectionParameter>(k_SamplingCellAttributeMatrixPath_Key, "Sampling Cell Attribute Matrix", "", DataPath{}));
+
+  return params;
+}
+
+//------------------------------------------------------------------------------
+IFilter::UniquePointer NearestPointFuseRegularGridsFilter::clone() const
+{
+  return std::make_unique<NearestPointFuseRegularGridsFilter>();
+}
+
+//------------------------------------------------------------------------------
+IFilter::PreflightResult NearestPointFuseRegularGridsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+{
+  /****************************************************************************
+   * Write any preflight sanity checking codes in this function
+   ***************************************************************************/
+
+  /**
+   * These are the values that were gathered from the UI or the pipeline file or
+   * otherwise passed into the filter. These are here for your convenience. If you
+   * do not need some of them remove them.
+   */
+  auto pReferenceCellAttributeMatrixPathValue = filterArgs.value<DataPath>(k_ReferenceCellAttributeMatrixPath_Key);
+  auto pSamplingCellAttributeMatrixPathValue = filterArgs.value<DataPath>(k_SamplingCellAttributeMatrixPath_Key);
+
+
+
+  // Declare the preflightResult variable that will be populated with the results
+  // of the preflight. The PreflightResult type contains the output Actions and
+  // any preflight updated values that you want to be displayed to the user, typically
+  // through a user interface (UI).
+  PreflightResult preflightResult;
+
+  // If your filter is making structural changes to the DataStructure then the filter
+  // is going to create OutputActions subclasses that need to be returned. This will
+  // store those actions.
+  complex::Result<OutputActions> resultOutputActions;
+
+  // If your filter is going to pass back some `preflight updated values` then this is where you
+  // would create the code to store those values in the appropriate object. Note that we
+  // in line creating the pair (NOT a std::pair<>) of Key:Value that will get stored in
+  // the std::vector<PreflightValue> object.
+  std::vector<PreflightValue> preflightUpdatedValues;
+
+  // If the filter needs to pass back some updated values via a key:value string:string set of values
+  // you can declare and update that string here.
+  // None found in this filter based on the filter parameters
+
+  // If this filter makes changes to the DataStructure in the form of
+  // creating/deleting/moving/renaming DataGroups, Geometries, DataArrays then you
+  // will need to use one of the `*Actions` classes located in complex/Filter/Actions
+  // to relay that information to the preflight and execute methods. This is done by
+  // creating an instance of the Action class and then storing it in the resultOutputActions variable.
+  // This is done through a `push_back()` method combined with a `std::move()`. For the
+  // newly initiated to `std::move` once that code is executed what was once inside the Action class
+  // instance variable is *no longer there*. The memory has been moved. If you try to access that
+  // variable after this line you will probably get a crash or have subtle bugs. To ensure that this
+  // does not happen we suggest using braces `{}` to scope each of the action's declaration and store
+  // so that the programmer is not tempted to use the action instance past where it should be used.
+  // You have to create your own Actions class if there isn't something specific for your filter's needs
+
+  // Store the preflight updated value(s) into the preflightUpdatedValues vector using
+  // the appropriate methods.
+  // None found based on the filter parameters
+
+  // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
+  return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
+}
+
+//------------------------------------------------------------------------------
+Result<> NearestPointFuseRegularGridsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+{
+
+  NearestPointFuseRegularGridsInputValues inputValues;
+
+    inputValues.ReferenceCellAttributeMatrixPath = filterArgs.value<DataPath>(k_ReferenceCellAttributeMatrixPath_Key);
+  inputValues.SamplingCellAttributeMatrixPath = filterArgs.value<DataPath>(k_SamplingCellAttributeMatrixPath_Key);
+
+
+  return NearestPointFuseRegularGrids(dataStructure, messageHandler, shouldCancel, &inputValues)();
+}
+} // namespace complex

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/NearestPointFuseRegularGridsFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/NearestPointFuseRegularGridsFilter.hpp
@@ -24,6 +24,8 @@ public:
   NearestPointFuseRegularGridsFilter& operator=(NearestPointFuseRegularGridsFilter&&) noexcept = delete;
 
   // Parameter Keys
+  static inline constexpr StringLiteral k_ReferenceGeometryPath_Key = "reference_geometry_path";
+  static inline constexpr StringLiteral k_SamplingGeometryPath_Key = "sampling_geometry_path";
   static inline constexpr StringLiteral k_ReferenceCellAttributeMatrixPath_Key = "reference_cell_attribute_matrix_path";
   static inline constexpr StringLiteral k_SamplingCellAttributeMatrixPath_Key = "sampling_cell_attribute_matrix_path";
 
@@ -89,8 +91,7 @@ protected:
    * @param messageHandler The MessageHandler object
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure & data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel)
-      const override;
+  Result<> executeImpl(DataStructure& data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace complex
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/NearestPointFuseRegularGridsFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/NearestPointFuseRegularGridsFilter.hpp
@@ -28,6 +28,8 @@ public:
   static inline constexpr StringLiteral k_SamplingGeometryPath_Key = "sampling_geometry_path";
   static inline constexpr StringLiteral k_ReferenceCellAttributeMatrixPath_Key = "reference_cell_attribute_matrix_path";
   static inline constexpr StringLiteral k_SamplingCellAttributeMatrixPath_Key = "sampling_cell_attribute_matrix_path";
+  static inline constexpr StringLiteral k_UseFill_Key = "use_fill";
+  static inline constexpr StringLiteral k_FillValue_Key = "fill_value";
 
   /**
    * @brief Returns the name of the filter.

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/NearestPointFuseRegularGridsFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/NearestPointFuseRegularGridsFilter.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "ComplexCore/ComplexCore_export.hpp"
+
+#include "complex/Filter/FilterTraits.hpp"
+#include "complex/Filter/IFilter.hpp"
+
+namespace complex
+{
+/**
+ * @class NearestPointFuseRegularGridsFilter
+ * @brief This filter will ....
+ */
+class COMPLEXCORE_EXPORT NearestPointFuseRegularGridsFilter : public IFilter
+{
+public:
+  NearestPointFuseRegularGridsFilter() = default;
+  ~NearestPointFuseRegularGridsFilter() noexcept override = default;
+
+  NearestPointFuseRegularGridsFilter(const NearestPointFuseRegularGridsFilter&) = delete;
+  NearestPointFuseRegularGridsFilter(NearestPointFuseRegularGridsFilter&&) noexcept = delete;
+
+  NearestPointFuseRegularGridsFilter& operator=(const NearestPointFuseRegularGridsFilter&) = delete;
+  NearestPointFuseRegularGridsFilter& operator=(NearestPointFuseRegularGridsFilter&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_ReferenceCellAttributeMatrixPath_Key = "reference_cell_attribute_matrix_path";
+  static inline constexpr StringLiteral k_SamplingCellAttributeMatrixPath_Key = "sampling_cell_attribute_matrix_path";
+
+  /**
+   * @brief Returns the name of the filter.
+   * @return
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the C++ classname of this filter.
+   * @return
+   */
+  std::string className() const override;
+
+  /**
+   * @brief Returns the uuid of the filter.
+   * @return
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief Returns the human readable name of the filter.
+   * @return
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
+   * @brief Returns the parameters of the filter (i.e. its inputs)
+   * @return
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief Returns a copy of the filter.
+   * @return
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param ds The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  PreflightResult preflightImpl(const DataStructure& ds, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+
+  /**
+   * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
+   * On failure, there is no guarantee that the DataStructure is in a correct state.
+   * @param ds The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  Result<> executeImpl(DataStructure & data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel)
+      const override;
+};
+} // namespace complex
+
+COMPLEX_DEF_FILTER_TRAITS(complex, NearestPointFuseRegularGridsFilter, "c8746bf8-fa5f-48b0-8a47-11023402e543");
+/* LEGACY UUID FOR THIS FILTER cbaf9e68-5ded-560c-9440-509289100ea8 */

--- a/src/Plugins/ComplexCore/test/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/test/CMakeLists.txt
@@ -83,6 +83,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   MapPointCloudToRegularGridTest.cpp
   MinNeighborsTest.cpp
   MoveDataTest.cpp
+  NearestPointFuseRegularGridsTest.cpp
   PartitionGeometryTest.cpp
   PipelineTest.cpp
   PointSampleTriangleGeometryFilterTest.cpp

--- a/src/Plugins/ComplexCore/test/NearestPointFuseRegularGridsTest.cpp
+++ b/src/Plugins/ComplexCore/test/NearestPointFuseRegularGridsTest.cpp
@@ -7,7 +7,7 @@
 
 using namespace complex;
 
-TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: Valid Filter Execution", "[ComplexCore][NearestPointFuseRegularGridsFilter][.][UNIMPLEMENTED][!mayfail]")
+TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: Valid Filter Execution", "[ComplexCore][NearestPointFuseRegularGridsFilter]")
 {
   // Instantiate the filter, a DataStructure object and an Arguments Object
   NearestPointFuseRegularGridsFilter filter;
@@ -15,8 +15,12 @@ TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: Valid Filter Executi
   Arguments args;
 
   // Create default Parameters for the filter.
-  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceCellAttributeMatrixPath_Key, std::make_any<DataPath>(DataPath{}));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_UseFill_Key, std::make_any<bool>(true));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_FillValue_Key, std::make_any<float64>(9.8));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingGeometryPath_Key, std::make_any<DataPath>(DataPath{}));
   args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingCellAttributeMatrixPath_Key, std::make_any<DataPath>(DataPath{}));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceGeometryPath_Key, std::make_any<DataPath>(DataPath{}));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceCellAttributeMatrixPath_Key, std::make_any<DataPath>(DataPath{}));
 
   // Preflight the filter and check result
   auto preflightResult = filter.preflight(ds, args);

--- a/src/Plugins/ComplexCore/test/NearestPointFuseRegularGridsTest.cpp
+++ b/src/Plugins/ComplexCore/test/NearestPointFuseRegularGridsTest.cpp
@@ -1,36 +1,13 @@
-/**
- * This file is auto generated from the original ComplexCore/NearestPointFuseRegularGridsFilter
- * runtime information. These are the steps that need to be taken to utilize this
- * unit test in the proper way.
- *
- * 1: Validate each of the default parameters that gets created.
- * 2: Inspect the actual filter to determine if the filter in its default state
- * would pass or fail BOTH the preflight() and execute() methods
- * 3: UPDATE the ```REQUIRE(result.result.valid());``` code to have the proper
- *
- * 4: Add additional unit tests to actually test each code path within the filter
- *
- * There are some example Catch2 ```TEST_CASE``` sections for your inspiration.
- *
- * NOTE the format of the ```TEST_CASE``` macro. Please stick to this format to
- * allow easier parsing of the unit tests.
- *
- * When you start working on this unit test remove "[NearestPointFuseRegularGridsFilter][.][UNIMPLEMENTED]"
- * from the TEST_CASE macro. This will enable this unit test to be run by default
- * and report errors.
- */
-
-
 #include <catch2/catch.hpp>
 
 #include "complex/Parameters/DataGroupSelectionParameter.hpp"
 
-#include "ComplexCore/Filters/NearestPointFuseRegularGridsFilter.hpp"
 #include "ComplexCore/ComplexCore_test_dirs.hpp"
+#include "ComplexCore/Filters/NearestPointFuseRegularGridsFilter.hpp"
 
 using namespace complex;
 
-TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: Valid Filter Execution","[ComplexCore][NearestPointFuseRegularGridsFilter][.][UNIMPLEMENTED][!mayfail]")
+TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: Valid Filter Execution", "[ComplexCore][NearestPointFuseRegularGridsFilter][.][UNIMPLEMENTED][!mayfail]")
 {
   // Instantiate the filter, a DataStructure object and an Arguments Object
   NearestPointFuseRegularGridsFilter filter;
@@ -41,7 +18,6 @@ TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: Valid Filter Executi
   args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceCellAttributeMatrixPath_Key, std::make_any<DataPath>(DataPath{}));
   args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingCellAttributeMatrixPath_Key, std::make_any<DataPath>(DataPath{}));
 
-
   // Preflight the filter and check result
   auto preflightResult = filter.preflight(ds, args);
   REQUIRE(preflightResult.outputActions.valid());
@@ -51,7 +27,7 @@ TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: Valid Filter Executi
   REQUIRE(executeResult.result.valid());
 }
 
-//TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: InValid Filter Execution")
+// TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: InValid Filter Execution")
 //{
 //
-//}
+// }

--- a/src/Plugins/ComplexCore/test/NearestPointFuseRegularGridsTest.cpp
+++ b/src/Plugins/ComplexCore/test/NearestPointFuseRegularGridsTest.cpp
@@ -5,8 +5,8 @@
 #include "ComplexCore/ComplexCore_test_dirs.hpp"
 #include "ComplexCore/Filters/NearestPointFuseRegularGridsFilter.hpp"
 
-#include "complex/Filter/Actions/CreateImageGeometryAction.hpp"
 #include "complex/Filter/Actions/CreateArrayAction.hpp"
+#include "complex/Filter/Actions/CreateImageGeometryAction.hpp"
 #include "complex/UnitTest/UnitTestCommon.hpp"
 
 using namespace complex;
@@ -267,7 +267,7 @@ TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: Invalid Execution", 
   NearestPointFuseRegularGridsFilter filter;
   DataStructure dataStructure(std::move(CreateDualImageGeomDataStructure(refDims, refOrigin, refSpacing)));
 
-  dataStructure.getDataAs<ImageGeom>(sampleImageGeomPath)->setSpacing(0,0,0);
+  dataStructure.getDataAs<ImageGeom>(sampleImageGeomPath)->setSpacing(0, 0, 0);
 
   Arguments args;
 

--- a/src/Plugins/ComplexCore/test/NearestPointFuseRegularGridsTest.cpp
+++ b/src/Plugins/ComplexCore/test/NearestPointFuseRegularGridsTest.cpp
@@ -5,33 +5,285 @@
 #include "ComplexCore/ComplexCore_test_dirs.hpp"
 #include "ComplexCore/Filters/NearestPointFuseRegularGridsFilter.hpp"
 
+#include "complex/Filter/Actions/CreateImageGeometryAction.hpp"
+#include "complex/Filter/Actions/CreateArrayAction.hpp"
+#include "complex/UnitTest/UnitTestCommon.hpp"
+
 using namespace complex;
 
-TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: Valid Filter Execution", "[ComplexCore][NearestPointFuseRegularGridsFilter]")
+namespace
 {
+const DataPath sampleImageGeomPath({"Sample ImageGeom"});
+const std::string sampleCellDataName = "Sample CellData";
+const DataPath sampleCellDataPath = sampleImageGeomPath.createChildPath(sampleCellDataName);
+const DataPath sampleDataArrayPath = sampleCellDataPath.createChildPath("sampleDataArray");
+
+const DataPath refImageGeomPath({"Reference ImageGeom"});
+const std::string refCellDataName = "Reference CellData";
+const DataPath refCellDataPath = refImageGeomPath.createChildPath(refCellDataName);
+const DataPath refDataArrayPath = refCellDataPath.createChildPath("refDataArray");
+const DataPath copiedDataArrayPath = refCellDataPath.createChildPath("sampleDataArray");
+
+DataStructure CreateDualImageGeomDataStructure(CreateImageGeometryAction::DimensionType refDims, CreateImageGeometryAction::OriginType refOrigin, CreateImageGeometryAction::SpacingType refSpacing)
+{
+  DataStructure dataStructure;
+
+  const CreateImageGeometryAction::DimensionType dims = {5, 5, 1};
+  const CreateImageGeometryAction::OriginType origin = {0.0f, 0.0f, 0.0f};
+  const CreateImageGeometryAction::SpacingType spacing = {1.0f, 1.0f, 1.0f};
+
+  auto sampleAction = CreateImageGeometryAction(sampleImageGeomPath, dims, origin, spacing, sampleCellDataName);
+  Result<> sampleActionResult = sampleAction.apply(dataStructure, IDataAction::Mode::Execute);
+  COMPLEX_RESULT_REQUIRE_VALID(sampleActionResult);
+
+  auto sampleDataAction = CreateArrayAction(DataType::float64, {25}, {1}, sampleDataArrayPath);
+  Result<> sampleDataActionResult = sampleDataAction.apply(dataStructure, IDataAction::Mode::Execute);
+  COMPLEX_RESULT_REQUIRE_VALID(sampleDataActionResult);
+
+  auto* sampleDataStore = dataStructure.getDataAs<Float64Array>(sampleDataArrayPath)->getDataStore();
+  std::iota(sampleDataStore->begin(), sampleDataStore->end(), 1.0);
+
+  auto refAction = CreateImageGeometryAction(refImageGeomPath, refDims, refOrigin, refSpacing, refCellDataName);
+  Result<> refActionResult = refAction.apply(dataStructure, IDataAction::Mode::Execute);
+  COMPLEX_RESULT_REQUIRE_VALID(refActionResult);
+
+  auto refDataAction = CreateArrayAction(DataType::int32, {25}, {1}, refDataArrayPath);
+  Result<> refDataActionResult = refDataAction.apply(dataStructure, IDataAction::Mode::Execute);
+  COMPLEX_RESULT_REQUIRE_VALID(refDataActionResult);
+
+  auto* refDataStore = dataStructure.getDataAs<Int32Array>(refDataArrayPath)->getDataStore();
+  std::iota(refDataStore->begin(), refDataStore->end(), 26);
+
+  return dataStructure;
+}
+} // namespace
+
+TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: Basic Valid Execution", "[ComplexCore][NearestPointFuseRegularGridsFilter]")
+{
+  const CreateImageGeometryAction::DimensionType refDims = {5, 5, 1};
+  const CreateImageGeometryAction::OriginType refOrigin = {2.5f, 2.5f, 0.0f};
+  const CreateImageGeometryAction::SpacingType refSpacing = {1.0f, 1.0f, 1.0f};
+
   // Instantiate the filter, a DataStructure object and an Arguments Object
   NearestPointFuseRegularGridsFilter filter;
-  DataStructure ds;
+  DataStructure dataStructure(std::move(CreateDualImageGeomDataStructure(refDims, refOrigin, refSpacing)));
   Arguments args;
 
   // Create default Parameters for the filter.
   args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_UseFill_Key, std::make_any<bool>(true));
   args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_FillValue_Key, std::make_any<float64>(9.8));
-  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingGeometryPath_Key, std::make_any<DataPath>(DataPath{}));
-  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingCellAttributeMatrixPath_Key, std::make_any<DataPath>(DataPath{}));
-  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceGeometryPath_Key, std::make_any<DataPath>(DataPath{}));
-  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceCellAttributeMatrixPath_Key, std::make_any<DataPath>(DataPath{}));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingGeometryPath_Key, std::make_any<DataPath>(sampleImageGeomPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingCellAttributeMatrixPath_Key, std::make_any<DataPath>(sampleCellDataPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceGeometryPath_Key, std::make_any<DataPath>(refImageGeomPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceCellAttributeMatrixPath_Key, std::make_any<DataPath>(refCellDataPath));
 
   // Preflight the filter and check result
-  auto preflightResult = filter.preflight(ds, args);
+  auto preflightResult = filter.preflight(dataStructure, args);
   REQUIRE(preflightResult.outputActions.valid());
 
   // Execute the filter and check the result
-  auto executeResult = filter.execute(ds, args);
+  auto executeResult = filter.execute(dataStructure, args);
   REQUIRE(executeResult.result.valid());
+
+  auto& copiedArray = dataStructure.getDataRefAs<Float64Array>(copiedDataArrayPath);
+  REQUIRE(copiedArray[0] == 13.0);
+  REQUIRE(copiedArray[1] == 14.0);
+  REQUIRE(copiedArray[2] == 15.0);
+  REQUIRE(copiedArray[3] == 9.8);
+  REQUIRE(copiedArray[4] == 9.8);
+  REQUIRE(copiedArray[5] == 18.0);
+  REQUIRE(copiedArray[6] == 19.0);
+  REQUIRE(copiedArray[7] == 20.0);
+  REQUIRE(copiedArray[8] == 9.8);
+  REQUIRE(copiedArray[9] == 9.8);
+  REQUIRE(copiedArray[10] == 23.0);
+  REQUIRE(copiedArray[11] == 24.0);
+  REQUIRE(copiedArray[12] == 25.0);
+  REQUIRE(copiedArray[13] == 9.8);
+  REQUIRE(copiedArray[14] == 9.8);
+  REQUIRE(copiedArray[15] == 9.8);
+  REQUIRE(copiedArray[16] == 9.8);
+  REQUIRE(copiedArray[17] == 9.8);
+  REQUIRE(copiedArray[18] == 9.8);
+  REQUIRE(copiedArray[19] == 9.8);
+  REQUIRE(copiedArray[20] == 9.8);
+  REQUIRE(copiedArray[21] == 9.8);
+  REQUIRE(copiedArray[22] == 9.8);
+  REQUIRE(copiedArray[23] == 9.8);
+  REQUIRE(copiedArray[24] == 9.8);
 }
 
-// TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: InValid Filter Execution")
-//{
-//
-// }
+TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: No Overlap Valid Execution", "[ComplexCore][NearestPointFuseRegularGridsFilter]")
+{
+  const CreateImageGeometryAction::DimensionType refDims = {5, 5, 1};
+  const CreateImageGeometryAction::OriginType refOrigin = {10.0f, 10.0f, 3.0f};
+  const CreateImageGeometryAction::SpacingType refSpacing = {1.0f, 1.0f, 1.0f};
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  NearestPointFuseRegularGridsFilter filter;
+  DataStructure dataStructure(std::move(CreateDualImageGeomDataStructure(refDims, refOrigin, refSpacing)));
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_UseFill_Key, std::make_any<bool>(true));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_FillValue_Key, std::make_any<float64>(9.8));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingGeometryPath_Key, std::make_any<DataPath>(sampleImageGeomPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingCellAttributeMatrixPath_Key, std::make_any<DataPath>(sampleCellDataPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceGeometryPath_Key, std::make_any<DataPath>(refImageGeomPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceCellAttributeMatrixPath_Key, std::make_any<DataPath>(refCellDataPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  REQUIRE(executeResult.result.valid());
+
+  auto& copiedArray = dataStructure.getDataRefAs<Float64Array>(copiedDataArrayPath);
+  for(const auto& value : copiedArray)
+  {
+    REQUIRE(value == 9.8);
+  }
+}
+
+TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: Nested Valid Execution", "[ComplexCore][NearestPointFuseRegularGridsFilter]")
+{
+  const CreateImageGeometryAction::DimensionType refDims = {5, 5, 1};
+  const CreateImageGeometryAction::OriginType refOrigin = {1.0f, 1.0f, 0.0f};
+  const CreateImageGeometryAction::SpacingType refSpacing = {0.25f, 0.25f, 0.25f};
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  NearestPointFuseRegularGridsFilter filter;
+  DataStructure dataStructure(std::move(CreateDualImageGeomDataStructure(refDims, refOrigin, refSpacing)));
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_UseFill_Key, std::make_any<bool>(true));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_FillValue_Key, std::make_any<float64>(9.8));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingGeometryPath_Key, std::make_any<DataPath>(sampleImageGeomPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingCellAttributeMatrixPath_Key, std::make_any<DataPath>(sampleCellDataPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceGeometryPath_Key, std::make_any<DataPath>(refImageGeomPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceCellAttributeMatrixPath_Key, std::make_any<DataPath>(refCellDataPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  REQUIRE(executeResult.result.valid());
+
+  auto& copiedArray = dataStructure.getDataRefAs<Float64Array>(copiedDataArrayPath);
+  REQUIRE(copiedArray[0] == 7.0);
+  REQUIRE(copiedArray[1] == 7.0);
+  REQUIRE(copiedArray[2] == 7.0);
+  REQUIRE(copiedArray[3] == 7.0);
+  REQUIRE(copiedArray[4] == 8.0);
+  REQUIRE(copiedArray[5] == 7.0);
+  REQUIRE(copiedArray[6] == 7.0);
+  REQUIRE(copiedArray[7] == 7.0);
+  REQUIRE(copiedArray[8] == 7.0);
+  REQUIRE(copiedArray[9] == 8.0);
+  REQUIRE(copiedArray[10] == 7.0);
+  REQUIRE(copiedArray[11] == 7.0);
+  REQUIRE(copiedArray[12] == 7.0);
+  REQUIRE(copiedArray[13] == 7.0);
+  REQUIRE(copiedArray[14] == 8.0);
+  REQUIRE(copiedArray[15] == 7.0);
+  REQUIRE(copiedArray[16] == 7.0);
+  REQUIRE(copiedArray[17] == 7.0);
+  REQUIRE(copiedArray[18] == 7.0);
+  REQUIRE(copiedArray[19] == 8.0);
+  REQUIRE(copiedArray[20] == 12.0);
+  REQUIRE(copiedArray[21] == 12.0);
+  REQUIRE(copiedArray[22] == 12.0);
+  REQUIRE(copiedArray[23] == 12.0);
+  REQUIRE(copiedArray[24] == 13.0);
+}
+
+TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: Encompassing Valid Execution", "[ComplexCore][NearestPointFuseRegularGridsFilter]")
+{
+  const CreateImageGeometryAction::DimensionType refDims = {5, 5, 1};
+  const CreateImageGeometryAction::OriginType refOrigin = {-2.0f, -2.0f, 0.0f};
+  const CreateImageGeometryAction::SpacingType refSpacing = {2.0f, 2.0f, 2.0f};
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  NearestPointFuseRegularGridsFilter filter;
+  DataStructure dataStructure(std::move(CreateDualImageGeomDataStructure(refDims, refOrigin, refSpacing)));
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_UseFill_Key, std::make_any<bool>(true));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_FillValue_Key, std::make_any<float64>(9.8));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingGeometryPath_Key, std::make_any<DataPath>(sampleImageGeomPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingCellAttributeMatrixPath_Key, std::make_any<DataPath>(sampleCellDataPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceGeometryPath_Key, std::make_any<DataPath>(refImageGeomPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceCellAttributeMatrixPath_Key, std::make_any<DataPath>(refCellDataPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  REQUIRE(executeResult.result.valid());
+
+  auto& copiedArray = dataStructure.getDataRefAs<Float64Array>(copiedDataArrayPath);
+  REQUIRE(copiedArray[0] == 9.8);
+  REQUIRE(copiedArray[1] == 9.8);
+  REQUIRE(copiedArray[2] == 9.8);
+  REQUIRE(copiedArray[3] == 9.8);
+  REQUIRE(copiedArray[4] == 9.8);
+  REQUIRE(copiedArray[5] == 9.8);
+  REQUIRE(copiedArray[6] == 1.0);
+  REQUIRE(copiedArray[7] == 3.0);
+  REQUIRE(copiedArray[8] == 5.0);
+  REQUIRE(copiedArray[9] == 9.8);
+  REQUIRE(copiedArray[10] == 9.8);
+  REQUIRE(copiedArray[11] == 11.0);
+  REQUIRE(copiedArray[12] == 13.0);
+  REQUIRE(copiedArray[13] == 15.0);
+  REQUIRE(copiedArray[14] == 9.8);
+  REQUIRE(copiedArray[15] == 9.8);
+  REQUIRE(copiedArray[16] == 21.0);
+  REQUIRE(copiedArray[17] == 23.0);
+  REQUIRE(copiedArray[18] == 25.0);
+  REQUIRE(copiedArray[19] == 9.8);
+  REQUIRE(copiedArray[20] == 9.8);
+  REQUIRE(copiedArray[21] == 9.8);
+  REQUIRE(copiedArray[22] == 9.8);
+  REQUIRE(copiedArray[23] == 9.8);
+  REQUIRE(copiedArray[24] == 9.8);
+}
+
+TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: Invalid Execution", "[ComplexCore][NearestPointFuseRegularGridsFilter]")
+{
+  const CreateImageGeometryAction::DimensionType refDims = {5, 5, 1};
+  const CreateImageGeometryAction::OriginType refOrigin = {0.0f, 0.0f, 0.0f};
+  const CreateImageGeometryAction::SpacingType refSpacing = {1.0f, 1.0f, 1.0f};
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  NearestPointFuseRegularGridsFilter filter;
+  DataStructure dataStructure(std::move(CreateDualImageGeomDataStructure(refDims, refOrigin, refSpacing)));
+
+  dataStructure.getDataAs<ImageGeom>(sampleImageGeomPath)->setSpacing(0,0,0);
+
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_UseFill_Key, std::make_any<bool>(true));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_FillValue_Key, std::make_any<float64>(9.8));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingGeometryPath_Key, std::make_any<DataPath>(sampleImageGeomPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingCellAttributeMatrixPath_Key, std::make_any<DataPath>(sampleCellDataPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceGeometryPath_Key, std::make_any<DataPath>(refImageGeomPath));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceCellAttributeMatrixPath_Key, std::make_any<DataPath>(refCellDataPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  REQUIRE(!executeResult.result.valid());
+}

--- a/src/Plugins/ComplexCore/test/NearestPointFuseRegularGridsTest.cpp
+++ b/src/Plugins/ComplexCore/test/NearestPointFuseRegularGridsTest.cpp
@@ -1,0 +1,57 @@
+/**
+ * This file is auto generated from the original ComplexCore/NearestPointFuseRegularGridsFilter
+ * runtime information. These are the steps that need to be taken to utilize this
+ * unit test in the proper way.
+ *
+ * 1: Validate each of the default parameters that gets created.
+ * 2: Inspect the actual filter to determine if the filter in its default state
+ * would pass or fail BOTH the preflight() and execute() methods
+ * 3: UPDATE the ```REQUIRE(result.result.valid());``` code to have the proper
+ *
+ * 4: Add additional unit tests to actually test each code path within the filter
+ *
+ * There are some example Catch2 ```TEST_CASE``` sections for your inspiration.
+ *
+ * NOTE the format of the ```TEST_CASE``` macro. Please stick to this format to
+ * allow easier parsing of the unit tests.
+ *
+ * When you start working on this unit test remove "[NearestPointFuseRegularGridsFilter][.][UNIMPLEMENTED]"
+ * from the TEST_CASE macro. This will enable this unit test to be run by default
+ * and report errors.
+ */
+
+
+#include <catch2/catch.hpp>
+
+#include "complex/Parameters/DataGroupSelectionParameter.hpp"
+
+#include "ComplexCore/Filters/NearestPointFuseRegularGridsFilter.hpp"
+#include "ComplexCore/ComplexCore_test_dirs.hpp"
+
+using namespace complex;
+
+TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: Valid Filter Execution","[ComplexCore][NearestPointFuseRegularGridsFilter][.][UNIMPLEMENTED][!mayfail]")
+{
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  NearestPointFuseRegularGridsFilter filter;
+  DataStructure ds;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_ReferenceCellAttributeMatrixPath_Key, std::make_any<DataPath>(DataPath{}));
+  args.insertOrAssign(NearestPointFuseRegularGridsFilter::k_SamplingCellAttributeMatrixPath_Key, std::make_any<DataPath>(DataPath{}));
+
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(ds, args);
+  REQUIRE(preflightResult.outputActions.valid());
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(ds, args);
+  REQUIRE(executeResult.result.valid());
+}
+
+//TEST_CASE("ComplexCore::NearestPointFuseRegularGridsFilter: InValid Filter Execution")
+//{
+//
+//}


### PR DESCRIPTION
Ready for review

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `complex/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `complex/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [ ] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to complex!** -->
