### PR TITLE
ENH: Add support to DatasetReader for getting filters on the dataset

### DIFF
--- a/src/complex/Utilities/Parsing/HDF5/H5Support.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5Support.cpp
@@ -204,6 +204,30 @@ std::string complex::HDF5::Support::StringForHDFType(hid_t dataTypeIdentifier)
   return "Unknown";
 }
 
+std::string complex::HDF5::Support::GetNameFromFilterType(H5Z_filter_t id)
+{
+  switch(id)
+  {
+  case H5Z_FILTER_DEFLATE:
+    return "GZIP";
+  case H5Z_FILTER_SHUFFLE:
+    return "SHUFFLE";
+  case H5Z_FILTER_FLETCHER32:
+    return "FLETCHER32";
+  case H5Z_FILTER_SZIP:
+    return "SZIP";
+  case H5Z_FILTER_NBIT:
+    return "NBIT";
+  case H5Z_FILTER_SCALEOFFSET:
+    return "SCALE-OFFSET";
+  case H5Z_FILTER_ERROR:
+  case H5Z_FILTER_NONE:
+    return "NONE";
+  default:
+    return "UNKNOWN";
+  }
+}
+
 #if 0
 hid_t Support::getDatasetType(hid_t locationID, const std::string& datasetName)
 {

--- a/src/complex/Utilities/Parsing/HDF5/H5Support.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5Support.cpp
@@ -217,7 +217,7 @@ std::string complex::HDF5::Support::GetNameFromFilterType(H5Z_filter_t id)
   case H5Z_FILTER_SZIP:
     return "SZIP";
   case H5Z_FILTER_NBIT:
-    return "NBIT";
+    return "N-BIT";
   case H5Z_FILTER_SCALEOFFSET:
     return "SCALE-OFFSET";
   case H5Z_FILTER_ERROR:

--- a/src/complex/Utilities/Parsing/HDF5/H5Support.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/H5Support.hpp
@@ -289,5 +289,12 @@ hid_t COMPLEX_EXPORT GetDatasetType(hid_t locationId, const std::string& dataset
  */
 std::string COMPLEX_EXPORT StringForHDFType(hid_t dataTypeIdentifier);
 
+/**
+ * @brief Returns a std::string of the name of the given filter type.
+ * @param id
+ * @return std::string
+ */
+std::string COMPLEX_EXPORT GetNameFromFilterType(H5Z_filter_t id);
+
 } // namespace Support
 } // namespace complex::HDF5

--- a/src/complex/Utilities/Parsing/HDF5/Readers/DatasetReader.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/Readers/DatasetReader.cpp
@@ -321,7 +321,6 @@ std::string DatasetReader::getFilterName() const
 {
   std::string filterNames;
   const hid_t cpListId = H5Dget_create_plist(getId());
-  // const hid_t apListId = H5Dget_access_plist(getId());
   const int numFilters = H5Pget_nfilters(cpListId);
   for(int j = 0; j < numFilters; ++j)
   {

--- a/src/complex/Utilities/Parsing/HDF5/Readers/DatasetReader.cpp
+++ b/src/complex/Utilities/Parsing/HDF5/Readers/DatasetReader.cpp
@@ -317,6 +317,35 @@ std::vector<hsize_t> DatasetReader::getDimensions() const
   return dims;
 }
 
+std::string DatasetReader::getFilterName() const
+{
+  std::string filterNames;
+  const hid_t cpListId = H5Dget_create_plist(getId());
+  // const hid_t apListId = H5Dget_access_plist(getId());
+  const int numFilters = H5Pget_nfilters(cpListId);
+  for(int j = 0; j < numFilters; ++j)
+  {
+    unsigned int flags;
+    unsigned int filterConfig;
+    size_t cdNElements = 0;
+    char name[1024];
+    H5Z_filter_t filter = H5Pget_filter2(cpListId, j, &flags, &cdNElements, nullptr, std::size(name) / sizeof(*name), name, &filterConfig);
+    std::vector<unsigned int> cdValues(cdNElements);
+    filter = H5Pget_filter2(cpListId, j, &flags, &cdNElements, cdValues.data(), std::size(name) / sizeof(*name), name, &filterConfig);
+    if(j != 0)
+    {
+      filterNames += ", ";
+    }
+    filterNames += HDF5::Support::GetNameFromFilterType(filter);
+  }
+  if(filterNames.empty())
+  {
+    filterNames = "NONE";
+  }
+  return filterNames;
+  // return name;
+}
+
 // declare readAsVector
 template COMPLEX_EXPORT std::vector<int8_t> DatasetReader::readAsVector<int8_t>() const;
 template COMPLEX_EXPORT std::vector<int16_t> DatasetReader::readAsVector<int16_t>() const;

--- a/src/complex/Utilities/Parsing/HDF5/Readers/DatasetReader.hpp
+++ b/src/complex/Utilities/Parsing/HDF5/Readers/DatasetReader.hpp
@@ -120,6 +120,8 @@ public:
    */
   std::vector<hsize_t> getDimensions() const;
 
+  std::string getFilterName() const;
+
 protected:
   /**
    * @brief Closes the HDF5 ID and resets it to 0.


### PR DESCRIPTION


<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `complex/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `complex/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [ ] 1 Unit test to test output from the filter against known exemplar set of data
- [ ] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [ ] No commented out code (rare exceptions to this is allowed..)
- [ ] No API changes were made (or the changes have been approved)
- [ ] No major design changes were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added license to new files (if any)
- [ ] Added example pipelines that use the filter
- [ ] Classes and methods are properly documented


<!-- **Thanks for contributing to complex!** -->
