### PR TITLE
ENH: Add proper sample and crystal reference frame rotations to pipelines

### DIFF
--- a/src/Plugins/OrientationAnalysis/docs/ImportH5OimDataFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ImportH5OimDataFilter.md
@@ -13,11 +13,9 @@ This **Filter** will read a single .h5 file into a new **Image Geometry**, allow
 |-------|
 |![](Images/ReadEDAXH5_1.png)|
 
-
 | User interface AFTER setting the "Z Spacing" and selecting files.  |
 |-------|
 |![](Images/ReadEDAXH5_2.png)|
-
 
 ## Notes About Reference Frames
 
@@ -28,8 +26,15 @@ The user should be aware that simply reading the file then performing operations
 
 If the data has come from a TSL acquisition system and the settings of the acquisition software were in the default modes, the following reference frame transformations may need to be performed based on the version of the OIM Analysis software being used to collect the data:
 
-+ Sample Reference Frame: 180<sup>o</sup> about the <010> Axis
 + Crystal Reference Frame: 90<sup>o</sup> about the <001> Axis
++ Sample Reference Frame: 180<sup>o</sup> about the <010> Axis
+
+### Important Consideration for Sample Reference Frame
+
+If the user is importing more than a single slice from the HDF5 file and using the "Rotate Sample Reference Frame" filter,
+the user should **CHECK** the option **ON** for "Perform Slice By Slice Transform".
+
+## Thresholding out Unindexed Scan Points
 
 The user also may want to assign un-indexed pixels to be ignored by flagging them as "bad". The [Threshold Objects](../MultiThresholdObjects/index.html) **Filter** can be used to define this *mask* by thresholding on values such as *Confidence Index* > xx or *Image Quality* > desired quality.
 

--- a/src/Plugins/OrientationAnalysis/pipelines/ImportEdaxOIMData.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/ImportEdaxOIMData.d3dpipeline
@@ -1,7 +1,6 @@
 {
   "isDisabled": false,
-  "name": "ImportEdaxOIMData.d3dpipeline",
-  "pinnedParams": [],
+  "name": "Untitled Pipeline",
   "pipeline": [
     {
       "args": {
@@ -13,11 +12,19 @@
           0.0,
           0.0
         ],
-        "read_pattern_data": true,
+        "read_pattern_data": false,
         "selected_scan_names": {
-          "input_file_path": "Data/OrientationAnalysis/EdaxOIMData.h5",
+          "input_file_path": "Data/Hikari_Ni_Sequence.h5",
           "scan_names": [
-            "Scan 1"
+            "Scan 1",
+            "Scan 2",
+            "Scan 3",
+            "Scan 4",
+            "Scan 5",
+            "Scan 6",
+            "Scan 7",
+            "Scan 8",
+            "Scan 9"
           ],
           "stacking_order": 0
         },
@@ -27,6 +34,70 @@
       "filter": {
         "name": "complex::ImportH5OimDataFilter",
         "uuid": "4ad3d47c-b1e1-4429-bc65-5e021be62ba0"
+      },
+      "isDisabled": false
+    },
+    {
+      "args": {
+        "cell_euler_angles_array_path": "ImageGeom/Cell Data/EulerAngles",
+        "rotation_axis": [
+          0.0,
+          0.0,
+          1.0,
+          90.0
+        ]
+      },
+      "comments": "",
+      "filter": {
+        "name": "complex::RotateEulerRefFrameFilter",
+        "uuid": "0458edcd-3655-4465-adc8-b036d76138b5"
+      },
+      "isDisabled": false
+    },
+    {
+      "args": {
+        "created_image_geometry": "",
+        "remove_original_geometry": true,
+        "rotate_slice_by_slice": true,
+        "rotation_axis": [
+          0.0,
+          1.0,
+          0.0,
+          180.0
+        ],
+        "rotation_matrix": [
+          [
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.0,
+            1.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.0,
+            0.0,
+            1.0,
+            0.0
+          ],
+          [
+            0.0,
+            0.0,
+            0.0,
+            1.0
+          ]
+        ],
+        "rotation_representation": 0,
+        "selected_image_geometry": "ImageGeom"
+      },
+      "comments": "",
+      "filter": {
+        "name": "complex::RotateSampleRefFrameFilter",
+        "uuid": "d2451dc1-a5a1-4ac2-a64d-7991669dcffc"
       },
       "isDisabled": false
     },
@@ -43,5 +114,5 @@
       "isDisabled": false
     }
   ],
-  "workflowParams": []
+  "version": 1
 }

