### PR TITLE
FILTER : WriteStatsGenOdfAngleFile

### DIFF
--- a/src/Plugins/OrientationAnalysis/CMakeLists.txt
+++ b/src/Plugins/OrientationAnalysis/CMakeLists.txt
@@ -71,6 +71,7 @@ set(FilterList
   RodriguesConvertorFilter
   RotateEulerRefFrameFilter
   WritePoleFigureFilter
+  WriteStatsGenOdfAngleFileFilter
 )
   
 set(STUB_FILTERS
@@ -91,9 +92,6 @@ set(STUB_FILTERS
   GenerateFaceMisorientationColoring
   GenerateOrientationMatrixTranspose
   # ImportEbsdMontage # MISSING 1 or more Parameter Implementations
-  # OrientationUtility # MISSING 1 or more Parameter Implementations  
-  #OrientationUtility # MISSING 1 or more Parameter Implementations
-  WriteStatsGenOdfAngleFile
 )
 
 create_complex_plugin(NAME ${PLUGIN_NAME}
@@ -205,6 +203,7 @@ set(filter_algorithms
   RodriguesConvertor
   RotateEulerRefFrame
   WritePoleFigure
+  WriteStatsGenOdfAngleFile
 )
 
 

--- a/src/Plugins/OrientationAnalysis/docs/WriteStatsGenOdfAngleFileFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/WriteStatsGenOdfAngleFileFilter.md
@@ -1,0 +1,103 @@
+# Export StatsGenerator ODF Angle File
+
+## Group (Subgroup)
+
+IO (Output)
+
+## Description 
+
+This **Filter** is used in a workflow where the user would like to generate a synthetic microstructure with an ODF that matches (as closely as possible) an existing experimental data set or other data set that is being mimicked. The basic workflow is the following:
+
+1. Import Euler angle data (e.g., ANG or CTF files)
+2. Optionally threshold the data so each cell is marked as allowable or not-allowable
+3. Insert the "Export StatsGenerator ODF Angle File" **Filter** in the **Pipeline**
+4. Run the **Pipeline** to produce the file
+5. Launch **StatsGenerator**
+6. Generate the data
+7. Click on the ODF Tab
+8. Click on the *Bulk Load* sub tab
+9. Select the file that was just written
+10. Load the data and inspect the ODF that was generated
+
+
+## Important Change from Earlier Versions of StatsGenerator 
+
+**StatsGenerator can not load data from standard .ang or .ctf files. If you want to get the ODF from an existing experimental data set and you have one of those files then you must use the functionality of this filter**
+
+## Notes on Implementation 
+
++ A separate file is written for each phase
++ Spaces are the default as the delimiters between values. The user can select another value
++ Default values of 1.0 are used for both the _weight_ and _sigma_. **If the user needs a stronger texture due to a low number of angles then larger values should be used such as 10, 100 or even 1000.**
++ The user has the option to convert the supplied Euler angles to degrees. **StatsGenerator** is able to import Euler angles as either degrees or radians based on user input, so the output type from this **Filter** could remain as radians or be converted to degrees. The user should remain cognizant of what representation their angles are in so that the correct option is chosen during the import process in **StatsGenerator**
+
+## Example File 
+
+The file written is a simple text file that contains a short comment section and a single _Header_ line of data. All comment lines should come **BEFORE** the actual header line. There is a single header line in the form of "Key:Value" and then the lines of data.
+
+	# All lines starting with '#' are comments and should come before the header.
+	# DREAM.3D StatsGenerator Angles Input File
+	# DREAM.3D Version 6.1.107.0d8bad9
+	# Angle Data is space delimited.
+	# Euler0 Euler1 Euler2 Weight Sigma
+	Angle Count:100
+	0 0 0 1 1
+	3.6 1.8 3.6 1 1
+	7.2 3.6 7.2 1 1
+	10.8 5.4 10.8 1 1
+	14.4 7.2 14.4 1 1
+	
+The **only** required header line is:
+
+	Angle Count:100
+
+There are 5 columns of data which are the 3 Euler Angles, the Weight Value and the Sigma Value.
+
+
+### Delimiter 
+
+Choice of delimiter is as follows:
+
+    0 = , (comma)
+    1 = ; (semicolon)
+    2 = (space)   <==== DEFAULT VALUE
+    3 = : (colon)
+    4 = \t (tab)
+
+
+## Parameters 
+
+| Name | Type | Description |
+|---------|---------| --------------- |
+| Output File | File Path | Output angles file path |
+| Default Weight | float | This value will be used for the Weight column |
+| Default Sigma | int | This value will be used for the Sigma column |
+| Delimiter | Enumeration | The delimiter separating the data |
+| Convert to Degrees | bool | Whether to convert the Euler angles from radians to degrees. If the Euler angles are already in degrees, this option will "convert" the data again, resulting in garbage orientations! |
+| Only Write Good Elements | bool | Whether to only write the Euler angles for those elements denoted as true in the supplied mask array |
+
+
+## Required Objects 
+
+| Kind | Default Name | Type | Component Dimensions | Description |
+|-------|---------------------|--------|---------------------------------|-----------------|
+| **Element Attribute Array** | EulerAngles | float | (3) | Three angles defining the orientation of the **Element** in Bunge convention (Z-X-Z) |
+| **Element Attribute Array** | Phases | int32_t | (1) |  Specifies to which **Ensemble** each **Element** belongs |
+| **Element Attribute Array** | Mask | bool | (1) | Used to define **Elements** as *good* or *bad*. Only required if _Only Write Good Elements_ is checked |
+
+## Created Objects 
+
+None
+
+## Example Pipelines 
+
++ Export Small IN100 ODF Data (StatsGenerator)
+
+## License & Copyright 
+
+Please see the description file distributed with this **Plugin**
+
+## DREAM.3D Mailing Lists 
+
+If you need more help with a **Filter**, please consider asking your question on the [DREAM.3D Users Google group!](https://groups.google.com/forum/?hl=en#!forum/dream3d-users)
+

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteStatsGenOdfAngleFile.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteStatsGenOdfAngleFile.cpp
@@ -1,0 +1,172 @@
+#include "WriteStatsGenOdfAngleFile.hpp"
+
+#include "complex/Common/Constants.hpp"
+#include "complex/DataStructure/DataArray.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
+#include "complex/Utilities/StringUtilities.hpp"
+
+class QFile;
+using namespace complex;
+
+namespace
+{
+constexpr std::array<char, 5> k_Delimiters = {',', ';', ' ', '"', '\t'};
+const std::array<std::string, 5> k_DelimiterStr = {"Comma", "Semicolon", "Space", "Colon", "Tab"};
+} // namespace
+
+// -----------------------------------------------------------------------------
+WriteStatsGenOdfAngleFile::WriteStatsGenOdfAngleFile(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel,
+                                                     WriteStatsGenOdfAngleFileInputValues* inputValues)
+: m_DataStructure(dataStructure)
+, m_InputValues(inputValues)
+, m_ShouldCancel(shouldCancel)
+, m_MessageHandler(mesgHandler)
+{
+}
+
+// -----------------------------------------------------------------------------
+WriteStatsGenOdfAngleFile::~WriteStatsGenOdfAngleFile() noexcept = default;
+
+// -----------------------------------------------------------------------------
+const std::atomic_bool& WriteStatsGenOdfAngleFile::getCancel()
+{
+  return m_ShouldCancel;
+}
+
+// -----------------------------------------------------------------------------
+Result<> WriteStatsGenOdfAngleFile::operator()()
+{
+  Result<> results;
+
+  // Make sure any directory path is also available as the user may have just typed
+  // in a path without actually creating the full path
+  Result<> createDirectoriesResult = CreateOutputDirectories(m_InputValues->OutputFile.parent_path());
+  if(createDirectoriesResult.invalid())
+  {
+    return createDirectoriesResult;
+  }
+
+  const auto& cellPhases = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->CellPhasesArrayPath);
+  BoolArray* maskPtr = nullptr;
+  if(m_InputValues->UseGoodVoxels)
+  {
+    maskPtr = m_DataStructure.getDataAs<BoolArray>(m_InputValues->GoodVoxelsArrayPath);
+  }
+
+  // Figure out how many unique phase values we have by looping over all the phase values
+  const usize totalPoints = cellPhases.getNumberOfTuples();
+  std::set<int32> uniquePhases;
+  for(usize i = 0; i < totalPoints; i++)
+  {
+    uniquePhases.insert(cellPhases[i]);
+  }
+
+  uniquePhases.erase(0); // remove Phase 0 as this is a Special Phase for DREAM3D
+
+  const std::string absPath = std::filesystem::absolute(m_InputValues->OutputFile).parent_path().string();
+  const std::string fName = m_InputValues->OutputFile.stem().string();
+  const std::string suffix = m_InputValues->OutputFile.extension().string();
+
+  for(const auto& phase : uniquePhases)
+  {
+    // Dry run to figure out how many lines we are going to have
+    int32 const lineCount = determineOutputLineCount(cellPhases, maskPtr, totalPoints, phase);
+    if(lineCount == 0)
+    {
+      results = MergeResults(results, MakeWarningVoidResult(-9403, fmt::format("No valid data for phase '{}'. No ODF Angle file written for phase.", phase)));
+      continue;
+    }
+
+    m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Writing file for phase '{}'", phase));
+
+    const std::string absFilePath = fmt::format("{}/{}_Phase_{}{}", absPath, fName, phase, suffix);
+
+    std::ofstream file(absFilePath, std::ios::out | std::ios::trunc | std::ios_base::binary);
+    if(!file.is_open())
+    {
+      return MakeErrorResult(-9404, fmt::format("Error creating output file '{}'", absFilePath));
+    }
+
+    Result<> writeResult = writeOutputFile(file, cellPhases, maskPtr, lineCount, totalPoints, phase);
+    if(writeResult.invalid())
+    {
+      return writeResult;
+    }
+    file.flush();
+    file.close();
+  }
+
+  return results;
+}
+
+// -----------------------------------------------------------------------------
+int WriteStatsGenOdfAngleFile::determineOutputLineCount(const Int32Array& cellPhases, const BoolArray* mask, usize totalPoints, int32 phase) const
+{
+  int32 lineCount = 0;
+  for(usize i = 0; i < totalPoints; i++)
+  {
+    if(cellPhases[i] == phase)
+    {
+      if(!m_InputValues->UseGoodVoxels || (m_InputValues->UseGoodVoxels && (*mask)[i]))
+      {
+        lineCount++;
+      }
+    }
+  }
+
+  return lineCount;
+}
+
+// -----------------------------------------------------------------------------
+Result<> WriteStatsGenOdfAngleFile::writeOutputFile(std::ofstream& out, const Int32Array& cellPhases, const BoolArray* mask, int32 lineCount, usize totalPoints, int32 phase) const
+{
+  const auto& eulerAngles = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->CellEulerAnglesArrayPath);
+
+  out << "# All lines starting with '#' are comments and should come before the data.\n";
+  out << "# DREAM.3D StatsGenerator ODF Angles Input File\n";
+  out << "# DREAM.3D Version 7.0.0\n";
+
+  const auto delimiter = k_Delimiters[m_InputValues->Delimiter];
+
+  out << "# Angle Data is " << k_DelimiterStr[m_InputValues->Delimiter] << " delimited.\n";
+
+  if(m_InputValues->ConvertToDegrees)
+  {
+    out << "# Euler angles are expressed in degrees\n";
+  }
+  else
+  {
+    out << "# Euler angles are expressed in radians\n";
+  }
+  out << "# Euler0 Euler1 Euler2 Weight Sigma\n";
+  out << "Angle Count:" << lineCount << "\n";
+
+  for(usize i = 0; i < totalPoints; i++)
+  {
+    bool writeLine = false;
+
+    if(cellPhases[i] == phase)
+    {
+      if(!m_InputValues->UseGoodVoxels || (m_InputValues->UseGoodVoxels && (*mask)[i]))
+      {
+        writeLine = true;
+      }
+    }
+
+    if(writeLine)
+    {
+      float32 euler0 = eulerAngles[i * 3 + 0];
+      float32 euler1 = eulerAngles[i * 3 + 1];
+      float32 euler2 = eulerAngles[i * 3 + 2];
+      if(m_InputValues->ConvertToDegrees)
+      {
+        euler0 = euler0 * Constants::k_180OverPiF;
+        euler1 = euler1 * Constants::k_180OverPiF;
+        euler2 = euler2 * Constants::k_180OverPiF;
+      }
+      out << std::fixed << std::setprecision(8) << euler0 << delimiter << euler1 << delimiter << euler2 << delimiter << m_InputValues->Weight << delimiter << m_InputValues->Sigma << "\n";
+    }
+  }
+
+  return {};
+}

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteStatsGenOdfAngleFile.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteStatsGenOdfAngleFile.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "OrientationAnalysis/OrientationAnalysis_export.hpp"
+
+#include "complex/DataStructure/DataArray.hpp"
+#include "complex/DataStructure/DataPath.hpp"
+#include "complex/DataStructure/DataStructure.hpp"
+#include "complex/Filter/IFilter.hpp"
+#include "complex/Parameters/ChoicesParameter.hpp"
+#include "complex/Parameters/FileSystemPathParameter.hpp"
+namespace complex
+{
+
+struct ORIENTATIONANALYSIS_EXPORT WriteStatsGenOdfAngleFileInputValues
+{
+  FileSystemPathParameter::ValueType OutputFile;
+  float32 Weight;
+  int32 Sigma;
+  ChoicesParameter::ValueType Delimiter;
+  bool ConvertToDegrees;
+  bool UseGoodVoxels;
+  DataPath CellEulerAnglesArrayPath;
+  DataPath CellPhasesArrayPath;
+  DataPath GoodVoxelsArrayPath;
+};
+
+/**
+ * @class WriteStatsGenOdfAngleFile
+ * @brief This filter will generate a synthetic microstructure with an ODF that matches (as closely as possible) an existing experimental data set or other data set that is being mimicked..
+ */
+
+class ORIENTATIONANALYSIS_EXPORT WriteStatsGenOdfAngleFile
+{
+public:
+  WriteStatsGenOdfAngleFile(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, WriteStatsGenOdfAngleFileInputValues* inputValues);
+  ~WriteStatsGenOdfAngleFile() noexcept;
+
+  WriteStatsGenOdfAngleFile(const WriteStatsGenOdfAngleFile&) = delete;
+  WriteStatsGenOdfAngleFile(WriteStatsGenOdfAngleFile&&) noexcept = delete;
+  WriteStatsGenOdfAngleFile& operator=(const WriteStatsGenOdfAngleFile&) = delete;
+  WriteStatsGenOdfAngleFile& operator=(WriteStatsGenOdfAngleFile&&) noexcept = delete;
+
+  Result<> operator()();
+
+  const std::atomic_bool& getCancel();
+
+  int determineOutputLineCount(const Int32Array& cellPhases, const BoolArray* mask, usize totalPoints, int32 phase) const;
+  Result<> writeOutputFile(std::ofstream& out, const Int32Array& cellPhases, const BoolArray* mask, int32 lineCount, usize totalPoints, int32 phase) const;
+
+private:
+  DataStructure& m_DataStructure;
+  const WriteStatsGenOdfAngleFileInputValues* m_InputValues = nullptr;
+  const std::atomic_bool& m_ShouldCancel;
+  const IFilter::MessageHandler& m_MessageHandler;
+};
+
+} // namespace complex

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteStatsGenOdfAngleFileFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteStatsGenOdfAngleFileFilter.cpp
@@ -1,0 +1,148 @@
+#include "WriteStatsGenOdfAngleFileFilter.hpp"
+
+#include "OrientationAnalysis/Filters/Algorithms/WriteStatsGenOdfAngleFile.hpp"
+
+#include "complex/DataStructure/DataPath.hpp"
+#include "complex/Filter/Actions/EmptyAction.hpp"
+#include "complex/Parameters/ArraySelectionParameter.hpp"
+#include "complex/Parameters/BoolParameter.hpp"
+#include "complex/Parameters/ChoicesParameter.hpp"
+#include "complex/Parameters/FileSystemPathParameter.hpp"
+#include "complex/Parameters/NumberParameter.hpp"
+
+#include <filesystem>
+namespace fs = std::filesystem;
+
+using namespace complex;
+
+namespace complex
+{
+//------------------------------------------------------------------------------
+std::string WriteStatsGenOdfAngleFileFilter::name() const
+{
+  return FilterTraits<WriteStatsGenOdfAngleFileFilter>::name.str();
+}
+
+//------------------------------------------------------------------------------
+std::string WriteStatsGenOdfAngleFileFilter::className() const
+{
+  return FilterTraits<WriteStatsGenOdfAngleFileFilter>::className;
+}
+
+//------------------------------------------------------------------------------
+Uuid WriteStatsGenOdfAngleFileFilter::uuid() const
+{
+  return FilterTraits<WriteStatsGenOdfAngleFileFilter>::uuid;
+}
+
+//------------------------------------------------------------------------------
+std::string WriteStatsGenOdfAngleFileFilter::humanName() const
+{
+  return "Export StatsGenerator ODF Angle File";
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> WriteStatsGenOdfAngleFileFilter::defaultTags() const
+{
+  return {"IO", "Output", "Write", "Export"};
+}
+
+//------------------------------------------------------------------------------
+Parameters WriteStatsGenOdfAngleFileFilter::parameters() const
+{
+  Parameters params;
+
+  // Create the parameter descriptors that are needed for this filter
+  params.insertSeparator(Parameters::Separator{"Input Parameters"});
+  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputFile_Key, "Output File", "The output angles file path", fs::path("Data/Output/StatsGenODF.txt"),
+                                                          FileSystemPathParameter::ExtensionsType{}, FileSystemPathParameter::PathType::OutputFile));
+  params.insert(std::make_unique<Float32Parameter>(k_Weight_Key, "Default Weight", "This value will be used for the Weight column", 1.0f));
+  params.insert(std::make_unique<Int32Parameter>(k_Sigma_Key, "Default Sigma", "This value will be used for the Sigma column", 1));
+  params.insert(std::make_unique<ChoicesParameter>(k_Delimiter_Key, "Delimiter", "The delimiter separating the data", k_SpaceDelimiter,
+                                                   ChoicesParameter::Choices{", (comma)", "; (semicolon)", " (space)", ": (colon)", "\\t {tab}"}));
+  params.insert(std::make_unique<BoolParameter>(
+      k_ConvertToDegrees_Key, "Convert to Degrees",
+      "Whether to convert the Euler angles from radians to degrees. If the Euler angles are already in degrees, this option will 'convert' the data again, resulting in garbage orientations!", false));
+  params.insertLinkableParameter(
+      std::make_unique<BoolParameter>(k_UseGoodVoxels_Key, "Only Write Good Elements", "Whether to only write the Euler angles for those elements denoted as true in the supplied mask array", false));
+  params.insertSeparator(Parameters::Separator{"Required Element Data"});
+  params.insert(std::make_unique<ArraySelectionParameter>(k_CellEulerAnglesArrayPath_Key, "Euler Angles", "Three angles defining the orientation of the Element in Bunge convention (Z-X-Z)",
+                                                          DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::float32}, ArraySelectionParameter::AllowedComponentShapes{{3}}));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_CellPhasesArrayPath_Key, "Phases", "Specifies to which Ensemble each Element belongs", DataPath{},
+                                                          ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_GoodVoxelsArrayPath_Key, "Mask", "Used to define Elements as good or bad. Only required if Only Write Good Elements is checked", DataPath{},
+                                                          ArraySelectionParameter::AllowedTypes{DataType::boolean}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
+  // Associate the Linkable Parameter(s) to the children parameters that they control
+  params.linkParameters(k_UseGoodVoxels_Key, k_GoodVoxelsArrayPath_Key, true);
+
+  return params;
+}
+
+//------------------------------------------------------------------------------
+IFilter::UniquePointer WriteStatsGenOdfAngleFileFilter::clone() const
+{
+  return std::make_unique<WriteStatsGenOdfAngleFileFilter>();
+}
+
+//------------------------------------------------------------------------------
+IFilter::PreflightResult WriteStatsGenOdfAngleFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
+                                                                        const std::atomic_bool& shouldCancel) const
+{
+  auto pOutputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key);
+  auto pWeightValue = filterArgs.value<float32>(k_Weight_Key);
+  auto pSigmaValue = filterArgs.value<int32>(k_Sigma_Key);
+  auto pDelimiterValue = filterArgs.value<ChoicesParameter::ValueType>(k_Delimiter_Key);
+  auto pConvertToDegreesValue = filterArgs.value<bool>(k_ConvertToDegrees_Key);
+  auto pUseGoodVoxelsValue = filterArgs.value<bool>(k_UseGoodVoxels_Key);
+  auto pCellEulerAnglesArrayPathValue = filterArgs.value<DataPath>(k_CellEulerAnglesArrayPath_Key);
+  auto pCellPhasesArrayPathValue = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
+  auto pGoodVoxelsArrayPathValue = filterArgs.value<DataPath>(k_GoodVoxelsArrayPath_Key);
+
+  PreflightResult preflightResult;
+  complex::Result<OutputActions> resultOutputActions;
+  std::vector<PreflightValue> preflightUpdatedValues;
+
+  if(pWeightValue < 1.0f)
+  {
+    MakePreflightErrorResult(-9400, "The default 'Weight' value should be at least 1.0. Undefined results will occur from this filter.");
+  }
+
+  if(pSigmaValue < 1)
+  {
+    MakePreflightErrorResult(-9401, "The default 'Sigma' value should be at least 1. Undefined results will occur from this filter.");
+  }
+
+  std::vector<DataPath> dataArrays = {pCellEulerAnglesArrayPathValue, pCellPhasesArrayPathValue};
+  if(pUseGoodVoxelsValue)
+  {
+    dataArrays.push_back(pGoodVoxelsArrayPathValue);
+  }
+  if(!dataStructure.validateNumberOfTuples(dataArrays))
+  {
+    MakePreflightErrorResult(
+        -9402,
+        "One or more of the input arrays (euler angles, phases, and mask) does not have matching numbers of tuples. Make sure you are selecting cell level arrays from the same attribute matrix.");
+  }
+
+  return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
+}
+
+//------------------------------------------------------------------------------
+Result<> WriteStatsGenOdfAngleFileFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                                                      const std::atomic_bool& shouldCancel) const
+{
+  WriteStatsGenOdfAngleFileInputValues inputValues;
+
+  inputValues.OutputFile = filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key);
+  inputValues.Weight = filterArgs.value<float32>(k_Weight_Key);
+  inputValues.Sigma = filterArgs.value<int32>(k_Sigma_Key);
+  inputValues.Delimiter = filterArgs.value<ChoicesParameter::ValueType>(k_Delimiter_Key);
+  inputValues.ConvertToDegrees = filterArgs.value<bool>(k_ConvertToDegrees_Key);
+  inputValues.UseGoodVoxels = filterArgs.value<bool>(k_UseGoodVoxels_Key);
+  inputValues.CellEulerAnglesArrayPath = filterArgs.value<DataPath>(k_CellEulerAnglesArrayPath_Key);
+  inputValues.CellPhasesArrayPath = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
+  inputValues.GoodVoxelsArrayPath = filterArgs.value<DataPath>(k_GoodVoxelsArrayPath_Key);
+
+  return WriteStatsGenOdfAngleFile(dataStructure, messageHandler, shouldCancel, &inputValues)();
+}
+} // namespace complex

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteStatsGenOdfAngleFileFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteStatsGenOdfAngleFileFilter.cpp
@@ -63,15 +63,18 @@ Parameters WriteStatsGenOdfAngleFileFilter::parameters() const
   params.insert(std::make_unique<BoolParameter>(
       k_ConvertToDegrees_Key, "Convert to Degrees",
       "Whether to convert the Euler angles from radians to degrees. If the Euler angles are already in degrees, this option will 'convert' the data again, resulting in garbage orientations!", false));
