### PR TITLE
ENH: Update MoveData filter to allow multiple moves at once

### DIFF
--- a/src/Plugins/ComplexCore/test/MoveDataTest.cpp
+++ b/src/Plugins/ComplexCore/test/MoveDataTest.cpp
@@ -37,28 +37,34 @@ TEST_CASE("ComplexCore::MoveData Successful", "[Complex::Core][MoveData]")
 
   const DataPath k_Group1Path({k_Group1Name});
   const DataPath k_Group3Path({k_Group2Name, k_Group3Name});
+  const DataPath k_Group4Path({k_Group2Name, k_Group4Name});
 
-  args.insertOrAssign(MoveData::k_Data_Key, std::make_any<DataPath>(k_Group3Path));
+  args.insertOrAssign(MoveData::k_Data_Key, std::make_any<std::vector<DataPath>>({k_Group3Path, k_Group4Path}));
   args.insertOrAssign(MoveData::k_NewParent_Key, std::make_any<DataPath>(k_Group1Path));
 
   // Preflight the filter and check result
   auto preflightResult = filter.preflight(dataStructure, args);
-  COMPLEX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+  COMPLEX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
 
   // Execute the filter and check the result
   auto executeResult = filter.execute(dataStructure, args);
-  COMPLEX_RESULT_REQUIRE_VALID(executeResult.result);
+  COMPLEX_RESULT_REQUIRE_VALID(executeResult.result)
 
   const auto* group1 = dataStructure.getDataAs<DataGroup>(k_Group1Path);
-  REQUIRE(group1->getDataMap().getSize() == 1);
+  REQUIRE(group1->getDataMap().getSize() == 2);
 
   const auto* group2 = dataStructure.getDataAs<DataGroup>(DataPath({k_Group2Name}));
-  REQUIRE(group2->getDataMap().getSize() == 1);
+  REQUIRE(group2->getDataMap().getSize() == 0);
 
   REQUIRE(dataStructure.getDataAs<DataGroup>(k_Group3Path) == nullptr);
 
   const DataPath newGroup3Path = k_Group1Path.createChildPath(k_Group3Name);
   REQUIRE(dataStructure.getDataAs<DataGroup>(newGroup3Path) != nullptr);
+
+  REQUIRE(dataStructure.getDataAs<DataGroup>(k_Group4Path) == nullptr);
+
+  const DataPath newGroup4Path = k_Group1Path.createChildPath(k_Group4Name);
+  REQUIRE(dataStructure.getDataAs<DataGroup>(newGroup4Path) != nullptr);
 }
 
 TEST_CASE("ComplexCore::MoveData Unsuccessful", "[Complex::Core][MoveData]")
@@ -70,8 +76,21 @@ TEST_CASE("ComplexCore::MoveData Unsuccessful", "[Complex::Core][MoveData]")
   const DataPath k_Group2Path({k_Group2Name});
   const DataPath k_Group3Path({k_Group3Name});
 
-  args.insertOrAssign(MoveData::k_Data_Key, std::make_any<DataPath>(k_Group3Path));
-  args.insertOrAssign(MoveData::k_NewParent_Key, std::make_any<DataPath>(k_Group2Path));
+  SECTION("Object already exists in new data path")
+  {
+    args.insertOrAssign(MoveData::k_Data_Key, std::make_any<std::vector<DataPath>>({k_Group3Path}));
+    args.insertOrAssign(MoveData::k_NewParent_Key, std::make_any<DataPath>(k_Group2Path));
+  }
+  SECTION("Cannot reparent object to itself")
+  {
+    args.insertOrAssign(MoveData::k_Data_Key, std::make_any<std::vector<DataPath>>({k_Group3Path}));
+    args.insertOrAssign(MoveData::k_NewParent_Key, std::make_any<DataPath>(k_Group3Path));
+  }
+  SECTION("Cannot reparent object to a child object")
+  {
+    args.insertOrAssign(MoveData::k_Data_Key, std::make_any<std::vector<DataPath>>({k_Group2Path}));
+    args.insertOrAssign(MoveData::k_NewParent_Key, std::make_any<DataPath>(k_Group3Path));
+  }
 
   // Preflight the filter and check result
   auto preflightResult = filter.preflight(dataStructure, args);

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD SurfaceMeshing/(01) Small IN100 Quick Mesh.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD SurfaceMeshing/(01) Small IN100 Quick Mesh.d3dpipeline
@@ -101,7 +101,7 @@
     },
     {
       "args": {
-        "data": "DataContainer/CellEnsembleData",
+        "data": ["DataContainer/CellEnsembleData"],
         "new_parent": "DataContainer"
       },
       "comments": "",

--- a/src/complex/DataStructure/BaseGroup.cpp
+++ b/src/complex/DataStructure/BaseGroup.cpp
@@ -104,6 +104,10 @@ bool BaseGroup::canInsert(const DataObject* obj) const
   {
     return false;
   }
+  if(const auto* objGroup = dynamic_cast<const BaseGroup*>(obj); objGroup != nullptr && objGroup->isParentOf(this))
+  {
+    return false;
+  }
   return true;
 }
 

