### PR TITLE
TESTING: DataPath Test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(complex_test
   ArgumentsTest.cpp
   BitTest.cpp
   DataArrayTest.cpp
+  DataPathTest.cpp
   DataStructObserver.hpp
   DataStructObserver.cpp
   DataStructTest.cpp

--- a/test/DataPathTest.cpp
+++ b/test/DataPathTest.cpp
@@ -6,17 +6,56 @@ using namespace complex;
 
 namespace
 {
-const std::vector<std::string> k_CommonStringsVec = {};
-const std::vector<std::string> k_EdgeCaseStringsVec = {};
-const std::vector<std::string> k_InvalidStringsVec = {};
+const std::vector<std::string> k_CommonStringsVec = {"Path1/Path2", "Path1", "", " "};
+const std::vector<std::string> k_EdgeCaseStringsVec = {" / ", "Path1/ Path2", "Path1 / Path2 ", "Path1/ "};
+const std::vector<std::string> k_InvalidStringsVec = {"Path1/", "Path1//Path3"};
+
+bool CompareFromStringToExemplar(const std::string& input, const DataPath& exemplar)
+{
+  auto result = DataPath::FromString(input);
+  if(result.has_value())
+  {
+    return (result.value() == exemplar);
+  }
+  else
+  {
+    return false;
+  }
 }
+} // namespace
 
 TEST_CASE("Valid DataPath Creation")
 {
+  DataPath commonExemplar1 = DataPath({"Path1"}).createChildPath("Path2");
+  REQUIRE(CompareFromStringToExemplar(k_CommonStringsVec[0], commonExemplar1));
 
+  DataPath commonExemplar2 = DataPath({"Path1"});
+  REQUIRE(CompareFromStringToExemplar(k_CommonStringsVec[1], commonExemplar2));
+
+  DataPath commonExemplar3 = DataPath{};
+  REQUIRE(CompareFromStringToExemplar(k_CommonStringsVec[2], commonExemplar3));
+
+  DataPath commonExemplar4 = DataPath({" "});
+  REQUIRE(CompareFromStringToExemplar(k_CommonStringsVec[3], commonExemplar4));
+
+  DataPath edgeExemplar1 = DataPath({" "}).createChildPath(" ");
+  REQUIRE(CompareFromStringToExemplar(k_EdgeCaseStringsVec[0], edgeExemplar1));
+
+  DataPath edgeExemplar2 = DataPath({"Path1"}).createChildPath(" Path2");
+  REQUIRE(CompareFromStringToExemplar(k_EdgeCaseStringsVec[1], edgeExemplar2));
+
+  DataPath edgeExemplar3 = DataPath({"Path1 "}).createChildPath(" Path2 ");
+  REQUIRE(CompareFromStringToExemplar(k_EdgeCaseStringsVec[2], edgeExemplar3));
+
+  DataPath edgeExemplar4 = DataPath({"Path1"}).createChildPath(" ");
+  REQUIRE(CompareFromStringToExemplar(k_EdgeCaseStringsVec[3], edgeExemplar4));
 }
 
 TEST_CASE("Invalid DataPath Creation")
 {
+  DataPath invalidExemplar1 = DataPath{};
+  REQUIRE(!CompareFromStringToExemplar(k_InvalidStringsVec[0], invalidExemplar1));
 
+  DataPath invalidExemplar2 = DataPath{};
+  REQUIRE(!CompareFromStringToExemplar(k_InvalidStringsVec[1], invalidExemplar2));
 }

--- a/test/DataPathTest.cpp
+++ b/test/DataPathTest.cpp
@@ -1,0 +1,22 @@
+#include <catch2/catch.hpp>
+
+#include "complex/DataStructure/DataPath.hpp"
+
+using namespace complex;
+
+namespace
+{
+const std::vector<std::string> k_CommonStringsVec = {};
+const std::vector<std::string> k_EdgeCaseStringsVec = {};
+const std::vector<std::string> k_InvalidStringsVec = {};
+}
+
+TEST_CASE("Valid DataPath Creation")
+{
+
+}
+
+TEST_CASE("Invalid DataPath Creation")
+{
+
+}


### PR DESCRIPTION
Added a DataPath test to insure strings are processed correctly

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `complex/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `complex/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to complex!** -->
