### PR TITLE
ENH: Import Ascii Parameter Updates

### DIFF
--- a/src/Plugins/ComplexCore/pipelines/Import_CSV_Data.d3dpipeline
+++ b/src/Plugins/ComplexCore/pipelines/Import_CSV_Data.d3dpipeline
@@ -32,7 +32,11 @@
         "input_file": "Data/ASCII_Data/ConfidenceIndex.csv",
         "n_comp": 1,
         "n_skip_lines": 0,
-        "n_tuples": 480000,
+        "n_tuples": [
+          [
+            480000.0
+          ]
+        ],
         "output_data_array": "[Image Geometry]/Cell Data/Confidence Index",
         "scalar_type": 8
       },
@@ -47,7 +51,11 @@
         "input_file": "Data/ASCII_Data/FeatureIds.csv",
         "n_comp": 1,
         "n_skip_lines": 0,
-        "n_tuples": 480000,
+        "n_tuples": [
+          [
+            480000.0
+          ]
+        ],
         "output_data_array": "[Image Geometry]/Cell Data/FeatureIds",
         "scalar_type": 4
       },
@@ -62,7 +70,11 @@
         "input_file": "Data/ASCII_Data/ImageQuality.csv",
         "n_comp": 1,
         "n_skip_lines": 0,
-        "n_tuples": 480000,
+        "n_tuples": [
+          [
+            480000.0
+          ]
+        ],
         "output_data_array": "[Image Geometry]/Cell Data/Image Quality",
         "scalar_type": 8
       },
@@ -77,7 +89,11 @@
         "input_file": "Data/ASCII_Data/IPFColor.csv",
         "n_comp": 3,
         "n_skip_lines": 0,
-        "n_tuples": 480000,
+        "n_tuples": [
+          [
+            480000.0
+          ]
+        ],
         "output_data_array": "[Image Geometry]/Cell Data/IPFColors",
         "scalar_type": 0
       },

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
@@ -66,7 +66,7 @@ Parameters ImportTextFilter::parameters() const
                                                   "This value will specify which data format is used by the array's data store. An empty string results in in-memory data store.", ""));
 
   params.insertSeparator(Parameters::Separator{"Tuple Handling"});
