### PR TITLE
Bug: Fix issue where not selecting any import paths would lead to the entire file being imported.

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportDREAM3DFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ImportDREAM3DFilter.cpp
@@ -78,13 +78,6 @@ IFilter::PreflightResult ImportDREAM3DFilter::preflightImpl(const DataStructure&
     return {nonstd::make_unexpected(std::vector<Error>{Error{k_FailedOpenFileReaderError, "Failed to open the HDF5 file at the specified path."}})};
   }
 
-  // Require at least one DataPath to import
-  // NX does not allow the use of this value as intended.
-  if(importData.DataPaths.has_value() && importData.DataPaths->empty())
-  {
-    importData.DataPaths = std::nullopt;
-  }
-
   OutputActions actions;
   auto action = std::make_unique<ImportH5ObjectPathsAction>(importData.FilePath, importData.DataPaths);
   actions.appendAction(std::move(action));

--- a/src/complex/Filter/Actions/ImportH5ObjectPathsAction.hpp
+++ b/src/complex/Filter/Actions/ImportH5ObjectPathsAction.hpp
@@ -18,6 +18,15 @@ public:
 
   ImportH5ObjectPathsAction() = delete;
 
+  /**
+   * @brief Constructs the action
+   * @param importFile The file to import data from
+   * @param paths The vector of paths to import.
+   *
+   * <b>IMPORTANT NOTE</b>. If the std::optional<> paths argument does NOT have a value then
+   * then entire file will be imported. If it has a value, but the std::vector<> has a size of
+   * zero (0), then NOTHING will be imported.
+   */
   ImportH5ObjectPathsAction(const std::filesystem::path& importFile, const PathsType& paths);
 
   ~ImportH5ObjectPathsAction() noexcept override;


### PR DESCRIPTION
Inside the ImportH5ObjectPathsAction.cpp file there is this code

```
std::vector<DataPath> getImportPaths(const DataStructure& importStructure, const std::optional<std::vector<DataPath>>& importPaths)
{
  std::vector<DataPath> paths = (importPaths.has_value() ? importPaths.value() : importStructure.getAllDataPaths());
  sortImportPaths(paths);
  return paths;
}
```

This states that if there is NO value in the std::optional then we import everything. If the user does not select anything in the UI then the std::optional ended up *not* having a value instead of an empty std::vector<>. This fixes the filter to adhere to the assumption.