### PR TITLE
BUG: Catch nullptr trying to rename DataObject

### DIFF
--- a/src/complex/DataStructure/DataObject.cpp
+++ b/src/complex/DataStructure/DataObject.cpp
@@ -164,14 +164,15 @@ std::string DataObject::getName() const
 
 bool DataObject::canRename(const std::string& name) const
 {
-  if(!IsValidName(name))
-  {
-    return false;
-  }
-
+  
   if(name == getName())
   {
     return true;
+  }
+
+  if(!IsValidName(name))
+  {
+    return false;
   }
 
   const auto* dataStructPtr = getDataStructure();
@@ -192,11 +193,6 @@ bool DataObject::canRename(const std::string& name) const
 
 bool DataObject::rename(const std::string& name)
 {
-  if(name == m_Name)
-  {
-    return true;
-  }
-
   if(!canRename(name))
   {
     return false;

--- a/src/complex/DataStructure/DataObject.cpp
+++ b/src/complex/DataStructure/DataObject.cpp
@@ -169,16 +169,34 @@ bool DataObject::canRename(const std::string& name) const
     return false;
   }
 
-  auto dataStruct = getDataStructure();
-  if(dataStruct == nullptr)
+  if(name == getName())
+  {
+    return true;
+  }
+
+  const auto* dataStructPtr = getDataStructure();
+  if(dataStructPtr == nullptr)
   {
     return false;
   }
-  return !std::any_of(m_ParentList.cbegin(), m_ParentList.cend(), [dataStruct, name](IdType parentId) { return dataStruct->getDataAs<BaseGroup>(parentId)->contains(name); });
+
+  return !std::any_of(m_ParentList.cbegin(), m_ParentList.cend(), [dataStructPtr, name](IdType parentId) {
+    const auto* baseGroupPtr = dataStructPtr->getDataAs<BaseGroup>(parentId);
+    if(baseGroupPtr == nullptr)
+    {
+      std::cout << "DataObject::canRename(name=" << name << ") cannot get baseGroup from parentId = " << parentId << std::endl;
+    }
+    return baseGroupPtr != nullptr && baseGroupPtr->contains(name);
+  });
 }
 
 bool DataObject::rename(const std::string& name)
 {
+  if(name == m_Name)
+  {
+    return true;
+  }
+
   if(!canRename(name))
   {
     return false;


### PR DESCRIPTION
Fix an unchecked pointer access in DataObject::canRename() in the lambda