### PR TITLE
ENH: Calculate "Most Populated Bin" Array In Find Attribute Array Statistics

### DIFF
--- a/src/Plugins/ComplexCore/docs/FindArrayStatisticsFilter.md
+++ b/src/Plugins/ComplexCore/docs/FindArrayStatisticsFilter.md
@@ -30,6 +30,8 @@ The user must select a destination **Attribute Matrix** in which the computed st
 
 Special operations occur for certain statistics if the supplied array is of type _bool_ (for example, a mask array produced [when thresholding](@ref multithresholdobjects)).  The length, minimum, maximum, median, mode, and summation are computed as normal (although the resulting values may be platform dependent).  The mean and standard deviation for a boolean array will be true if there are more instances of true in the array than false.  If _Standardize Data_ is chosen for a boolean array, no actual modifications will be made to the input.  These operations for boolean inputs are chosen as a basic convention, and are not intended be representative of true boolean logic.
 
+**Note**: If *Find Histogram* is on AND *Compute Statistics Per Feature/Ensemble* is on, then any features that have the exact same value throughout the entire feature will have its first histogram bin set to the total count of feature values.  All other bins will be 0.
+
 ## Parameters ##
 
 | Name                                    | Type | Description                                                                                                                                                       |

--- a/src/Plugins/ComplexCore/docs/FindArrayStatisticsFilter.md
+++ b/src/Plugins/ComplexCore/docs/FindArrayStatisticsFilter.md
@@ -8,19 +8,19 @@ DREAM3D Review (Statistics)
 
 This **Filter** computes a variety of statistics for a given scalar array.  The currently available statistics are array length, minimum, maximum, (arithmetic) mean, median, mode, standard deviation, and summation; any combination of these statistics may be computed by this **Filter**.  Any scalar array, of any primitive type, may be used as input.  The type of the output arrays depends on the kind of statistic computed:
 
-| Statistic               | Primitive Type                     |
-|-------------------------|------------------------------------|
-| Histogram               | float (of user set component size) |
-| Length                  | signed 64-bit integer              |
-| Minimum                 | same type as input                 |
-| Maximum                 | same type as input                 |
-| Mean                    | double                             |
-| Median                  | double                             |
-| Mode                    | same type as input                 |
-| Standard Deviation      | double                             |
-| Summation               | double                             |
-| Standardized            | double                             |
-| Number of Unique Values | signed 32-bit integer              |
+| Statistic               | Primitive Type                      |
+|-------------------------|-------------------------------------|
+| Histogram               | uint64 (of user set component size) |
+| Length                  | signed 64-bit integer               |
+| Minimum                 | same type as input                  |
+| Maximum                 | same type as input                  |
+| Mean                    | double                              |
+| Median                  | double                              |
+| Mode                    | same type as input                  |
+| Standard Deviation      | double                              |
+| Summation               | double                              |
+| Standardized            | double                              |
+| Number of Unique Values | signed 32-bit integer               |
 
 The user may optionally use a mask to specify points to be ignored when computing the statistics; only points where the supplied mask is _true_ will be considered when computing statistics.  Additionally, the user may select to have the statistics computed per **Feature** or **Ensemble** by supplying an Ids array.  For example, if the user opts to compute statistics per **Feature** and selects an array that has 10 unique **Feature** Ids, then this **Filter** will compute 10 sets of statistics (e.g., find the mean of the supplied array for each **Feature**, find the total number of points in each **Feature** (the length), etc.).  
 
@@ -72,7 +72,8 @@ None
 | Kind                | Default Name            | Type                              | Component Dimensions | Description                                                                                                                                                                                                                                                                                            |
 |---------------------|-------------------------|-----------------------------------|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Attribute Array** | Feature-Has-Data        | bool                              | (1)                  | Indicates, for each feature, whether or not the feature actually contains any data (only usable when *Compute Statistics Per Feature/Ensemble* is turned on). This array is especially useful to help determine whether or not the outputted statistics are actually valid or not for a given feature. |