+
+  params.insertSeparator(Parameters::Separator{"Optional Data Mask"});
   params.insertLinkableParameter(
       std::make_unique<BoolParameter>(k_UseGoodVoxels_Key, "Only Write Good Elements", "Whether to only write the Euler angles for those elements denoted as true in the supplied mask array", false));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_GoodVoxelsArrayPath_Key, "Mask", "Used to define Elements as good or bad. Only required if Only Write Good Elements is checked", DataPath{},
+                                                          ArraySelectionParameter::AllowedTypes{DataType::boolean}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
+
   params.insertSeparator(Parameters::Separator{"Required Element Data"});
   params.insert(std::make_unique<ArraySelectionParameter>(k_CellEulerAnglesArrayPath_Key, "Euler Angles", "Three angles defining the orientation of the Element in Bunge convention (Z-X-Z)",
                                                           DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::float32}, ArraySelectionParameter::AllowedComponentShapes{{3}}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_CellPhasesArrayPath_Key, "Phases", "Specifies to which Ensemble each Element belongs", DataPath{},
                                                           ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_GoodVoxelsArrayPath_Key, "Mask", "Used to define Elements as good or bad. Only required if Only Write Good Elements is checked", DataPath{},
-                                                          ArraySelectionParameter::AllowedTypes{DataType::boolean}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
   // Associate the Linkable Parameter(s) to the children parameters that they control
   params.linkParameters(k_UseGoodVoxels_Key, k_GoodVoxelsArrayPath_Key, true);
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteStatsGenOdfAngleFileFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteStatsGenOdfAngleFileFilter.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "OrientationAnalysis/OrientationAnalysis_export.hpp"
+
+#include "complex/Filter/FilterTraits.hpp"
+#include "complex/Filter/IFilter.hpp"
+
+namespace complex
+{
+/**
+ * @class WriteStatsGenOdfAngleFileFilter
+ * @brief This filter will generate a synthetic microstructure with an ODF that matches (as closely as possible) an existing experimental data set or other data set that is being mimicked.
+ */
+class ORIENTATIONANALYSIS_EXPORT WriteStatsGenOdfAngleFileFilter : public IFilter
+{
+public:
+  WriteStatsGenOdfAngleFileFilter() = default;
+  ~WriteStatsGenOdfAngleFileFilter() noexcept override = default;
+
+  WriteStatsGenOdfAngleFileFilter(const WriteStatsGenOdfAngleFileFilter&) = delete;
+  WriteStatsGenOdfAngleFileFilter(WriteStatsGenOdfAngleFileFilter&&) noexcept = delete;
+
+  WriteStatsGenOdfAngleFileFilter& operator=(const WriteStatsGenOdfAngleFileFilter&) = delete;
+  WriteStatsGenOdfAngleFileFilter& operator=(WriteStatsGenOdfAngleFileFilter&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_OutputFile_Key = "output_file";
+  static inline constexpr StringLiteral k_Weight_Key = "weight";
+  static inline constexpr StringLiteral k_Sigma_Key = "sigma";
+  static inline constexpr StringLiteral k_Delimiter_Key = "delimiter";
+  static inline constexpr StringLiteral k_ConvertToDegrees_Key = "convert_to_degrees";
+  static inline constexpr StringLiteral k_UseGoodVoxels_Key = "use_good_voxels";
+  static inline constexpr StringLiteral k_CellEulerAnglesArrayPath_Key = "cell_euler_angles_array_path";
+  static inline constexpr StringLiteral k_CellPhasesArrayPath_Key = "cell_phases_array_path";
+  static inline constexpr StringLiteral k_GoodVoxelsArrayPath_Key = "good_voxels_array_path";
+
+  static inline constexpr uint64 k_CommaDelimiter = 0;
+  static inline constexpr uint64 k_SemiColonDelimiter = 1;
+  static inline constexpr uint64 k_SpaceDelimiter = 2;
+  static inline constexpr uint64 k_ColonDelimiter = 3;
+  static inline constexpr uint64 k_TabDelimiter = 4;
+
+  /**
+   * @brief Returns the name of the filter.
+   * @return
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the C++ classname of this filter.
+   * @return
+   */
+  std::string className() const override;
+
+  /**
+   * @brief Returns the uuid of the filter.
+   * @return
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief Returns the human readable name of the filter.
+   * @return
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
+   * @brief Returns the parameters of the filter (i.e. its inputs)
+   * @return
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief Returns a copy of the filter.
+   * @return
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param ds The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  PreflightResult preflightImpl(const DataStructure& ds, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+
+  /**
+   * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
+   * On failure, there is no guarantee that the DataStructure is in a correct state.
+   * @param ds The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  Result<> executeImpl(DataStructure& data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+};
+} // namespace complex
+
+COMPLEX_DEF_FILTER_TRAITS(complex, WriteStatsGenOdfAngleFileFilter, "aa6d399b-715e-44f1-9902-f1bd18faf1c5");
+/* LEGACY UUID FOR THIS FILTER a4952f40-22dd-54ec-8c38-69c3fcd0e6f7 */

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/OrientationAnalysisLegacyUUIDMapping.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/OrientationAnalysisLegacyUUIDMapping.hpp
@@ -67,6 +67,7 @@
 #include "OrientationAnalysis/Filters/FindGBCDMetricBasedFilter.hpp"
 #include "OrientationAnalysis/Filters/FindGBPDMetricBasedFilter.hpp"
 #include "OrientationAnalysis/Filters/FindSlipTransmissionMetricsFilter.hpp"
+#include "OrientationAnalysis/Filters/WriteStatsGenOdfAngleFileFilter.hpp"
 // @@__HEADER__TOKEN__DO__NOT__DELETE__@@
 
 #include <map>
@@ -139,6 +140,7 @@ namespace complex
     // {complex::Uuid::FromString("e1343abe-e5ad-5eb1-a89d-c209e620e4de").value(), complex::FilterTraits<ConvertHexGridToSquareGrid>::uuid}, // ConvertHexGridToSquareGrid
     // {complex::Uuid::FromString("ec58f4fe-8e51-527e-9536-8b6f185684be").value(), complex::FilterTraits<GenerateOrientationMatrixTranspose>::uuid}, // GenerateOrientationMatrixTranspose
     {complex::Uuid::FromString("d67e9f28-2fe5-5188-b0f8-323a7e603de6").value(), complex::FilterTraits<FindGBCDMetricBasedFilter>::uuid}, // FindGBCDMetricBased
+    {complex::Uuid::FromString("a4952f40-22dd-54ec-8c38-69c3fcd0e6f7").value(), complex::FilterTraits<WriteStatsGenOdfAngleFileFilter>::uuid}, // WriteStatsGenOdfAngleFile
     // @@__MAP__UPDATE__TOKEN__DO__NOT__DELETE__@@
   };
 

--- a/src/Plugins/OrientationAnalysis/test/CMakeLists.txt
+++ b/src/Plugins/OrientationAnalysis/test/CMakeLists.txt
@@ -51,6 +51,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   RodriguesConvertorTest.cpp
   RotateEulerRefFrameTest.cpp
   WritePoleFigureTest.cpp
+  WriteStatsGenOdfAngleFileTest.cpp
 )
 set(DISABLED_TESTS
   # ConvertHexGridToSquareGridTest.cpp    # MISSING 1 or more Parameter Implementations
@@ -64,13 +65,9 @@ set(DISABLED_TESTS
   INLWriterTest.cpp
 
   # ImportEbsdMontageTest.cpp    # MISSING 1 or more Parameter Implementations
-  # ImportH5EspritDataTest.cpp    # MISSING 1 or more Parameter Implementations
-  # ImportH5OimDataTest.cpp    # MISSING 1 or more Parameter Implementations
-  # OrientationUtilityTest.cpp    # MISSING 1 or more Parameter Implementations
 
   ReplaceElementAttributesWithNeighborValuesTest.cpp
   Stereographic3DTest.cpp
-  WriteStatsGenOdfAngleFileTest.cpp
 )
 
 create_complex_plugin_unit_test(PLUGIN_NAME ${PLUGIN_NAME}
@@ -139,6 +136,7 @@ if(EXISTS "${DREAM3D_DATA_DIR}" AND COMPLEX_DOWNLOAD_TEST_FILES)
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR} ARCHIVE_NAME feature_boundary_neighbor_slip_transmission.tar.gz SHA512 fb4a92bdfcff1f2b167cdce2126087e76c9022deb0f0bd8a658482f88f8593bacc0e23b8056d56390f767bc1dd21912fb01a976e3cb670738f1a39d46ad9ef28)
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR} ARCHIVE_NAME 6_6_read_ang_data.tar.gz SHA512 1777431a1623e2fffdc2daad9be51a72c3bdf6a83a33893827892c98a811991e21f1cf636e036604d0bbc523d8ca0b9d655c28be3d0e89ccafc1486dfa0bd0c7)
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR} ARCHIVE_NAME 6_6_read_ctf_data.tar.gz SHA512 e7ac4706d22574396aaa5d67b2a2b4e32db5005e841d3b6dafad65c74615441c028e4cba0ce0721c8929dace495afd6ef844585e2ce6d3b092582a258befd7c2)
+  download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR} ARCHIVE_NAME write_stats_gen_odf_angle_file.tar.gz SHA512 be3f663aae1f78e5b789200421534ed9fe293187ec3514796ac8177128b34ded18bb9a98b8e838bb283f9818ac30dc4b19ec379bdd581b1a98eb36d967cdd319)
 
 endif()
 

