### PR TITLE
ENH: Extend CopyFeatureArrayToElementArray filter to work for multiple feature arrays at once

### DIFF
--- a/pipelines/PorosityAnalysis.d3dpipeline
+++ b/pipelines/PorosityAnalysis.d3dpipeline
@@ -102,9 +102,9 @@
     },
     {
       "args": {
-        "created_array_name": "EquivalentDiameters",
+        "created_array_suffix": "",
         "feature_ids_path": "RoboMet.3D Image Stack/Optical Data/FeatureIds",
-        "selected_feature_array_path": "RoboMet.3D Image Stack/Pore Data/EquivalentDiameters"
+        "selected_feature_array_path": ["RoboMet.3D Image Stack/Pore Data/EquivalentDiameters"]
       },
       "comments": "",
       "filter": {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyFeatureArrayToElementArray.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CopyFeatureArrayToElementArray.hpp
@@ -29,7 +29,7 @@ public:
   // Parameter Keys
   static inline constexpr StringLiteral k_SelectedFeatureArrayPath_Key = "selected_feature_array_path";
   static inline constexpr StringLiteral k_CellFeatureIdsArrayPath_Key = "feature_ids_path";
-  static inline constexpr StringLiteral k_CreatedArrayName_Key = "created_array_name";
+  static inline constexpr StringLiteral k_CreatedArraySuffix_Key = "created_array_suffix";
 
   /**
    * @brief Returns the name of the filter.

--- a/src/Plugins/ITKImageProcessing/pipelines/(02) Image Segmentation.d3dpipeline
+++ b/src/Plugins/ITKImageProcessing/pipelines/(02) Image Segmentation.d3dpipeline
@@ -102,9 +102,9 @@
     },
     {
       "args": {
-        "created_array_name": "EquivalentDiameters",
+        "created_array_suffix": "",
         "feature_ids_path": "ImageDataContainer/Cell Data/FeatureIds",
-        "selected_feature_array_path": "ImageDataContainer/CellFeatureData/EquivalentDiameters"
+        "selected_feature_array_path": ["ImageDataContainer/CellFeatureData/EquivalentDiameters"]
       },
       "comments": "",
       "filter": {

--- a/src/complex/Parameters/MultiArraySelectionParameter.cpp
+++ b/src/complex/Parameters/MultiArraySelectionParameter.cpp
@@ -139,7 +139,7 @@ Result<> MultiArraySelectionParameter::validatePaths(const DataStructure& dataSt
       errors.push_back(Error{FilterParameter::Constants::k_Validate_Type_Error, fmt::format("{}Object at path '{}' is not an IArray type", prefix, path.toString())});
       continue;
     }
-    if(m_AllowedTypes.count(dataArray->getArrayType()) == 0)
+    if(m_AllowedTypes.find(IArray::ArrayType::Any) == m_AllowedTypes.end() && m_AllowedTypes.count(dataArray->getArrayType()) == 0)
     {
       errors.push_back(Error{FilterParameter::Constants::k_Validate_Type_Error, fmt::format("{}Array at path '{}' was of type {}, but only {} are allowed", prefix, path.toString(),
                                                                                             dataArray->getTypeName(), IArray::StringListFromArrayType(m_AllowedTypes))});


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `complex/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `complex/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to complex!** -->
