### PR TITLE
BUG: Fix issue writing RectilinearGrid geometries.

### DIFF
--- a/src/complex/DataStructure/IO/HDF5/RectGridGeomIO.cpp
+++ b/src/complex/DataStructure/IO/HDF5/RectGridGeomIO.cpp
@@ -95,7 +95,7 @@ Result<> RectGridGeomIO::writeData(DataStructureWriter& dataStructureWriter, con
     return result;
   }
 
-  result = WriteDataId(groupWriter, geometry.getXBoundsId(), IOConstants::k_ZBoundsTag);
+  result = WriteDataId(groupWriter, geometry.getZBoundsId(), IOConstants::k_ZBoundsTag);
   if(result.invalid())
   {
     return result;


### PR DESCRIPTION
The X Bounds data id would be written for the Z bounds data id.