--- a/src/Plugins/OrientationAnalysis/test/WriteStatsGenOdfAngleFileTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/WriteStatsGenOdfAngleFileTest.cpp
@@ -84,7 +84,6 @@ TEST_CASE("OrientationAnalysis::WriteStatsGenOdfAngleFileFilter: InValid Filter 
   args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_ConvertToDegrees_Key, std::make_any<bool>(true));
   args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_UseGoodVoxels_Key, std::make_any<bool>(true));
   args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_CellEulerAnglesArrayPath_Key, std::make_any<DataPath>(Constants::k_EulersArrayPath));
-  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_CellPhasesArrayPath_Key, std::make_any<DataPath>(Constants::k_PhasesArrayPath));
   args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_GoodVoxelsArrayPath_Key, std::make_any<DataPath>(Constants::k_MaskArrayPath));
 
   SECTION("default weight < 1")
@@ -99,13 +98,14 @@ TEST_CASE("OrientationAnalysis::WriteStatsGenOdfAngleFileFilter: InValid Filter 
 
   SECTION("input cell data arrays have mismatching tuples")
   {
-    auto* invalidPhaseArray = Int32Array::CreateWithStore<Int32DataStore>(dataStructure, "Invalid_Phases_Array", std::vector<usize>{50, 50, 1}, std::vector<usize>{1});
+    auto* invalidPhaseArray = UInt32Array::CreateWithStore<UInt32DataStore>(dataStructure, "Invalid_Phases_Array", std::vector<usize>{50, 50, 1}, std::vector<usize>{1});
 
     args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_CellPhasesArrayPath_Key, std::make_any<DataPath>(DataPath({"Invalid_Phases_Array"})));
   }
 
   auto preflightResult = filter.preflight(dataStructure, args);
   COMPLEX_RESULT_REQUIRE_INVALID(preflightResult.outputActions)
