### PR TITLE
BUG: Various Fixes For ApplyTransformationToGeometry

### DIFF
--- a/src/Plugins/ComplexCore/docs/ApplyTransformationToGeometryFilter.md
+++ b/src/Plugins/ComplexCore/docs/ApplyTransformationToGeometryFilter.md
@@ -25,6 +25,10 @@ take place are the actual coordinates of the vertices.
 If the user selects an **Image Geometry** then the user should select one of the *Interpolation* methods and then also
 select the appropriate *Cell Attribute Matrix*.
 
+The **Scale** and **Rotation** transformation types will automatically translate the volume to (0, 0, 0), apply the scaling/rotation,
+and then translate the volume back to its original location.  If the **Manual Transformation Matrix** or **Pre-Computed Transformation
+Matrix** types are selected, then it is up to the user to make sure that those translations are included, if necessary.
+
 ## Example Transformations
 
 | Description | Example Output Image |

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ApplyTransformationToGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ApplyTransformationToGeometry.cpp
@@ -1,7 +1,6 @@
 #include "ApplyTransformationToGeometry.hpp"
 
 #include "complex/DataStructure/DataArray.hpp"
-#include "complex/DataStructure/DataGroup.hpp"
 #include "complex/DataStructure/Geometry/INodeGeometry0D.hpp"
 #include "complex/Utilities/DataGroupUtilities.hpp"
 #include "complex/Utilities/ParallelAlgorithmUtilities.hpp"

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ApplyTransformationToGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ApplyTransformationToGeometry.cpp
@@ -155,10 +155,9 @@ Result<> ApplyTransformationToGeometry::operator()()
   ImageRotationUtilities::Matrix4fR translationFromGlobalOriginMat = ImageRotationUtilities::Matrix4fR::Identity();
   if(isNodeBased)
   {
-    Point3D<float32> minPoint = {0.0F, 0.0F, 0.0F};
     auto& nodeGeometry0D = m_DataStructure.getDataRefAs<INodeGeometry0D>(m_InputValues->SelectedGeometryPath);
     auto boundingBox = nodeGeometry0D.getBoundingBox();
-    minPoint = boundingBox.getMinPoint();
+    Point3Df minPoint = boundingBox.getMinPoint();
     translationToGlobalOriginMat = ImageRotationUtilities::GenerateTranslationTransformationMatrix({-minPoint[0], -minPoint[1], -minPoint[2]});
     translationFromGlobalOriginMat = ImageRotationUtilities::GenerateTranslationTransformationMatrix({minPoint[0], minPoint[1], minPoint[2]});
   }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ApplyTransformationToGeometry.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/ApplyTransformationToGeometry.cpp
