### PR TITLE
ENH: Allow Naming STL AttributeMatrices

### DIFF
--- a/src/Plugins/ComplexCore/docs/StlFileReaderFilter.md
+++ b/src/Plugins/ComplexCore/docs/StlFileReaderFilter.md
@@ -29,6 +29,10 @@ This **Filter**  will read a binary STL File and create a **Triangle Geometry** 
 | STL File | File Path  | The input .stl file path |
 | Scale Output | Bool | Should the output vertex values be scaled |
 | Scale Factor | Float | Apply the scaling factor to each vertex |
+| Vertex Attribute Matrix | String | Name of the created Vertex Attribute Matrix |
+| Face Attribute Matrix | String | Name of the created Face Attribute Matrix |
+| Shared Vertex Attribute Matrix | String | Name of the created Shared Vertex Attribute Matrix |
+| Shared Face Attribute Matrix | String | Name of the created Shared Face Attribute Matrix |
 
 ## Required Geometry ##
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
@@ -10,6 +10,7 @@
 #include "complex/Parameters/DataGroupCreationParameter.hpp"
 #include "complex/Parameters/FileSystemPathParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
+#include "complex/Parameters/StringParameter.hpp"
 
 #include <filesystem>
 #include <tuple>
@@ -74,6 +75,12 @@ Parameters StlFileReaderFilter::parameters() const
   params.insert(std::make_unique<DataGroupCreationParameter>(k_GeometryDataPath_Key, "Geometry Name [Data Group]", "The complete path to the DataGroup containing the created Geometry data",
                                                              DataPath({"[Triangle Geometry]"})));
 
+  params.insert(std::make_unique<StringParameter>(k_VertexMatrix_Key, "Vertex Matrix Name", "Name of the created Vertex Attribute Matrix", INodeGeometry0D::k_VertexDataName));
+  params.insert(std::make_unique<StringParameter>(k_FaceMatrix_Key, "Face Matrix Name", "Name of the created Face Attribute Matrix", INodeGeometry2D::k_FaceDataName));
+
+  params.insert(std::make_unique<StringParameter>(k_SharedVertexMatrix_Key, "Vertex Matrix Name", "Name of the created Vertex Attribute Matrix", CreateTriangleGeometryAction::k_DefaultVerticesName));
+  params.insert(std::make_unique<StringParameter>(k_SharedFaceMatrix_Key, "Face Matrix Name", "Name of the created Face Attribute Matrix", CreateTriangleGeometryAction::k_DefaultFacesName));
+
   return params;
 }
 
@@ -94,6 +101,10 @@ IFilter::PreflightResult StlFileReaderFilter::preflightImpl(const DataStructure&
    */
   auto pStlFilePathValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_StlFilePath_Key);
   auto pTriangleGeometryPath = filterArgs.value<DataPath>(k_GeometryDataPath_Key);
+  auto vertexMatrixName = filterArgs.value<std::string>(k_VertexMatrix_Key);
+  auto faceMatrixName = filterArgs.value<std::string>(k_FaceMatrix_Key);
+  auto sharedVertexMatrixName = filterArgs.value<std::string>(k_SharedVertexMatrix_Key);
+  auto sharedFaceMatrixName = filterArgs.value<std::string>(k_SharedFaceMatrix_Key);
 
   PreflightResult preflightResult;
 
@@ -147,8 +158,8 @@ IFilter::PreflightResult StlFileReaderFilter::preflightImpl(const DataStructure&
   // past this point, we are going to scope each section so that we don't accidentally introduce bugs
 
   // Create the Triangle Geometry action and store it
-  auto createTriangleGeometryAction = std::make_unique<CreateTriangleGeometryAction>(pTriangleGeometryPath, numTriangles, 1, INodeGeometry0D::k_VertexDataName, INodeGeometry2D::k_FaceDataName,
-                                                                                     CreateTriangleGeometryAction::k_DefaultVerticesName, CreateTriangleGeometryAction::k_DefaultFacesName);
+  auto createTriangleGeometryAction =
+      std::make_unique<CreateTriangleGeometryAction>(pTriangleGeometryPath, numTriangles, 1, vertexMatrixName, faceMatrixName, sharedVertexMatrixName, sharedFaceMatrixName);
   auto faceNormalsPath = createTriangleGeometryAction->getFaceDataPath().createChildPath(k_FaceNormals);
   resultOutputActions.value().actions.push_back(std::move(createTriangleGeometryAction));
   // Create the face Normals DataArray action and store it

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.cpp
@@ -78,8 +78,10 @@ Parameters StlFileReaderFilter::parameters() const
   params.insert(std::make_unique<StringParameter>(k_VertexMatrix_Key, "Vertex Matrix Name", "Name of the created Vertex Attribute Matrix", INodeGeometry0D::k_VertexDataName));
   params.insert(std::make_unique<StringParameter>(k_FaceMatrix_Key, "Face Matrix Name", "Name of the created Face Attribute Matrix", INodeGeometry2D::k_FaceDataName));
 
-  params.insert(std::make_unique<StringParameter>(k_SharedVertexMatrix_Key, "Vertex Matrix Name", "Name of the created Vertex Attribute Matrix", CreateTriangleGeometryAction::k_DefaultVerticesName));
-  params.insert(std::make_unique<StringParameter>(k_SharedFaceMatrix_Key, "Face Matrix Name", "Name of the created Face Attribute Matrix", CreateTriangleGeometryAction::k_DefaultFacesName));
+  params.insert(std::make_unique<StringParameter>(k_SharedVertexMatrix_Key, "Shared Vertex Matrix Name", "Name of the created Shared Vertex Attribute Matrix",
+                                                  CreateTriangleGeometryAction::k_DefaultVerticesName));
+  params.insert(
+      std::make_unique<StringParameter>(k_SharedFaceMatrix_Key, "Shared Face Matrix Name", "Name of the created Shared Face Attribute Matrix", CreateTriangleGeometryAction::k_DefaultFacesName));
 
   return params;
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/StlFileReaderFilter.hpp
@@ -33,6 +33,10 @@ public:
   static inline constexpr StringLiteral k_FaceNormalsDataPath_Key = "face_normals_data_path";
   static inline constexpr StringLiteral k_ScaleOutput = "scale_output";
   static inline constexpr StringLiteral k_ScaleFactor = "scale_factor";
+  static inline constexpr StringLiteral k_VertexMatrix_Key = "vertex_matrix";
+  static inline constexpr StringLiteral k_FaceMatrix_Key = "face_matrix";
+  static inline constexpr StringLiteral k_SharedVertexMatrix_Key = "shared_vertex_matrix";
+  static inline constexpr StringLiteral k_SharedFaceMatrix_Key = "shared_face_matrix";
 
   /**
    * @brief Returns the name of the filter.


### PR DESCRIPTION
Allow custom naming of StlFileReader AttributeMatrices.

Closes #534 

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `complex/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `complex/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to complex!** -->