+
   auto executeResult = filter.execute(dataStructure, args);
   COMPLEX_RESULT_REQUIRE_INVALID(executeResult.result)
 }

--- a/src/Plugins/OrientationAnalysis/test/WriteStatsGenOdfAngleFileTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/WriteStatsGenOdfAngleFileTest.cpp
@@ -1,0 +1,111 @@
+#include "complex/Parameters/BoolParameter.hpp"
+#include "complex/Parameters/ChoicesParameter.hpp"
+#include "complex/Parameters/FileSystemPathParameter.hpp"
+#include "complex/UnitTest/UnitTestCommon.hpp"
+
+#include "OrientationAnalysis/Filters/WriteStatsGenOdfAngleFileFilter.hpp"
+#include "OrientationAnalysis/OrientationAnalysis_test_dirs.hpp"
+
+#include <catch2/catch.hpp>
+
+#include <filesystem>
+#include <sstream>
+namespace fs = std::filesystem;
+
+using namespace complex;
+
+TEST_CASE("OrientationAnalysis::WriteStatsGenOdfAngleFileFilter: Valid Filter Execution", "[OrientationAnalysis][WriteStatsGenOdfAngleFileFilter]")
+{
+  const complex::UnitTest::TestFileSentinel testDataSentinel(complex::unit_test::k_CMakeExecutable, complex::unit_test::k_TestFilesDir, "write_stats_gen_odf_angle_file.tar.gz",
+                                                             "write_stats_gen_odf_angle_file");
+
+  // Read Exemplar DREAM3D File
+  auto exemplarFilePath = fs::path(fmt::format("{}/write_stats_gen_odf_angle_file/write_stats_gen_odf_angle_file.dream3d", unit_test::k_TestFilesDir));
+  DataStructure dataStructure = UnitTest::LoadDataStructure(exemplarFilePath);
+
+  fs::path exemplarOutput1Path = fs::path(fmt::format("{}/write_stats_gen_odf_angle_file/StatsGenODF_Phase_1.txt", unit_test::k_TestFilesDir));
+  fs::path exemplarOutput2Path = fs::path(fmt::format("{}/write_stats_gen_odf_angle_file/StatsGenODF_RadiansNoMask_Phase_1.txt", unit_test::k_TestFilesDir));
+  fs::path computedOutput1Path(fmt::format("{}/StatsGenODF_Phase_1.txt", unit_test::k_BinaryTestOutputDir));
+  fs::path computedOutput2Path(fmt::format("{}/StatsGenODF_RadiansNoMask_Phase_1.txt", unit_test::k_BinaryTestOutputDir));
+
+  WriteStatsGenOdfAngleFileFilter filter;
+  Arguments args;
+
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_OutputFile_Key,
+                      std::make_any<FileSystemPathParameter::ValueType>(fs::path(fmt::format("{}/StatsGenODF.txt", unit_test::k_BinaryTestOutputDir))));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_Weight_Key, std::make_any<float32>(1.0f));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_Sigma_Key, std::make_any<int32>(1));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_Delimiter_Key, std::make_any<ChoicesParameter::ValueType>(WriteStatsGenOdfAngleFileFilter::k_SpaceDelimiter));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_ConvertToDegrees_Key, std::make_any<bool>(true));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_UseGoodVoxels_Key, std::make_any<bool>(true));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_CellEulerAnglesArrayPath_Key, std::make_any<DataPath>(Constants::k_EulersArrayPath));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_CellPhasesArrayPath_Key, std::make_any<DataPath>(Constants::k_PhasesArrayPath));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_GoodVoxelsArrayPath_Key, std::make_any<DataPath>(Constants::k_MaskArrayPath));
+  auto preflightResult = filter.preflight(dataStructure, args);
+  COMPLEX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+  auto executeResult = filter.execute(dataStructure, args);
+  COMPLEX_RESULT_REQUIRE_VALID(executeResult.result)
+
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_OutputFile_Key,
+                      std::make_any<FileSystemPathParameter::ValueType>(fs::path(fmt::format("{}/StatsGenODF_RadiansNoMask.txt", unit_test::k_BinaryTestOutputDir))));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_ConvertToDegrees_Key, std::make_any<bool>(false));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_UseGoodVoxels_Key, std::make_any<bool>(false));
+  preflightResult = filter.preflight(dataStructure, args);
+  COMPLEX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+  executeResult = filter.execute(dataStructure, args);
+  COMPLEX_RESULT_REQUIRE_VALID(executeResult.result)
+
+  std::vector<size_t> linesToSkip{2};
+  std::ifstream computedFile1(computedOutput1Path);
+  std::ifstream exemplarFile1(exemplarOutput1Path);
+  UnitTest::CompareAsciiFiles(computedFile1, exemplarFile1, linesToSkip);
+  std::ifstream computedFile2(computedOutput2Path);
+  std::ifstream exemplarFile2(exemplarOutput2Path);
+  UnitTest::CompareAsciiFiles(computedFile2, exemplarFile2, linesToSkip);
+}
+
+TEST_CASE("OrientationAnalysis::WriteStatsGenOdfAngleFileFilter: InValid Filter Execution", "[OrientationAnalysis][WriteStatsGenOdfAngleFileFilter]")
+{
+  const complex::UnitTest::TestFileSentinel testDataSentinel(complex::unit_test::k_CMakeExecutable, complex::unit_test::k_TestFilesDir, "write_stats_gen_odf_angle_file.tar.gz",
+                                                             "write_stats_gen_odf_angle_file");
+
+  // Read Exemplar DREAM3D File
+  auto exemplarFilePath = fs::path(fmt::format("{}/write_stats_gen_odf_angle_file/write_stats_gen_odf_angle_file.dream3d", unit_test::k_TestFilesDir));
+  DataStructure dataStructure = UnitTest::LoadDataStructure(exemplarFilePath);
+
+  WriteStatsGenOdfAngleFileFilter filter;
+  Arguments args;
+
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_OutputFile_Key,
+                      std::make_any<FileSystemPathParameter::ValueType>(fs::path(fmt::format("{}/StatsGenODF.txt", unit_test::k_BinaryTestOutputDir))));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_Weight_Key, std::make_any<float32>(1.0f));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_Sigma_Key, std::make_any<int32>(1));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_Delimiter_Key, std::make_any<ChoicesParameter::ValueType>(WriteStatsGenOdfAngleFileFilter::k_SpaceDelimiter));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_ConvertToDegrees_Key, std::make_any<bool>(true));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_UseGoodVoxels_Key, std::make_any<bool>(true));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_CellEulerAnglesArrayPath_Key, std::make_any<DataPath>(Constants::k_EulersArrayPath));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_CellPhasesArrayPath_Key, std::make_any<DataPath>(Constants::k_PhasesArrayPath));
+  args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_GoodVoxelsArrayPath_Key, std::make_any<DataPath>(Constants::k_MaskArrayPath));
+
+  SECTION("default weight < 1")
+  {
+    args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_Weight_Key, std::make_any<float32>(-1.0f));
+  }
+
+  SECTION("default sigma < 1")
+  {
+    args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_Sigma_Key, std::make_any<int32>(0));
+  }
+
+  SECTION("input cell data arrays have mismatching tuples")
+  {
+    auto* invalidPhaseArray = Int32Array::CreateWithStore<Int32DataStore>(dataStructure, "Invalid_Phases_Array", std::vector<usize>{50, 50, 1}, std::vector<usize>{1});
+
+    args.insertOrAssign(WriteStatsGenOdfAngleFileFilter::k_CellPhasesArrayPath_Key, std::make_any<DataPath>(DataPath({"Invalid_Phases_Array"})));
+  }
+
+  auto preflightResult = filter.preflight(dataStructure, args);
+  COMPLEX_RESULT_REQUIRE_INVALID(preflightResult.outputActions)
+  auto executeResult = filter.execute(dataStructure, args);
+  COMPLEX_RESULT_REQUIRE_INVALID(executeResult.result)
+}


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the complex repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start complex commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `complex/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `complex/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to complex!** -->
