### PR TITLE
BUG: Use shared face list to return number of cells in the geometry

### DIFF
--- a/src/complex/DataStructure/Geometry/INodeGeometry1D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry1D.cpp
@@ -59,14 +59,13 @@ void INodeGeometry1D::resizeEdgeList(usize size)
 
 usize INodeGeometry1D::getNumberOfCells() const
 {
-  auto& edges = getEdgesRef();
-  return edges.getNumberOfTuples();
+  return getNumberOfEdges();
 }
 
 usize INodeGeometry1D::getNumberOfEdges() const
 {
-  auto& edges = getEdgesRef();
-  return edges.getNumberOfTuples();
+  const auto* edgesPtr = getEdges();
+  return edgesPtr == nullptr ? 0 : edgesPtr->getNumberOfTuples();
 }
 
 void INodeGeometry1D::setEdgePointIds(usize edgeId, nonstd::span<usize> vertexIds)

--- a/src/complex/DataStructure/Geometry/INodeGeometry2D.cpp
+++ b/src/complex/DataStructure/Geometry/INodeGeometry2D.cpp
@@ -59,8 +59,8 @@ void INodeGeometry2D::resizeFaceList(usize size)
 
 usize INodeGeometry2D::getNumberOfFaces() const
 {
-  const auto& faces = getFacesRef();
-  return faces.getNumberOfTuples();
+  const auto* facesPtr = getFaces();
+  return facesPtr == nullptr ? 0 : facesPtr->getNumberOfTuples();
 }
 
 void INodeGeometry2D::setFacePointIds(usize faceId, nonstd::span<usize> vertexIds)

--- a/src/complex/DataStructure/Geometry/QuadGeom.cpp
+++ b/src/complex/DataStructure/Geometry/QuadGeom.cpp
@@ -158,8 +158,7 @@ std::shared_ptr<DataObject> QuadGeom::deepCopy(const DataPath& copyPath)
 
 usize QuadGeom::getNumberOfCells() const
 {
-  auto& quads = getFacesRef();
-  return quads.getNumberOfTuples();
+  return getNumberOfFaces();
 }
 
 usize QuadGeom::getNumberOfVerticesPerFace() const

--- a/src/complex/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.cpp
@@ -159,7 +159,22 @@ std::shared_ptr<DataObject> TriangleGeom::deepCopy(const DataPath& copyPath)
 
 usize TriangleGeom::getNumberOfCells() const
 {
-  return getFacesRef().getNumberOfTuples();
+  if(!m_FaceListId.has_value())
+  {
+    return 0;
+  }
+  const DataStructure* dataStructure = getDataStructure();
+  if(dataStructure == nullptr)
+  {
+    return 0;
+  }
+
+  auto* sharedTriListPtr = dataStructure->getDataAs<MeshIndexArrayType>(m_FaceListId.value());
+  if(sharedTriListPtr == nullptr)
+  {
+    return 0;
+  }
+  return sharedTriListPtr->getNumberOfTuples();
 }
 
 usize TriangleGeom::getNumberOfVerticesPerFace() const

--- a/src/complex/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/complex/DataStructure/Geometry/TriangleGeom.cpp
@@ -159,22 +159,7 @@ std::shared_ptr<DataObject> TriangleGeom::deepCopy(const DataPath& copyPath)
 
 usize TriangleGeom::getNumberOfCells() const
 {
-  if(!m_FaceListId.has_value())
-  {
-    return 0;
-  }
-  const DataStructure* dataStructure = getDataStructure();
-  if(dataStructure == nullptr)
-  {
-    return 0;
-  }
-
-  auto* sharedTriListPtr = dataStructure->getDataAs<MeshIndexArrayType>(m_FaceListId.value());
-  if(sharedTriListPtr == nullptr)
-  {
-    return 0;
-  }
-  return sharedTriListPtr->getNumberOfTuples();
+  return getNumberOfFaces();
 }
 
 usize TriangleGeom::getNumberOfVerticesPerFace() const


### PR DESCRIPTION
We should be using the SharedFaceList/SharedEdgeList/SharedQuadList to return the number of "Cells" for those geometries instead of trying to get the Cell Data Attribute Matrix and number of tuples.