### PR TITLE
Now report failure on pipeline failure when using shell scripts in tests 

### DIFF
--- a/src/Plugins/OrientationAnalysis/test/ctest_pipeline_driver.bat
+++ b/src/Plugins/OrientationAnalysis/test/ctest_pipeline_driver.bat
@@ -45,8 +45,8 @@ echo EXE_SFX %EXE_SFX%
 cd @CMAKE_RUNTIME_OUTPUT_DIRECTORY@\%CONFIG_DIR%
 
 @PIPELINE_RUNNER_NAME@%EXE_SFX%@EXE_EXT@ "@ARGS_PIPELINE_PATH@"
+IF %ERRORLEVEL% NEQ 0 EXIT 1
 
 ::-----------------------------------------------------------------------------
 :: These files need to be deleted after the test has completed
 @DELETE_FILE_COMMANDS@
-


### PR DESCRIPTION
The batch file running the OrientationAnalysis tests did not error out when the pipeline failed.