-  params.insert(std::make_unique<BoolParameter>(
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(
       k_AdvancedOptions_Key, "Set Tuple Dimensions [not required if creating inside an Attribute Matrix]",
       "This allows the user to set the tuple dimensions directly rather than just inheriting them \n\nThis option is NOT required if you are creating the Data Array in an Attribute Matrix", true));
 
@@ -75,6 +75,8 @@ Parameters ImportTextFilter::parameters() const
   tableInfo.setColsInfo(DynamicTableInfo::DynamicVectorInfo(1, "DIM {}"));
   params.insert(std::make_unique<DynamicTableParameter>(k_NTuplesKey, "Data Array Dimensions (Slowest to Fastest Dimensions)",
                                                         "Slowest to Fastest Dimensions. Note this might be opposite displayed by an image geometry.", tableInfo));
+
+  params.linkParameters(k_AdvancedOptions_Key, k_NTuplesKey, false);
 
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
@@ -88,7 +88,6 @@ IFilter::PreflightResult ImportTextFilter::preflightImpl(const DataStructure& da
 {
   auto numericType = args.value<NumericType>(k_ScalarTypeKey);
   auto arrayPath = args.value<DataPath>(k_DataArrayKey);
-  auto nTuples = args.value<uint64>(k_NTuplesKey);
   auto nComp = args.value<uint64>(k_NCompKey);
 
   auto useDims = args.value<bool>(k_AdvancedOptions_Key);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
@@ -5,10 +5,13 @@
 #include "complex/Common/TypesUtility.hpp"
 #include "complex/Filter/Actions/CreateArrayAction.hpp"
 #include "complex/Parameters/ArrayCreationParameter.hpp"
+#include "complex/Parameters/BoolParameter.hpp"
 #include "complex/Parameters/ChoicesParameter.hpp"
+#include "complex/Parameters/DynamicTableParameter.hpp"
 #include "complex/Parameters/FileSystemPathParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
 #include "complex/Parameters/NumericTypeParameter.hpp"
+#include "complex/Parameters/StringParameter.hpp"
 #include "complex/Utilities/DataArrayUtilities.hpp"
 #include "complex/Utilities/Parsing/Text/CsvParser.hpp"
 
@@ -52,12 +55,27 @@ Parameters ImportTextFilter::parameters() const
   params.insert(std::make_unique<FileSystemPathParameter>(k_InputFileKey, "Input File", "File path that points to the imported file", fs::path("<file to import goes here>"),
                                                           FileSystemPathParameter::ExtensionsType{}, FileSystemPathParameter::PathType::InputFile));
   params.insert(std::make_unique<NumericTypeParameter>(k_ScalarTypeKey, "Scalar Type", "Data Type to interpret and store data into.", NumericType::int8));
-  params.insert(std::make_unique<UInt64Parameter>(k_NTuplesKey, "Number of Tuples", "Number of tuples in resulting array (i.e. number of lines to read)", 0));
   params.insert(std::make_unique<UInt64Parameter>(k_NCompKey, "Number of Components", "Number of columns", 1));
   params.insert(std::make_unique<UInt64Parameter>(k_NSkipLinesKey, "Skip Header Lines", "Number of lines at the start of the file to skip", 0));
   params.insert(std::make_unique<ChoicesParameter>(k_DelimiterChoiceKey, "Delimiter", "Delimiter for values on a line", 0,
                                                    ChoicesParameter::Choices{", (comma)", "; (semicolon)", "  (space)", ": (colon)", "\\t (Tab)"}));
+
+  params.insertSeparator(Parameters::Separator{"Created DataArray"});
   params.insert(std::make_unique<ArrayCreationParameter>(k_DataArrayKey, "Created Array Path", "DataPath or Name for the underlying Data Array", DataPath{}));
+  params.insert(std::make_unique<StringParameter>(k_DataFormat_Key, "Data Format",
+                                                  "This value will specify which data format is used by the array's data store. An empty string results in in-memory data store.", ""));
+
+  params.insertSeparator(Parameters::Separator{"Tuple Handling"});
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(
+      k_AdvancedOptions_Key, "Set Tuple Dimensions [not required if creating inside an Attribute Matrix]",
+      "This allows the user to set the tuple dimensions directly rather than just inheriting them \n\nThis option is NOT required if you are creating the Data Array in an Attribute Matrix", true));
+
+  DynamicTableInfo tableInfo;
+  tableInfo.setRowsInfo(DynamicTableInfo::StaticVectorInfo(1));
+  tableInfo.setColsInfo(DynamicTableInfo::DynamicVectorInfo(1, "DIM {}"));
+  params.insert(std::make_unique<DynamicTableParameter>(k_NTuplesKey, "Data Array Dimensions (Slowest to Fastest Dimensions)",
+                                                        "Slowest to Fastest Dimensions. Note this might be opposite displayed by an image geometry.", tableInfo));
+
   return params;
 }
 
@@ -72,7 +90,49 @@ IFilter::PreflightResult ImportTextFilter::preflightImpl(const DataStructure& da
   auto arrayPath = args.value<DataPath>(k_DataArrayKey);
   auto nTuples = args.value<uint64>(k_NTuplesKey);
   auto nComp = args.value<uint64>(k_NCompKey);
-  auto action = std::make_unique<CreateArrayAction>(ConvertNumericTypeToDataType(numericType), std::vector<usize>{nTuples}, std::vector<usize>{nComp}, arrayPath);
+
+  auto useDims = args.value<bool>(k_AdvancedOptions_Key);
+  auto tableData = args.value<DynamicTableParameter::ValueType>(k_NTuplesKey);
+  auto dataFormat = args.value<std::string>(k_DataFormat_Key);
+
+  std::vector<usize> tupleDims = {};
+
+  auto* parentAM = data.getDataAs<AttributeMatrix>(arrayPath.getParent());
+  if(parentAM == nullptr)
+  {
+    if(!useDims)
+    {
+      return MakePreflightErrorResult(
+          -77602, "The DataArray to be created is not within an AttributeMatrix, so the dimensions cannot be determined implicitly. Check Set Tuple Dimensions to set the dimensions");
+    }
+    else
+    {
+      const auto& rowData = tableData.at(0);
+      tupleDims.reserve(rowData.size());
+      for(auto floatValue : rowData)
+      {
+        if(floatValue == 0)
+        {
+          return MakePreflightErrorResult(-77603, "Tuple dimension cannot be zero");
+        }
+
+        tupleDims.push_back(static_cast<usize>(floatValue));
+      }
+    }
+  }
+  else
+  {
+    tupleDims = parentAM->getShape();
+    if(useDims)
+    {
+      return {ConvertResultTo<OutputActions>(
+          MakeWarningVoidResult(-77604, "You checked Set Tuple Dimensions, but selected a DataPath that has an Attribute Matrix as the parent. The Attribute Matrix tuples will override your "
+                                        "custom dimensions. It is recommended to uncheck Set Tuple Dimensions for the sake of clarity."),
+          {})};
+    }
+  }
+
+  auto action = std::make_unique<CreateArrayAction>(ConvertNumericTypeToDataType(numericType), tupleDims, std::vector<usize>{nComp}, arrayPath, dataFormat);
 
   OutputActions actions;
   actions.actions.push_back(std::move(action));
@@ -84,8 +144,6 @@ Result<> ImportTextFilter::executeImpl(DataStructure& data, const Arguments& arg
 {
   auto inputFilePath = args.value<fs::path>(k_InputFileKey);
   auto numericType = args.value<NumericType>(k_ScalarTypeKey);
-
-  // auto components = args.value<uint64>(k_NCompKey);
   auto skipLines = args.value<uint64>(k_NSkipLinesKey);
   auto choiceIndex = args.value<uint64>(k_DelimiterChoiceKey);
   auto path = args.value<DataPath>(k_DataArrayKey);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
@@ -126,8 +126,9 @@ IFilter::PreflightResult ImportTextFilter::preflightImpl(const DataStructure& da
     tupleDims = parentAM->getShape();
     if(useDims)
     {
-      resultOutputActions.warnings().push_back(Warning{-77604, "You checked Set Tuple Dimensions, but selected a DataPath that has an Attribute Matrix as the parent. The Attribute Matrix tuples will override your "
-                                        "custom dimensions. It is recommended to uncheck Set Tuple Dimensions for the sake of clarity."});
+      resultOutputActions.warnings().push_back(
+          Warning{-77604, "You checked Set Tuple Dimensions, but selected a DataPath that has an Attribute Matrix as the parent. The Attribute Matrix tuples will override your "
+                          "custom dimensions. It is recommended to uncheck Set Tuple Dimensions for the sake of clarity."});
     }
   }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
@@ -11,7 +11,7 @@
 #include "complex/Parameters/FileSystemPathParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
 #include "complex/Parameters/NumericTypeParameter.hpp"
-#include "complex/Parameters/StringParameter.hpp"
+#include "complex/Parameters/DataStoreFormatParameter.hpp"
 #include "complex/Utilities/DataArrayUtilities.hpp"
 #include "complex/Utilities/Parsing/Text/CsvParser.hpp"
 
@@ -62,8 +62,8 @@ Parameters ImportTextFilter::parameters() const
 
   params.insertSeparator(Parameters::Separator{"Created DataArray"});
   params.insert(std::make_unique<ArrayCreationParameter>(k_DataArrayKey, "Created Array Path", "DataPath or Name for the underlying Data Array", DataPath{}));
-  params.insert(std::make_unique<StringParameter>(k_DataFormat_Key, "Data Format",
-                                                  "This value will specify which data format is used by the array's data store. An empty string results in in-memory data store.", ""));
+  params.insert(std::make_unique<DataStoreFormatParameter>(k_DataFormat_Key, "Data Format",
+                                                           "This value will specify which data format is used by the array's data store. An empty string results in in-memory data store.", ""));
 
   params.insertSeparator(Parameters::Separator{"Tuple Handling"});
   params.insertLinkableParameter(std::make_unique<BoolParameter>(

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.cpp
@@ -7,11 +7,11 @@
 #include "complex/Parameters/ArrayCreationParameter.hpp"
 #include "complex/Parameters/BoolParameter.hpp"
 #include "complex/Parameters/ChoicesParameter.hpp"
+#include "complex/Parameters/DataStoreFormatParameter.hpp"
 #include "complex/Parameters/DynamicTableParameter.hpp"
 #include "complex/Parameters/FileSystemPathParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
 #include "complex/Parameters/NumericTypeParameter.hpp"
-#include "complex/Parameters/DataStoreFormatParameter.hpp"
 #include "complex/Utilities/DataArrayUtilities.hpp"
 #include "complex/Utilities/Parsing/Text/CsvParser.hpp"
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportTextFilter.hpp
@@ -26,6 +26,8 @@ public:
   static inline constexpr StringLiteral k_NSkipLinesKey = "n_skip_lines";
   static inline constexpr StringLiteral k_DelimiterChoiceKey = "delimiter_choice";
   static inline constexpr StringLiteral k_DataArrayKey = "output_data_array";
+  static inline constexpr StringLiteral k_DataFormat_Key = "data_format";
+  static inline constexpr StringLiteral k_AdvancedOptions_Key = "advanced_options";
 
   /**
    * @brief

--- a/src/Plugins/ComplexCore/test/AlignSectionsFeatureCentroidTest.cpp
+++ b/src/Plugins/ComplexCore/test/AlignSectionsFeatureCentroidTest.cpp
@@ -6,10 +6,10 @@
 #include "complex/Parameters/ArraySelectionParameter.hpp"
 #include "complex/Parameters/ChoicesParameter.hpp"
 #include "complex/Parameters/Dream3dImportParameter.hpp"
+#include "complex/Parameters/DynamicTableParameter.hpp"
 #include "complex/Parameters/FileSystemPathParameter.hpp"
 #include "complex/Parameters/NumericTypeParameter.hpp"
 #include "complex/UnitTest/UnitTestCommon.hpp"
-#include "complex/Utilities/Parsing/HDF5/Readers/FileReader.hpp"
 
 #include <catch2/catch.hpp>
 
@@ -78,6 +78,8 @@ TEST_CASE("ComplexCore::AlignSectionsFeatureCentroidFilter", "[Reconstruction][A
 
   CompareExemplarToGeneratedData(dataStructure, dataStructure, k_CellAttributeMatrix, k_ExemplarDataContainer);
 
+  const static DynamicTableInfo::TableDataType k_TupleDims = {{static_cast<double>(k_NumSlices)}};
+
   // Read Exemplar Shifts File
   {
     static constexpr StringLiteral k_InputFileKey = "input_file";
@@ -97,7 +99,7 @@ TEST_CASE("ComplexCore::AlignSectionsFeatureCentroidFilter", "[Reconstruction][A
     args.insertOrAssign(k_InputFileKey, std::make_any<FileSystemPathParameter::ValueType>(
                                             fs::path(fmt::format("{}/6_6_align_sections_feature_centroids/6_6_align_sections_feature_centroids.txt", unit_test::k_TestFilesDir))));
     args.insertOrAssign(k_ScalarTypeKey, std::make_any<NumericTypeParameter::ValueType>(complex::NumericType::float32));
-    args.insertOrAssign(k_NTuplesKey, std::make_any<uint64>(k_NumSlices));
+    args.insertOrAssign(k_NTuplesKey, std::make_any<DynamicTableParameter::ValueType>(k_TupleDims));
     args.insertOrAssign(k_NCompKey, std::make_any<uint64>(k_NumColumns));
     args.insertOrAssign(k_NSkipLinesKey, std::make_any<uint64>(k_SkipHeaderLines));
     args.insertOrAssign(k_DelimiterChoiceKey, std::make_any<ChoicesParameter::ValueType>(k_Comma));
@@ -129,7 +131,7 @@ TEST_CASE("ComplexCore::AlignSectionsFeatureCentroidFilter", "[Reconstruction][A
     Arguments args;
     args.insertOrAssign(k_InputFileKey, std::make_any<FileSystemPathParameter::ValueType>(computedShiftsFile));
     args.insertOrAssign(k_ScalarTypeKey, std::make_any<NumericTypeParameter::ValueType>(complex::NumericType::float32));
-    args.insertOrAssign(k_NTuplesKey, std::make_any<uint64>(k_NumSlices));
+    args.insertOrAssign(k_NTuplesKey, std::make_any<DynamicTableParameter::ValueType>(k_TupleDims));
     args.insertOrAssign(k_NCompKey, std::make_any<uint64>(k_NumColumns));
     args.insertOrAssign(k_NSkipLinesKey, std::make_any<uint64>(k_SkipHeaderLines));
     args.insertOrAssign(k_DelimiterChoiceKey, std::make_any<ChoicesParameter::ValueType>(k_Comma));

--- a/src/Plugins/ComplexCore/test/CoreFilterTest.cpp
+++ b/src/Plugins/ComplexCore/test/CoreFilterTest.cpp
@@ -80,6 +80,7 @@ TEST_CASE("CoreFilterTest:RunCoreFilter")
   {
     static constexpr uint64 k_NComp = 3;
     static constexpr uint64 k_NSkipLines = 0;
+    const static DynamicTableInfo::TableDataType k_TupleDims = {{static_cast<double>(k_NLines)}};
 
     ImportTextFilter filter;
     DataStructure dataStructure;
@@ -88,7 +89,7 @@ TEST_CASE("CoreFilterTest:RunCoreFilter")
 
     args.insert("input_file", std::make_any<fs::path>(k_FileName));
     args.insert("scalar_type", std::make_any<NumericType>(NumericType::int32));
-    args.insert("n_tuples", std::make_any<DynamicTableParameter::ValueType>(k_NLines));
+    args.insert("n_tuples", std::make_any<DynamicTableParameter::ValueType>(k_TupleDims));
     args.insert("n_comp", std::make_any<uint64>(k_NComp));
     args.insert("n_skip_lines", std::make_any<uint64>(k_NSkipLines));
     args.insert("delimiter_choice", std::make_any<uint64>(0));

--- a/src/Plugins/ComplexCore/test/CoreFilterTest.cpp
+++ b/src/Plugins/ComplexCore/test/CoreFilterTest.cpp
@@ -7,6 +7,7 @@
 #include "complex/DataStructure/DataArray.hpp"
 #include "complex/DataStructure/DataGroup.hpp"
 #include "complex/Filter/IFilter.hpp"
+#include "complex/Parameters/DynamicTableParameter.hpp"
 #include "complex/Parameters/FileSystemPathParameter.hpp"
 
 #include <catch2/catch.hpp>
@@ -87,7 +88,7 @@ TEST_CASE("CoreFilterTest:RunCoreFilter")
 
     args.insert("input_file", std::make_any<fs::path>(k_FileName));
     args.insert("scalar_type", std::make_any<NumericType>(NumericType::int32));
-    args.insert("n_tuples", std::make_any<uint64>(k_NLines));
+    args.insert("n_tuples", std::make_any<DynamicTableParameter::ValueType>(k_NLines));
     args.insert("n_comp", std::make_any<uint64>(k_NComp));
     args.insert("n_skip_lines", std::make_any<uint64>(k_NSkipLines));
     args.insert("delimiter_choice", std::make_any<uint64>(0));

--- a/src/Plugins/ComplexCore/test/GenerateColorTableTest.cpp
+++ b/src/Plugins/ComplexCore/test/GenerateColorTableTest.cpp
@@ -1,13 +1,14 @@
 #include <catch2/catch.hpp>
 
-#include "complex/Parameters/ArrayCreationParameter.hpp"
-#include "complex/UnitTest/UnitTestCommon.hpp"
-#include "complex/Utilities/ColorPresetsUtilities.hpp"
-#include "complex/Utilities/StringUtilities.hpp"
-
 #include "ComplexCore/ComplexCore_test_dirs.hpp"
 #include "ComplexCore/Filters/GenerateColorTableFilter.hpp"
 #include "ComplexCore/Filters/ImportTextFilter.hpp"
+
+#include "complex/Parameters/ArrayCreationParameter.hpp"
+#include "complex/Parameters/DynamicTableParameter.hpp"
+#include "complex/UnitTest/UnitTestCommon.hpp"
+#include "complex/Utilities/ColorPresetsUtilities.hpp"
+#include "complex/Utilities/StringUtilities.hpp"
 
 namespace fs = std::filesystem;
 using namespace complex;
@@ -82,7 +83,7 @@ TEST_CASE("ComplexCore::GenerateColorTableFilter: Valid filter execution")
     args.insertOrAssign(ImportTextFilter::k_InputFileKey, std::make_any<fs::path>(k_InputImageFilePath));
     args.insertOrAssign(ImportTextFilter::k_ScalarTypeKey, std::make_any<NumericType>(NumericType::float32));
     args.insertOrAssign(ImportTextFilter::k_NCompKey, std::make_any<uint64>(1));
-    args.insertOrAssign(ImportTextFilter::k_NTuplesKey, std::make_any<uint64>(37989));
+    args.insertOrAssign(ImportTextFilter::k_NTuplesKey, std::make_any<DynamicTableParameter::ValueType>(DynamicTableInfo::TableDataType{{static_cast<double>(37989)}}));
     args.insertOrAssign(ImportTextFilter::k_DataArrayKey, std::make_any<DataPath>(DataPath{{Constants::k_Confidence_Index.str()}}));
 
     IFilter::ExecuteResult executeResult = filter.execute(dataStructure, args);

--- a/src/Plugins/OrientationAnalysis/test/AlignSectionsMisorientationTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/AlignSectionsMisorientationTest.cpp
@@ -8,6 +8,7 @@
 #include "complex/Core/Application.hpp"
 #include "complex/Parameters/ChoicesParameter.hpp"
 #include "complex/Parameters/Dream3dImportParameter.hpp"
+#include "complex/Parameters/DynamicTableParameter.hpp"
 #include "complex/Parameters/FileSystemPathParameter.hpp"
 #include "complex/Parameters/NumericTypeParameter.hpp"
 #include "complex/UnitTest/UnitTestCommon.hpp"
@@ -76,7 +77,7 @@ TEST_CASE("OrientationAnalysis::AlignSectionsMisorientation Small IN100 Pipeline
     // read in the exemplar shift data file
     args.insertOrAssign(k_InputFileKey, std::make_any<FileSystemPathParameter::ValueType>(fs::path(fmt::format("{}/align_sections_misorientation.txt", unit_test::k_TestFilesDir))));
     args.insertOrAssign(k_ScalarTypeKey, std::make_any<NumericTypeParameter::ValueType>(complex::NumericType::int32));
-    args.insertOrAssign(k_NTuplesKey, std::make_any<uint64>(116));
+    args.insertOrAssign(k_NTuplesKey, std::make_any<DynamicTableParameter::ValueType>(DynamicTableInfo::TableDataType{{static_cast<double>(116)}}));
     args.insertOrAssign(k_NCompKey, std::make_any<uint64>(6));
     args.insertOrAssign(k_NSkipLinesKey, std::make_any<uint64>(0));
     args.insertOrAssign(k_DelimiterChoiceKey, std::make_any<ChoicesParameter::ValueType>(4));
@@ -146,7 +147,7 @@ TEST_CASE("OrientationAnalysis::AlignSectionsMisorientation Small IN100 Pipeline
     Arguments args;
     args.insertOrAssign(k_InputFileKey, std::make_any<FileSystemPathParameter::ValueType>(computedShiftsFile));
     args.insertOrAssign(k_ScalarTypeKey, std::make_any<NumericTypeParameter::ValueType>(complex::NumericType::int32));
-    args.insertOrAssign(k_NTuplesKey, std::make_any<uint64>(116));
+    args.insertOrAssign(k_NTuplesKey, std::make_any<DynamicTableParameter::ValueType>(DynamicTableInfo::TableDataType{{static_cast<double>(116)}}));
     args.insertOrAssign(k_NCompKey, std::make_any<uint64>(6));
     args.insertOrAssign(k_NSkipLinesKey, std::make_any<uint64>(0));
     args.insertOrAssign(k_DelimiterChoiceKey, std::make_any<ChoicesParameter::ValueType>(4));

--- a/src/Plugins/OrientationAnalysis/test/AlignSectionsMutualInformationTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/AlignSectionsMutualInformationTest.cpp
@@ -7,6 +7,7 @@
 #include "complex/Parameters/ArraySelectionParameter.hpp"
 #include "complex/Parameters/BoolParameter.hpp"
 #include "complex/Parameters/ChoicesParameter.hpp"
+#include "complex/Parameters/DynamicTableParameter.hpp"
 #include "complex/Parameters/FileSystemPathParameter.hpp"
 #include "complex/Parameters/NumericTypeParameter.hpp"
 #include "complex/UnitTest/UnitTestCommon.hpp"
@@ -67,6 +68,8 @@ TEST_CASE("OrientationAnalysis::AlignSectionsMutualInformationFilter: Valid filt
     COMPLEX_RESULT_REQUIRE_VALID(executeResult.result)
   }
 
+  const static DynamicTableInfo::TableDataType k_TupleDims = {{static_cast<double>(k_NumSlices)}};
+
   // Read Exemplar Shifts File
   {
     static constexpr StringLiteral k_InputFileKey = "input_file";
@@ -87,7 +90,7 @@ TEST_CASE("OrientationAnalysis::AlignSectionsMutualInformationFilter: Valid filt
     args.insertOrAssign(k_InputFileKey, std::make_any<FileSystemPathParameter::ValueType>(
                                             fs::path(fmt::format("{}/6_5_align_sections_mutual_information/6_5_align_sections_mutual_information.txt", unit_test::k_TestFilesDir))));
     args.insertOrAssign(k_ScalarTypeKey, std::make_any<NumericTypeParameter::ValueType>(complex::NumericType::int32));
-    args.insertOrAssign(k_NTuplesKey, std::make_any<uint64>(k_NumSlices));
+    args.insertOrAssign(k_NTuplesKey, std::make_any<DynamicTableParameter::ValueType>(k_TupleDims));
     args.insertOrAssign(k_NCompKey, std::make_any<uint64>(6));
     args.insertOrAssign(k_NSkipLinesKey, std::make_any<uint64>(0));
     args.insertOrAssign(k_DelimiterChoiceKey, std::make_any<ChoicesParameter::ValueType>(4));
@@ -120,7 +123,7 @@ TEST_CASE("OrientationAnalysis::AlignSectionsMutualInformationFilter: Valid filt
     Arguments args;
     args.insertOrAssign(k_InputFileKey, std::make_any<FileSystemPathParameter::ValueType>(computedShiftsFile));
     args.insertOrAssign(k_ScalarTypeKey, std::make_any<NumericTypeParameter::ValueType>(complex::NumericType::int32));
-    args.insertOrAssign(k_NTuplesKey, std::make_any<uint64>(k_NumSlices));
+    args.insertOrAssign(k_NTuplesKey, std::make_any<DynamicTableParameter::ValueType>(k_TupleDims));
     args.insertOrAssign(k_NCompKey, std::make_any<uint64>(6));
     args.insertOrAssign(k_NSkipLinesKey, std::make_any<uint64>(0));
     args.insertOrAssign(k_DelimiterChoiceKey, std::make_any<ChoicesParameter::ValueType>(4));

--- a/src/Plugins/OrientationAnalysis/test/FindAvgOrientationsTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/FindAvgOrientationsTest.cpp
@@ -32,6 +32,7 @@ of doing that.
 #include "complex/Parameters/ArraySelectionParameter.hpp"
 #include "complex/Parameters/BoolParameter.hpp"
 #include "complex/Parameters/ChoicesParameter.hpp"
+#include "complex/Parameters/DynamicTableParameter.hpp"
 #include "complex/Parameters/FileSystemPathParameter.hpp"
 #include "complex/Parameters/NumericTypeParameter.hpp"
 #include "complex/UnitTest/UnitTestCommon.hpp"
@@ -66,7 +67,7 @@ void runImportTextFilter(const std::string k_InputFileName, complex::NumericType
   args.insertOrAssign(FindAvgOrientationsTest::k_InputFileKey,
                       std::make_any<FileSystemPathParameter::ValueType>(fs::path(fmt::format("{}/ASCII_Data/{}.csv", unit_test::k_TestFilesDir, k_InputFileName))));
   args.insertOrAssign(FindAvgOrientationsTest::k_ScalarTypeKey, std::make_any<NumericTypeParameter::ValueType>(k_NumericType));
-  args.insertOrAssign(FindAvgOrientationsTest::k_NTuplesKey, std::make_any<uint64>(k_NumTuples));
+  args.insertOrAssign(FindAvgOrientationsTest::k_NTuplesKey, std::make_any<DynamicTableParameter::ValueType>(DynamicTableInfo::TableDataType{{static_cast<double>(k_NumTuples)}}));
   args.insertOrAssign(FindAvgOrientationsTest::k_NCompKey, std::make_any<uint64>(k_NumComponents));
   args.insertOrAssign(FindAvgOrientationsTest::k_NSkipLinesKey, std::make_any<uint64>(0));
   args.insertOrAssign(FindAvgOrientationsTest::k_DelimiterChoiceKey, std::make_any<ChoicesParameter::ValueType>(0));

--- a/src/Plugins/OrientationAnalysis/test/RotateEulerRefFrameTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/RotateEulerRefFrameTest.cpp
@@ -6,6 +6,7 @@
 
 #include "complex/Core/Application.hpp"
 #include "complex/Parameters/ChoicesParameter.hpp"
+#include "complex/Parameters/DynamicTableParameter.hpp"
 #include "complex/Parameters/FileSystemPathParameter.hpp"
 #include "complex/Parameters/NumericTypeParameter.hpp"
 #include "complex/Parameters/VectorParameter.hpp"
@@ -24,7 +25,7 @@ TEST_CASE("OrientationAnalysis::RotateEulerRefFrame", "[OrientationAnalysis]")
   app->loadPlugins(unit_test::k_BuildDir.view(), true);
 
   const uint64 k_NumComponents = 3;
-  const uint64 k_NumTuples = 480000;
+  const static DynamicTableInfo::TableDataType k_NumTuples = {{static_cast<double>(480000)}};
   const complex::NumericType k_NumericType = complex::NumericType::float32;
 
   // Constant strings and DataPaths to be used later
@@ -57,7 +58,7 @@ TEST_CASE("OrientationAnalysis::RotateEulerRefFrame", "[OrientationAnalysis]")
     Arguments args;
     args.insertOrAssign(k_InputFileKey, std::make_any<FileSystemPathParameter::ValueType>(fs::path(inputFile)));
     args.insertOrAssign(k_ScalarTypeKey, std::make_any<NumericTypeParameter::ValueType>(k_NumericType));
-    args.insertOrAssign(k_NTuplesKey, std::make_any<uint64>(k_NumTuples));
+    args.insertOrAssign(k_NTuplesKey, std::make_any<DynamicTableParameter::ValueType>(k_NumTuples));
     args.insertOrAssign(k_NCompKey, std::make_any<uint64>(k_NumComponents));
     args.insertOrAssign(k_NSkipLinesKey, std::make_any<uint64>(0));
     args.insertOrAssign(k_DelimiterChoiceKey, std::make_any<ChoicesParameter::ValueType>(0));
@@ -79,7 +80,7 @@ TEST_CASE("OrientationAnalysis::RotateEulerRefFrame", "[OrientationAnalysis]")
     Arguments args;
     args.insertOrAssign(k_InputFileKey, std::make_any<FileSystemPathParameter::ValueType>(fs::path(comparisonDataFile)));
     args.insertOrAssign(k_ScalarTypeKey, std::make_any<NumericTypeParameter::ValueType>(k_NumericType));
-    args.insertOrAssign(k_NTuplesKey, std::make_any<uint64>(k_NumTuples));
+    args.insertOrAssign(k_NTuplesKey, std::make_any<DynamicTableParameter::ValueType>(k_NumTuples));
     args.insertOrAssign(k_NCompKey, std::make_any<uint64>(k_NumComponents));
     args.insertOrAssign(k_NSkipLinesKey, std::make_any<uint64>(0));
     args.insertOrAssign(k_DelimiterChoiceKey, std::make_any<ChoicesParameter::ValueType>(0));


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `complex/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `complex/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to complex!** -->
