### PR TITLE
BUG: Disable parallel for Find Neighborhoods and Fix Copy Error In Fill Bad Data

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FillBadData.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FillBadData.cpp
@@ -108,7 +108,12 @@ Result<> FillBadData::operator()()
 
   const SizeVec3 udims = selectedImageGeom.getDimensions();
 
-  auto* m_CellPhases = m_DataStructure.getDataAs<Int32Array>(m_InputValues->featureIdsArrayPath);
+  Int32Array* cellPhasesPtr = nullptr;
+
+  if(m_InputValues->storeAsNewPhase)
+  {
+    cellPhasesPtr = m_DataStructure.getDataAs<Int32Array>(m_InputValues->cellPhasesArrayPath);
+  }
 
   std::array<int64_t, 3> dims = {
       static_cast<int64_t>(udims[0]),
@@ -145,9 +150,9 @@ Result<> FillBadData::operator()()
   {
     for(size_t i = 0; i < totalPoints; i++)
     {
-      if((*m_CellPhases)[i] > maxPhase)
+      if((*cellPhasesPtr)[i] > maxPhase)
       {
-        maxPhase = (*m_CellPhases)[i];
+        maxPhase = (*cellPhasesPtr)[i];
       }
     }
   }
@@ -218,7 +223,7 @@ Result<> FillBadData::operator()()
           m_FeatureIds[currentIndex] = 0;
           if(m_InputValues->storeAsNewPhase)
           {
-            (*m_CellPhases)[currentIndex] = static_cast<int32>(maxPhase) + 1;
+            (*cellPhasesPtr)[currentIndex] = static_cast<int32>(maxPhase) + 1;
           }
         }
       }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindNeighborhoods.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindNeighborhoods.cpp
@@ -109,8 +109,7 @@ const std::atomic_bool& FindNeighborhoods::getCancel()
 // -----------------------------------------------------------------------------
 void FindNeighborhoods::updateNeighborHood(size_t sourceIndex, size_t destIndex)
 {
-  static std::mutex mutex;
-  std::lock_guard<std::mutex> lock(mutex);
+  const std::lock_guard<std::mutex> lock(m_Mutex);
   (*m_Neighborhoods)[sourceIndex]++;
   m_LocalNeighborhoodList[sourceIndex].push_back(static_cast<int32_t>(destIndex));
 }
@@ -120,8 +119,7 @@ void FindNeighborhoods::updateNeighborHood(size_t sourceIndex, size_t destIndex)
 // -----------------------------------------------------------------------------
 void FindNeighborhoods::updateProgress(size_t numCompleted, size_t totalFeatures)
 {
-  static std::mutex mutex;
-  std::lock_guard<std::mutex> lock(mutex);
+  const std::lock_guard<std::mutex> lock(m_Mutex);
   m_IncCount += numCompleted;
   m_NumCompleted = m_NumCompleted + numCompleted;
   if(m_IncCount > m_ProgIncrement)
@@ -187,7 +185,7 @@ Result<> FindNeighborhoods::operator()()
 
   ParallelDataAlgorithm parallelAlgorithm;
   parallelAlgorithm.setRange(Range(0, totalFeatures));
-  parallelAlgorithm.setParallelizationEnabled(true);
+  parallelAlgorithm.setParallelizationEnabled(false);
   parallelAlgorithm.execute(FindNeighborhoodsImpl(this, totalFeatures, centroids, bins, criticalDistance));
 
   // Output Variables

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindNeighborhoods.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindNeighborhoods.hpp
@@ -8,6 +8,8 @@
 #include "complex/DataStructure/NeighborList.hpp"
 #include "complex/Filter/IFilter.hpp"
 
+#include <mutex>
+
 namespace complex
 {
 
@@ -51,6 +53,8 @@ private:
   const FindNeighborhoodsInputValues* m_InputValues = nullptr;
   const std::atomic_bool& m_ShouldCancel;
   const IFilter::MessageHandler& m_MessageHandler;
+
+  std::mutex m_Mutex;
 
   Int32Array* m_Neighborhoods = nullptr;
   std::vector<std::vector<int32_t>> m_LocalNeighborhoodList;


### PR DESCRIPTION
- Moved mutex lock for find neighborhoods to object itself
- Fixed bug where cell Phases was actually a pointer to feature Ids