### PR TITLE
Added nightly asan build

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1,0 +1,46 @@
+name: asan
+
+on:
+  schedule:
+    - cron: '15 5 * * *'
+
+jobs:
+  build:
+    env:
+      VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Add C++ Problem Matcher
+        uses: ammaraskar/gcc-problem-matcher@0.2.0
+      - name: Install Dependencies
+        run: |
+          sudo apt-get -y install ninja-build
+      - name: Setup NuGet Credentials
+        shell: bash
+        run: |
+          mono `vcpkg fetch nuget | tail -n 1` \
+          sources add \
+          -source "https://nuget.pkg.github.com/BlueQuartzSoftware/index.json" \
+          -storepasswordincleartext \
+          -name "GitHub" \
+          -username "BlueQuartzSoftware" \
+          -password "${{secrets.GITHUB_TOKEN}}"
+          mono `vcpkg fetch nuget | tail -n 1` \
+          setapikey "${{secrets.GITHUB_TOKEN}}" \
+          -source "https://nuget.pkg.github.com/BlueQuartzSoftware/index.json"
+      - name: Configure
+        env:
+          CC: clang-10
+          CXX: clang++-10
+        run: |
+          cmake --preset ci-asan ${{github.workspace}}
+      - name: Build
+        run: |
+          cmake --build --preset ci-asan
+      - name: Test
+        run: |
+          ctest --preset ci-asan

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -48,6 +48,20 @@
       }
     },
     {
+      "name": "ci-asan",
+      "inherits": "ci",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Debug"
+        },
+        "CMAKE_CXX_FLAGS": {
+          "type": "STRING",
+          "value": "-O1 -fsanitize=address -fno-omit-frame-pointer"
+        }
+      }
+    },
+    {
       "name": "ci-windows-v142",
       "displayName": "ci-windows-v142",
       "description": "Build configuration for GitHub Actions CI",
@@ -168,6 +182,12 @@
       "description": "Build configuration for GitHub actions CI",
       "configurePreset": "ci-linux-x64",
       "configuration": "Release"
+    },
+    {
+      "name": "ci-asan",
+      "displayName": "asan CI build",
+      "description": "Build configuration for GitHub actions CI",
+      "configurePreset": "ci-asan"
     }
   ],
   "testPresets": [
@@ -217,6 +237,15 @@
       "description": "Build configuration for GitHub actions CI",
       "configurePreset": "ci-linux-x64",
       "configuration": "Release",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "ci-asan",
+      "displayName": "asan CI build",
+      "description": "Build configuration for GitHub actions CI",
+      "configurePreset": "ci-asan",
       "output": {
         "outputOnFailure": true
       }


### PR DESCRIPTION
The build should run at 5:15 UTC. GitHub Actions documentation recommends setting scheduled builds at times other than on the hour to avoid heavy load and delayed builds.