--- a/src/complex/DataStructure/DataObject.cpp
+++ b/src/complex/DataStructure/DataObject.cpp
@@ -211,8 +211,18 @@ const Metadata& DataObject::getMetadata() const
 bool DataObject::hasParent(const DataPath& parentPath) const
 {
   const auto dataPaths = getDataPaths();
-  const auto originalCellDataPathIt =
-      std::find_if(dataPaths.begin(), dataPaths.end(), [parentPath](const DataPath& path) { return StringUtilities::contains(path.toString(), parentPath.toString()); });
+  const auto originalCellDataPathIt = std::find_if(dataPaths.begin(), dataPaths.end(), [parentPath](const DataPath& path) {
+    DataPath pathAncestor = path.getParent();
+    while(!pathAncestor.empty())
+    {
+      if(parentPath == pathAncestor)
+      {
+        return true;
+      }
+      pathAncestor = pathAncestor.getParent();
+    }
+    return false;
+  });
   return originalCellDataPathIt != dataPaths.end();
 }
 

--- a/src/complex/Filter/Actions/MoveDataAction.cpp
+++ b/src/complex/Filter/Actions/MoveDataAction.cpp
@@ -15,6 +15,7 @@ constexpr int32 k_MissingParentObjectCode = -6403;
 constexpr int32 k_FailedAddParentCode = -6404;
 constexpr int32 k_FailedRemoveParentCode = -6405;
 constexpr int32 k_FailedFindOldParentCode = -6406;
+constexpr int32 k_RecursiveParentCode = -6407;
 } // namespace
 
 namespace complex
@@ -36,6 +37,11 @@ Result<> MoveDataAction::apply(DataStructure& dataStructure, Mode mode) const
     return MakeErrorResult(k_MissingDataObjectCode, fmt::format("{}Could not find DataObject at '{}'", prefix, m_Path.toString()));
   }
 
+  if(m_Path == m_NewParentPath)
+  {
+    return MakeErrorResult(k_RecursiveParentCode, fmt::format("{}Cannot move data object at path '{}' into itself.", prefix, m_Path.toString()));
+  }
+
   auto parentIds = dataObject->getParentIds();
   for(const auto parentId : parentIds)
   {
@@ -52,6 +58,11 @@ Result<> MoveDataAction::apply(DataStructure& dataStructure, Mode mode) const
   if(newParent == nullptr)
   {
     return MakeErrorResult(k_MissingParentObjectCode, fmt::format("{}Could not find a possible parent object at '{}'", prefix, m_NewParentPath.toString()));
+  }
+
+  if(const auto* dataGroup = dataStructure.getDataAs<BaseGroup>(m_Path); dataGroup != nullptr && dataGroup->isParentOf(newParent))
+  {
+    return MakeErrorResult(k_RecursiveParentCode, fmt::format("{}Cannot move data object '{}' into one one of its children ({})", prefix, m_Path.toString(), m_NewParentPath.toString()));
   }
 
   if(!dataStructure.setAdditionalParent(dataObject->getId(), newParent->getId()))

--- a/src/complex/Filter/Actions/MoveDataAction.cpp
+++ b/src/complex/Filter/Actions/MoveDataAction.cpp
@@ -60,11 +60,6 @@ Result<> MoveDataAction::apply(DataStructure& dataStructure, Mode mode) const
     return MakeErrorResult(k_MissingParentObjectCode, fmt::format("{}Could not find a possible parent object at '{}'", prefix, m_NewParentPath.toString()));
   }
 
-  if(const auto* dataGroup = dataStructure.getDataAs<BaseGroup>(m_Path); dataGroup != nullptr && dataGroup->isParentOf(newParent))
-  {
-    return MakeErrorResult(k_RecursiveParentCode, fmt::format("{}Cannot move data object '{}' into one one of its children ({})", prefix, m_Path.toString(), m_NewParentPath.toString()));
-  }
-
   if(!dataStructure.setAdditionalParent(dataObject->getId(), newParent->getId()))
   {
     return MakeErrorResult(k_FailedAddParentCode, fmt::format("{}Could not add new parent at '{}' to DataObject at '{}' ", prefix, m_NewParentPath.toString(), m_Path.toString()));


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `complex/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `complex/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [ ] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to complex!** -->
