### PR TITLE
BUG/STYLE: CreateDataArray: Reordered Parameters and Additional Checks

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.cpp
@@ -68,24 +68,25 @@ Parameters CreateDataArray::parameters() const
   Parameters params;
 
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
-  params.insertLinkableParameter(std::make_unique<BoolParameter>(
-      k_AdvancedOptions_Key, "Set Tuple Dimensions [not required if creating inside an Attribute Matrix]",
-      "This allows the user to set the tuple dimensions directly rather than just inheriting them \n\nThis option is NOT required if you are creating the Data Array in an Attribute Matrix", true));
-
   params.insert(std::make_unique<NumericTypeParameter>(k_NumericType_Key, "Numeric Type", "Numeric Type of data to create", NumericType::int32));
   params.insert(std::make_unique<StringParameter>(k_InitilizationValue_Key, "Initialization Value", "This value will be used to fill the new array", "0"));
   params.insert(std::make_unique<UInt64Parameter>(k_NumComps_Key, "Number of Components", "Number of components", 1));
 
+  params.insertSeparator(Parameters::Separator{"Created DataArray"});
+  params.insert(std::make_unique<ArrayCreationParameter>(k_DataPath_Key, "Created Array", "Array storing the data", DataPath{}));
+  params.insert(std::make_unique<DataStoreFormatParameter>(k_DataFormat_Key, "Data Format",
+                                                           "This value will specify which data format is used by the array's data store. An empty string results in in-memory data store.", ""));
+
+  params.insertSeparator(Parameters::Separator{"Tuple Handling"});
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(
+      k_AdvancedOptions_Key, "Set Tuple Dimensions [not required if creating inside an Attribute Matrix]",
+      "This allows the user to set the tuple dimensions directly rather than just inheriting them \n\nThis option is NOT required if you are creating the Data Array in an Attribute Matrix", true));
   DynamicTableInfo tableInfo;
   tableInfo.setRowsInfo(DynamicTableInfo::StaticVectorInfo(1));
   tableInfo.setColsInfo(DynamicTableInfo::DynamicVectorInfo(1, "DIM {}"));
 
   params.insert(std::make_unique<DynamicTableParameter>(k_TupleDims_Key, "Data Array Dimensions (Slowest to Fastest Dimensions)",
                                                         "Slowest to Fastest Dimensions. Note this might be opposite displayed by an image geometry.", tableInfo));
-  params.insertSeparator(Parameters::Separator{"Created DataArray"});
-  params.insert(std::make_unique<ArrayCreationParameter>(k_DataPath_Key, "Created Array", "Array storing the data", DataPath{}));
-  params.insert(std::make_unique<DataStoreFormatParameter>(k_DataFormat_Key, "Data Format",
-                                                           "This value will specify which data format is used by the array's data store. An empty string results in in-memory data store.", ""));
 
   // Associate the Linkable Parameter(s) to the children parameters that they control
   params.linkParameters(k_AdvancedOptions_Key, k_TupleDims_Key, true);
