### PR TITLE
[WIP] DEBUG: Changes to allow easier debugging of the FindNeighborHoods filter

### DIFF
--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindNeighborhoods.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/Algorithms/FindNeighborhoods.hpp
@@ -22,6 +22,7 @@ struct COMPLEXCORE_EXPORT FindNeighborhoodsInputValues
   DataPath NeighborhoodsArrayName;
   DataPath NeighborhoodListArrayName;
   DataPath InputImageGeometry;
+  bool ParallelExecution;
 };
 
 /**

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighborhoodsFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighborhoodsFilter.cpp
@@ -10,6 +10,7 @@
 #include "complex/Parameters/DataObjectNameParameter.hpp"
 #include "complex/Parameters/GeometrySelectionParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
+#include "complex/Parameters/BoolParameter.hpp"
 
 using namespace complex;
 
@@ -52,6 +53,9 @@ Parameters FindNeighborhoodsFilter::parameters() const
 
   // Create the parameter descriptors that are needed for this filter
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
+
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_Parallel_Key, "Parallel Execution", "Runs the filter using multiple cores where possible", false));
+
 
   params.insert(std::make_unique<Float32Parameter>(k_MultiplesOfAverage_Key, "Multiples of Average Diameter", "Defines the search radius to use when looking for 'neighboring' Features", 1.0F));
 
@@ -140,7 +144,7 @@ Result<> FindNeighborhoodsFilter::executeImpl(DataStructure& dataStructure, cons
                                               const std::atomic_bool& shouldCancel) const
 {
   FindNeighborhoodsInputValues inputValues;
-
+  inputValues.ParallelExecution =  filterArgs.value<bool>(k_Parallel_Key);
   inputValues.MultiplesOfAverage = filterArgs.value<float32>(k_MultiplesOfAverage_Key);
   inputValues.EquivalentDiametersArrayPath = filterArgs.value<DataPath>(k_EquivalentDiametersArrayPath_Key);
   inputValues.FeaturePhasesArrayPath = filterArgs.value<DataPath>(k_FeaturePhasesArrayPath_Key);

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighborhoodsFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/FindNeighborhoodsFilter.hpp
@@ -31,6 +31,7 @@ public:
   static inline constexpr StringLiteral k_NeighborhoodsArrayName_Key = "neighborhoods_array_name";
   static inline constexpr StringLiteral k_NeighborhoodListArrayName_Key = "neighborhood_list_array_name";
   static inline constexpr StringLiteral k_SelectedImageGeometry_Key = "selected_image_geometry_path";
+  static inline constexpr StringLiteral k_Parallel_Key = "parallel_execution";
 
   /**
    * @brief Returns the name of the filter.

--- a/src/Plugins/ComplexCore/test/FindNeighborhoodsTest.cpp
+++ b/src/Plugins/ComplexCore/test/FindNeighborhoodsTest.cpp
@@ -74,3 +74,34 @@ TEST_CASE("ComplexCore::FindNeighborhoods", "[ComplexCore][FindNeighborhoods]")
   WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/find_neighborhoods.dream3d", unit_test::k_BinaryTestOutputDir)));
 #endif
 }
+
+//
+//TEST_CASE("ComplexCore::FindNeighborhoods Debug", "[ComplexCore][FindNeighborhoods]")
+//{
+//
+//  // Read the Small IN100 Data set
+//  auto baseDataFilePath = fs::path(fmt::format("/tmp/7_after.dream3d"));
+//  DataStructure dataStructure = UnitTest::LoadDataStructure(baseDataFilePath);
+//
+//  // Compare the k_Neighborhoods output array with those precalculated from the file
+//  {
+//    const DataPath exemplarPath = DataPath::FromString("ImageDataContainerNX/CellFeatureData/Neighborhoods").value();
+//    const DataPath parallelPath = DataPath::FromString("ImageDataContainerNX/CellFeatureData/Neighborhoods Parallel").value();
+//    UnitTest::CompareArrays<int32>(dataStructure.getDataAs<IDataArray>(exemplarPath), dataStructure.getDataAs<IDataArray>(parallelPath));
+//  }
+//
+//  // Compare the k_NeighborhoodList output neighborlist with those precalculated from the file
+//  {
+//    const DataPath exemplarPath = DataPath::FromString("ImageDataContainerNX/CellFeatureData/NeighborhoodList").value();
+//    const DataPath parallelPath = DataPath::FromString("ImageDataContainerNX/CellFeatureData/NeighborhoodList Parallel").value();
+//
+//    UnitTest::CompareNeighborLists<int32>(dataStructure.getDataAs<NeighborList<int32>>(exemplarPath), dataStructure.getDataAs<NeighborList<int32>>(parallelPath));
+//  }
+//
+//// Write the DataStructure out to the file system
+//#ifdef COMPLEX_WRITE_TEST_OUTPUT
+//  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/find_neighborhoods.dream3d", unit_test::k_BinaryTestOutputDir)));
+//#endif
+//}
+
+


### PR DESCRIPTION
@nyoungbq  This is a validation branch only. If you use the pipelines we were working with you can run the FindNeighborHoods filter in both parallel and serial in the same pipeline, then use the output from the pipeline to run through the commented out unit test. It validated on macOS (x64).