-| **Attribute Array** | Histogram               | float                             | (Number of Bins)     | Histogram of the input array, if _Find Histogram_ is checked                                                                                                                                                                                                                                           |
+| **Attribute Array** | Histogram               | uint64                            | (Number of Bins)     | Histogram of the input array, if _Find Histogram_ is checked                                                                                                                                                                                                                                           |
+| **Attribute Array** | Most Populated Bin      | uint64                            | (2)                  | Most populated bin from the histogram of the input array, if _Find Histogram_ is checked.  First component is the bin index (0-based), second component is the number of values in the bin.                                                                                                            |
 | **Attribute Array** | Length                  | int64_t                           | (1)                  | Length of the input array, if _Find Length_ is checked                                                                                                                                                                                                                                                 |
 | **Attribute Array** | Minimum                 | same as input **Attribute Array** | (1)                  | Minimum of the input array, if _Find Minimum_ is checked                                                                                                                                                                                                                                               |
 | **Attribute Array** | Maximum                 | same as input **Attribute Array** | (1)                  | Maximum of the input array, if _Find Maximum_ is checked                                                                                                                                                                                                                                               |

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindArrayStatistics.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindArrayStatistics.cpp
@@ -112,7 +112,7 @@ public:
       now = std::chrono::steady_clock::now();
       if(progressCount > progressIncrement && std::chrono::duration_cast<std::chrono::milliseconds>(now - initialTime).count() > milliDelay)
       {
-        m_Filter->sendThreadSafeInfoMessage(fmt::format("Min/Max/Summation/Mode/Length Feature/Ensemble [{}-{}]: {:.2f}%", start, end, 100.0f * static_cast<float>(i) / static_cast<float>(numTuples)));
+        m_Filter->sendThreadSafeInfoMessage(fmt::format("Calculating FeatureHasData Array [{}-{}]: {:.2f}%", start, end, 100.0f * static_cast<float>(i) / static_cast<float>(numTuples)));
         progressCount = 0;
         initialTime = std::chrono::steady_clock::now();
       }
@@ -253,7 +253,7 @@ public:
       now = std::chrono::steady_clock::now();
       if(progressCount > progressIncrement && std::chrono::duration_cast<std::chrono::milliseconds>(now - initialTime).count() > milliDelay)
       {
-        m_Filter->sendThreadSafeInfoMessage(fmt::format("Storing data for feature/ensembles [{}-{}] {}/{}", start, end, start, end));
+        m_Filter->sendThreadSafeInfoMessage(fmt::format("Storing data for feature/ensembles [{}-{}] {}/{}", start, end, j, end));
         progressCount = 0;
         initialTime = std::chrono::steady_clock::now();
       }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindArrayStatistics.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindArrayStatistics.cpp
@@ -215,7 +215,7 @@ public:
           const float32 increment = (histMax - histMin) / (m_NumBins);
           if(std::fabs(increment) < 1E-10)
           {
-            histogram = {static_cast<float32>(length[localFeatureIndex])};
+            histogram[0] = static_cast<float32>(length[localFeatureIndex]);
           }
           else
           {

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindArrayStatistics.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindArrayStatistics.cpp
@@ -579,7 +579,14 @@ void FindStatistics(const DataArray<T>& source, const Int32Array* featureIds, co
                                                         inputValues->UseFullRange, inputValues->NumBins, mask, featureIds, source, featureHasDataPtr, lengthArrayPtr, minArrayPtr, maxArrayPtr,
                                                         meanArrayPtr, modeArrayPtr, stdDevArrayPtr, summationArrayPtr, histArrayPtr, filter),
                       simplePartitioner);
+#else
+    auto impl = FindArrayStatisticsByIndexImpl<T>(inputValues->FindLength, inputValues->FindMin, inputValues->FindMax, inputValues->FindMean, inputValues->FindMode, inputValues->FindStdDeviation,
+                                                  inputValues->FindSummation, inputValues->FindHistogram, inputValues->MinRange, inputValues->MaxRange, inputValues->UseFullRange, inputValues->NumBins,
+                                                  mask, featureIds, source, featureHasDataPtr, lengthArrayPtr, minArrayPtr, maxArrayPtr, meanArrayPtr, modeArrayPtr, stdDevArrayPtr, summationArrayPtr,
+                                                  histArrayPtr, filter);
+    impl.compute(0, numFeatures);
 #endif