@@ -32,7 +32,6 @@ const std::atomic_bool& ApplyTransformationToGeometry::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ApplyTransformationToGeometry::applyImageGeometryTransformation()
 {
-
   // Pure translation for Image Geom, just return
   if(m_InputValues->TransformationSelection == k_TranslationIdx)
   {
@@ -81,9 +80,9 @@ Result<> ApplyTransformationToGeometry::applyImageGeometryTransformation()
     const std::vector<usize> dims = {static_cast<usize>(rotateArgs.xpNew), static_cast<usize>(rotateArgs.ypNew), static_cast<usize>(rotateArgs.zpNew)};
     const std::vector<float32> spacing = {rotateArgs.xResNew, rotateArgs.yResNew, rotateArgs.zResNew};
     auto origin = srcImageGeom.getOrigin().toContainer<std::vector<float32>>();
-    origin[0] += rotateArgs.xMinNew;
-    origin[1] += rotateArgs.yMinNew;
-    origin[2] += rotateArgs.zMinNew;
+    origin[0] = rotateArgs.xMinNew;
+    origin[1] = rotateArgs.yMinNew;
+    origin[2] = rotateArgs.zMinNew;
 
     std::vector<usize> const dataArrayShape = {dims[2], dims[1], dims[0]}; // The DataArray shape goes slowest to fastest (ZYX), opposite of ImageGeometry dimensions
     destImageGeom.setDimensions(dims);
@@ -150,6 +149,21 @@ Result<> ApplyTransformationToGeometry::operator()()
     return MakeErrorResult(-84500, fmt::format("Keeping the original geometry is not supported."));
   }
 
+  auto* imageGeometryPtr = m_DataStructure.getDataAs<ImageGeom>(m_InputValues->SelectedGeometryPath);
+  const bool isNodeBased = (imageGeometryPtr == nullptr);
+
+  ImageRotationUtilities::Matrix4fR translationToGlobalOriginMat = ImageRotationUtilities::Matrix4fR::Identity();
+  ImageRotationUtilities::Matrix4fR translationFromGlobalOriginMat = ImageRotationUtilities::Matrix4fR::Identity();
+  if(isNodeBased)
+  {
+    Point3D<float32> minPoint = {0.0F, 0.0F, 0.0F};
+    auto& nodeGeometry0D = m_DataStructure.getDataRefAs<INodeGeometry0D>(m_InputValues->SelectedGeometryPath);
+    auto boundingBox = nodeGeometry0D.getBoundingBox();
+    minPoint = boundingBox.getMinPoint();
+    translationToGlobalOriginMat = ImageRotationUtilities::GenerateTranslationTransformationMatrix({-minPoint[0], -minPoint[1], -minPoint[2]});
+    translationFromGlobalOriginMat = ImageRotationUtilities::GenerateTranslationTransformationMatrix({minPoint[0], minPoint[1], minPoint[2]});
+  }
+
   switch(m_InputValues->TransformationSelection)
   {
   case k_NoTransformIdx: // No-Op
@@ -170,6 +184,12 @@ Result<> ApplyTransformationToGeometry::operator()()
   case k_RotationIdx: // Rotation via axis-angle
   {
     m_TransformationMatrix = ImageRotationUtilities::GenerateRotationTransformationMatrix(m_InputValues->Rotation);
+    if(isNodeBased)
+    {
+      // Translate the geometry to/from the global origin
+      m_TransformationMatrix = translationFromGlobalOriginMat * m_TransformationMatrix * translationToGlobalOriginMat;
+    }
+
     break;
   }
   case k_TranslationIdx: // Translation
@@ -180,19 +200,23 @@ Result<> ApplyTransformationToGeometry::operator()()
   case k_ScaleIdx: // Scale
   {
     m_TransformationMatrix = ImageRotationUtilities::GenerateScaleTransformationMatrix(m_InputValues->Scale);
+    if(isNodeBased)
+    {
+      // Translate the geometry to/from the global origin
+      m_TransformationMatrix = translationFromGlobalOriginMat * m_TransformationMatrix * translationToGlobalOriginMat;
+    }
     break;
   }
   }
 
-  auto* geometryPtr = m_DataStructure.getDataAs<ImageGeom>(m_InputValues->SelectedGeometryPath);
-
-  if(geometryPtr != nullptr) // Function for applying Image Transformation
+  // Apply geometry transformation
+  if(isNodeBased)
   {
-    applyImageGeometryTransformation();
+    applyNodeGeometryTransformation();
   }
   else
   {
-    applyNodeGeometryTransformation();
+    applyImageGeometryTransformation();
   }
 
   return {};

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApplyTransformationToGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ApplyTransformationToGeometryFilter.cpp
@@ -2,7 +2,6 @@
 
 #include "ComplexCore/Filters/Algorithms/ApplyTransformationToGeometry.hpp"
 
-#include "complex/Common/Constants.hpp"
 #include "complex/DataStructure/DataArray.hpp"
 #include "complex/DataStructure/DataPath.hpp"
 #include "complex/DataStructure/Geometry/ImageGeom.hpp"
@@ -191,9 +190,9 @@ IFilter::PreflightResult ApplyTransformationToGeometryFilter::preflightImpl(cons
     {
       auto pRotationValue = filterArgs.value<VectorFloat32Parameter::ValueType>(k_Rotation_Key);
       auto origin = imageGeomPtr->getOrigin();
-      ImageRotationUtilities::Matrix4fR translationToGlobalOriginMat = ImageRotationUtilities::GenerateTranslationTransformationMatrix({-origin[0], -origin[1], -origin[2]});
+      const ImageRotationUtilities::Matrix4fR translationToGlobalOriginMat = ImageRotationUtilities::GenerateTranslationTransformationMatrix({-origin[0], -origin[1], -origin[2]});
       transformationMatrix = ImageRotationUtilities::GenerateRotationTransformationMatrix(pRotationValue);
-      ImageRotationUtilities::Matrix4fR translationFromGlobalOriginMat = ImageRotationUtilities::GenerateTranslationTransformationMatrix({origin[0], origin[1], origin[2]});
+      const ImageRotationUtilities::Matrix4fR translationFromGlobalOriginMat = ImageRotationUtilities::GenerateTranslationTransformationMatrix({origin[0], origin[1], origin[2]});
       transformationMatrix = translationFromGlobalOriginMat * transformationMatrix * translationToGlobalOriginMat;
       transformationMatrixDesc = ImageRotationUtilities::GenerateTransformationMatrixDescription(transformationMatrix);
       break;
@@ -209,9 +208,9 @@ IFilter::PreflightResult ApplyTransformationToGeometryFilter::preflightImpl(cons
     {
       auto pScaleValue = filterArgs.value<VectorFloat32Parameter::ValueType>(k_Scale_Key);
       auto origin = imageGeomPtr->getOrigin();
-      ImageRotationUtilities::Matrix4fR translationToGlobalOriginMat = ImageRotationUtilities::GenerateTranslationTransformationMatrix({-origin[0], -origin[1], -origin[2]});
+      const ImageRotationUtilities::Matrix4fR translationToGlobalOriginMat = ImageRotationUtilities::GenerateTranslationTransformationMatrix({-origin[0], -origin[1], -origin[2]});
       transformationMatrix = ImageRotationUtilities::GenerateScaleTransformationMatrix(pScaleValue);
-      ImageRotationUtilities::Matrix4fR translationFromGlobalOriginMat = ImageRotationUtilities::GenerateTranslationTransformationMatrix({origin[0], origin[1], origin[2]});
+      const ImageRotationUtilities::Matrix4fR translationFromGlobalOriginMat = ImageRotationUtilities::GenerateTranslationTransformationMatrix({origin[0], origin[1], origin[2]});
       transformationMatrix = translationFromGlobalOriginMat * transformationMatrix * translationToGlobalOriginMat;
       transformationMatrixDesc = ImageRotationUtilities::GenerateTransformationMatrixDescription(transformationMatrix);
       break;

--- a/src/Plugins/ComplexCore/test/ApplyTransformationToGeometryTest.cpp
+++ b/src/Plugins/ComplexCore/test/ApplyTransformationToGeometryTest.cpp
@@ -27,7 +27,6 @@ namespace
 
 namespace apply_transformation_to_geometry
 {
-const complex::ChoicesParameter::ValueType k_NoTransformIdx = 0ULL;
 const complex::ChoicesParameter::ValueType k_PrecomputedTransformationMatrixIdx = 1ULL;
 const complex::ChoicesParameter::ValueType k_ManualTransformationMatrixIdx = 2ULL;
 const complex::ChoicesParameter::ValueType k_RotationIdx = 3ULL;
@@ -45,7 +44,6 @@ const std::string k_TranslationGeometryName("6_6_Translation");
 const std::string k_ManualGeometryName("6_6_Manual");
 const std::string k_PrecomputedGeometryName("6_6_Precomputed");
 
-const std::string k_InputGeometryName66("InputData");
 const std::string k_RotationGeometryName66("6_6_Rotation");
 const std::string k_ScaleGeometryName66("6_6_Scale");
 const std::string k_TranslationGeometryName66("6_6_Translation");

--- a/src/Plugins/ITKImageProcessing/CMakeLists.txt
+++ b/src/Plugins/ITKImageProcessing/CMakeLists.txt
@@ -308,7 +308,7 @@ if(EXISTS "${DREAM3D_DATA_DIR}" AND COMPLEX_DOWNLOAD_TEST_FILES)
   
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR}
                    ARCHIVE_NAME ITKMhaFileReaderTest.tar.gz
-                   SHA512 7b44c28dad8dc70ad79f9dc6247ab2a17e3c0e08cf0400e361acaea965b0881eaa3815af21c1ec9bdba19f70c0bdd67b7c4382e527c844a20da39d6a229dc5fa)   
+                   SHA512 8db2efc772ccd96f1dc4113b262c5469cfc7299dafddeb53a807d8d62a0dbc9a29493438728c44cc345d5e2d2911bd2d0af6e2be8fe0713c883143bdf6bd814f)
                    
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR}
                    ARCHIVE_NAME Porosity_Image.tar.gz

--- a/src/Plugins/ITKImageProcessing/CMakeLists.txt
+++ b/src/Plugins/ITKImageProcessing/CMakeLists.txt
@@ -307,8 +307,8 @@ if(EXISTS "${DREAM3D_DATA_DIR}" AND COMPLEX_DOWNLOAD_TEST_FILES)
   endif()
   
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR}
-                   ARCHIVE_NAME ITKMhaFileReaderTest.tar.gz
-                   SHA512 8db2efc772ccd96f1dc4113b262c5469cfc7299dafddeb53a807d8d62a0dbc9a29493438728c44cc345d5e2d2911bd2d0af6e2be8fe0713c883143bdf6bd814f)
+                   ARCHIVE_NAME ITKMhaFileReaderTest_rev2.tar.gz
+                   SHA512 82592ffb6904389da1475e9c57f0be724d29db22ba9c942fd02d08ce3f8c73dc39a245503e584e56ca4ea7554d63cf1db5fb46e6e426768020f1ca0542822d0a)
                    
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR}
                    ARCHIVE_NAME Porosity_Image.tar.gz

