### PR TITLE
BUG: Fix HDF5::GetNameFromBuffer checks

### DIFF
--- a/src/complex/Utilities/Parsing/HDF5/H5.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5.cpp
@@ -1,5 +1,7 @@
 #include "H5.hpp"
 
+#include <fmt/core.h>
+
 #include <stdexcept>
 #include <vector>
 
@@ -115,12 +117,25 @@ complex::HDF5::IdType complex::HDF5::getIdForType(Type type)
 
 std::string complex::HDF5::GetNameFromBuffer(std::string_view buffer)
 {
-  size_t substrIndex = buffer.find_last_of('/');
-  if(substrIndex > 0)
+  if(buffer.empty())
   {
-    substrIndex++;
+    throw std::runtime_error(fmt::format("complex::HDF5::GetNameFromBuffer : HDF5 data path cannot be empty."));
   }
-  return std::string(buffer.substr(substrIndex));
+
+  size_t substrIndex = buffer.find_last_of('/');
+  if(substrIndex == std::string::npos)
+  {
+    return std::string(buffer);
+  }
+  if(substrIndex == buffer.size() - 1)
+  {
+    if(buffer.size() == 1)
+    {
+      return std::string(buffer);
+    }
+    throw std::runtime_error(fmt::format("complex::HDF5::GetNameFromBuffer : Invalid HDF5 data path '{}'. Path cannot end with a /", buffer));
+  }
+  return std::string(buffer.substr(++substrIndex));
 }
 
 std::string complex::HDF5::GetPathFromId(IdType id)

--- a/test/H5Test.cpp
+++ b/test/H5Test.cpp
@@ -768,3 +768,17 @@ TEST_CASE("xdmf")
   Result<> result = DREAM3D::WriteFile(GetDataDir() / "xdmfTest.dream3d", dataStructure, {}, true);
   COMPLEX_RESULT_REQUIRE_VALID(result);
 }
+
+TEST_CASE("H5 Utilities")
+{
+  REQUIRE_THROWS(complex::HDF5::GetNameFromBuffer(""));
+  REQUIRE_THROWS(complex::HDF5::GetNameFromBuffer("/Group/"));
+  std::string objectName = complex::HDF5::GetNameFromBuffer("/");
+  REQUIRE(objectName == "/");
+  objectName = complex::HDF5::GetNameFromBuffer("/Group/Geometry/Data");
+  REQUIRE(objectName == "Data");
+  objectName = complex::HDF5::GetNameFromBuffer("Data");
+  REQUIRE(objectName == "Data");
+  objectName = complex::HDF5::GetNameFromBuffer("/Data");
+  REQUIRE(objectName == "Data");
+}


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `complex/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `complex/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to complex!** -->