+
     if(inputValues->FindMedian || inputValues->FindNumUniqueValues)
     {
       filter->sendThreadSafeInfoMessage("Starting Median Calculation..");

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindArrayStatistics.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindArrayStatistics.hpp
@@ -37,6 +37,7 @@ struct COMPLEXCORE_EXPORT FindArrayStatisticsInputValues
   DataPath MaskArrayPath;
   DataPath DestinationAttributeMatrix;
   DataPath HistogramArrayName;
+  DataPath MostPopulatedBinArrayName;
   DataPath FeatureHasDataArrayName;
   DataPath LengthArrayName;
   DataPath MinimumArrayName;

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindArrayStatisticsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindArrayStatisticsFilter.cpp
@@ -250,6 +250,7 @@ Parameters FindArrayStatisticsFilter::parameters() const
   params.linkParameters(k_FindHistogram_Key, k_NumBins_Key, true);
   params.linkParameters(k_FindHistogram_Key, k_MinRange_Key, true);
   params.linkParameters(k_FindHistogram_Key, k_MaxRange_Key, true);
+  params.linkParameters(k_FindHistogram_Key, k_MostPopulatedBinArrayName_Key, true);
   params.linkParameters(k_FindLength_Key, k_LengthArrayName_Key, true);
   params.linkParameters(k_FindMin_Key, k_MinimumArrayName_Key, true);
   params.linkParameters(k_FindMax_Key, k_MaximumArrayName_Key, true);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindArrayStatisticsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindArrayStatisticsFilter.cpp
@@ -184,7 +184,7 @@ Parameters FindArrayStatisticsFilter::parameters() const
   params.insert(std::make_unique<Float64Parameter>(k_MaxRange_Key, "Histogram Max Value", "Max cutoff value for histogram", 0.0));
   params.insert(
       std::make_unique<BoolParameter>(k_UseFullRange_Key, "Use Full Range for Histogram", "If true, ignore min and max and use min and max from array upon which histogram is computed", false));
-  params.insert(std::make_unique<Int32Parameter>(k_NumBins_Key, "Number of Bins", "Number of bins in histogram", 0));
+  params.insert(std::make_unique<Int32Parameter>(k_NumBins_Key, "Number of Bins", "Number of bins in histogram", 1));
   params.insert(std::make_unique<DataObjectNameParameter>(k_HistogramArrayName_Key, "Histogram Array Name", "The name of the histogram array", "Histogram"));
 
   params.insertSeparator(Parameters::Separator{"Optional Data Mask"});
@@ -296,12 +296,11 @@ IFilter::PreflightResult FindArrayStatisticsFilter::preflightImpl(const DataStru
     return {ConvertResultTo<OutputActions>(MakeWarningVoidResult(-57200, "No statistics have been selected, so this filter will perform no operations"), {})};
   }
 
-  usize numBins = 0;
-  if(pNumBinsValue < 0)
+  if(pNumBinsValue < 1)
   {
-    resultOutputActions.warnings().push_back({-57201, "Value entered for number of bins is beyond the representable range for a 32 bit integer. The filter will use the default value of 0."});
+    return {MakeErrorResult<OutputActions>(-57201, "Value entered for number of bins must be a non-zero, positive value."), {}};
   }
-  numBins = static_cast<usize>(pNumBinsValue);
+  usize numBins = static_cast<usize>(pNumBinsValue);
 
   std::vector<DataPath> inputDataArrayPaths;
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindArrayStatisticsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindArrayStatisticsFilter.cpp
@@ -48,6 +48,8 @@ OutputActions CreateCompatibleArrays(const DataStructure& data, const Arguments&
   auto destinationAttributeMatrixValue = args.value<DataPath>(FindArrayStatisticsFilter::k_DestinationAttributeMatrix_Key);
   DataType dataType = inputArray->getDataType();
 
+  size_t tupleSize = std::accumulate(tupleDims.begin(), tupleDims.end(), static_cast<usize>(1), std::multiplies<>());
+
   OutputActions actions;
 
   auto amAction = std::make_unique<CreateAttributeMatrixAction>(destinationAttributeMatrixValue, tupleDims);
@@ -93,7 +95,6 @@ OutputActions CreateCompatibleArrays(const DataStructure& data, const Arguments&
   if(findMode)
   {
     auto arrayPath = args.value<std::string>(FindArrayStatisticsFilter::k_ModeArrayName_Key);
-    size_t tupleSize = std::accumulate(tupleDims.begin(), tupleDims.end(), static_cast<usize>(1), std::multiplies<>());
     auto action = std::make_unique<CreateNeighborListAction>(dataType, tupleSize, destinationAttributeMatrixValue.createChildPath(arrayPath));
     actions.appendAction(std::move(action));
   }
@@ -111,9 +112,16 @@ OutputActions CreateCompatibleArrays(const DataStructure& data, const Arguments&
   }
   if(findHistogramValue)
   {
-    auto arrayPath = args.value<std::string>(FindArrayStatisticsFilter::k_HistogramArrayName_Key);
-    auto action = std::make_unique<CreateArrayAction>(DataType::float32, tupleDims, std::vector<usize>{numBins}, destinationAttributeMatrixValue.createChildPath(arrayPath));
-    actions.appendAction(std::move(action));
+    {
+      auto arrayPath = args.value<std::string>(FindArrayStatisticsFilter::k_HistogramArrayName_Key);
+      auto action = std::make_unique<CreateArrayAction>(DataType::uint64, tupleDims, std::vector<usize>{numBins}, destinationAttributeMatrixValue.createChildPath(arrayPath));
+      actions.appendAction(std::move(action));
+    }
+    {
+      auto arrayPath = args.value<std::string>(FindArrayStatisticsFilter::k_MostPopulatedBinArrayName_Key);
+      auto action = std::make_unique<CreateArrayAction>(DataType::uint64, tupleDims, std::vector<usize>{2}, destinationAttributeMatrixValue.createChildPath(arrayPath));
+      actions.appendAction(std::move(action));
+    }
   }
   if(standardizeDataValue)
   {
@@ -186,6 +194,7 @@ Parameters FindArrayStatisticsFilter::parameters() const
       std::make_unique<BoolParameter>(k_UseFullRange_Key, "Use Full Range for Histogram", "If true, ignore min and max and use min and max from array upon which histogram is computed", false));
   params.insert(std::make_unique<Int32Parameter>(k_NumBins_Key, "Number of Bins", "Number of bins in histogram", 1));
   params.insert(std::make_unique<DataObjectNameParameter>(k_HistogramArrayName_Key, "Histogram Array Name", "The name of the histogram array", "Histogram"));
+  params.insert(std::make_unique<DataObjectNameParameter>(k_MostPopulatedBinArrayName_Key, "Most Populated Bin Array Name", "The name of the Most Populated Bin array", "Most Populated Bin"));
 
   params.insertSeparator(Parameters::Separator{"Optional Data Mask"});
   params.insertLinkableParameter(
@@ -400,6 +409,7 @@ Result<> FindArrayStatisticsFilter::executeImpl(DataStructure& dataStructure, co
   inputValues.DestinationAttributeMatrix = filterArgs.value<DataPath>(k_DestinationAttributeMatrix_Key);
   inputValues.FeatureHasDataArrayName = inputValues.DestinationAttributeMatrix.createChildPath(filterArgs.value<std::string>(k_FeatureHasDataArrayName_Key));
   inputValues.HistogramArrayName = inputValues.DestinationAttributeMatrix.createChildPath(filterArgs.value<std::string>(k_HistogramArrayName_Key));
+  inputValues.MostPopulatedBinArrayName = inputValues.DestinationAttributeMatrix.createChildPath(filterArgs.value<std::string>(k_MostPopulatedBinArrayName_Key));
   inputValues.LengthArrayName = inputValues.DestinationAttributeMatrix.createChildPath(filterArgs.value<std::string>(k_LengthArrayName_Key));
   inputValues.MinimumArrayName = inputValues.DestinationAttributeMatrix.createChildPath(filterArgs.value<std::string>(k_MinimumArrayName_Key));
   inputValues.MaximumArrayName = inputValues.DestinationAttributeMatrix.createChildPath(filterArgs.value<std::string>(k_MaximumArrayName_Key));

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindArrayStatisticsFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindArrayStatisticsFilter.hpp
@@ -48,6 +48,7 @@ public:
   static inline constexpr StringLiteral k_MaskArrayPath_Key = "mask_array_path";
   static inline constexpr StringLiteral k_DestinationAttributeMatrix_Key = "destination_attribute_matrix";
   static inline constexpr StringLiteral k_HistogramArrayName_Key = "histogram_array_name";
+  static inline constexpr StringLiteral k_MostPopulatedBinArrayName_Key = "most_populated_bin_array_name";
   static inline constexpr StringLiteral k_LengthArrayName_Key = "length_array_name";
   static inline constexpr StringLiteral k_MinimumArrayName_Key = "minimum_array_name";
   static inline constexpr StringLiteral k_MaximumArrayName_Key = "maximum_array_name";

--- a/src/Plugins/ComplexCore/test/FindArrayStatisticsTest.cpp
+++ b/src/Plugins/ComplexCore/test/FindArrayStatisticsTest.cpp
@@ -53,6 +53,7 @@ TEST_CASE("ComplexCore::FindArrayStatisticsFilter: Test Algorithm", "[ComplexCor
   maskDataStore[10] = true;
 
   const std::string histogram = "Histogram";
+  const std::string mostPopulatedBin = "Most Populated Bin";
   const std::string length = "Length";
   const std::string min = "Minimum";
   const std::string max = "Maximum";
@@ -90,6 +91,7 @@ TEST_CASE("ComplexCore::FindArrayStatisticsFilter: Test Algorithm", "[ComplexCor
     args.insertOrAssign(FindArrayStatisticsFilter::k_MaskArrayPath_Key, std::make_any<DataPath>(DataPath({"TestData", "Mask"})));
     args.insertOrAssign(FindArrayStatisticsFilter::k_DestinationAttributeMatrix_Key, std::make_any<DataPath>(statsDataPath));
     args.insertOrAssign(FindArrayStatisticsFilter::k_HistogramArrayName_Key, std::make_any<std::string>(histogram));
+    args.insertOrAssign(FindArrayStatisticsFilter::k_MostPopulatedBinArrayName_Key, std::make_any<std::string>(mostPopulatedBin));
     args.insertOrAssign(FindArrayStatisticsFilter::k_LengthArrayName_Key, std::make_any<std::string>(length));
     args.insertOrAssign(FindArrayStatisticsFilter::k_MinimumArrayName_Key, std::make_any<std::string>(min));
     args.insertOrAssign(FindArrayStatisticsFilter::k_MaximumArrayName_Key, std::make_any<std::string>(max));
@@ -135,8 +137,10 @@ TEST_CASE("ComplexCore::FindArrayStatisticsFilter: Test Algorithm", "[ComplexCor
     auto* standardizeArray = dataStructure.getDataAs<Float32Array>(inputArrayPath.getParent().createChildPath(standardization));
     REQUIRE(standardizeArray != nullptr);
     REQUIRE(standardizeArray->getNumberOfTuples() == 11);
-    auto* histArray = dataStructure.getDataAs<Float32Array>(statsDataPath.createChildPath(histogram));
+    auto* histArray = dataStructure.getDataAs<UInt64Array>(statsDataPath.createChildPath(histogram));
     REQUIRE(histArray != nullptr);
+    auto* mostPopulatedBinArray = dataStructure.getDataAs<UInt64Array>(statsDataPath.createChildPath(mostPopulatedBin));
+    REQUIRE(mostPopulatedBinArray != nullptr);
     auto* numUniqueValuesArray = dataStructure.getDataAs<Int32Array>(statsDataPath.createChildPath(numUniqueValues));
     REQUIRE(numUniqueValuesArray != nullptr);
 
@@ -183,11 +187,13 @@ TEST_CASE("ComplexCore::FindArrayStatisticsFilter: Test Algorithm", "[ComplexCor
     REQUIRE(std::fabs(stand7 - .58999f) < UnitTest::EPSILON);
     REQUIRE(std::fabs(stand8 - -.4f) < UnitTest::EPSILON);
     REQUIRE(std::fabs(stand9 - -.33f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs((*histArray)[0] - 4.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs((*histArray)[1] - 2.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs((*histArray)[2] - 2.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs((*histArray)[3] - 0.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs((*histArray)[4] - 1.0f) < UnitTest::EPSILON);
+    REQUIRE((*histArray)[0] == 4);
+    REQUIRE((*histArray)[1] == 2);
+    REQUIRE((*histArray)[2] == 2);
+    REQUIRE((*histArray)[3] == 0);
+    REQUIRE((*histArray)[4] == 1);
+    REQUIRE((*mostPopulatedBinArray)[0] == 0);
+    REQUIRE((*mostPopulatedBinArray)[1] == 4);
   }
 }
 
@@ -241,6 +247,7 @@ TEST_CASE("ComplexCore::FindArrayStatisticsFilter: Test Algorithm By Index", "[C
   testFeatIdsDataStore[11] = 2;
 
   const std::string histogram = "Histogram";
+  const std::string mostPopulatedBin = "Most Populated Bin";
   const std::string length = "Length";
   const std::string min = "Minimum";
   const std::string max = "Maximum";
@@ -278,6 +285,7 @@ TEST_CASE("ComplexCore::FindArrayStatisticsFilter: Test Algorithm By Index", "[C
     args.insertOrAssign(FindArrayStatisticsFilter::k_MaskArrayPath_Key, std::make_any<DataPath>(DataPath({"TestData", "Mask"})));
     args.insertOrAssign(FindArrayStatisticsFilter::k_DestinationAttributeMatrix_Key, std::make_any<DataPath>(statsDataPath));
     args.insertOrAssign(FindArrayStatisticsFilter::k_HistogramArrayName_Key, std::make_any<std::string>(histogram));
+    args.insertOrAssign(FindArrayStatisticsFilter::k_MostPopulatedBinArrayName_Key, std::make_any<std::string>(mostPopulatedBin));
     args.insertOrAssign(FindArrayStatisticsFilter::k_LengthArrayName_Key, std::make_any<std::string>(length));
     args.insertOrAssign(FindArrayStatisticsFilter::k_MinimumArrayName_Key, std::make_any<std::string>(min));
     args.insertOrAssign(FindArrayStatisticsFilter::k_MaximumArrayName_Key, std::make_any<std::string>(max));
@@ -331,10 +339,13 @@ TEST_CASE("ComplexCore::FindArrayStatisticsFilter: Test Algorithm By Index", "[C
     auto* standardizeArray = dataStructure.getDataAs<Float32Array>(inputArrayPath.getParent().createChildPath(standardization));
     REQUIRE(standardizeArray != nullptr);
     REQUIRE(standardizeArray->getNumberOfTuples() == 12);
-    auto* histArray = dataStructure.getDataAs<Float32Array>(statsDataPath.createChildPath(histogram));
+    auto* histArray = dataStructure.getDataAs<UInt64Array>(statsDataPath.createChildPath(histogram));
     REQUIRE(histArray != nullptr);
     REQUIRE(histArray->getNumberOfTuples() == 3);
     REQUIRE(histArray->getNumberOfComponents() == 5);
+    auto* mostPopulatedBinArray = dataStructure.getDataAs<UInt64Array>(statsDataPath.createChildPath(mostPopulatedBin));
+    REQUIRE(mostPopulatedBinArray != nullptr);
+    REQUIRE(mostPopulatedBinArray->getNumberOfTuples() == 3);
     auto* numUniqueValuesArray = dataStructure.getDataAs<Int32Array>(statsDataPath.createChildPath(numUniqueValues));
     REQUIRE(numUniqueValuesArray != nullptr);
     REQUIRE(numUniqueValuesArray->getNumberOfTuples() == 3);
@@ -437,20 +448,26 @@ TEST_CASE("ComplexCore::FindArrayStatisticsFilter: Test Algorithm By Index", "[C
     REQUIRE(std::fabs(stand7 - 0.0f) < UnitTest::EPSILON);
     REQUIRE(std::fabs(stand8 - 1.0f) < UnitTest::EPSILON);
     REQUIRE(std::fabs(stand9 - -1.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist1_1 - 1.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist1_2 - 0.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist1_3 - 0.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist1_4 - 0.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist1_5 - 1.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist2_1 - 1.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist2_2 - 0.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist2_3 - 0.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist2_4 - 1.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist2_5 - 2.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist3_1 - 2.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist3_2 - 0.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist3_3 - 0.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist3_4 - 0.0f) < UnitTest::EPSILON);
-    REQUIRE(std::fabs(hist3_5 - 2.0f) < UnitTest::EPSILON);
+    REQUIRE(hist1_1 == 1);
+    REQUIRE(hist1_2 == 0);
+    REQUIRE(hist1_3 == 0);
+    REQUIRE(hist1_4 == 0);
+    REQUIRE(hist1_5 == 1);
+    REQUIRE(hist2_1 == 1);
+    REQUIRE(hist2_2 == 0);
+    REQUIRE(hist2_3 == 0);
+    REQUIRE(hist2_4 == 1);
+    REQUIRE(hist2_5 == 2);
+    REQUIRE(hist3_1 == 2);
+    REQUIRE(hist3_2 == 0);
+    REQUIRE(hist3_3 == 0);
+    REQUIRE(hist3_4 == 0);
+    REQUIRE(hist3_5 == 2);
+    REQUIRE((*mostPopulatedBinArray)[0] == 0);
+    REQUIRE((*mostPopulatedBinArray)[1] == 1);
+    REQUIRE((*mostPopulatedBinArray)[2] == 4);
+    REQUIRE((*mostPopulatedBinArray)[3] == 2);
+    REQUIRE((*mostPopulatedBinArray)[4] == 0);
+    REQUIRE((*mostPopulatedBinArray)[5] == 2);
   }
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/FindGBPDMetricBased.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/FindGBPDMetricBased.cpp
@@ -578,7 +578,7 @@ Result<> FindGBPDMetricBased::operator()()
 #ifdef COMPLEX_ENABLE_MULTICORE
   tbb::concurrent_vector<gbpd_metric_based::TriAreaAndNormals> selectedTriangles(0);
 #else
-  std::vector<GBPDMetricBased::TriAreaAndNormals> selectedTriangles(0);
+  std::vector<gbpd_metric_based::TriAreaAndNormals> selectedTriangles(0);
 #endif
 
   usize triChunkSize = 50000;

--- a/src/complex/Utilities/Math/StatisticsCalculations.hpp
+++ b/src/complex/Utilities/Math/StatisticsCalculations.hpp
@@ -236,11 +236,11 @@ size_t findNumUniqueValues(const C<T, Ts...>& source)
 
 // -----------------------------------------------------------------------------
 template <template <typename, typename...> class C, typename T, typename... Ts>
-std::vector<float> findHistogram(const C<T, Ts...>& source, float histmin, float histmax, bool histfullrange, int32_t numBins)
+std::vector<uint64_t> findHistogram(const C<T, Ts...>& source, float histmin, float histmax, bool histfullrange, int32_t numBins)
 {
   if(source.empty())
   {
-    return std::vector<float>(numBins, 0);
+    return std::vector<uint64_t>(numBins, 0);
   }
 
   float min = 0.0f;
@@ -263,11 +263,11 @@ std::vector<float> findHistogram(const C<T, Ts...>& source, float histmin, float
     numBins = 1;
   }
 
-  std::vector<float> histogram(numBins, 0);
+  std::vector<uint64_t> histogram(numBins, 0);
 
   if(numBins == 1) // if one bin, just set the first element to total number of points
   {
-    histogram[0] = static_cast<float>(source.size());
+    histogram[0] = static_cast<uint64_t>(source.size());
   }
   else
   {


### PR DESCRIPTION
+ Calculates the "Most Populated Bin" array when "Find Histogram" is ON.  The "Most Populated Bin" array is a 2-component array that stores the index and value count of the most populated bin in the first and second components, respectively.  This array is also calculated per feature when "Compute Statistics Per Feature/Ensemble" is ON.

+ Fixed a crash that was occurring when calculating a histogram per feature.  The edge case where a feature happens to have identical values was not being handled.  The value count for the feature is stored in the first component of the histogram and the rest of the components are 0s.

+ Added a missing serial execution option to FindArrayStatistics... previously if multithreaded was turned off then the filter would just do nothing.

+ Fixed a compile error that was occurring when multithreading was turned off.

+ Required the number of histogram bins to be at least 1, because 0 or negative bins makes no sense.

+ Updated the histogram array to output uint64 values instead of floats, because the output values should be value counts for each bin.  Therefore, floats don't make sense.