### PR TITLE
BUG FIX: ApplyTransformationToGeometry now applies precomputed transformations correctly.

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ApplyTransformationToGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ApplyTransformationToGeometry.cpp
@@ -73,7 +73,24 @@ Result<> ApplyTransformationToGeometry::applyImageGeometryTransformation()
   const auto& srcCellDataAM = srcImageGeom.getCellDataRef();
 
   const DataPath destCellDataAMPath = destImageGeom.getCellDataPath();
-  // auto& destCellDataAM = destImageGeom.getCellDataRef();
+
+  if(m_InputValues->TransformationSelection == k_PrecomputedTransformationMatrixIdx)
+  {
+    // Adjust the destination objects because we didn't have the transformation matrix values during preflight
+    auto& destCellDataAM = destImageGeom.getCellDataRef();
+    const std::vector<usize> dims = {static_cast<usize>(rotateArgs.xpNew), static_cast<usize>(rotateArgs.ypNew), static_cast<usize>(rotateArgs.zpNew)};
+    const std::vector<float32> spacing = {rotateArgs.xResNew, rotateArgs.yResNew, rotateArgs.zResNew};
+    auto origin = srcImageGeom.getOrigin().toContainer<std::vector<float32>>();
+    origin[0] += rotateArgs.xMinNew;
+    origin[1] += rotateArgs.yMinNew;
+    origin[2] += rotateArgs.zMinNew;
+
+    std::vector<usize> const dataArrayShape = {dims[2], dims[1], dims[0]}; // The DataArray shape goes slowest to fastest (ZYX), opposite of ImageGeometry dimensions
+    destImageGeom.setDimensions(dims);
+    destImageGeom.setOrigin(origin);
+    destImageGeom.setSpacing(spacing);
+    destCellDataAM.resizeTuples(dataArrayShape);
+  }
 
   for(const auto& [dataId, srcDataObject] : srcCellDataAM)
   {


### PR DESCRIPTION
When using the precomputed transformation matrix option on an image geometry in the ApplyTransformationToGeometry filter, the filter would crash because the precomputed transformation matrix cannot be read during preflight and so the transformed image geometry, cell attribute matrix, and cell data arrays were being created in preflight using the default identity matrix, which was causing these objects to have the same dimensions as the source objects.  But then in execute the objects were expected to be the correct sizes using the actual precomputed transformation matrix, causing an index-out-of-bounds error.

I updated the filter so that the destination geometry's dimensions, origin, and spacing and the cell attribute matrix's tuple shape are adjusted in execute right before calculating and copying values into the destination arrays.  I also updated the PreflightUpdatedValue to display "Precomputed transformation matrix unknown during preflight." when the precomputed transformation matrix option is chosen.