--- a/src/Plugins/ITKImageProcessing/test/ITKMhaFileReaderTest.cpp
+++ b/src/Plugins/ITKImageProcessing/test/ITKMhaFileReaderTest.cpp
@@ -14,7 +14,7 @@ using namespace complex;
 
 TEST_CASE("ITKImageProcessing::ITKMhaFileReader: Read 2D & 3D Image Data", "[ITKImageProcessing][ITKMhaFileReader]")
 {
-  const complex::UnitTest::TestFileSentinel testDataSentinel(complex::unit_test::k_CMakeExecutable, complex::unit_test::k_TestFilesDir, "ITKMhaFileReaderTest.tar.gz", "ITKMhaFileReaderTest");
+  const complex::UnitTest::TestFileSentinel testDataSentinel(complex::unit_test::k_CMakeExecutable, complex::unit_test::k_TestFilesDir, "ITKMhaFileReaderTest_rev2.tar.gz", "ITKMhaFileReaderTest");
 
   // Load plugins (this is needed because ITKMhaFileReader needs access to the ComplexCore plugin)
   const std::shared_ptr<UnitTest::make_shared_enabler> app = std::make_shared<UnitTest::make_shared_enabler>();

--- a/src/complex/Utilities/ImageRotationUtilities.cpp
+++ b/src/complex/Utilities/ImageRotationUtilities.cpp
@@ -218,12 +218,7 @@ ImageRotationUtilities::Matrix4fR GenerateRotationTransformationMatrix(const Vec
 //------------------------------------------------------------------------------
 ImageRotationUtilities::Matrix4fR GenerateTranslationTransformationMatrix(const VectorFloat32Parameter::ValueType& pTranslationValue)
 {
-  ImageRotationUtilities::Matrix4fR transformationMatrix;
-  transformationMatrix.fill(0.0F);
-  transformationMatrix(0, 0) = 1.0f;
-  transformationMatrix(1, 1) = 1.0f;
-  transformationMatrix(2, 2) = 1.0f;
-  transformationMatrix(3, 3) = 1.0f;
+  ImageRotationUtilities::Matrix4fR transformationMatrix = ImageRotationUtilities::Matrix4fR::Identity();
   transformationMatrix(0, 3) = pTranslationValue[0];
   transformationMatrix(1, 3) = pTranslationValue[1];
   transformationMatrix(2, 3) = pTranslationValue[2];

--- a/src/complex/Utilities/ImageRotationUtilities.cpp
+++ b/src/complex/Utilities/ImageRotationUtilities.cpp
@@ -67,9 +67,9 @@ float DetermineSpacing(const FloatVec3& spacing, const Eigen::Vector3f& axisNew)
 
   const std::array<float, 3> axes = {xAngle, yAngle, zAngle};
 
-  const std::array<float, 3>::const_iterator maxElementIter = std::max_element(axes.cbegin(), axes.cend());
+  const std::array<float, 3>::const_iterator maxElementIterPtr = std::max_element(axes.cbegin(), axes.cend());
 
-  const size_t index = std::distance(axes.cbegin(), maxElementIter);
+  const size_t index = std::distance(axes.cbegin(), maxElementIterPtr);
 
   return spacing[index];
 }


### PR DESCRIPTION
+ Automatically add translations to/from (0, 0, 0) for Scaling and Rotation transformation types.

+ Only calculate rotation args if absolutely required.

+ Set transformed origin to the minimum coordinate from the transformed volume.