### PR TITLE
ENH: Organize target groups for the Download/Copy/Extract targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,11 +95,10 @@ set(FETCH_FILE_PATH "${complex_BINARY_DIR}/complex_fetch_remote_files.cmake")
 set_property(GLOBAL PROPERTY FETCH_FILE_PATH "${FETCH_FILE_PATH}")
 file(WRITE ${FETCH_FILE_PATH} "# -----------------------------------------------------------------------
 # This file has the commands to download each of the test files.
-# The assumption is that the WORKING_DIRECTORY to what ever calls this command is set to the Binary
-# directory. The WORKING_DIRECTORY is set to the following CMake code:
+# The WORKING_DIRECTORY is set to the following CMake code:
 # ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>
 # -----------------------------------------------------------------------\n
-cmake_policy(SET CMP0012 NEW)\n
+cmake_policy(SET CMP0012 NEW)
 cmake_policy(SET CMP0054 NEW)\n")
 
 set(TEST_WORKING_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
@@ -111,7 +110,7 @@ if(COMPLEX_BUILD_TESTS AND COMPLEX_DOWNLOAD_TEST_FILES)
   add_custom_target(Fetch_Remote_Data_Files ALL
     COMMAND "${CMAKE_COMMAND}" -P "${FETCH_FILE_PATH}"
     COMMENT "Downloading Test Data Files"
-    WORKING_DIRECTORY "${TEST_WORKING_DIR}"
+  #  WORKING_DIRECTORY "${TEST_WORKING_DIR}"
   )
   set_target_properties(Fetch_Remote_Data_Files PROPERTIES FOLDER ZZ_FETCH_TEST_FILES)
 endif()

--- a/cmake/Utility.cmake
+++ b/cmake/Utility.cmake
@@ -111,6 +111,7 @@ function(download_test_data)
   #----------------------------------------------------------------------------
   set(fetch_data_file "${test_files_dir}/${ARGS_ARCHIVE_NAME}.cmake")
   set(DATA_DEST_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/Data")
+  file(MAKE_DIRECTORY "${DATA_DEST_DIR}")
   # Strip off the .tar.gz extension
   string(REPLACE ".tar.gz" "" ARCHIVE_BASE_NAME "${ARGS_ARCHIVE_NAME}")
 

--- a/src/Plugins/ComplexCore/CMakeLists.txt
+++ b/src/Plugins/ComplexCore/CMakeLists.txt
@@ -318,11 +318,11 @@ source_group(TREE "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}" PREFIX ${PLU
 # -----------------------------------------------------------------------
 if(EXISTS "${${PLUGIN_NAME}_SOURCE_DIR}/pipelines")
   set(PIPELINE_DEST_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/pipelines/${PLUGIN_NAME}")
-  add_custom_target(${PLUGIN_NAME}PipelineFolderCopy ALL
+  add_custom_target(Copy_${PLUGIN_NAME}_Pipeline_Folder ALL
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${${PLUGIN_NAME}_SOURCE_DIR}/pipelines"
     ${PIPELINE_DEST_DIR}
     COMMENT "Copying Pipeline Folder into Binary Directory")
-  set_target_properties(${PLUGIN_NAME}PipelineFolderCopy PROPERTIES FOLDER ZZ_COPY_FILES)
+  set_target_properties(Copy_${PLUGIN_NAME}_Pipeline_Folder PROPERTIES FOLDER Plugins/${PLUGIN_NAME})
 
   set(INSTALL_DESTINATION "pipelines/${PLUGIN_NAME}")
   install(DIRECTORY
@@ -354,7 +354,7 @@ if(EXISTS "${DREAM3D_DATA_DIR}" AND COMPLEX_DOWNLOAD_TEST_FILES)
 									 SHA512 70388864301ca1ea7fce7b1666d3abf682eee68c7d8b7a9bf532df7aff11e7ea9de7dc2dc80e33f0e363cbad023b663bff97df4be362f0312d311e9d5bedf370
 									 INSTALL
 									 COPY_DATA)
-  add_custom_target(Copy_${PLUGIN_NAME}ASCIIData ALL
+  add_custom_target(Copy_${PLUGIN_NAME}_ASCIIData ALL
                   COMMAND ${CMAKE_COMMAND} -E tar xzf "${DREAM3D_DATA_DIR}/TestFiles/ASCIIData.tar.gz" 
                   COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different "${DREAM3D_DATA_DIR}/TestFiles/ASCIIData" "${DATA_DEST_DIR}/ASCIIData"
                   COMMAND ${CMAKE_COMMAND} -E rm -rf "${DREAM3D_DATA_DIR}/TestFiles/ASCIIData"
@@ -362,6 +362,7 @@ if(EXISTS "${DREAM3D_DATA_DIR}" AND COMPLEX_DOWNLOAD_TEST_FILES)
                   COMMENT "Copying ${PLUGIN_NAME}/ASCIIData data into Binary Directory"
                   DEPENDS Fetch_Remote_Data_Files  # Make sure all remote files are downloaded before trying this
                 )
+  set_target_properties(Copy_${PLUGIN_NAME}_ASCIIData PROPERTIES FOLDER Plugins/${PLUGIN_NAME})
 
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR}
 									 ARCHIVE_NAME STL_Models.tar.gz
@@ -376,6 +377,8 @@ if(EXISTS "${DREAM3D_DATA_DIR}" AND COMPLEX_DOWNLOAD_TEST_FILES)
                   COMMENT "Copying ${PLUGIN_NAME}/STL_Models data into Binary Directory"
                   DEPENDS Fetch_Remote_Data_Files  # Make sure all remote files are downloaded before trying this
                 )
+  set_target_properties(Copy_${PLUGIN_NAME}_STL_Models PROPERTIES FOLDER Plugins/${PLUGIN_NAME})
+
 endif()
 
 # -----------------------------------------------------------------------

--- a/src/Plugins/ITKImageProcessing/CMakeLists.txt
+++ b/src/Plugins/ITKImageProcessing/CMakeLists.txt
@@ -274,11 +274,11 @@ endif()
 # -----------------------------------------------------------------------
 if(EXISTS "${${PLUGIN_NAME}_SOURCE_DIR}/pipelines")
   set(PIPELINE_DEST_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/pipelines/${PLUGIN_NAME}")
-  add_custom_target(${PLUGIN_NAME}PipelineFolderCopy ALL
+  add_custom_target(Copy_${PLUGIN_NAME}_Pipeline_Folder ALL
                     COMMAND ${CMAKE_COMMAND} -E copy_directory "${${PLUGIN_NAME}_SOURCE_DIR}/pipelines"
                     ${PIPELINE_DEST_DIR}
                     COMMENT "Copying Pipeline Folder into Binary Directory")
-  set_target_properties(${PLUGIN_NAME}PipelineFolderCopy PROPERTIES FOLDER ZZ_COPY_FILES)
+  set_target_properties(Copy_${PLUGIN_NAME}_Pipeline_Folder PROPERTIES FOLDER Plugins/${PLUGIN_NAME})
 
   set(INSTALL_DESTINATION "pipelines/${PLUGIN_NAME}")
   install(DIRECTORY
@@ -323,7 +323,7 @@ if(EXISTS "${DREAM3D_DATA_DIR}" AND COMPLEX_DOWNLOAD_TEST_FILES)
                    COMMENT "Copying ${PLUGIN_NAME}/Porosity_Image data into Binary Directory"
                    DEPENDS Fetch_Remote_Data_Files  # Make sure all remote files are downloaded before trying this
                  )
-              
+  set_target_properties(Copy_${PLUGIN_NAME}_Porosity_Image PROPERTIES FOLDER Plugins/${PLUGIN_NAME})
 endif()
 
 # -----------------------------------------------------------------------
@@ -337,8 +337,7 @@ if(FALSE)
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${${PLUGIN_NAME}_SOURCE_DIR}/data ${DATA_DEST_DIR}/${PLUGIN_NAME}
     COMMENT "Copying ${PLUGIN_NAME} data into Binary Directory"
     )
-  set_target_properties(Copy_${PLUGIN_NAME}_Data PROPERTIES FOLDER ZZ_COPY_FILES)
-
+  set_target_properties(Copy_${PLUGIN_NAME}_Data PROPERTIES FOLDER Plugins/${PLUGIN_NAME})
 
   set(Installed_Data_Files
   )

--- a/src/Plugins/OrientationAnalysis/CMakeLists.txt
+++ b/src/Plugins/OrientationAnalysis/CMakeLists.txt
@@ -272,11 +272,11 @@ add_subdirectory(${${PLUGIN_NAME}_SOURCE_DIR}/test)
 # -----------------------------------------------------------------------
 if(EXISTS "${${PLUGIN_NAME}_SOURCE_DIR}/pipelines")
   set(PIPELINE_DEST_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/pipelines/${PLUGIN_NAME}")
-  add_custom_target(${PLUGIN_NAME}_Pipeline_Folder_Copy ALL
+  add_custom_target(Copy_${PLUGIN_NAME}_Pipeline_Folder ALL
                     COMMAND ${CMAKE_COMMAND} -E copy_directory "${${PLUGIN_NAME}_SOURCE_DIR}/pipelines"
                     ${PIPELINE_DEST_DIR}
                     COMMENT "Copying Pipeline Folder into Binary Directory")
-  set_target_properties(${PLUGIN_NAME}_Pipeline_Folder_Copy PROPERTIES FOLDER ZZ_COPY_FILES)
+  set_target_properties(Copy_${PLUGIN_NAME}_Pipeline_Folder PROPERTIES FOLDER Plugins/${PLUGIN_NAME})
 
   set(INSTALL_DESTINATION "pipelines/${PLUGIN_NAME}")
   install(DIRECTORY
@@ -316,6 +316,8 @@ if(EXISTS "${DREAM3D_DATA_DIR}" AND COMPLEX_DOWNLOAD_TEST_FILES)
                    COMMENT "Copying ${PLUGIN_NAME}/T12-MAI-2010 data into Binary Directory"
                    DEPENDS Fetch_Remote_Data_Files  # Make sure all remote files are downloaded before trying this
                  )
+  set_target_properties(Copy_${PLUGIN_NAME}_T12-MAI-2010 PROPERTIES FOLDER Plugins/${PLUGIN_NAME})
+
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR} 
                     ARCHIVE_NAME Textured_Copper.tar.gz 
                     SHA512 cb231a13abbc21fe2046fc0fc7be9753ea51440bce1827bd20ee225499cd38be07d67955ff8c09d15ad91c4c1934e2a0e34406a703e7e49fbe53068b29ef440e
@@ -329,6 +331,7 @@ if(EXISTS "${DREAM3D_DATA_DIR}" AND COMPLEX_DOWNLOAD_TEST_FILES)
                    COMMENT "Copying ${PLUGIN_NAME}/Textured_Copper data into Binary Directory"
                    DEPENDS Fetch_Remote_Data_Files  # Make sure all remote files are downloaded before trying this
                  )
+  set_target_properties(Copy_${PLUGIN_NAME}_Textured_Copper PROPERTIES FOLDER Plugins/${PLUGIN_NAME})
 
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR} 
                     ARCHIVE_NAME Small_IN100.tar.gz 
@@ -342,6 +345,7 @@ if(EXISTS "${DREAM3D_DATA_DIR}" AND COMPLEX_DOWNLOAD_TEST_FILES)
                    COMMENT "Copying ${PLUGIN_NAME}/Small_IN100 data into Binary Directory"
                    DEPENDS Fetch_Remote_Data_Files  # Make sure all remote files are downloaded before trying this
                  )                   
+  set_target_properties(Copy_${PLUGIN_NAME}_Small_IN100 PROPERTIES FOLDER Plugins/${PLUGIN_NAME})
 endif()
 # -----------------------------------------------------------------------
 # Create build folder copy rules and install rules for the 'data' folder
@@ -351,7 +355,7 @@ add_custom_target(Copy_${PLUGIN_NAME}_Data ALL
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${${PLUGIN_NAME}_SOURCE_DIR}/data ${DATA_DEST_DIR}/${PLUGIN_NAME}
   COMMENT "Copying ${PLUGIN_NAME} data into Binary Directory"
   )
-set_target_properties(Copy_${PLUGIN_NAME}_Data PROPERTIES FOLDER ZZ_COPY_FILES)
+set_target_properties(Copy_${PLUGIN_NAME}_Data PROPERTIES FOLDER Plugins/${PLUGIN_NAME})
 
 set(Installed_Data_Files
   ${${PLUGIN_NAME}_SOURCE_DIR}/data/Ensemble.ini


### PR DESCRIPTION
This will help organize the Visual Studio solutions a bit more with respect to the copy of data and copy of pipeline folders