### PR TITLE
Updated fmt to 10.0.0

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/CalculateArrayHistogram.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/CalculateArrayHistogram.cpp
@@ -172,7 +172,7 @@ Result<> CalculateArrayHistogram::operator()()
     if(overflow > 0)
     {
       const std::string arrayName = inputData.getName();
-      CalculateArrayHistogram::updateProgress(fmt::format("{} values not categorized into bin for array {}", overflow, arrayName));
+      CalculateArrayHistogram::updateProgress(fmt::format("{} values not categorized into bin for array {}", overflow.load(), arrayName));
     }
   }
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ConditionalSetValue.cpp
@@ -153,7 +153,7 @@ IFilter::PreflightResult ConditionalSetValue::preflightImpl(const DataStructure&
   if(result.invalid())
   {
     return {MakeErrorResult<OutputActions>(::k_ConvertReplaceValueTypeError, fmt::format("{}({}): Function {}: Error. Cannot convert {} to the type {}.", "ReplaceValueInArrayFunctor", __FILE__,
-                                                                                         __LINE__, replaceValueString, inputDataObject.getDataObjectType()))};
+                                                                                         __LINE__, replaceValueString, fmt::underlying(inputDataObject.getDataObjectType())))};
   }
 
   result = CheckValueConvertsToArrayType(removeValueString, inputDataObject);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateGeometryFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/CreateGeometryFilter.cpp
