### PR TITLE
ENH: H5 Import error fixes

### DIFF
--- a/src/complex/DataStructure/DataMap.cpp
+++ b/src/complex/DataStructure/DataMap.cpp
@@ -317,8 +317,12 @@ DataMap& DataMap::operator=(DataMap&& rhs) noexcept
   m_Map = std::move(rhs.m_Map);
   return *this;
 }
+
 void DataMap::updateIds(const std::vector<std::pair<IdType, IdType>>& updatedIds)
 {
+  using UpdatedValueType = std::pair<IdType, std::shared_ptr<DataObject>>;
+  std::list<UpdatedValueType> movedValues;
+
   for(const auto& updatedId : updatedIds)
   {
     if(!contains(updatedId.first))
@@ -326,8 +330,15 @@ void DataMap::updateIds(const std::vector<std::pair<IdType, IdType>>& updatedIds
       continue;
     }
 
-    auto extractedPair = m_Map.extract(updatedId.first);
-    extractedPair.key() = updatedId.second;
-    m_Map.insert(std::move(extractedPair));
+    // Copy and remove updated values
+    auto ptr = m_Map[updatedId.first];
+    movedValues.emplace_back(UpdatedValueType{updatedId.first, ptr});
+    m_Map.erase(updatedId.first);
+  }
+
+  // Re-assign updated values
+  for(const UpdatedValueType& updatedValue : movedValues)
+  {
+    m_Map[updatedValue.first] = updatedValue.second;
   }
 }

--- a/src/complex/DataStructure/DataObject.cpp
+++ b/src/complex/DataStructure/DataObject.cpp
@@ -57,16 +57,20 @@ DataObject& DataObject::operator=(const DataObject& rhs)
     return *this;
   }
   m_DataStructure = rhs.m_DataStructure;
+  m_ParentList = rhs.m_ParentList;
   m_Id = rhs.m_Id;
   m_Name = rhs.m_Name;
+  m_Metadata = rhs.m_Metadata;
   return *this;
 }
 
 DataObject& DataObject::operator=(DataObject&& rhs) noexcept
 {
   m_DataStructure = rhs.m_DataStructure;
+  m_ParentList = std::move(rhs.m_ParentList);
   m_Id = rhs.m_Id;
   m_Name = std::move(rhs.m_Name);
+  m_Metadata = std::move(rhs.m_Metadata);
   return *this;
 }
 
@@ -187,6 +191,11 @@ bool DataObject::rename(const std::string& name)
 DataObject::ParentCollectionType DataObject::getParentIds() const
 {
   return m_ParentList;
+}
+
+void DataObject::clearParents()
+{
+  m_ParentList.clear();
 }
 
 Metadata& DataObject::getMetadata()

--- a/src/complex/DataStructure/DataObject.hpp
+++ b/src/complex/DataStructure/DataObject.hpp
@@ -222,6 +222,11 @@ public:
   ParentCollectionType getParentIds() const;
 
   /**
+   * @brief Clears the list of parent IDs.
+   */
+  void clearParents();
+
+  /**
    * @brief Returns a vector of DataPaths to the object.
    * @return std::vector<DataPath>
    */

--- a/src/complex/DataStructure/DataStructure.cpp
+++ b/src/complex/DataStructure/DataStructure.cpp
@@ -589,6 +589,9 @@ bool DataStructure::insert(const std::shared_ptr<DataObject>& dataObject, const 
     dataObject->setId(generateId());
   }
 
+  // Clears the DataObject's parent IDs to avoid clashes.
+  dataObject->clearParents();
+
   if(dataPath.empty())
   {
     return insertIntoRoot(dataObject);
@@ -824,6 +827,7 @@ void DataStructure::resetIds(DataObject::IdType startingId)
       dataObjectPtr->checkUpdatedIds(updatedIds);
     }
   }
+  m_RootGroup.updateIds(updatedIds);
 }
 
 void DataStructure::exportHeirarchyAsGraphViz(std::ostream& outputStream)


### PR DESCRIPTION
* Updated DataMap::updateIds to prevent replacing other values while updating an ID value.
* Added DataObject::clearParents() method.
* Updated DataStructure::insert to clear imported DataObject parent IDs.
* Updated DataStructure::resetIds to update the root DataMap IDs as well.

Closes #539

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `complex/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `complex/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to complex!** -->