@@ -113,7 +114,7 @@ IFilter::PreflightResult CreateDataArray::preflightImpl(const DataStructure& dat
 
   if(initValue.empty())
   {
-    return {MakeErrorResult<OutputActions>(k_EmptyParameterError, fmt::format("{}: Init Value cannot be empty.{}({})", humanName(), __FILE__, __LINE__)), {}};
+    return MakePreflightErrorResult(k_EmptyParameterError, fmt::format("{}: Init Value cannot be empty.{}({})", humanName(), __FILE__, __LINE__));
   }
   // Sanity check that what the user entered for an init value can be converted safely to the final numeric type
   Result<> result = CheckValueConverts(initValue, numericType);
@@ -130,8 +131,8 @@ IFilter::PreflightResult CreateDataArray::preflightImpl(const DataStructure& dat
   {
     if(!useDims)
     {
-      return {MakeErrorResult<OutputActions>(
-          -78602, "The DataArray to be created is not within an AttributeMatrix, so the dimensions cannot be determined implicitly. Check Set Tuple Dimensions to set the dimensions")};
+      return MakePreflightErrorResult(
+          -78602, "The DataArray to be created is not within an AttributeMatrix, so the dimensions cannot be determined implicitly. Check Set Tuple Dimensions to set the dimensions");
     }
     else
     {
@@ -139,6 +140,11 @@ IFilter::PreflightResult CreateDataArray::preflightImpl(const DataStructure& dat
       tupleDims.reserve(rowData.size());
       for(auto floatValue : rowData)
       {
+        if(floatValue == 0)
+        {
+          return MakePreflightErrorResult(-78603, "Tuple dimension cannot be zero");
+        }
+
         tupleDims.push_back(static_cast<usize>(floatValue));
       }
     }
@@ -149,7 +155,7 @@ IFilter::PreflightResult CreateDataArray::preflightImpl(const DataStructure& dat
     if(useDims)
     {
       return {ConvertResultTo<OutputActions>(
-          MakeWarningVoidResult(-78603, "You checked Set Tuple Dimensions, but selected a DataPath that has an Attribute Matrix as the parent. The Attribute Matrix tuples will override your "
+          MakeWarningVoidResult(-78604, "You checked Set Tuple Dimensions, but selected a DataPath that has an Attribute Matrix as the parent. The Attribute Matrix tuples will override your "
                                         "custom dimensions. It is recommended to uncheck Set Tuple Dimensions for the sake of clarity."),
           {})};
     }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateDataArray.cpp
@@ -112,6 +112,8 @@ IFilter::PreflightResult CreateDataArray::preflightImpl(const DataStructure& dat
   auto tableData = filterArgs.value<DynamicTableParameter::ValueType>(k_TupleDims_Key);
   auto dataFormat = filterArgs.value<std::string>(k_DataFormat_Key);
 
+  complex::Result<OutputActions> resultOutputActions;
+
   if(initValue.empty())
   {
     return MakePreflightErrorResult(k_EmptyParameterError, fmt::format("{}: Init Value cannot be empty.{}({})", humanName(), __FILE__, __LINE__));
@@ -154,19 +156,17 @@ IFilter::PreflightResult CreateDataArray::preflightImpl(const DataStructure& dat
     tupleDims = parentAM->getShape();
     if(useDims)
     {
-      return {ConvertResultTo<OutputActions>(
-          MakeWarningVoidResult(-78604, "You checked Set Tuple Dimensions, but selected a DataPath that has an Attribute Matrix as the parent. The Attribute Matrix tuples will override your "
-                                        "custom dimensions. It is recommended to uncheck Set Tuple Dimensions for the sake of clarity."),
-          {})};
+      resultOutputActions.warnings().push_back(
+          Warning{-78604, "You checked Set Tuple Dimensions, but selected a DataPath that has an Attribute Matrix as the parent. The Attribute Matrix tuples will override your "
+                          "custom dimensions. It is recommended to uncheck Set Tuple Dimensions for the sake of clarity."});
     }
   }
 
-  OutputActions actions;
   auto action = std::make_unique<CreateArrayAction>(ConvertNumericTypeToDataType(numericType), tupleDims, compDims, dataArrayPath, dataFormat);
 
-  actions.actions.push_back(std::move(action));
+  resultOutputActions.value().actions.push_back(std::move(action));
 
-  return {std::move(actions)};
+  return {std::move(resultOutputActions)};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/ComplexCore/test/CreateDataArrayTest.cpp
+++ b/src/Plugins/ComplexCore/test/CreateDataArrayTest.cpp
@@ -84,7 +84,7 @@ TEST_CASE("ComplexCore::CreateDataArray(Invalid Parameters)", "[ComplexCore][Cre
     args.insert(CreateDataArray::k_InitilizationValue_Key, std::make_any<std::string>("1"));
 
     auto result = filter.execute(dataStructure, args);
-    COMPLEX_RESULT_REQUIRE_VALID(result.result);
+    COMPLEX_RESULT_REQUIRE_INVALID(result.result);
   }
   SECTION("Section5")
   {


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `complex/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `complex/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to complex!** -->
