### PR TITLE
Updated actions to versions that uses non-deprecated node version

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,11 +33,11 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          submodules: true        
+          submodules: true
       - name: Add C++ Problem Matcher
-        uses: ammaraskar/gcc-problem-matcher@a141586609e2a558729b99a8c574c048f7f56204
+        uses: ammaraskar/gcc-problem-matcher@0.2.0
       - name: Install Dependencies
         run: |
           sudo apt-get -y install ninja-build
@@ -59,7 +59,7 @@ jobs:
           CC: ${{matrix.cc}}
           CXX: ${{matrix.cxx}}
         run: |
-          cmake --preset ci-linux-x64 ${{github.workspace}} 
+          cmake --preset ci-linux-x64 ${{github.workspace}}
       - name: Build
         run: |
           cmake --build --preset ci-linux-x64

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true 
       - name: Add C++ Problem Matcher
-        uses: ammaraskar/gcc-problem-matcher@a141586609e2a558729b99a8c574c048f7f56204
+        uses: ammaraskar/gcc-problem-matcher@0.2.0
       - name: Install Dependencies
         run: |
           brew install ninja

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,13 +25,13 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Add C++ Problem Matcher
         uses: ammaraskar/msvc-problem-matcher@0.2.0
       - name: Setup Build Environment
-        uses: ilammy/msvc-dev-cmd@v1.12.0
+        uses: ilammy/msvc-dev-cmd@v1.12.1
         with:
           vsversion: 2022
       - name: Setup NuGet Credentials


### PR DESCRIPTION
Node actions need to be updated from Node 12 to 16.
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/