--- a/src/Plugins/OrientationAnalysis/pipelines/ReadAng.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/ReadAng.d3dpipeline
@@ -1,7 +1,6 @@
 {
   "isDisabled": false,
-  "name": "ReadAng.d3dpipeline",
-  "pinnedParams": [],
+  "name": "Untitled Pipeline",
   "pipeline": [
     {
       "args": {
@@ -10,9 +9,96 @@
         "data_container_name": "DataContainer",
         "input_file": "Data/Small_IN100/Slice_1.ang"
       },
+      "comments": "",
       "filter": {
         "name": "complex::ReadAngDataFilter",
         "uuid": "5b062816-79ac-47ce-93cb-e7966896bcbd"
+      },
+      "isDisabled": false
+    },
+    {
+      "args": {
+        "cell_euler_angles_array_path": "DataContainer/Cell Data/EulerAngles",
+        "rotation_axis": [
+          0.0,
+          0.0,
+          1.0,
+          90.0
+        ]
+      },
+      "comments": "",
+      "filter": {
+        "name": "complex::RotateEulerRefFrameFilter",
+        "uuid": "0458edcd-3655-4465-adc8-b036d76138b5"
+      },
+      "isDisabled": false
+    },
+    {
+      "args": {
+        "created_image_geometry": "DataContainer",
+        "remove_original_geometry": true,
+        "rotate_slice_by_slice": false,
+        "rotation_axis": [
+          0.0,
+          1.0,
+          0.0,
+          180.0
+        ],
+        "rotation_matrix": [
+          [
+            0.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.0,
+            0.0,
+            0.0
+          ]
+        ],
+        "rotation_representation": 0,
+        "selected_image_geometry": "DataContainer"
+      },
+      "comments": "",
+      "filter": {
+        "name": "complex::RotateSampleRefFrameFilter",
+        "uuid": "d2451dc1-a5a1-4ac2-a64d-7991669dcffc"
+      },
+      "isDisabled": false
+    },
+    {
+      "args": {
+        "array_thresholds": {
+          "inverted": false,
+          "thresholds": [
+            {
+              "array_path": "DataContainer/Cell Data/Confidence Index",
+              "comparison": 1,
+              "inverted": false,
+              "type": "array",
+              "union": 0,
+              "value": 0.1
+            }
+          ],
+          "type": "collection",
+          "union": 0
+        },
+        "created_data_path": "Mask",
+        "created_mask_type": 10,
+        "custom_false_value": 0.0,
+        "custom_true_value": 1.0,
+        "use_custom_false_value": false,
+        "use_custom_true_value": false
+      },
+      "comments": "",
+      "filter": {
+        "name": "complex::MultiThresholdObjects",
+        "uuid": "4246245e-1011-4add-8436-0af6bed19228"
       },
       "isDisabled": false
     },
@@ -30,6 +116,7 @@
         ],
         "use_good_voxels": false
       },
+      "comments": "",
       "filter": {
         "name": "complex::GenerateIPFColorsFilter",
         "uuid": "64cb4f27-6e5e-4dd2-8a03-0c448cb8f5e6"
@@ -37,5 +124,5 @@
       "isDisabled": false
     }
   ],
-  "workflowParams": []
+  "version": 1
 }

--- a/src/Plugins/OrientationAnalysis/pipelines/ReadCTF.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/ReadCTF.d3dpipeline
@@ -1,7 +1,6 @@
 {
   "isDisabled": false,
-  "name": "ReadCTF.d3dpipeline",
-  "pinnedParams": [],
+  "name": "Untitled Pipeline",
   "pipeline": [
     {
       "args": {
@@ -12,9 +11,88 @@
         "edax_hexagonal_alignment": false,
         "input_file": "Data/T12-MAI-2010/fw-ar-IF1-aptr12-corr.ctf"
       },
+      "comments": "",
       "filter": {
         "name": "complex::ReadCtfDataFilter",
         "uuid": "7751923c-afb9-4032-8372-8078325c69a4"
+      },
+      "isDisabled": false
+    },
+    {
+      "args": {
+        "created_image_geometry": "",
+        "remove_original_geometry": true,
+        "rotate_slice_by_slice": false,
+        "rotation_axis": [
+          0.0,
+          1.0,
+          0.0,
+          180.0
+        ],
+        "rotation_matrix": [
+          [
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.0,
+            1.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.0,
+            0.0,
+            1.0,
+            0.0
+          ],
+          [
+            0.0,
+            0.0,
+            0.0,
+            1.0
+          ]
+        ],
+        "rotation_representation": 0,
+        "selected_image_geometry": "DataContainer"
+      },
+      "comments": "",
+      "filter": {
+        "name": "complex::RotateSampleRefFrameFilter",
+        "uuid": "d2451dc1-a5a1-4ac2-a64d-7991669dcffc"
+      },
+      "isDisabled": false
+    },
+    {
+      "args": {
+        "array_thresholds": {
+          "inverted": false,
+          "thresholds": [
+            {
+              "array_path": "DataContainer/Cell Data/Error",
+              "comparison": 2,
+              "inverted": false,
+              "type": "array",
+              "union": 0,
+              "value": 0.0
+            }
+          ],
+          "type": "collection",
+          "union": 0
+        },
+        "created_data_path": "Mask",
+        "created_mask_type": 10,
+        "custom_false_value": 0.0,
+        "custom_true_value": 1.0,
+        "use_custom_false_value": false,
+        "use_custom_true_value": false
+      },
+      "comments": "",
+      "filter": {
+        "name": "complex::MultiThresholdObjects",
+        "uuid": "4246245e-1011-4add-8436-0af6bed19228"
       },
       "isDisabled": false
     },
@@ -24,14 +102,15 @@
         "cell_ipf_colors_array_name": "IPFColors",
         "cell_phases_array_path": "DataContainer/Cell Data/Phases",
         "crystal_structures_array_path": "DataContainer/CellEnsembleData/CrystalStructures",
-        "good_voxels_array_path": "",
+        "good_voxels_array_path": "DataContainer/Cell Data/Mask",
         "reference_dir": [
           0.0,
           0.0,
           1.0
         ],
-        "use_good_voxels": false
+        "use_good_voxels": true
       },
+      "comments": "",
       "filter": {
         "name": "complex::GenerateIPFColorsFilter",
         "uuid": "64cb4f27-6e5e-4dd2-8a03-0c448cb8f5e6"
@@ -39,5 +118,5 @@
       "isDisabled": false
     }
   ],
-  "workflowParams": []
+  "version": 1
 }


### PR DESCRIPTION
The basic pipeline of reading a .ang or a .ctf file were missing critical filters to set the crystal and sample reference frame correctly.
