### PR TITLE
FILTER: Update DeleteData Filter to allow deleting of multiple objects

### DIFF
--- a/pipelines/PorosityAnalysis.d3dpipeline
+++ b/pipelines/PorosityAnalysis.d3dpipeline
@@ -205,18 +205,10 @@
     },
     {
       "args": {
-        "removed_data_path": "RoboMet.3D Image Stack/EnsembleAttributeMatrix/CrystalStructures"
-      },
-      "comments": "",
-      "filter": {
-        "name": "complex::DeleteData",
-        "uuid": "bf286740-e987-49fe-a7c8-6e566e3a0606"
-      },
-      "isDisabled": false
-    },
-    {
-      "args": {
-        "removed_data_path": "RoboMet.3D Image Stack/EnsembleAttributeMatrix/PhaseTypes"
+        "removed_data_path": [
+		  "RoboMet.3D Image Stack/EnsembleAttributeMatrix/CrystalStructures",
+		  "RoboMet.3D Image Stack/EnsembleAttributeMatrix/PhaseTypes"
+		]
       },
       "comments": "",
       "filter": {

--- a/src/Plugins/ComplexCore/pipelines/Import_ASCII.d3dpipeline
+++ b/src/Plugins/ComplexCore/pipelines/Import_ASCII.d3dpipeline
@@ -1,6 +1,6 @@
 {
   "isDisabled": false,
-  "name": "CreateEnsembleInfoTest2.d3dpipeline",
+  "name": "Import_ASCII.d3dpipeline",
   "pinnedParams": [],
   "pipeline": [
     {
@@ -36,9 +36,9 @@
         "selected_data_group": "[Image Geometry]/CellData",
         "tuple_dimensions": [
           [
-            1,
-			201,
-			189
+            1.0,
+            201.0,
+            189.0
           ]
         ],
         "use_existing_group": true,
@@ -109,29 +109,11 @@
     },
     {
       "args": {
-        "removed_data_path": "[Image Geometry]/CellData/phi1"
-      },
-      "comments": "",
-      "filter": {
-        "name": "complex::DeleteData",
-        "uuid": "bf286740-e987-49fe-a7c8-6e566e3a0606"
-      },
-      "isDisabled": false
-    },
-    {
-      "args": {
-        "removed_data_path": "[Image Geometry]/CellData/Phi"
-      },
-      "comments": "",
-      "filter": {
-        "name": "complex::DeleteData",
-        "uuid": "bf286740-e987-49fe-a7c8-6e566e3a0606"
-      },
-      "isDisabled": false
-    },
-    {
-      "args": {
-        "removed_data_path": "[Image Geometry]/CellData/phi2"
+        "removed_data_path": [
+          "[Image Geometry]/CellData/phi1",
+          "[Image Geometry]/CellData/Phi",
+          "[Image Geometry]/CellData/phi2"
+        ]
       },
       "comments": "",
       "filter": {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/DeleteData.cpp
@@ -4,10 +4,10 @@
 #include "complex/DataStructure/DataArray.hpp"
 #include "complex/Filter/Actions/DeleteDataAction.hpp"
 #include "complex/Parameters/ChoicesParameter.hpp"
-#include "complex/Parameters/DataPathSelectionParameter.hpp"
+#include "complex/Parameters/MultiPathSelectionParameter.hpp"
 
 /**The commented out code in this filter and the header is set up to offer deeper control
- * of the dataStructre. The current state of the dataStructure abstracts the underlying data graph
+ * of the dataStructure. The current state of the dataStructure abstracts the underlying data graph
  * into a heirarchical structure, thus the advanced handling and data management is not necessary.
  * Should the code be uncommented one should review the test cases and round out the development.
  * The DeleteDataAction also implements code that has been commented out so it will need review as
@@ -56,7 +56,7 @@ Parameters DeleteData::parameters() const
   //                                                                            "Delete DataObject and All Child Objects"})); // sequence dependent DO NOT REORDER
 
   params.insertSeparator(Parameters::Separator{"Required Input Data Objects"});
-  params.insert(std::make_unique<DataPathSelectionParameter>(k_DataPath_Key, "DataPath to remove", "The complete path to the DataObject to be removed", DataPath({"DataStructure", "DataObject"})));
+  params.insert(std::make_unique<MultiPathSelectionParameter>(k_DataPath_Key, "DataPaths to remove", "The complete path to the DataObjects to be removed", MultiPathSelectionParameter::ValueType{}));
 
   return params;
 }
@@ -69,118 +69,123 @@ IFilter::UniquePointer DeleteData::clone() const
 IFilter::PreflightResult DeleteData::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
 {
   // auto deletionType = static_cast<DeletionType>(args.value<ChoicesParameter::ValueType>(k_DeletionType_Key));
-  auto dataObjectPath = args.value<DataPath>(k_DataPath_Key);
-  const auto* dataObject = dataStructure.getDataAs<DataObject>(dataObjectPath);
+  const auto dataObjectPaths = args.value<MultiPathSelectionParameter::ValueType>(k_DataPath_Key);
 
   OutputActions deleteActions;
-  // switch(deletionType)
-  //{
-  // case DeletionType::DeleteDataObject: {
-  //   // original
-  //   // Remove Singular Node
-  //   // Rules:
-  //   // - If multiparented, throw warning of effects and recommend DataPath removal instead
-  //   // - Edges that point to node will all be deleted
-  //   // - Node will be deleted
-  //  - IN CURRENT STATE BEHAVES MORE LIKE REMOVE START NODE AND ALL CHILDREN
-
-  if(dataObject->getParentIds().size() > 1)
+  for(const auto& dataObjectPath : dataObjectPaths)
   {
-    return {ConvertResultTo<OutputActions>(
-        MakeWarningVoidResult(-61501, fmt::format("The object is multiparented, deleting this data could affect other unintended nodes. Consider using the Delete DataPath instead.")), {})};
+    const auto* dataObject = dataStructure.getDataAs<DataObject>(dataObjectPath);
+
+    // switch(deletionType)
+    //{
+    // case DeletionType::DeleteDataObject: {
+    //   // original
+    //   // Remove Singular Node
+    //   // Rules:
+    //   // - If multiparented, throw warning of effects and recommend DataPath removal instead
+    //   // - Edges that point to node will all be deleted
+    //   // - Node will be deleted
+    //  - IN CURRENT STATE BEHAVES MORE LIKE REMOVE START NODE AND ALL CHILDREN
+
+    if(dataObject->getParentIds().size() > 1)
+    {
+      return {ConvertResultTo<OutputActions>(
+          MakeWarningVoidResult(-61501, fmt::format("The object is multiparented, deleting this data could affect other unintended nodes. Consider using the Delete DataPath instead.")), {})};
+    }
+
+    auto action = std::make_unique<DeleteDataAction>(dataObjectPath, DeleteDataAction::DeleteType::JustObject);
+    deleteActions.actions.push_back(std::move(action));
+
+    //  break;
+    //}
+
+    // case DeletionType::DeleteDataPath: {
+    //   // Remove Edge (DataPath)
+    //   // Rules:
+    //   // - Neither of the nodes (parent or child) should be deleted
+    //   // - The edge between the nodes should be removed from both the respective parent and child list
+
+    //  // check parent that its not a top level path [ie no parent] (can't be removed)
+    //  if(dataObjectPath.getLength() < 2)
+    //  {
+    //    return {MakeErrorResult<OutputActions>(
+    //        -61502, fmt::format("The DataPath [{}] cannot be processed because it is a top level datapath. Consider using an DataObject removal instead.", dataObjectPath.toString()))};
+    //  }
+
+    //  auto action = std::make_unique<DeleteDataAction>(dataObjectPath, DeleteDataAction::DeleteType::JustPath);
+    //  deleteActions.actions.push_back(std::move(action));
+
+    //  break;
+    //}
+
+    // case DeletionType::DeleteUnsharedChildren: {
+    //   // Remove Start Node and Children Recursively (Independent Removal Only)
+    //   // Rules:
+    //   // - If multiparented, any node and all children of that node will are kept
+    //   // - Edges that point to deleted nodes wil be removed
+    //   // - If start object is multiparented recommend edge removal instead
+
+    //  // check parent count (Base Case)
+    //  if(dataObject->getParentIds().size() > 1)
+    //  {
+    //    return {
+    //        ConvertResultTo<OutputActions>(MakeWarningVoidResult(-61503, fmt::format("The object cannot be processed because it is multiparented. Consider using the Delete DataPath instead.")),
+    //        {})};
+    //  }
+    //  else
+    //  {
+    //    const auto* baseGroup = dynamic_cast<const BaseGroup*>(dataObject);
+    //    if(baseGroup == nullptr) // Object is the lowest level in its path
+    //    {
+    //      auto action = std::make_unique<DeleteDataAction>(dataObjectPath, DeleteDataAction::DeleteType::JustObject);
+    //      deleteActions.actions.push_back(std::move(action));
+    //      return {ConvertResultTo<OutputActions>(
+    //          MakeWarningVoidResult(-61504, fmt::format("The object type cannot be processed because no children exist for it. Object given is of type '{}', consider remove ",
+    //                                                    dataStructure.getData(dataObjectPath)->getTypeName())),
+    //          {})};
+    //    }
+    //    else
+    //    {
+    //      // recurse action
+    //      auto action = std::make_unique<DeleteDataAction>(dataObjectPath, DeleteDataAction::DeleteType::IndependentChildren);
+    //      deleteActions.actions.push_back(std::move(action));
+    //    }
+    //  }
+
+    //  break;
+    //}
+
+    // case DeletionType::DeleteChildren: {
+    //   // Remove Start Node and Children Recursively (Complete Removal)
+    //   // Rules:
+    //   // - All children will be removed regardless of parent count
+    //   // - Edges that point to deleted nodes wil be removed
+    //   // - Warn of absolute deletion of data and effects
+
+    //  // This needs to be implemented down the line
+    //  // ConvertResultTo<OutputActions>(MakeWarningVoidResult(-61505, fmt::format("This action will remove the underlying data which could affect other structures if it is multiparented")), {});
+
+    //  const auto* baseGroup = dynamic_cast<const BaseGroup*>(dataObject);
+    //  if(baseGroup == nullptr) // Object is the lowest level in its path
+    //  {
+    //    auto action = std::make_unique<DeleteDataAction>(dataObjectPath, DeleteDataAction::DeleteType::JustObject);
+    //    deleteActions.actions.push_back(std::move(action));
+    //    return {ConvertResultTo<OutputActions>(
+    //        MakeWarningVoidResult(-61505, fmt::format("The object type cannot be processed because no children exist for it. Object given is of type '{}', consider remove ",
+    //                                                  dataStructure.getData(dataObjectPath)->getTypeName())),
+    //        {})};
+    //  }
+    //  else
+    //  {
+    //    // recurse action
+    //    auto action = std::make_unique<DeleteDataAction>(dataObjectPath, DeleteDataAction::DeleteType::AllChildren);
+    //    deleteActions.actions.push_back(std::move(action));
+    //  }
+
+    //  break;
+    //}
+    //}
   }
-
-  auto action = std::make_unique<DeleteDataAction>(dataObjectPath, DeleteDataAction::DeleteType::JustObject);
-  deleteActions.actions.push_back(std::move(action));
-
-  //  break;
-  //}
-
-  // case DeletionType::DeleteDataPath: {
-  //   // Remove Edge (DataPath)
-  //   // Rules:
-  //   // - Neither of the nodes (parent or child) should be deleted
-  //   // - The edge between the nodes should be removed from both the respective parent and child list
-
-  //  // check parent that its not a top level path [ie no parent] (can't be removed)
-  //  if(dataObjectPath.getLength() < 2)
-  //  {
-  //    return {MakeErrorResult<OutputActions>(
-  //        -61502, fmt::format("The DataPath [{}] cannot be processed because it is a top level datapath. Consider using an DataObject removal instead.", dataObjectPath.toString()))};
-  //  }
-
-  //  auto action = std::make_unique<DeleteDataAction>(dataObjectPath, DeleteDataAction::DeleteType::JustPath);
-  //  deleteActions.actions.push_back(std::move(action));
-
-  //  break;
-  //}
-
-  // case DeletionType::DeleteUnsharedChildren: {
-  //   // Remove Start Node and Children Recursively (Independent Removal Only)
-  //   // Rules:
-  //   // - If multiparented, any node and all children of that node will are kept
-  //   // - Edges that point to deleted nodes wil be removed
-  //   // - If start object is multiparented recommend edge removal instead
-
-  //  // check parent count (Base Case)
-  //  if(dataObject->getParentIds().size() > 1)
-  //  {
-  //    return {
-  //        ConvertResultTo<OutputActions>(MakeWarningVoidResult(-61503, fmt::format("The object cannot be processed because it is multiparented. Consider using the Delete DataPath instead.")), {})};
-  //  }
-  //  else
-  //  {
-  //    const auto* baseGroup = dynamic_cast<const BaseGroup*>(dataObject);
-  //    if(baseGroup == nullptr) // Object is the lowest level in its path
-  //    {
-  //      auto action = std::make_unique<DeleteDataAction>(dataObjectPath, DeleteDataAction::DeleteType::JustObject);
-  //      deleteActions.actions.push_back(std::move(action));
-  //      return {ConvertResultTo<OutputActions>(
-  //          MakeWarningVoidResult(-61504, fmt::format("The object type cannot be processed because no children exist for it. Object given is of type '{}', consider remove ",
-  //                                                    dataStructure.getData(dataObjectPath)->getTypeName())),
-  //          {})};
-  //    }
-  //    else
-  //    {
-  //      // recurse action
-  //      auto action = std::make_unique<DeleteDataAction>(dataObjectPath, DeleteDataAction::DeleteType::IndependentChildren);
-  //      deleteActions.actions.push_back(std::move(action));
-  //    }
-  //  }
-
-  //  break;
-  //}
-
-  // case DeletionType::DeleteChildren: {
-  //   // Remove Start Node and Children Recursively (Complete Removal)
-  //   // Rules:
-  //   // - All children will be removed regardless of parent count
-  //   // - Edges that point to deleted nodes wil be removed
-  //   // - Warn of absolute deletion of data and effects
-
-  //  // This needs to be implemented down the line
-  //  // ConvertResultTo<OutputActions>(MakeWarningVoidResult(-61505, fmt::format("This action will remove the underlying data which could affect other structures if it is multiparented")), {});
-
-  //  const auto* baseGroup = dynamic_cast<const BaseGroup*>(dataObject);
-  //  if(baseGroup == nullptr) // Object is the lowest level in its path
-  //  {
-  //    auto action = std::make_unique<DeleteDataAction>(dataObjectPath, DeleteDataAction::DeleteType::JustObject);
-  //    deleteActions.actions.push_back(std::move(action));
-  //    return {ConvertResultTo<OutputActions>(
-  //        MakeWarningVoidResult(-61505, fmt::format("The object type cannot be processed because no children exist for it. Object given is of type '{}', consider remove ",
-  //                                                  dataStructure.getData(dataObjectPath)->getTypeName())),
-  //        {})};
-  //  }
-  //  else
-  //  {
-  //    // recurse action
-  //    auto action = std::make_unique<DeleteDataAction>(dataObjectPath, DeleteDataAction::DeleteType::AllChildren);
-  //    deleteActions.actions.push_back(std::move(action));
-  //  }
-
-  //  break;
-  //}
-  //}
 
   return {std::move(deleteActions)};
 }

--- a/src/Plugins/ComplexCore/test/DeleteDataTest.cpp
+++ b/src/Plugins/ComplexCore/test/DeleteDataTest.cpp
@@ -1,7 +1,7 @@
 #include "ComplexCore/Filters/DeleteData.hpp"
 
 #include "complex/Common/TypeTraits.hpp"
-#include "complex/Parameters/DataGroupSelectionParameter.hpp"
+#include "complex/Parameters/MultiPathSelectionParameter.hpp"
 #include "complex/Parameters/VectorParameter.hpp"
 #include "complex/UnitTest/UnitTestCommon.hpp"
 #include "complex/unit_test/complex_test_dirs.hpp"
@@ -30,12 +30,13 @@ TEST_CASE("ComplexCore::Delete Singular Data Array", "[ComplexCore][DeleteData]"
 
   DataStructure dataStructure = UnitTest::CreateAllPrimitiveTypes(imageDims);
 
-  DataPath selectedDataGroupPath({k_LevelZero, k_LevelOne, k_Int8DataSet});
+  DataPath selectedDataPath1({k_LevelZero, k_LevelOne, k_Int8DataSet});
+  DataPath selectedDataPath2({k_LevelZero, k_LevelOne, k_Int16DataSet});
   Arguments args;
 
   // Create default Parameters for the filter.
   // args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
-  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath));
+  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<MultiPathSelectionParameter::ValueType>({selectedDataPath1, selectedDataPath2}));
 
   DeleteData filter;
 
@@ -47,8 +48,9 @@ TEST_CASE("ComplexCore::Delete Singular Data Array", "[ComplexCore][DeleteData]"
   auto executeResult = filter.execute(dataStructure, args);
   REQUIRE(executeResult.result.valid());
 
-  DataObject* removedDataArray = dataStructure.getData(selectedDataGroupPath);
+  DataObject* removedDataArray = dataStructure.getData(selectedDataPath1);
   REQUIRE(removedDataArray == nullptr);
+  REQUIRE(dataStructure.getData(selectedDataPath2) == nullptr);
 }
 
 TEST_CASE("ComplexCore::Delete Data Object (Node removal)", "[ComplexCore][DeleteData]")
@@ -70,7 +72,7 @@ TEST_CASE("ComplexCore::Delete Data Object (Node removal)", "[ComplexCore][Delet
 
   // Create default Parameters for the filter.
   // args.insertOrAssign(DeleteData::k_DeletionType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DeleteData::DeletionType::DeleteDataObject)));
-  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<DataPath>(selectedDataGroupPath));
+  args.insertOrAssign(DeleteData::k_DataPath_Key, std::make_any<MultiPathSelectionParameter::ValueType>({selectedDataGroupPath}));
 
   // Preflight the filter and check result
   auto preflightResult = filter.preflight(dataStructure, args);

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD Statistics/(05) Small IN100 Crystallographic Statistics.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD Statistics/(05) Small IN100 Crystallographic Statistics.d3dpipeline
@@ -1,23 +1,23 @@
 {
   "isDisabled": false,
-  "name": "(05) SmallIN100 Crystallographic Statistics.d3dpipeline",
+  "name": "(05) Small IN100 Crystallographic Statistics.d3dpipeline",
   "pinnedParams": [],
   "pipeline": [
     {
       "args": {
         "Import_File_Data": {
           "data_paths": [
+            "DataContainer",
+            "DataContainer/CellData",
+            "DataContainer/CellData/Image Quality",
+            "DataContainer/CellData/Confidence Index",
+            "DataContainer/CellData/SEM Signal",
+            "DataContainer/CellData/Fit",
+            "DataContainer/CellData/EulerAngles",
+            "DataContainer/CellData/Phases",
             "DataContainer/CellEnsembleData",
             "DataContainer/CellEnsembleData/CrystalStructures",
             "DataContainer/CellEnsembleData/LatticeConstants",
-            "DataContainer",
-            "DataContainer/CellData",
-            "DataContainer/CellData/Confidence Index",
-            "DataContainer/CellData/EulerAngles",
-            "DataContainer/CellData/Fit",
-            "DataContainer/CellData/Image Quality",
-            "DataContainer/CellData/Phases",
-            "DataContainer/CellData/SEM Signal",
             "DataContainer/CellData/Mask",
             "DataContainer/CellData/Quats",
             "DataContainer/CellFeatureData",
@@ -52,10 +52,609 @@
         },
         "Imported Pipeline": {
           "isDisabled": false,
-          "name": "Untitled Pipeline",
-          "pipeline": []
+          "name": "(01) Small IN100 Morphological Statistics",
+          "pipeline": [
+            {
+              "args": {
+                "Import_File_Data": {
+                  "data_paths": [
+                    "DataContainer",
+                    "DataContainer/CellData",
+                    "DataContainer/CellData/Image Quality",
+                    "DataContainer/CellData/Confidence Index",
+                    "DataContainer/CellData/SEM Signal",
+                    "DataContainer/CellData/Fit",
+                    "DataContainer/CellData/EulerAngles",
+                    "DataContainer/CellData/Phases",
+                    "DataContainer/CellEnsembleData",
+                    "DataContainer/CellEnsembleData/CrystalStructures",
+                    "DataContainer/CellEnsembleData/LatticeConstants",
+                    "DataContainer/CellData/Mask",
+                    "DataContainer/CellData/Quats",
+                    "DataContainer/CellFeatureData",
+                    "DataContainer/CellFeatureData/Active",
+                    "DataContainer/CellData/FeatureIds",
+                    "DataContainer/CellFeatureData/Phases",
+                    "DataContainer/CellFeatureData/AvgQuats",
+                    "DataContainer/CellFeatureData/AvgEulerAngles",
+                    "DataContainer/CellFeatureData/NumNeighbors2",
+                    "DataContainer/NewGrain Data",
+                    "DataContainer/CellData/ParentIds",
+                    "DataContainer/CellFeatureData/ParentIds",
+                    "DataContainer/NewGrain Data/Active",
+                    "DataContainer/CellData/IPFColors"
+                  ],
+                  "file_path": "Data/Output/Reconstruction/SmallIN100_Final.dream3d"
+                },
+                "Imported Pipeline": {
+                  "isDisabled": false,
+                  "name": "(08) Small IN100 Full Reconstruction",
+                  "pipeline": [
+                    {
+                      "args": {
+                        "cell_attribute_matrix_name": "CellData",
+                        "cell_ensemble_attribute_matrix_name": "CellEnsembleData",
+                        "data_container_name": "DataContainer",
+                        "read_h5_ebsd_filter": {
+                          "end_slice": 117,
+                          "euler_representation": 0,
+                          "hdf5_data_paths": [
+                            "Confidence Index",
+                            "EulerAngles",
+                            "Fit",
+                            "Image Quality",
+                            "Phases",
+                            "SEM Signal",
+                            "X Position",
+                            "Y Position"
+                          ],
+                          "input_file_path": "Data/Output/Reconstruction/Small_IN100.h5ebsd",
+                          "start_slice": 1,
+                          "use_recommended_transform": true
+                        }
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::ReadH5EbsdFilter",
+                        "uuid": "db291b6c-9aaf-432d-9547-430c865a539c"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "array_thresholds": {
+                          "inverted": false,
+                          "thresholds": [
+                            {
+                              "array_path": "DataContainer/CellData/Image Quality",
+                              "comparison": 0,
+                              "inverted": false,
+                              "type": "array",
+                              "union": 0,
+                              "value": 120.0
+                            },
+                            {
+                              "array_path": "DataContainer/CellData/Confidence Index",
+                              "comparison": 0,
+                              "inverted": false,
+                              "type": "array",
+                              "union": 0,
+                              "value": 0.1
+                            }
+                          ],
+                          "type": "collection",
+                          "union": 0
+                        },
+                        "created_data_path": "DataContainer/CellData/Mask"
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::MultiThresholdObjects",
+                        "uuid": "4246245e-1011-4add-8436-0af6bed19228"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "input_orientation_array_path": "DataContainer/CellData/EulerAngles",
+                        "input_type": 0,
+                        "output_orientation_array_name": "Quats",
+                        "output_type": 2
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::ConvertOrientations",
+                        "uuid": "501e54e6-a66f-4eeb-ae37-00e649c00d4b"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "alignment_shift_file_name": "Data/Output/Alignment_By_Misorientation_Shifts.txt",
+                        "cell_phases_array_path": "DataContainer/CellData/Phases",
+                        "crystal_structures_array_path": "DataContainer/CellEnsembleData/CrystalStructures",
+                        "good_voxels_array_path": "DataContainer/CellData/Mask",
+                        "misorientation_tolerance": 5.0,
+                        "quats_array_path": "DataContainer/CellData/Quats",
+                        "selected_image_geometry_path": "DataContainer",
+                        "use_good_voxels": true,
+                        "write_alignment_shifts": false
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::AlignSectionsMisorientationFilter",
+                        "uuid": "8df2135c-7079-49f4-9756-4f3c028a5ced"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "fill_holes": false,
+                        "good_voxels": "DataContainer/CellData/Mask",
+                        "image_geometry": "DataContainer"
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::IdentifySample",
+                        "uuid": "94d47495-5a89-4c7f-a0ee-5ff20e6bd273"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "alignment_shift_file_name": "Data/Output/Alignment_By_Feature_Centroid_Shifts.txt",
+                        "good_voxels_array_path": "DataContainer/CellData/Mask",
+                        "reference_slice": 0,
+                        "selected_cell_data_path": "DataContainer/CellData",
+                        "selected_image_geometry_path": "DataContainer",
+                        "use_reference_slice": true,
+                        "write_alignment_shifts": false
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::AlignSectionsFeatureCentroidFilter",
+                        "uuid": "b83f9bae-9ccf-4932-96c3-7f2fdb091452"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "cell_phases_array_path": "DataContainer/CellData/Phases",
+                        "crystal_structures_array_path": "DataContainer/CellEnsembleData/CrystalStructures",
+                        "good_voxels_array_path": "DataContainer/CellData/Mask",
+                        "image_geometry_path": "DataContainer",
+                        "misorientation_tolerance": 5.0,
+                        "number_of_neighbors": 4,
+                        "quats_array_path": "DataContainer/CellData/Quats"
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::BadDataNeighborOrientationCheckFilter",
+                        "uuid": "3f342977-aea1-49e1-a9c2-f73760eba0d3"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "cell_phases_array_path": "DataContainer/CellData/Phases",
+                        "confidence_index_array_path": "DataContainer/CellData/Confidence Index",
+                        "crystal_structures_array_path": "DataContainer/CellEnsembleData/CrystalStructures",
+                        "ignored_data_array_paths": [],
+                        "image_geometry_path": "DataContainer",
+                        "level": 2,
+                        "min_confidence": 0.20000000298023224,
+                        "misorientation_tolerance": 5.0,
+                        "quats_array_path": "DataContainer/CellData/Quats"
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::NeighborOrientationCorrelationFilter",
+                        "uuid": "4625c192-7e46-4333-a294-67a2eb64cb37"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "active_array_name": "Active",
+                        "cell_feature_attribute_matrix_name": "CellFeatureData",
+                        "cell_phases_array_path": "DataContainer/CellData/Phases",
+                        "crystal_structures_array_path": "DataContainer/CellEnsembleData/CrystalStructures",
+                        "feature_ids_array_name": "FeatureIds",
+                        "good_voxels_array_path": "DataContainer/CellData/Mask",
+                        "grid_geometry_path": "DataContainer",
+                        "misorientation_tolerance": 5.0,
+                        "quats_array_path": "DataContainer/CellData/Quats",
+                        "randomize_features": true,
+                        "use_good_voxels": true
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::EBSDSegmentFeaturesFilter",
+                        "uuid": "1810c2c7-63e3-41db-b204-a5821e6271c0"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "cell_features_attribute_matrix_path": "DataContainer/CellFeatureData",
+                        "cell_phases_array_path": "DataContainer/CellData/Phases",
+                        "feature_ids_path": "DataContainer/CellData/FeatureIds",
+                        "feature_phases_array_path": "Phases"
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::FindFeaturePhasesFilter",
+                        "uuid": "da5bb20e-4a8e-49d9-9434-fbab7bc434fc"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "avg_euler_angles_array_path": "AvgEulerAngles",
+                        "avg_quats_array_path": "AvgQuats",
+                        "cell_feature_attribute_matrix": "DataContainer/CellFeatureData",
+                        "cell_feature_ids_array_path": "DataContainer/CellData/FeatureIds",
+                        "cell_phases_array_path": "DataContainer/CellData/Phases",
+                        "cell_quats_array_path": "DataContainer/CellData/Quats",
+                        "crystal_structures_array_path": "DataContainer/CellEnsembleData/CrystalStructures"
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::FindAvgOrientationsFilter",
+                        "uuid": "086ddb9a-928f-46ab-bad6-b1498270d71e"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "boundary_cells": "BoundaryCells",
+                        "cell_feature_arrays": "DataContainer/CellFeatureData",
+                        "feature_ids": "DataContainer/CellData/FeatureIds",
+                        "image_geometry": "DataContainer",
+                        "neighbor_list": "NeighborList2",
+                        "number_of_neighbors": "NumNeighbors2",
+                        "shared_surface_area_list": "SharedSurfaceAreaList2",
+                        "store_boundary_cells": false,
+                        "store_surface_features": false,
+                        "surface_features": "SurfaceFeatures"
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::FindNeighbors",
+                        "uuid": "7177e88c-c3ab-4169-abe9-1fdaff20e598"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "active_array_name": "Active",
+                        "angle_tolerance": 2.0,
+                        "avg_quats_array_path": "DataContainer/CellFeatureData/AvgQuats",
+                        "axis_tolerance": 3.0,
+                        "cell_parent_ids_array_name": "ParentIds",
+                        "contiguous_neighbor_list_array_path": "DataContainer/CellFeatureData/NeighborList2",
+                        "crystal_structures_array_path": "DataContainer/CellEnsembleData/CrystalStructures",
+                        "feature_ids_path": "DataContainer/CellData/FeatureIds",
+                        "feature_parent_ids_array_name": "ParentIds",
+                        "feature_phases_array_path": "DataContainer/CellFeatureData/Phases",
+                        "new_cell_feature_attribute_matrix_name": "NewGrain Data",
+                        "non_contiguous_neighbor_list_array_path": "",
+                        "use_non_contiguous_neighbors": false
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::MergeTwinsFilter",
+                        "uuid": "f173786a-50cd-4c3c-9518-48ef6fc2bac9"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "equivalent_diameters_path": "EquivalentDiameters",
+                        "feature_attribute_matrix": "DataContainer/CellFeatureData",
+                        "feature_ids_path": "DataContainer/CellData/FeatureIds",
+                        "geometry_path": "DataContainer",
+                        "num_elements_path": "NumElements",
+                        "save_element_sizes": false,
+                        "volumes_path": "Volumes"
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::CalculateFeatureSizesFilter",
+                        "uuid": "c666ee17-ca58-4969-80d0-819986c72485"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "apply_single_phase": false,
+                        "feature_ids_path": "DataContainer/CellData/FeatureIds",
+                        "feature_phases_path": "",
+                        "image_geom_path": "DataContainer",
+                        "min_allowed_features_size": 16,
+                        "num_cells_path": "DataContainer/CellFeatureData/NumElements",
+                        "phase_number": 0
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::RemoveMinimumSizeFeaturesFilter",
+                        "uuid": "074472d3-ba8d-4a1a-99f2-2d56a0d082a0"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "boundary_cells": "BoundaryCells",
+                        "cell_feature_arrays": "DataContainer/CellFeatureData",
+                        "feature_ids": "DataContainer/CellData/FeatureIds",
+                        "image_geometry": "DataContainer",
+                        "neighbor_list": "NeighborList",
+                        "number_of_neighbors": "NumNeighbors",
+                        "shared_surface_area_list": "SharedSurfaceAreaList",
+                        "store_boundary_cells": false,
+                        "store_surface_features": false,
+                        "surface_features": "SurfaceFeatures"
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::FindNeighbors",
+                        "uuid": "7177e88c-c3ab-4169-abe9-1fdaff20e598"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "apply_to_single_phase": false,
+                        "cell_attribute_matrix": "DataContainer/CellData",
+                        "feature_ids": "DataContainer/CellData/FeatureIds",
+                        "feature_phases": "Data Container/Feature Data/Phases",
+                        "ignored_voxel_arrays": [],
+                        "image_geom": "DataContainer",
+                        "min_num_neighbors": 2,
+                        "num_neighbors": "DataContainer/CellFeatureData/NumNeighbors",
+                        "phase_number": 0
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::MinNeighbors",
+                        "uuid": "4ab5153f-6014-4e6d-bbd6-194068620389"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "cell_phases_array_path": "Phases",
+                        "feature_ids_path": "DataContainer/CellData/FeatureIds",
+                        "ignored_data_array_paths": [],
+                        "min_allowed_defect_size": 1000,
+                        "selected_image_geometry": "DataContainer",
+                        "store_as_new_phase": false
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::FillBadDataFilter",
+                        "uuid": "a59eb864-9e6b-40bb-9292-e5281b0b4f3e"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "feature_ids_path": "DataContainer/CellData/FeatureIds",
+                        "ignored_data_array_paths": [],
+                        "num_iterations": 2,
+                        "operation": 0,
+                        "selected_image_geometry": "DataContainer",
+                        "x_dir_on": true,
+                        "y_dir_on": true,
+                        "z_dir_on": true
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::ErodeDilateBadDataFilter",
+                        "uuid": "7f2f7378-580e-4337-8c04-a29e7883db0b"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "feature_ids_path": "DataContainer/CellData/FeatureIds",
+                        "ignored_data_array_paths": [],
+                        "num_iterations": 2,
+                        "operation": 1,
+                        "selected_image_geometry": "DataContainer",
+                        "x_dir_on": true,
+                        "y_dir_on": true,
+                        "z_dir_on": true
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::ErodeDilateBadDataFilter",
+                        "uuid": "7f2f7378-580e-4337-8c04-a29e7883db0b"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "cell_euler_angles_array_path": "DataContainer/CellData/EulerAngles",
+                        "cell_ip_fcolors_array_name": "IPFColors",
+                        "cell_phases_array_path": "DataContainer/CellData/Phases",
+                        "crystal_structures_array_path": "DataContainer/CellEnsembleData/CrystalStructures",
+                        "good_voxels_array_path": "DataContainer/CellData/Mask",
+                        "reference_dir": [
+                          0.0,
+                          0.0,
+                          1.0
+                        ],
+                        "use_good_voxels": true
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::GenerateIPFColorsFilter",
+                        "uuid": "64cb4f27-6e5e-4dd2-8a03-0c448cb8f5e6"
+                      },
+                      "isDisabled": false
+                    },
+                    {
+                      "args": {
+                        "export_file_path": "Data/Output/Reconstruction/SmallIN100_Final.dream3d",
+                        "write_xdmf_file": true
+                      },
+                      "comments": "",
+                      "filter": {
+                        "name": "complex::ExportDREAM3DFilter",
+                        "uuid": "b3a95784-2ced-41ec-8d3d-0242ac130003"
+                      },
+                      "isDisabled": false
+                    }
+                  ]
+                }
+              },
+              "comments": "",
+              "filter": {
+                "name": "complex::ImportDREAM3DFilter",
+                "uuid": "0dbd31c7-19e0-4077-83ef-f4a6459a0e2d"
+              },
+              "isDisabled": false
+            },
+            {
+              "args": {
+                "centroids_array_path": "Centroids",
+                "feature_attribute_matrix": "DataContainer/CellFeatureData",
+                "feature_ids_path": "DataContainer/CellData/FeatureIds",
+                "selected_image_geometry": "DataContainer"
+              },
+              "comments": "",
+              "filter": {
+                "name": "complex::FindFeatureCentroidsFilter",
+                "uuid": "c6875ac7-8bdd-4f69-b6ce-82ac09bd3421"
+              },
+              "isDisabled": false
+            },
+            {
+              "args": {
+                "equivalent_diameters_path": "EquivalentDiameters",
+                "feature_attribute_matrix": "DataContainer/CellFeatureData",
+                "feature_ids_path": "DataContainer/CellData/FeatureIds",
+                "geometry_path": "DataContainer",
+                "num_elements_path": "NumElements",
+                "save_element_sizes": false,
+                "volumes_path": "Size Volumes"
+              },
+              "comments": "",
+              "filter": {
+                "name": "complex::CalculateFeatureSizesFilter",
+                "uuid": "c666ee17-ca58-4969-80d0-819986c72485"
+              },
+              "isDisabled": false
+            },
+            {
+              "args": {
+                "aspect_ratios_array_name": "AspectRatios",
+                "axis_euler_angles_array_name": "AxisEulerAngles",
+                "axis_lengths_array_name": "AxisLengths",
+                "centroids_array_path": "DataContainer/CellFeatureData/Centroids",
+                "feature_ids_path": "DataContainer/CellData/FeatureIds",
+                "omega3s_array_name": "Omega3s",
+                "selected_image_geometry": "DataContainer",
+                "volumes_array_name": "Shape Volumes"
+              },
+              "comments": "",
+              "filter": {
+                "name": "complex::FindShapesFilter",
+                "uuid": "036b17d5-23bb-4a24-9187-c4a8dd918792"
+              },
+              "isDisabled": false
+            },
+            {
+              "args": {
+                "boundary_cells": "BoundaryCells",
+                "cell_feature_arrays": "DataContainer/CellFeatureData",
+                "feature_ids": "DataContainer/CellData/FeatureIds",
+                "image_geometry": "DataContainer",
+                "neighbor_list": "NeighborList",
+                "number_of_neighbors": "NumNeighbors",
+                "shared_surface_area_list": "SharedSurfaceAreaList",
+                "store_boundary_cells": false,
+                "store_surface_features": false,
+                "surface_features": "SurfaceFeatures"
+              },
+              "comments": "",
+              "filter": {
+                "name": "complex::FindNeighbors",
+                "uuid": "7177e88c-c3ab-4169-abe9-1fdaff20e598"
+              },
+              "isDisabled": false
+            },
+            {
+              "args": {
+                "centroids_array_path": "DataContainer/CellFeatureData/Centroids",
+                "equivalent_diameters_array_path": "DataContainer/CellFeatureData/EquivalentDiameters",
+                "feature_phases_array_path": "DataContainer/CellFeatureData/Phases",
+                "multiples_of_average": 1.0,
+                "neighborhood_list_array_name": "DataContainer/CellFeatureData/NeighborhoodList",
+                "neighborhoods_array_name": "DataContainer/CellFeatureData/Neighborhoods",
+                "selected_image_geometry_path": "DataContainer"
+              },
+              "comments": "",
+              "filter": {
+                "name": "complex::FindNeighborhoodsFilter",
+                "uuid": "924c10e3-2f39-4c08-9d7a-7fe029f74f6d"
+              },
+              "isDisabled": false
+            },
+            {
+              "args": {
+                "calc_manhattan_dist": true,
+                "do_boundaries": true,
+                "do_quad_points": true,
+                "do_triple_lines": true,
+                "feature_ids_path": "DataContainer/CellData/FeatureIds",
+                "g_bdistances_array_name": "GBManhattanDistances",
+                "nearest_neighbors_array_name": "NearestNeighbors",
+                "q_pdistances_array_name": "QPManhattanDistances",
+                "save_nearest_neighbors": false,
+                "selected_image_geometry": "DataContainer",
+                "t_jdistances_array_name": "TJManhattanDistances"
+              },
+              "comments": "",
+              "filter": {
+                "name": "complex::FindEuclideanDistMapFilter",
+                "uuid": "ba9ae8f6-443e-41d3-bb45-a08a139325c1"
+              },
+              "isDisabled": false
+            },
+            {
+              "args": {
+                "calculate_sphericity": true,
+                "feature_ids_path": "DataContainer/CellData/FeatureIds",
+                "num_cells_array_path": "DataContainer/CellFeatureData/NumElements",
+                "selected_image_geometry": "DataContainer",
+                "sphericity_array_name": "DataContainer/CellFeatureData/Sphericity",
+                "surface_area_volume_ratio_array_name": "DataContainer/CellFeatureData/SurfaceAreaVolumeRatio"
+              },
+              "comments": "",
+              "filter": {
+                "name": "complex::FindSurfaceAreaToVolumeFilter",
+                "uuid": "94e83e4f-797d-4594-b130-3819b7676f01"
+              },
+              "isDisabled": false
+            },
+            {
+              "args": {
+                "export_file_path": "Data/Output/Statistics/SmallIN100_Morph.dream3d",
+                "write_xdmf_file": true
+              },
+              "comments": "",
+              "filter": {
+                "name": "complex::ExportDREAM3DFilter",
+                "uuid": "b3a95784-2ced-41ec-8d3d-0242ac130003"
+              },
+              "isDisabled": false
+            }
+          ]
         }
       },
+      "comments": "",
       "filter": {
         "name": "complex::ImportDREAM3DFilter",
         "uuid": "0dbd31c7-19e0-4077-83ef-f4a6459a0e2d"
@@ -64,8 +663,9 @@
     },
     {
       "args": {
-        "removed_data_path": "DataContainer/CellFeatureData/AvgQuats"
+        "removed_data_path": []
       },
+      "comments": "",
       "filter": {
         "name": "complex::DeleteData",
         "uuid": "bf286740-e987-49fe-a7c8-6e566e3a0606"
@@ -82,6 +682,7 @@
         "cell_quats_array_path": "DataContainer/CellData/Quats",
         "crystal_structures_array_path": "DataContainer/CellEnsembleData/CrystalStructures"
       },
+      "comments": "",
       "filter": {
         "name": "complex::FindAvgOrientationsFilter",
         "uuid": "086ddb9a-928f-46ab-bad6-b1498270d71e"
@@ -98,6 +699,7 @@
         "misorientation_list_array_name": "MisorientationList",
         "neighbor_list_array_path": "DataContainer/CellFeatureData/NeighborhoodList"
       },
+      "comments": "",
       "filter": {
         "name": "complex::FindMisorientationsFilter",
         "uuid": "0b68fe25-b5ef-4805-ae32-20acb8d4e823"
@@ -132,6 +734,7 @@
         "slip_systems_array_name": "SlipSystems",
         "store_angle_components": false
       },
+      "comments": "",
       "filter": {
         "name": "complex::FindSchmidsFilter",
         "uuid": "b4681855-0a3d-4237-97f2-5aec509115c4"
@@ -151,6 +754,7 @@
         "quats_array_path": "DataContainer/CellData/Quats",
         "reference_orientation": 0
       },
+      "comments": "",
       "filter": {
         "name": "complex::FindFeatureReferenceMisorientationsFilter",
         "uuid": "24b54daf-3bf5-4331-93f6-03a49f719bf1"
@@ -171,6 +775,7 @@
         "quats_array_path": "DataContainer/CellData/Quats",
         "selected_image_geometry_path": "DataContainer"
       },
+      "comments": "",
       "filter": {
         "name": "complex::FindKernelAvgMisorientationsFilter",
         "uuid": "61cfc9c1-aa0e-452b-b9ef-d3b9e6268035"
@@ -182,6 +787,7 @@
         "export_file_path": "Data/Output/Statistics/SmallIN100_CrystalStats.dream3d",
         "write_xdmf_file": true
       },
+      "comments": "",
       "filter": {
         "name": "complex::ExportDREAM3DFilter",
         "uuid": "b3a95784-2ced-41ec-8d3d-0242ac130003"


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `complex/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `complex/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to complex!** -->