@@ -301,7 +301,6 @@ IFilter::PreflightResult CreateGeometryFilter::preflightImpl(const DataStructure
     usize zTuples = zBounds->getNumberOfTuples();
     if(xTuples < 2 || yTuples < 2 || zTuples < 2)
     {
-      fmt::format("One of the bounds arrays has a size less than two; all sizes must be at least two\nX Bounds Size: {}\nY Bounds Size: {}\nZ Bounds Size: {}\n", xTuples, yTuples, zTuples);
       return {nonstd::make_unexpected(
           std::vector<Error>{Error{-9844, fmt::format("One of the bounds arrays has a size less than two; all sizes must be at least two\nX Bounds Size: {}\nY Bounds Size: {}\nZ Bounds Size: {}\n",
                                                       xBounds->getNumberOfTuples(), yBounds->getNumberOfTuples(), zBounds->getNumberOfTuples())}})};

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportHDF5Dataset.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportHDF5Dataset.cpp
@@ -302,8 +302,9 @@ IFilter::PreflightResult ImportHDF5Dataset::preflightImpl(const DataStructure& d
       Result<HDF5::Type> type = datasetReader.getDataType();
       if(type.invalid())
       {
-        return {nonstd::make_unexpected(std::vector<Error>{
-            Error{-20015, fmt::format("The selected datatset '{}' with type '{}' is not a supported type for importing. Please select a different data set", datasetPath, datasetReader.getType())}})};
+        return {
+            nonstd::make_unexpected(std::vector<Error>{Error{-20015, fmt::format("The selected datatset '{}' with type '{}' is not a supported type for importing. Please select a different data set",
+                                                                                 datasetPath, fmt::underlying(datasetReader.getType()))}})};
       }
       DataType dataType = complex::HDF5::toCommonType(type.value()).value();
       auto action = std::make_unique<CreateArrayAction>(dataType, tDims, cDims, dataArrayPath);
@@ -385,7 +386,8 @@ Result<> ImportHDF5Dataset::executeImpl(DataStructure& dataStructure, const Argu
       break;
     }
     default: {
-      return {MakeErrorResult(-21001, fmt::format("The selected datatset '{}' with type '{}' is not a supported type for importing. Please select a different data set", datasetPath, type))};
+      return {MakeErrorResult(-21001,
+                              fmt::format("The selected datatset '{}' with type '{}' is not a supported type for importing. Please select a different data set", datasetPath, fmt::underlying(type)))};
     }
     }
     if(fillArrayResults.invalid())

--- a/src/Plugins/ComplexCore/test/RemoveMinimumSizeFeaturesTest.cpp
+++ b/src/Plugins/ComplexCore/test/RemoveMinimumSizeFeaturesTest.cpp
@@ -97,7 +97,8 @@ TEST_CASE("ComplexCore::RemoveMinimumSizeFeatures: Small IN100 Pipeline", "[Comp
 
       if(type != exemplarType)
       {
-        std::cout << fmt::format("DataArray {} and {} do not have the same type: {} vs {}. Data Will not be compared.", generatedDataArray.getName(), exemplarDataArray.getName(), type, exemplarType)
+        std::cout << fmt::format("DataArray {} and {} do not have the same type: {} vs {}. Data Will not be compared.", generatedDataArray.getName(), exemplarDataArray.getName(),
+                                 fmt::underlying(type), fmt::underlying(exemplarType))
                   << std::endl;
         continue;
       }

--- a/src/Plugins/ITKImageProcessing/test/ITKTestBase.cpp
+++ b/src/Plugins/ITKImageProcessing/test/ITKTestBase.cpp
@@ -228,7 +228,7 @@ Result<> CompareImages(DataStructure& dataStructure, const DataPath& baselineGeo
   // Make sure the data types are the same
   if(baseLineDataType != outputDataType)
   {
-    return MakeErrorResult(-14, fmt::format("DataTypes do not match. Output: {} Baseline: {}", outputDataType, baseLineDataType));
+    return MakeErrorResult(-14, fmt::format("DataTypes do not match. Output: {} Baseline: {}", fmt::underlying(outputDataType), fmt::underlying(baseLineDataType)));
   }
   // Make sure the geometry dimensions are the same
   if(baselineDims != outputDims)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WritePoleFigure.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WritePoleFigure.cpp
@@ -255,7 +255,7 @@ void drawScalarBar(canvas_ity::canvas& context, const PoleFigureConfiguration_t&
 
   // Draw the Max Value
   context.begin_path();
-  const std::string maxStr = fmt::format("{:.6}", config.maxScale);
+  const std::string maxStr = fmt::format("{:#.6}", config.maxScale);
   context.set_font(fontData.data(), static_cast<int>(fontData.size()), fontPtSize);
   context.set_color(canvas_ity::fill_style, 0.0f, 0.0f, 0.0f, 1.0f);
   context.text_baseline = baselines[0];
@@ -264,7 +264,7 @@ void drawScalarBar(canvas_ity::canvas& context, const PoleFigureConfiguration_t&
 
   // Draw the Min value
   context.begin_path();
-  const std::string minStr = fmt::format("{:.6}", config.minScale);
+  const std::string minStr = fmt::format("{:#.6}", config.minScale);
   context.set_font(fontData.data(), static_cast<int>(fontData.size()), fontPtSize);
   context.set_color(canvas_ity::fill_style, 0.0f, 0.0f, 0.0f, 1.0f);
   context.text_baseline = baselines[0];

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertOrientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertOrientations.cpp
@@ -362,12 +362,12 @@ IFilter::PreflightResult ConvertOrientations::preflightImpl(const DataStructure&
 
   if(static_cast<int>(inputType) < 0 || inputType >= OrientationRepresentation::Type::Unknown)
   {
-    return {MakeErrorResult<OutputActions>(::k_InputRepresentationTypeError, fmt::format("Input Representation Type must be a value from 0 to 6. '{}'", inputType))};
+    return {MakeErrorResult<OutputActions>(::k_InputRepresentationTypeError, fmt::format("Input Representation Type must be a value from 0 to 6. '{}'", fmt::underlying(inputType)))};
   }
 
   if(static_cast<int>(outputType) < 0 || outputType >= OrientationRepresentation::Type::Unknown)
   {
-    return {MakeErrorResult<OutputActions>(::k_OutputRepresentationTypeError, fmt::format("Output Representation Type must be a value from 0 to 6. '{}'", outputType))};
+    return {MakeErrorResult<OutputActions>(::k_OutputRepresentationTypeError, fmt::format("Output Representation Type must be a value from 0 to 6. '{}'", fmt::underlying(outputType)))};
   }
 
   auto pInputArrayPath = filterArgs.value<DataPath>(k_InputOrientationArrayPath_Key);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/GenerateFZQuaternions.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/GenerateFZQuaternions.cpp
@@ -222,7 +222,7 @@ IFilter::PreflightResult GenerateFZQuaternions::preflightImpl(const DataStructur
     }
     if(maskArray.getDataType() != complex::DataType::boolean && maskArray.getDataType() != complex::DataType::uint8 && maskArray.getDataType() != complex::DataType::int8)
     {
-      return {MakeErrorResult<OutputActions>(-49005, fmt::format("Mask Array is not [BOOL (10) | UINT8 (2) | INT8 (1)]: '{}'", maskArray.getDataType()))};
+      return {MakeErrorResult<OutputActions>(-49005, fmt::format("Mask Array is not [BOOL (10) | UINT8 (2) | INT8 (1)]: '{}'", fmt::underlying(maskArray.getDataType())))};
     }
 
     if(maskArray.getNumberOfTuples() != quatArray.getNumberOfTuples())
@@ -296,7 +296,7 @@ Result<> GenerateFZQuaternions::executeImpl(DataStructure& dataStructure, const 
   {
     std::string errorMessage = fmt::format("The Ensemble Phase information only references {} phase(s) but {} cell(s) had a phase value greater than {}. \
 This indicates a problem with the input cell phase data. DREAM.3D may have given INCORRECT RESULTS.",
-                                           numPhases - 1, warningCount, numPhases - 1);
+                                           numPhases - 1, warningCount.load(), numPhases - 1);
 
     return {MakeErrorResult<>(-49008, errorMessage)};
   }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Parameters/OEMEbsdScanSelectionParameter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Parameters/OEMEbsdScanSelectionParameter.cpp
@@ -225,7 +225,7 @@ Result<> OEMEbsdScanSelectionParameter::validate(const std::any& valueRef) const
   const ManufacturerType manufacturer = ReadManufacturer(value.inputFilePath.string());
   if(m_AllowedManufacturers.find(manufacturer) == m_AllowedManufacturers.end())
   {
-    errors.push_back({-20035, fmt::format("Original data source type {} is not a valid manufacturer", manufacturer)});
+    errors.push_back({-20035, fmt::format("Original data source type {} is not a valid manufacturer", fmt::underlying(manufacturer))});
     return {nonstd::make_unexpected(std::move(errors))};
   }
 

--- a/src/Plugins/OrientationAnalysis/test/BadDataNeighborOrientationCheckTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/BadDataNeighborOrientationCheckTest.cpp
@@ -122,7 +122,8 @@ TEST_CASE("OrientationAnalysis::BadDataNeighborOrientationCheckFilter: Small IN1
 
       if(type != exemplarType)
       {
-        std::cout << fmt::format("DataArray {} and {} do not have the same type: {} vs {}. Data Will not be compared.", generatedDataArray.getName(), exemplarDataArray.getName(), type, exemplarType)
+        std::cout << fmt::format("DataArray {} and {} do not have the same type: {} vs {}. Data Will not be compared.", generatedDataArray.getName(), exemplarDataArray.getName(),
+                                 fmt::underlying(type), fmt::underlying(exemplarType))
                   << std::endl;
         continue;
       }

--- a/src/Plugins/OrientationAnalysis/test/NeighborOrientationCorrelationTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/NeighborOrientationCorrelationTest.cpp
@@ -130,7 +130,8 @@ TEST_CASE("OrientationAnalysis::NeighborOrientationCorrelationFilter: Small IN10
 
       if(type != exemplarType)
       {
-        std::cout << fmt::format("DataArray {} and {} do not have the same type: {} vs {}. Data Will not be compared.", generatedDataArray.getName(), exemplarDataArray.getName(), type, exemplarType)
+        std::cout << fmt::format("DataArray {} and {} do not have the same type: {} vs {}. Data Will not be compared.", generatedDataArray.getName(), exemplarDataArray.getName(),
+                                 fmt::underlying(type), fmt::underlying(exemplarType))
                   << std::endl;
         continue;
       }

--- a/src/Plugins/OrientationAnalysis/test/ReadH5EbsdTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/ReadH5EbsdTest.cpp
@@ -79,7 +79,8 @@ TEST_CASE("OrientationAnalysis::ReadH5Ebsd: Valid filter execution", "[Orientati
 
       if(type != exemplarType)
       {
-        std::cout << fmt::format("DataArray {} and {} do not have the same type: {} vs {}. Data Will not be compared.", generatedDataArray.getName(), exemplarDataArray.getName(), type, exemplarType)
+        std::cout << fmt::format("DataArray {} and {} do not have the same type: {} vs {}. Data Will not be compared.", generatedDataArray.getName(), exemplarDataArray.getName(),
+                                 fmt::underlying(type), fmt::underlying(exemplarType))
                   << std::endl;
         continue;
       }

--- a/src/complex/Common/StringLiteral.hpp
+++ b/src/complex/Common/StringLiteral.hpp
@@ -6,6 +6,9 @@
 #include <string>
 #include <string_view>
 
+#include <fmt/core.h>
+#include <fmt/xchar.h>
+
 namespace complex
 {
 namespace detail
@@ -208,3 +211,39 @@ using WStringLiteral = BasicStringLiteral<wchar_t>;
 using String16Literal = BasicStringLiteral<char16_t>;
 using String32Literal = BasicStringLiteral<char32_t>;
 } // namespace complex
+
+template <class CharT>
+struct fmt::formatter<complex::BasicStringLiteral<CharT>>
+{
+  static constexpr const CharT* GetFormatString()
+  {
+    if constexpr(std::is_same_v<CharT, char>)
+    {
+      return "{}";
+    }
+    if constexpr(std::is_same_v<CharT, wchar_t>)
+    {
+      return L"{}";
+    }
+    if constexpr(std::is_same_v<CharT, char16_t>)
+    {
+      return u"{}";
+    }
+    if constexpr(std::is_same_v<CharT, char32_t>)
+    {
+      return U"{}";
+    }
+  }
+
+  constexpr typename basic_format_parse_context<CharT>::iterator parse(basic_format_parse_context<CharT>& ctx)
+  {
+    return ctx.begin();
+  }
+
+  typename buffer_context<CharT>::iterator format(const complex::BasicStringLiteral<CharT>& p, buffer_context<CharT>& ctx) const
+  {
+    static constexpr const CharT* formatStr = GetFormatString();
+
+    return fmt::format_to(ctx.out(), formatStr, p.view());
+  }
+};

--- a/src/complex/DataStructure/IDataStore.hpp
+++ b/src/complex/DataStructure/IDataStore.hpp
@@ -3,11 +3,12 @@
 #include "complex/Common/Types.hpp"
 #include "complex/complex_export.hpp"
 
-#include <fmt/format.h>
-
 #include <algorithm>
 #include <iterator>
+#include <memory>
 #include <optional>
+#include <string>
+#include <vector>
 
 namespace complex
 {

--- a/src/complex/Parameters/ArraySelectionParameter.cpp
+++ b/src/complex/Parameters/ArraySelectionParameter.cpp
@@ -6,7 +6,7 @@
 #include "complex/DataStructure/IDataArray.hpp"
 #include "complex/Utilities/StringUtilities.hpp"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <nlohmann/json.hpp>
 
@@ -15,14 +15,12 @@ using namespace complex;
 template <>
 struct fmt::formatter<complex::DataType>
 {
-  template <typename ParseContext>
-  constexpr auto parse(ParseContext& ctx)
+  constexpr format_parse_context::iterator parse(format_parse_context& ctx)
   {
     return ctx.begin();
   }
 
-  template <typename FormatContext>
-  auto format(const complex::DataType& value, FormatContext& ctx)
+  format_context::iterator format(const complex::DataType& value, format_context& ctx) const
   {
     return fmt::format_to(ctx.out(), "{}", complex::DataTypeToString(value));
   }
@@ -204,7 +202,7 @@ Result<> ArraySelectionParameter::validatePath(const DataStructure& dataStructur
       }
 
       return MakeErrorResult(FilterParameter::Constants::k_Validate_DataLocation_Error,
-                             fmt::format("{}DataArray at path '{}' was stored at '{}', but only {} are allowed", prefix, value.toString(), storeType, m_Location));
+                             fmt::format("{}DataArray at path '{}' was stored at '{}', but only {} are allowed", prefix, value.toString(), fmt::underlying(storeType), fmt::underlying(m_Location)));
     }
   }
   return {};

--- a/src/complex/Parameters/ChoicesParameter.cpp
+++ b/src/complex/Parameters/ChoicesParameter.cpp
@@ -4,24 +4,19 @@
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
-namespace fmt
-{
 template <>
-struct formatter<complex::Error>
+struct fmt::formatter<complex::Error>
 {
-  template <typename ParseContext>
-  constexpr auto parse(ParseContext& ctx)
+  constexpr format_parse_context::iterator parse(format_parse_context& ctx)
   {
     return ctx.begin();
   }
 
-  template <typename FormatContext>
-  auto format(const complex::Error& error, FormatContext& ctx)
+  format_context::iterator format(const complex::Error& error, format_context& ctx) const
   {
     return format_to(ctx.out(), "Error({}, {})", error.code, error.message);
   }
 };
-} // namespace fmt
 
 namespace complex
 {

--- a/src/complex/Parameters/NeighborListSelectionParameter.cpp
+++ b/src/complex/Parameters/NeighborListSelectionParameter.cpp
@@ -13,14 +13,12 @@ using namespace complex;
 template <>
 struct fmt::formatter<complex::DataType>
 {
-  template <typename ParseContext>
-  constexpr auto parse(ParseContext& ctx)
+  constexpr format_parse_context::iterator parse(format_parse_context& ctx)
   {
     return ctx.begin();
   }
 
-  template <typename FormatContext>
-  auto format(const complex::DataType& value, FormatContext& ctx)
+  format_context::iterator format(const complex::DataType& value, format_context& ctx) const
   {
     return fmt::format_to(ctx.out(), "{}", complex::DataTypeToString(value));
   }

--- a/src/complex/Parameters/util/CSVWizardData.cpp
+++ b/src/complex/Parameters/util/CSVWizardData.cpp
@@ -30,7 +30,7 @@
 
 #include "CSVWizardData.hpp"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using namespace complex;
 
@@ -163,7 +163,7 @@ Result<CSVWizardData> CSVWizardData::ReadJson(const nlohmann::json& json)
     auto delimiterObj = delimiters[i];
     if(!delimiterObj.is_number_integer())
     {
-      return MakeErrorResult<CSVWizardData>(-106, fmt::format("CSVWizardData: Delimiter at index {} is of type {} and is not an integer.", std::to_string(i), delimiterObj.type()));
+      return MakeErrorResult<CSVWizardData>(-106, fmt::format("CSVWizardData: Delimiter at index {} is of type {} and is not an integer.", std::to_string(i), fmt::underlying(delimiterObj.type())));
     }
 
     data.delimiters.push_back(delimiterObj.get<char>());

--- a/src/complex/Utilities/FilePathGenerator.cpp
+++ b/src/complex/Utilities/FilePathGenerator.cpp
@@ -44,7 +44,8 @@ std::vector<std::string> GenerateFileList(int32 start, int32 end, int32 incremen
     return fileList;
   }
   int32 index = 0;
-  std::string format_string = fmt::format("{{}}/{{}}{{:0{}d}}{{}}{{}}", paddingDigits);
+  std::string paddingSpecifier = paddingDigits >= 1 ? fmt::format(":0{}d", paddingDigits) : "";
+  std::string formatString = fmt::format("{{}}/{{}}{{{}}}{{}}{{}}", paddingSpecifier);
   for(int32 i = 0; i < (end - start) + 1; i += increment)
   {
     if(order == Ordering::LowToHigh)
@@ -55,7 +56,7 @@ std::vector<std::string> GenerateFileList(int32 start, int32 end, int32 incremen
     {
       index = end - i;
     }
-    std::string filePath = fmt::format(format_string, inputPath, filePrefix, index, fileSuffix, fileExtension);
+    std::string filePath = fmt::format(fmt::runtime(formatString), inputPath, filePrefix, index, fileSuffix, fileExtension);
     fileList.push_back(filePath);
   }
 

--- a/test/UnitTestCommon/include/complex/UnitTest/UnitTestCommon.hpp
+++ b/test/UnitTestCommon/include/complex/UnitTest/UnitTestCommon.hpp
@@ -721,7 +721,7 @@ void CompareArrays(const IArray* generatedArray, const IArray* exemplarArray)
   if(arrayType != exemplarArrayType)
   {
     std::cout << fmt::format("Generated array {} and exemplar array {} do not have the same array type: {} vs {}. Data Will not be compared.", generatedArray->getName(), exemplarArray->getName(),
-                             arrayType, exemplarArrayType)
+                             fmt::underlying(arrayType), fmt::underlying(exemplarArrayType))
               << std::endl;
     return;
   }
@@ -736,7 +736,8 @@ void CompareArrays(const IArray* generatedArray, const IArray* exemplarArray)
 
     if(type != exemplarType)
     {
-      std::cout << fmt::format("DataArray {} and {} do not have the same type: {} vs {}. Data Will not be compared.", generatedDataArray->getName(), exemplarDataArray->getName(), type, exemplarType)
+      std::cout << fmt::format("DataArray {} and {} do not have the same type: {} vs {}. Data Will not be compared.", generatedDataArray->getName(), exemplarDataArray->getName(),
+                               fmt::underlying(type), fmt::underlying(exemplarType))
                 << std::endl;
       return;
     }
@@ -750,8 +751,8 @@ void CompareArrays(const IArray* generatedArray, const IArray* exemplarArray)
     DataType exemplarType = exemplarDataArray->getDataType();
     if(type != exemplarType)
     {
-      std::cout << fmt::format("NeighborList {} and {} do not have the same type: {} vs {}. Data Will not be compared.", generatedDataArray->getName(), exemplarDataArray->getName(), type,
-                               exemplarType)
+      std::cout << fmt::format("NeighborList {} and {} do not have the same type: {} vs {}. Data Will not be compared.", generatedDataArray->getName(), exemplarDataArray->getName(),
+                               fmt::underlying(type), fmt::underlying(exemplarType))
                 << std::endl;
       return;
     }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -28,7 +28,7 @@
         "zlib",
         "zstd"
       ],
-      "baseline": "a7f8a05a400087e5dd4b0a5e46ece1b2123dc608"
+      "baseline": "6c6dfc3622e7aab7d9a8c3c906a4e52c278a319d"
     }
   ]
 }

--- a/wrapping/python/complexpy.cpp
+++ b/wrapping/python/complexpy.cpp
@@ -205,14 +205,12 @@ using namespace pybind11::literals;
 template <>
 struct fmt::formatter<complex::Error>
 {
-  template <typename ParseContext>
-  constexpr auto parse(ParseContext& ctx)
+  constexpr format_parse_context::iterator parse(format_parse_context& ctx)
   {
     return ctx.begin();
   }
 
-  template <typename FormatContext>
-  auto format(const complex::Error& value, FormatContext& ctx)
+  format_context::iterator format(const complex::Error& value, format_context& ctx) const
   {
     return fmt::format_to(ctx.out(), "Error(code={}, message='{}')", value.code, value.message);
   }
@@ -221,14 +219,12 @@ struct fmt::formatter<complex::Error>
 template <>
 struct fmt::formatter<complex::Warning>
 {
-  template <typename ParseContext>
-  constexpr auto parse(ParseContext& ctx)
+  constexpr format_parse_context::iterator parse(format_parse_context& ctx)
   {
     return ctx.begin();
   }
 
-  template <typename FormatContext>
-  auto format(const complex::Warning& value, FormatContext& ctx)
+  format_context::iterator format(const complex::Warning& value, format_context& ctx) const
   {
     return fmt::format_to(ctx.out(), "Warning(code={}, message='{}')", value.code, value.message);
   }


### PR DESCRIPTION
- Enums no longer implicitly get converted to their underlying values. Use `fmt::underlying(value)` to fix.
- Atomic variables must be explicitly loaded
- Custom formatters need to update their function signatures