### PR TITLE
ENH: Create DataModifiedAction that marks DataObjects as being modified by a filter

### DIFF
--- a/pipelines/Combo-EBSD-osc_r0c0.d3dpipeline
+++ b/pipelines/Combo-EBSD-osc_r0c0.d3dpipeline
@@ -66,7 +66,7 @@
     },
     {
       "args": {
-        "cell_euler_angles_array_path": "DataContainer/CellData/EulerAngles",
+        "euler_angles_array_path": "DataContainer/CellData/EulerAngles",
         "rotation_axis": [
           0.0,
           0.0,

--- a/src/Plugins/ComplexCore/docs/RemoveFlaggedFeaturesFilter.md
+++ b/src/Plugins/ComplexCore/docs/RemoveFlaggedFeaturesFilter.md
@@ -1,4 +1,4 @@
-# Remove Flagged Features
+# Remove/Extract Flagged Features
 
 ## Group (Subgroup)
 
@@ -6,7 +6,11 @@ Processing (Cleanup)
 
 ## Description
 
-This **Filter** will remove **Features** that have been flagged by another **Filter** from the structure.  The **Filter** requires that the user point to a boolean array at the **Feature** level that tells the **Filter** whether the **Feature** should remain in the structure.  If the boolean array is *false* for a **Feature**, then all **Cells** that belong to that **Feature** are temporarily *unassigned* and after all *undesired* **Features** are removed, the remaining **Features** are isotropically coarsened to fill in the gaps left by the removed **Features**.
+This **Filter** will remove **Features** that have been flagged by another **Filter** from the structure.  The **Filter**
+requires that the user point to a boolean array at the **Feature** level that tells the **Filter** whether the **Feature**
+should remain in the structure.  If the boolean array is *false* for a **Feature**, then all **Cells** that belong to that
+**Feature** are temporarily *unassigned*. Optionally, after all *undesired* **Features** are removed, the remaining **Features** are
+isotropically coarsened to fill in the gaps left by the removed **Features**.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ComplexCore/docs/RemoveFlaggedVertices.md
+++ b/src/Plugins/ComplexCore/docs/RemoveFlaggedVertices.md
@@ -6,14 +6,14 @@ DREAM3D Review (Geometry)
 
 ## Description
 
-This **Filter** removes **Vertices** from the supplied **Vertex Geometry** that are flagged by a boolean mask array.
-Specifically, **Vertices** flagged as *true* are removed from the **Geometry**. A new reduced **Vertex Geometry** is
+This **Filter** removes **Vertices** from the supplied **Vertex Geometry** that are flagged as **TRUE** by a boolean mask array.
+A new reduced **Vertex Geometry** is
 created that contains all the remaining **Vertices**. It is unknown until run time how many **Vertices** will be removed
 from the **Geometry**. Therefore, this **Filter** requires that a new **Data Container** be created to contain the
-reduced **Vertex Geometry**. This new **Data Container** will contain copies of any **Feature** or **Ensemble** *
-*Attribute Matrices** from the original **Data Container**. Additionally, all **Vertex** data will be copied, with
-tuples *removed* for any **Vertices** removed by the **Filter**. The user must supply a name for the reduced **Data
-Container**, but all other copied objects (**Attribute Matrices** and **Attribute Arrays**) will retain the same names
+reduced **Vertex Geometry**. This new **Vertex Geometry** will contain copies of any **Feature** or **Ensemble**
+**Attribute Matrices** from the original **Data Container**. Additionally, all **Vertex** data will be copied, with
+tuples *removed* for any **Vertices** removed by the **Filter**. The user must supply a name for the reduced **Vertex Geometry**,
+but all other copied objects (**Attribute Matrices** and **Attribute Arrays**) will retain the same names
 as the original source.
 
 *Note:* Since it cannot be known before run time how many **Vertices** will be removed, the new **Vertex Geometry** and

--- a/src/Plugins/ComplexCore/docs/ReplaceElementAttributesWithNeighborValuesFilter.md
+++ b/src/Plugins/ComplexCore/docs/ReplaceElementAttributesWithNeighborValuesFilter.md
@@ -12,8 +12,8 @@ maximum or minimum value. The attributes of the neighbor with the maximum/minimu
 reference **Cell**.
 
 *Note:* By default, the **Filter** will run only one iteration of the cleanup. If the user selects the *Loop Until Gone*
-option, then the **Filter** will run iteratively until no **Cells** exist that meet the users criteria. So, if a **Cell
-** meets the threshold and so are all of its neighbors, then that **Cell** will not be changed during that iteration and
+option, then the **Filter** will run iteratively until no **Cells** exist that meet the users criteria. So, if a **Cell**
+meets the threshold and so are all of its neighbors, then that **Cell** will not be changed during that iteration and
 will remain unchanged until one of its neighbors gets changed by a **Cell** further away.
 
 ## Examples

--- a/src/Plugins/ComplexCore/pipelines/ReplaceElementAttributesWithNeighbor.d3dpipeline
+++ b/src/Plugins/ComplexCore/pipelines/ReplaceElementAttributesWithNeighbor.d3dpipeline
@@ -104,7 +104,7 @@
     },
     {
       "args": {
-        "cell_euler_angles_array_path": "DataContainer/Cell Data/EulerAngles",
+        "euler_angles_array_path": "DataContainer/Cell Data/EulerAngles",
         "rotation_axis": [
           0.0,
           0.0,

--- a/src/Plugins/ComplexCore/pipelines/ReplaceElementAttributesWithNeighbor.d3dpipeline
+++ b/src/Plugins/ComplexCore/pipelines/ReplaceElementAttributesWithNeighbor.d3dpipeline
@@ -192,7 +192,7 @@
     },
     {
       "args": {
-        "confidence_index_array_path": "DataContainer/Cell Data/Confidence Index",
+        "comparison_data_path": "DataContainer/Cell Data/Confidence Index",
         "loop": true,
         "min_confidence": 0.10000000149011612,
         "selected_comparison": 0,

--- a/src/Plugins/ComplexCore/pipelines/VtkRectilinearGridWriter.d3dpipeline
+++ b/src/Plugins/ComplexCore/pipelines/VtkRectilinearGridWriter.d3dpipeline
@@ -192,7 +192,7 @@
             {
               "args": {
                 "cell_phases_array_path": "DataContainer/CellData/Phases",
-                "confidence_index_array_path": "DataContainer/CellData/Confidence Index",
+                "correlation_array_path": "DataContainer/CellData/Confidence Index",
                 "crystal_structures_array_path": "DataContainer/CellEnsembleData/CrystalStructures",
                 "ignored_data_array_paths": [],
                 "image_geometry_path": "DataContainer",

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsFeatureCentroidFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsFeatureCentroidFilter.cpp
@@ -135,7 +135,7 @@ IFilter::PreflightResult AlignSectionsFeatureCentroidFilter::preflightImpl(const
 
   // Inform users that the following arrays are going to be modified in place
   // Cell Data is going to be modified
-  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, cellDataGroupPath, {});
+  complex::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, cellDataGroupPath, {});
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsFeatureCentroidFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsFeatureCentroidFilter.cpp
@@ -9,6 +9,7 @@
 #include "complex/Parameters/FileSystemPathParameter.hpp"
 #include "complex/Parameters/GeometrySelectionParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 #include <filesystem>
 
@@ -131,6 +132,10 @@ IFilter::PreflightResult AlignSectionsFeatureCentroidFilter::preflightImpl(const
   {
     return {MakeErrorResult<OutputActions>(-3425, "Write Alignment Shifts is TRUE but the output file path is empty. Please ensure the file path is set for the alignment file.")};
   }
+
+  // Inform users that the following arrays are going to be modified in place
+  // Cell Data is going to be modified
+  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, cellDataGroupPath, {});
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsListFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsListFilter.cpp
@@ -8,6 +8,7 @@
 #include "complex/Parameters/BoolParameter.hpp"
 #include "complex/Parameters/FileSystemPathParameter.hpp"
 #include "complex/Parameters/GeometrySelectionParameter.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 #include <filesystem>
 
@@ -91,6 +92,10 @@ IFilter::PreflightResult AlignSectionsListFilter::preflightImpl(const DataStruct
     return {MakeErrorResult<OutputActions>(-8941, fmt::format("The Image Geometry is not 3D and cannot be run through this filter. The dimensions are ({},{},{})", imageGeom.getNumXCells(),
                                                               imageGeom.getNumYCells(), imageGeom.getNumZCells()))};
   }
+
+  // Inform users that the following arrays are going to be modified in place
+  // Cell Data is going to be modified
+  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, imageGeom.getCellDataPath(), {});
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsListFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/AlignSectionsListFilter.cpp
@@ -95,7 +95,7 @@ IFilter::PreflightResult AlignSectionsListFilter::preflightImpl(const DataStruct
 
   // Inform users that the following arrays are going to be modified in place
   // Cell Data is going to be modified
-  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, imageGeom.getCellDataPath(), {});
+  complex::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, imageGeom.getCellDataPath(), {});
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ErodeDilateBadDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ErodeDilateBadDataFilter.cpp
@@ -106,7 +106,7 @@ IFilter::PreflightResult ErodeDilateBadDataFilter::preflightImpl(const DataStruc
 
   // Inform users that the following arrays are going to be modified in place
   // Cell Data is going to be modified
-  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, pFeatureIdsArrayPathValue.getParent(), pIgnoredDataArrayPathsValue);
+  complex::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, pFeatureIdsArrayPathValue.getParent(), pIgnoredDataArrayPathsValue);
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ErodeDilateBadDataFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ErodeDilateBadDataFilter.cpp
@@ -10,6 +10,8 @@
 #include "complex/Parameters/GeometrySelectionParameter.hpp"
 #include "complex/Parameters/MultiArraySelectionParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
+#include "complex/Utilities/DataGroupUtilities.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 using namespace complex;
 
@@ -101,6 +103,10 @@ IFilter::PreflightResult ErodeDilateBadDataFilter::preflightImpl(const DataStruc
   {
     MakeErrorResult(-16700, fmt::format("Operation Selection must be 0 (Dilate) or 1 (Erode). {} was passed into the filter. ", pOperationValue));
   }
+
+  // Inform users that the following arrays are going to be modified in place
+  // Cell Data is going to be modified
+  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, pFeatureIdsArrayPathValue.getParent(), pIgnoredDataArrayPathsValue);
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/MinNeighbors.cpp
@@ -393,9 +393,9 @@ IFilter::PreflightResult MinNeighbors::preflightImpl(const DataStructure& dataSt
 
   // Inform users that the following arrays are going to be modified in place
   // Cell Data is going to be modified
-  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, featureIdsPath.getParent(), {});
+  complex::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, featureIdsPath.getParent(), {});
   // Feature Data is going to be modified
-  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, numNeighborsPath.getParent(), {});
+  complex::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, numNeighborsPath.getParent(), {});
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedFeaturesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveFlaggedFeaturesFilter.cpp
@@ -165,9 +165,9 @@ IFilter::PreflightResult RemoveFlaggedFeaturesFilter::preflightImpl(const DataSt
   {
     // Inform users that the following arrays are going to be modified in place
     // Cell Data is going to be modified
-    complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, pFeatureIdsArrayPathValue.getParent(), {});
+    complex::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, pFeatureIdsArrayPathValue.getParent(), {});
     // Feature Data is going to be modified
-    complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, pFlaggedFeaturesArrayPathValue.getParent(), {});
+    complex::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, pFlaggedFeaturesArrayPathValue.getParent(), {});
   }
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveMinimumSizeFeaturesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/RemoveMinimumSizeFeaturesFilter.cpp
@@ -389,7 +389,7 @@ IFilter::PreflightResult RemoveMinimumSizeFeaturesFilter::preflightImpl(const Da
 
   // Inform users that the following arrays are going to be modified in place
   // Feature Data is going to be modified
-  complex::AppendDataModifiedActions(data, resultOutputActions.value().modifiedActions, featureGroupDataPath, {});
+  complex::AppendDataObjectModifications(data, resultOutputActions.value().modifiedActions, featureGroupDataPath, {});
 
   resultOutputActions.warnings().push_back(Warning{k_NeighborListRemoval, ss});
 

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.cpp
@@ -9,6 +9,7 @@
 #include "complex/Parameters/ChoicesParameter.hpp"
 #include "complex/Parameters/GeometrySelectionParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 using namespace complex;
 
@@ -41,7 +42,7 @@ std::string ReplaceElementAttributesWithNeighborValuesFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ReplaceElementAttributesWithNeighborValuesFilter::defaultTags() const
 {
-  return {className(), "Processing", "Cleanup"};
+  return {className(), "Processing", "Cleanup", "Replace Values"};
 }
 
 //------------------------------------------------------------------------------
@@ -58,7 +59,7 @@ Parameters ReplaceElementAttributesWithNeighborValuesFilter::parameters() const
   params.insertSeparator(Parameters::Separator{"Required Input Cell Data"});
   params.insert(std::make_unique<GeometrySelectionParameter>(k_SelectedImageGeometry_Key, "Selected Image Geometry", "The target geometry", DataPath{},
                                                              GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image}));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_ConfidenceIndexArrayPath_Key, "Input Comparison Array", "The DataPath to the input array to use for comparison", DataPath{},
+  params.insert(std::make_unique<ArraySelectionParameter>(k_ComparisonDataPath, "Input Comparison Array", "The DataPath to the input array to use for comparison", DataPath{},
                                                           complex::GetAllDataTypes(), ArraySelectionParameter::AllowedComponentShapes{{1}}));
 
   return params;
@@ -74,11 +75,15 @@ IFilter::UniquePointer ReplaceElementAttributesWithNeighborValuesFilter::clone()
 IFilter::PreflightResult ReplaceElementAttributesWithNeighborValuesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                                                          const std::atomic_bool& shouldCancel) const
 {
-  auto pConfidenceIndexArrayPathValue = filterArgs.value<DataPath>(k_ConfidenceIndexArrayPath_Key);
+  auto pComparisonDataPath = filterArgs.value<DataPath>(k_ComparisonDataPath);
 
   complex::Result<OutputActions> resultOutputActions;
 
   std::vector<PreflightValue> preflightUpdatedValues;
+
+  // Inform users that the following arrays are going to be modified in place
+  // Cell Data is going to be modified
+  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, pComparisonDataPath.getParent(), {});
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
 }
@@ -93,7 +98,7 @@ Result<> ReplaceElementAttributesWithNeighborValuesFilter::executeImpl(DataStruc
   inputValues.MinConfidence = filterArgs.value<float32>(k_MinConfidence_Key);
   inputValues.SelectedComparison = filterArgs.value<ChoicesParameter::ValueType>(k_SelectedComparison_Key);
   inputValues.Loop = filterArgs.value<bool>(k_Loop_Key);
-  inputValues.InputArrayPath = filterArgs.value<DataPath>(k_ConfidenceIndexArrayPath_Key);
+  inputValues.InputArrayPath = filterArgs.value<DataPath>(k_ComparisonDataPath);
   inputValues.SelectedImageGeometryPath = filterArgs.value<DataPath>(k_SelectedImageGeometry_Key);
 
   return ReplaceElementAttributesWithNeighborValues(dataStructure, messageHandler, shouldCancel, &inputValues)();

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.cpp
@@ -83,7 +83,7 @@ IFilter::PreflightResult ReplaceElementAttributesWithNeighborValuesFilter::prefl
 
   // Inform users that the following arrays are going to be modified in place
   // Cell Data is going to be modified
-  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, pComparisonDataPath.getParent(), {});
+  complex::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, pComparisonDataPath.getParent(), {});
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
 }

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.hpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.hpp
@@ -28,7 +28,7 @@ public:
   static inline constexpr StringLiteral k_MinConfidence_Key = "min_confidence";
   static inline constexpr StringLiteral k_SelectedComparison_Key = "selected_comparison";
   static inline constexpr StringLiteral k_Loop_Key = "loop";
-  static inline constexpr StringLiteral k_ConfidenceIndexArrayPath_Key = "confidence_index_array_path";
+  static inline constexpr StringLiteral k_ComparisonDataPath = "comparison_data_path";
   static inline constexpr StringLiteral k_SelectedImageGeometry_Key = "selected_image_geometry";
 
   /**

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ResampleImageGeomFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ResampleImageGeomFilter.cpp
@@ -19,6 +19,7 @@
 #include "complex/Parameters/GeometrySelectionParameter.hpp"
 #include "complex/Parameters/VectorParameter.hpp"
 #include "complex/Utilities/DataGroupUtilities.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 #include "complex/Utilities/GeometryHelpers.hpp"
 #include "complex/Utilities/StringUtilities.hpp"
 
@@ -77,7 +78,8 @@ Parameters ResampleImageGeomFilter::parameters() const
   // Create the parameter descriptors that are needed for this filter
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
 
-  params.insertLinkableParameter(std::make_unique<ChoicesParameter>(k_ResamplingMode_Key, "Resampling Mode", "Mode can be 'Spacing (0)' or 'Scaling (1)'", k_SpacingModeIndex, ::k_Choices));
+  params.insertLinkableParameter(
+      std::make_unique<ChoicesParameter>(k_ResamplingMode_Key, "Resampling Mode", "Mode can be [0] Spacing, [1] Scaling as Percent, [2] Exact Dimensions as voxels", k_SpacingModeIndex, ::k_Choices));
 
   params.insert(std::make_unique<VectorFloat32Parameter>(k_Spacing_Key, "New Spacing",
                                                          "The new spacing values (dx, dy, dz). Larger spacing will cause less voxels, smaller spacing will cause more voxels.",
@@ -86,7 +88,7 @@ Parameters ResampleImageGeomFilter::parameters() const
   params.insert(
       std::make_unique<VectorFloat32Parameter>(k_Scaling_Key, "Scale Factor (percentages)",
                                                "The scale factor values (dx, dy, dz) to resample the geometry, in percentages. Larger percentages will cause more voxels, smaller percentages "
-                                               "will cause less voxels.  A percentage of 100 in any dimension will not resample the geometry in that dimension.  Percentages must be larger than 0.",
+                                               "will cause less voxels.  A percentage of 100 in any dimension will not resample the geometry in that dimension. Percentages must be larger than 0.",
                                                std::vector<float32>{100.0F, 100.0F, 100.0F}, std::vector<std::string>{"X%", "Y%", "Z%"}));
 
   params.insert(std::make_unique<VectorUInt64Parameter>(k_ExactDimensions_Key, "Exact Dimensions (pixels)", "The exact dimension size values (dx, dy, dz) to resample the geometry, in pixels.",
@@ -98,14 +100,14 @@ Parameters ResampleImageGeomFilter::parameters() const
   params.insert(std::make_unique<GeometrySelectionParameter>(k_SelectedImageGeometry_Key, "Selected Image Geometry", "The target geometry to resample", DataPath{},
                                                              GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image}));
 
-  params.insertSeparator(Parameters::Separator{"Renumber Features Input Parameters"});
+  params.insertSeparator(Parameters::Separator{"Renumber Features (Optional)"});
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_RenumberFeatures_Key, "Renumber Features", "Specifies if the feature IDs should be renumbered", false));
   params.insert(std::make_unique<ArraySelectionParameter>(k_CellFeatureIdsArrayPath_Key, "Feature IDs", "DataPath to Cell Feature IDs array", DataPath{},
                                                           ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insert(
       std::make_unique<AttributeMatrixSelectionParameter>(k_FeatureAttributeMatrix_Key, "Cell Feature Attribute Matrix", "DataPath to the feature Attribute Matrix", DataPath({"CellFeatureData"})));
 
-  params.insertSeparator({"Output Image Geometry"});
+  params.insertSeparator({"Created Image Geometry"});
   params.insert(std::make_unique<DataGroupCreationParameter>(k_CreatedImageGeometry_Key, "Created Image Geometry", "The location of the resampled geometry", DataPath()));
 
   // Associate the Linkable Parameter(s) to the children parameters that they control
@@ -327,6 +329,10 @@ IFilter::PreflightResult ResampleImageGeomFilter::preflightImpl(const DataStruct
   if(pRemoveOriginalGeometry)
   {
     resultOutputActions.value().appendDeferredAction(std::make_unique<RenameDataAction>(destImagePath, srcImagePath.getTargetName()));
+
+    // Inform users that the following arrays are going to be modified in place
+    // Cell Data is going to be modified
+    complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, srcImageGeom->getCellDataPath(), {});
   }
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()

--- a/src/Plugins/ComplexCore/src/ComplexCore/Filters/ResampleImageGeomFilter.cpp
+++ b/src/Plugins/ComplexCore/src/ComplexCore/Filters/ResampleImageGeomFilter.cpp
@@ -332,7 +332,7 @@ IFilter::PreflightResult ResampleImageGeomFilter::preflightImpl(const DataStruct
 
     // Inform users that the following arrays are going to be modified in place
     // Cell Data is going to be modified
-    complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, srcImageGeom->getCellDataPath(), {});
+    complex::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, srcImageGeom->getCellDataPath(), {});
   }
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()

--- a/src/Plugins/ComplexCore/test/ReplaceElementAttributesWithNeighborValuesTest.cpp
+++ b/src/Plugins/ComplexCore/test/ReplaceElementAttributesWithNeighborValuesTest.cpp
@@ -42,7 +42,7 @@ TEST_CASE("OrientationAnalysis::ReplaceElementAttributesWithNeighborValuesFilter
     args.insertOrAssign(ReplaceElementAttributesWithNeighborValuesFilter::k_MinConfidence_Key, std::make_any<float32>(0.1F));
     args.insertOrAssign(ReplaceElementAttributesWithNeighborValuesFilter::k_SelectedComparison_Key, std::make_any<ChoicesParameter::ValueType>(0));
     args.insertOrAssign(ReplaceElementAttributesWithNeighborValuesFilter::k_Loop_Key, std::make_any<bool>(true));
-    args.insertOrAssign(ReplaceElementAttributesWithNeighborValuesFilter::k_ConfidenceIndexArrayPath_Key, std::make_any<DataPath>(k_ConfidenceIndexPath));
+    args.insertOrAssign(ReplaceElementAttributesWithNeighborValuesFilter::k_ComparisonDataPath, std::make_any<DataPath>(k_ConfidenceIndexPath));
     args.insertOrAssign(ReplaceElementAttributesWithNeighborValuesFilter::k_SelectedImageGeometry_Key, std::make_any<DataPath>(k_DataContainerPath));
 
     // Preflight the filter and check result

--- a/src/Plugins/OrientationAnalysis/pipelines/CI_Histogram.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/CI_Histogram.d3dpipeline
@@ -19,7 +19,7 @@
     },
     {
       "args": {
-        "cell_euler_angles_array_path": "DataContainer/Cell Data/EulerAngles",
+        "euler_angles_array_path": "DataContainer/Cell Data/EulerAngles",
         "rotation_axis": [
           0.0,
           0.0,

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD Reconstruction/(08) Small IN100 Full Reconstruction.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD Reconstruction/(08) Small IN100 Full Reconstruction.d3dpipeline
@@ -150,7 +150,7 @@
     {
       "args": {
         "cell_phases_array_path": "DataContainer/CellData/Phases",
-        "confidence_index_array_path": "DataContainer/CellData/Confidence Index",
+        "correlation_array_path": "DataContainer/CellData/Confidence Index",
         "crystal_structures_array_path": "DataContainer/CellEnsembleData/CrystalStructures",
         "ignored_data_array_paths": [],
         "image_geometry_path": "DataContainer",

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD Statistics/(05) Small IN100 Crystallographic Statistics.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD Statistics/(05) Small IN100 Crystallographic Statistics.d3dpipeline
@@ -237,7 +237,7 @@
                     {
                       "args": {
                         "cell_phases_array_path": "DataContainer/CellData/Phases",
-                        "confidence_index_array_path": "DataContainer/CellData/Confidence Index",
+                        "correlation_array_path": "DataContainer/CellData/Confidence Index",
                         "crystal_structures_array_path": "DataContainer/CellEnsembleData/CrystalStructures",
                         "ignored_data_array_paths": [],
                         "image_geometry_path": "DataContainer",

--- a/src/Plugins/OrientationAnalysis/pipelines/Edax_IPF_Colors.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/Edax_IPF_Colors.d3dpipeline
@@ -19,7 +19,7 @@
     },
     {
       "args": {
-        "cell_euler_angles_array_path": "DataContainer/Cell Data/EulerAngles",
+        "euler_angles_array_path": "DataContainer/Cell Data/EulerAngles",
         "rotation_axis": [
           0.0,
           0.0,

--- a/src/Plugins/OrientationAnalysis/pipelines/FindGBCD-GBPDMetricBased.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/FindGBCD-GBPDMetricBased.d3dpipeline
@@ -493,7 +493,7 @@
                                                     {
                                                       "args": {
                                                         "cell_phases_array_path": "DataContainer/CellData/Phases",
-                                                        "confidence_index_array_path": "DataContainer/CellData/Confidence Index",
+                                                        "correlation_array_path": "DataContainer/CellData/Confidence Index",
                                                         "crystal_structures_array_path": "DataContainer/CellEnsembleData/CrystalStructures",
                                                         "ignored_data_array_paths": [],
                                                         "image_geometry_path": "DataContainer",

--- a/src/Plugins/OrientationAnalysis/pipelines/ImportEdaxOIMData.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/ImportEdaxOIMData.d3dpipeline
@@ -39,7 +39,7 @@
     },
     {
       "args": {
-        "cell_euler_angles_array_path": "ImageGeom/Cell Data/EulerAngles",
+        "euler_angles_array_path": "ImageGeom/Cell Data/EulerAngles",
         "rotation_axis": [
           0.0,
           0.0,

--- a/src/Plugins/OrientationAnalysis/pipelines/ReadAng.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/ReadAng.d3dpipeline
@@ -18,7 +18,7 @@
     },
     {
       "args": {
-        "cell_euler_angles_array_path": "DataContainer/Cell Data/EulerAngles",
+        "euler_angles_array_path": "DataContainer/Cell Data/EulerAngles",
         "rotation_axis": [
           0.0,
           0.0,

--- a/src/Plugins/OrientationAnalysis/pipelines/aptr12_Analysis.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/aptr12_Analysis.d3dpipeline
@@ -108,7 +108,7 @@
     },
     {
       "args": {
-        "confidence_index_array_path": "fw-ar-IF1-aptr12-corr/Cell Data/Error",
+        "comparison_data_path": "fw-ar-IF1-aptr12-corr/Cell Data/Error",
         "loop": true,
         "min_confidence": 0.0,
         "selected_comparison": 0,

--- a/src/Plugins/OrientationAnalysis/pipelines/avtr12_Analysis.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/avtr12_Analysis.d3dpipeline
@@ -108,7 +108,7 @@
     },
     {
       "args": {
-        "confidence_index_array_path": "fw-ar-IF1-avtr12-corr/Cell Data/Error",
+        "comparison_data_path": "fw-ar-IF1-avtr12-corr/Cell Data/Error",
         "loop": true,
         "min_confidence": 0.0,
         "selected_comparison": 0,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadH5Ebsd.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadH5Ebsd.cpp
@@ -365,7 +365,7 @@ Result<> ReadH5Ebsd::operator()()
                           std::make_any<VectorFloat32Parameter::ValueType>(std::vector<float32>{eulerTransAxis[0], eulerTransAxis[1], eulerTransAxis[2], eulerTransAngle}));
 
       complex::DataPath eulerDataPath = m_InputValues->cellAttributeMatrixPath.createChildPath(EbsdLib::CellData::EulerAngles); // get the Euler data from the DataStructure
-      args.insertOrAssign(RotateEulerRefFrameFilter::k_CellEulerAnglesArrayPath_Key, std::make_any<DataPath>(eulerDataPath));
+      args.insertOrAssign(RotateEulerRefFrameFilter::k_EulerAnglesArrayPath_Key, std::make_any<DataPath>(eulerDataPath));
       // Preflight the filter and check result
       auto preflightResult = rotEuler.preflight(m_DataStructure, args);
       if(preflightResult.outputActions.invalid())

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMisorientationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMisorientationFilter.cpp
@@ -171,7 +171,7 @@ IFilter::PreflightResult AlignSectionsMisorientationFilter::preflightImpl(const 
 
   // Inform users that the following arrays are going to be modified in place
   // Cell Data is going to be modified
-  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, pQuatsArrayPath.getParent(), {});
+  complex::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, pQuatsArrayPath.getParent(), {});
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMisorientationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMisorientationFilter.cpp
@@ -10,6 +10,7 @@
 #include "complex/Parameters/GeometrySelectionParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
 #include "complex/Utilities/DataArrayUtilities.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 #include <filesystem>
 
@@ -167,6 +168,10 @@ IFilter::PreflightResult AlignSectionsMisorientationFilter::preflightImpl(const 
   {
     return {MakeErrorResult<OutputActions>(k_OutputFilePathEmpty, "Write Alignment Shifts is TRUE but the output file path is empty. Please ensure the file path is set for the alignment file.")};
   }
+
+  // Inform users that the following arrays are going to be modified in place
+  // Cell Data is going to be modified
+  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, pQuatsArrayPath.getParent(), {});
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMutualInformationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMutualInformationFilter.cpp
@@ -134,7 +134,7 @@ IFilter::PreflightResult AlignSectionsMutualInformationFilter::preflightImpl(con
 
   // Inform users that the following arrays are going to be modified in place
   // Cell Data is going to be modified
-  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, pQuatsArrayPathValue.getParent(), {});
+  complex::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, pQuatsArrayPathValue.getParent(), {});
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMutualInformationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMutualInformationFilter.cpp
@@ -10,6 +10,7 @@
 #include "complex/Parameters/FileSystemPathParameter.hpp"
 #include "complex/Parameters/GeometrySelectionParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 #include <filesystem>
 namespace fs = std::filesystem;
@@ -130,6 +131,10 @@ IFilter::PreflightResult AlignSectionsMutualInformationFilter::preflightImpl(con
   {
     return {MakeErrorResult<OutputActions>(-3542, fmt::format("The following DataArrays all must have equal number of tuples but this was not satisfied.\n{}", tupleValidityCheck.error()))};
   }
+
+  // Inform users that the following arrays are going to be modified in place
+  // Cell Data is going to be modified
+  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, pQuatsArrayPathValue.getParent(), {});
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/BadDataNeighborOrientationCheckFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/BadDataNeighborOrientationCheckFilter.cpp
@@ -7,6 +7,7 @@
 #include "complex/Parameters/ArraySelectionParameter.hpp"
 #include "complex/Parameters/GeometrySelectionParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 using namespace complex;
 
@@ -97,6 +98,10 @@ IFilter::PreflightResult BadDataNeighborOrientationCheckFilter::preflightImpl(co
   auto pCellPhasesArrayPathValue = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
   auto pCrystalStructuresArrayPathValue = filterArgs.value<DataPath>(k_CrystalStructuresArrayPath_Key);
 
+  complex::Result<OutputActions> resultOutputActions;
+
+  std::vector<PreflightValue> preflightUpdatedValues;
+
   std::vector<DataPath> dataArrayPaths;
 
   auto* imageGeomPtr = dataStructure.getDataAs<ImageGeom>(pImageGeomPathValue);
@@ -184,7 +189,10 @@ IFilter::PreflightResult BadDataNeighborOrientationCheckFilter::preflightImpl(co
                                            fmt::format("The following DataArrays all must have equal number of tuples but this was not satisfied.\n{}", tupleValidityCheck.error()))};
   }
 
-  return {};
+  resultOutputActions.value().modifiedActions.emplace_back(DataModifiedAction{pGoodVoxelsArrayPathValue, DataModifiedAction::ModifiedType::DataArrayModified});
+
+  // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
+  return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/BadDataNeighborOrientationCheckFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/BadDataNeighborOrientationCheckFilter.cpp
@@ -189,7 +189,7 @@ IFilter::PreflightResult BadDataNeighborOrientationCheckFilter::preflightImpl(co
                                            fmt::format("The following DataArrays all must have equal number of tuples but this was not satisfied.\n{}", tupleValidityCheck.error()))};
   }
 
-  resultOutputActions.value().modifiedActions.emplace_back(DataModifiedAction{pGoodVoxelsArrayPathValue, DataModifiedAction::ModifiedType::DataArrayModified});
+  resultOutputActions.value().modifiedActions.emplace_back(DataObjectModification{pGoodVoxelsArrayPathValue, DataObjectModification::ModifiedType::DataArrayModified});
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/BadDataNeighborOrientationCheckFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/BadDataNeighborOrientationCheckFilter.cpp
@@ -189,7 +189,8 @@ IFilter::PreflightResult BadDataNeighborOrientationCheckFilter::preflightImpl(co
                                            fmt::format("The following DataArrays all must have equal number of tuples but this was not satisfied.\n{}", tupleValidityCheck.error()))};
   }
 
-  resultOutputActions.value().modifiedActions.emplace_back(DataObjectModification{pGoodVoxelsArrayPathValue, DataObjectModification::ModifiedType::DataArrayModified});
+  resultOutputActions.value().modifiedActions.emplace_back(
+      DataObjectModification{pGoodVoxelsArrayPathValue, DataObjectModification::ModifiedType::Modified, dataStructure.getData(pGoodVoxelsArrayPathValue)->getDataObjectType()});
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/GenerateFZQuaternions.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/GenerateFZQuaternions.cpp
@@ -136,7 +136,7 @@ std::string GenerateFZQuaternions::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> GenerateFZQuaternions::defaultTags() const
 {
-  return {className(), "Processing", "OrientationAnalysis"};
+  return {className(), "Processing", "OrientationAnalysis", "Quaternion"};
 }
 
 //------------------------------------------------------------------------------

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/GenerateQuaternionConjugateFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/GenerateQuaternionConjugateFilter.cpp
@@ -47,7 +47,7 @@ std::string GenerateQuaternionConjugateFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> GenerateQuaternionConjugateFilter::defaultTags() const
 {
-  return {className(), "Processing", "Crystallography"};
+  return {className(), "Processing", "Crystallography", "Orientation", "Quaternion"};
 }
 
 //------------------------------------------------------------------------------
@@ -60,8 +60,9 @@ Parameters GenerateQuaternionConjugateFilter::parameters() const
   params.insertSeparator(Parameters::Separator{"Input Data"});
   params.insert(std::make_unique<ArraySelectionParameter>(k_CellQuatsArrayPath_Key, "Quaternions", "Specifies the quaternions to convert", DataPath({"CellData", "Quats"}),
                                                           ArraySelectionParameter::AllowedTypes{DataType::float32}, ArraySelectionParameter::AllowedComponentShapes{{4}}));
-  params.insertSeparator(Parameters::Separator{"Output Data"});
-  params.insert(std::make_unique<DataObjectNameParameter>(k_OutputDataArrayPath_Key, "Output Data Array Path", "The name of the generated output DataArray", "Quaternions [Conjugate]"));
+  params.insertSeparator(Parameters::Separator{"Created Data"});
+  params.insert(
+      std::make_unique<DataObjectNameParameter>(k_OutputDataArrayPath_Key, "Created Quaternion Conjugate", "The name of the generated quaternion conjugate array", "Quaternions [Conjugate]"));
 
   return params;
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.cpp
@@ -64,7 +64,7 @@ Parameters NeighborOrientationCorrelationFilter::parameters() const
   params.insertSeparator(Parameters::Separator{"Cell Data"});
   params.insert(std::make_unique<GeometrySelectionParameter>(k_ImageGeometryPath_Key, "Image Geometry", "Path to the target geometry", DataPath{},
                                                              GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image}));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_ConfidenceIndexArrayPath_Key, "Confidence Index", "Specifies the confidence in the orientation of the Cell (TSL data)", DataPath{},
+  params.insert(std::make_unique<ArraySelectionParameter>(k_CorrelationArrayPath_Key, "Confidence Index", "Specifies the confidence in the orientation of the Cell (TSL data)", DataPath{},
                                                           ArraySelectionParameter::AllowedTypes{DataType::float32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_CellPhasesArrayPath_Key, "Cell Phases", "Specifies to which Ensemble each Cell belongs", DataPath({"Phases"}),
                                                           ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
@@ -94,7 +94,7 @@ IFilter::PreflightResult NeighborOrientationCorrelationFilter::preflightImpl(con
   auto pMinConfidenceValue = filterArgs.value<float32>(k_MinConfidence_Key);
   auto pMisorientationToleranceValue = filterArgs.value<float32>(k_MisorientationTolerance_Key);
   auto pLevelValue = filterArgs.value<int32>(k_Level_Key);
-  auto pConfidenceIndexArrayPathValue = filterArgs.value<DataPath>(k_ConfidenceIndexArrayPath_Key);
+  auto pConfidenceIndexArrayPathValue = filterArgs.value<DataPath>(k_CorrelationArrayPath_Key);
   auto pCellPhasesArrayPathValue = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
   auto pQuatsArrayPathValue = filterArgs.value<DataPath>(k_QuatsArrayPath_Key);
   auto pCrystalStructuresArrayPathValue = filterArgs.value<DataPath>(k_CrystalStructuresArrayPath_Key);
@@ -237,7 +237,7 @@ Result<> NeighborOrientationCorrelationFilter::executeImpl(DataStructure& dataSt
   inputValues.MinConfidence = filterArgs.value<float32>(k_MinConfidence_Key);
   inputValues.MisorientationTolerance = filterArgs.value<float32>(k_MisorientationTolerance_Key);
   inputValues.Level = filterArgs.value<int32>(k_Level_Key);
-  inputValues.ConfidenceIndexArrayPath = filterArgs.value<DataPath>(k_ConfidenceIndexArrayPath_Key);
+  inputValues.ConfidenceIndexArrayPath = filterArgs.value<DataPath>(k_CorrelationArrayPath_Key);
   inputValues.CellPhasesArrayPath = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
   inputValues.QuatsArrayPath = filterArgs.value<DataPath>(k_QuatsArrayPath_Key);
   inputValues.CrystalStructuresArrayPath = filterArgs.value<DataPath>(k_CrystalStructuresArrayPath_Key);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.cpp
@@ -7,6 +7,7 @@
 #include "complex/Parameters/GeometrySelectionParameter.hpp"
 #include "complex/Parameters/MultiArraySelectionParameter.hpp"
 #include "complex/Parameters/NumberParameter.hpp"
+#include "complex/Utilities/FilterUtilities.hpp"
 
 using namespace complex;
 
@@ -218,6 +219,10 @@ IFilter::PreflightResult NeighborOrientationCorrelationFilter::preflightImpl(con
     return {
         MakeErrorResult<OutputActions>(k_InvalidNumTuples, fmt::format("The following DataArrays all must have equal number of tuples but this was not satisfied.\n{}", tupleValidityCheck.error()))};
   }
+
+  // Inform users that the following arrays are going to be modified in place
+  // Cell Data is going to be modified
+  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, pConfidenceIndexArrayPathValue.getParent(), {});
 
   return {};
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.cpp
@@ -222,7 +222,7 @@ IFilter::PreflightResult NeighborOrientationCorrelationFilter::preflightImpl(con
 
   // Inform users that the following arrays are going to be modified in place
   // Cell Data is going to be modified
-  complex::AppendDataModifiedActions(dataStructure, resultOutputActions.value().modifiedActions, pConfidenceIndexArrayPathValue.getParent(), {});
+  complex::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, pConfidenceIndexArrayPathValue.getParent(), {});
 
   return {};
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.hpp
@@ -28,7 +28,7 @@ public:
   static inline constexpr StringLiteral k_MinConfidence_Key = "min_confidence";
   static inline constexpr StringLiteral k_MisorientationTolerance_Key = "misorientation_tolerance";
   static inline constexpr StringLiteral k_Level_Key = "level";
-  static inline constexpr StringLiteral k_ConfidenceIndexArrayPath_Key = "confidence_index_array_path";
+  static inline constexpr StringLiteral k_CorrelationArrayPath_Key = "correlation_array_path";
   static inline constexpr StringLiteral k_CellPhasesArrayPath_Key = "cell_phases_array_path";
   static inline constexpr StringLiteral k_QuatsArrayPath_Key = "quats_array_path";
   static inline constexpr StringLiteral k_CrystalStructuresArrayPath_Key = "crystal_structures_array_path";

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RotateEulerRefFrameFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RotateEulerRefFrameFilter.cpp
@@ -74,7 +74,7 @@ IFilter::PreflightResult RotateEulerRefFrameFilter::preflightImpl(const DataStru
 
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  resultOutputActions.value().modifiedActions.emplace_back(DataModifiedAction{pCellEulerAnglesArrayPathValue, DataModifiedAction::ModifiedType::DataArrayModified});
+  resultOutputActions.value().modifiedActions.emplace_back(DataObjectModification{pCellEulerAnglesArrayPathValue, DataObjectModification::ModifiedType::DataArrayModified});
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RotateEulerRefFrameFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RotateEulerRefFrameFilter.cpp
@@ -51,7 +51,7 @@ Parameters RotateEulerRefFrameFilter::parameters() const
                                                          VectorFloat32Parameter::ValueType{0.0f, 0.0f, 0.0f, 90.0F}, std::vector<std::string>{"i", "j", "k", "w (Deg)"}));
 
   params.insertSeparator(Parameters::Separator{"Input Data"});
-  params.insert(std::make_unique<ArraySelectionParameter>(k_CellEulerAnglesArrayPath_Key, "Euler Angles", "Three angles defining the orientation of the Cell in Bunge convention (Z-X-Z)", DataPath{},
+  params.insert(std::make_unique<ArraySelectionParameter>(k_EulerAnglesArrayPath_Key, "Input Euler Angles", "Three angles defining the orientation of the Cell in Bunge convention (Z-X-Z)", DataPath{},
                                                           ArraySelectionParameter::AllowedTypes{DataType::float32}, ArraySelectionParameter::AllowedComponentShapes{{3}}));
 
   return params;
@@ -68,11 +68,13 @@ IFilter::PreflightResult RotateEulerRefFrameFilter::preflightImpl(const DataStru
                                                                   const std::atomic_bool& shouldCancel) const
 {
   auto pRotationAxisAngleValue = filterArgs.value<VectorFloat32Parameter::ValueType>(k_RotationAxisAngle_Key);
-  auto pCellEulerAnglesArrayPathValue = filterArgs.value<DataPath>(k_CellEulerAnglesArrayPath_Key);
+  auto pCellEulerAnglesArrayPathValue = filterArgs.value<DataPath>(k_EulerAnglesArrayPath_Key);
 
   complex::Result<OutputActions> resultOutputActions;
 
   std::vector<PreflightValue> preflightUpdatedValues;
+
+  resultOutputActions.value().modifiedActions.emplace_back(DataModifiedAction{pCellEulerAnglesArrayPathValue, DataModifiedAction::ModifiedType::DataArrayModified});
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
@@ -84,7 +86,7 @@ Result<> RotateEulerRefFrameFilter::executeImpl(DataStructure& dataStructure, co
 {
   complex::RotateEulerRefFrameInputValues inputValues;
 
-  inputValues.eulerAngleDataPath = filterArgs.value<DataPath>(k_CellEulerAnglesArrayPath_Key);
+  inputValues.eulerAngleDataPath = filterArgs.value<DataPath>(k_EulerAnglesArrayPath_Key);
   inputValues.rotationAxis = filterArgs.value<VectorFloat32Parameter::ValueType>(k_RotationAxisAngle_Key);
 
   // Let the Algorithm instance do the work

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RotateEulerRefFrameFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RotateEulerRefFrameFilter.cpp
@@ -74,7 +74,8 @@ IFilter::PreflightResult RotateEulerRefFrameFilter::preflightImpl(const DataStru
 
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  resultOutputActions.value().modifiedActions.emplace_back(DataObjectModification{pCellEulerAnglesArrayPathValue, DataObjectModification::ModifiedType::DataArrayModified});
+  resultOutputActions.value().modifiedActions.emplace_back(
+      DataObjectModification{pCellEulerAnglesArrayPathValue, DataObjectModification::ModifiedType::Modified, dataStructure.getData(pCellEulerAnglesArrayPathValue)->getDataObjectType()});
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RotateEulerRefFrameFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RotateEulerRefFrameFilter.hpp
@@ -25,7 +25,7 @@ public:
 
   // Parameter Keys
   static inline constexpr StringLiteral k_RotationAxisAngle_Key = "rotation_axis";
-  static inline constexpr StringLiteral k_CellEulerAnglesArrayPath_Key = "cell_euler_angles_array_path";
+  static inline constexpr StringLiteral k_EulerAnglesArrayPath_Key = "euler_angles_array_path";
 
   /**
    * @brief Returns the name of the filter.

--- a/src/Plugins/OrientationAnalysis/test/NeighborOrientationCorrelationTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/NeighborOrientationCorrelationTest.cpp
@@ -83,7 +83,7 @@ TEST_CASE("OrientationAnalysis::NeighborOrientationCorrelationFilter: Small IN10
     args.insertOrAssign(NeighborOrientationCorrelationFilter::k_MinConfidence_Key, std::make_any<float32>(0.2f));
     args.insertOrAssign(NeighborOrientationCorrelationFilter::k_MisorientationTolerance_Key, std::make_any<float32>(5.0f));
     args.insertOrAssign(NeighborOrientationCorrelationFilter::k_Level_Key, std::make_any<int32>(2));
-    args.insertOrAssign(NeighborOrientationCorrelationFilter::k_ConfidenceIndexArrayPath_Key, std::make_any<DataPath>(k_ConfidenceIndexArrayPath));
+    args.insertOrAssign(NeighborOrientationCorrelationFilter::k_CorrelationArrayPath_Key, std::make_any<DataPath>(k_ConfidenceIndexArrayPath));
     args.insertOrAssign(NeighborOrientationCorrelationFilter::k_CellPhasesArrayPath_Key, std::make_any<DataPath>(k_PhasesArrayPath));
     args.insertOrAssign(NeighborOrientationCorrelationFilter::k_QuatsArrayPath_Key, std::make_any<DataPath>(k_QuatsArrayPath));
     args.insertOrAssign(NeighborOrientationCorrelationFilter::k_CrystalStructuresArrayPath_Key, std::make_any<DataPath>(k_CrystalStructuresArrayPath));

--- a/src/Plugins/OrientationAnalysis/test/OrientationAnalysisTestUtils.hpp
+++ b/src/Plugins/OrientationAnalysis/test/OrientationAnalysisTestUtils.hpp
@@ -301,7 +301,7 @@ inline void ExecuteNeighborOrientationCorrelation(DataStructure& dataStructure, 
   constexpr StringLiteral k_MinConfidence_Key = "min_confidence";
   constexpr StringLiteral k_MisorientationTolerance_Key = "misorientation_tolerance";
   constexpr StringLiteral k_Level_Key = "level";
-  constexpr StringLiteral k_ConfidenceIndexArrayPath_Key = "confidence_index_array_path";
+  constexpr StringLiteral k_CorrelationArrayPath_Key = "correlation_array_path";
   constexpr StringLiteral k_CellPhasesArrayPath_Key = "cell_phases_array_path";
   constexpr StringLiteral k_QuatsArrayPath_Key = "quats_array_path";
   constexpr StringLiteral k_CrystalStructuresArrayPath_Key = "crystal_structures_array_path";
@@ -313,7 +313,7 @@ inline void ExecuteNeighborOrientationCorrelation(DataStructure& dataStructure, 
   args.insertOrAssign(k_MinConfidence_Key, std::make_any<float32>(0.2f));
   args.insertOrAssign(k_MisorientationTolerance_Key, std::make_any<float32>(5.0f));
   args.insertOrAssign(k_Level_Key, std::make_any<int32>(2));
-  args.insertOrAssign(k_ConfidenceIndexArrayPath_Key, std::make_any<DataPath>(Constants::k_ConfidenceIndexArrayPath));
+  args.insertOrAssign(k_CorrelationArrayPath_Key, std::make_any<DataPath>(Constants::k_ConfidenceIndexArrayPath));
   args.insertOrAssign(k_CellPhasesArrayPath_Key, std::make_any<DataPath>(Constants::k_PhasesArrayPath));
   args.insertOrAssign(k_QuatsArrayPath_Key, std::make_any<DataPath>(Constants::k_QuatsArrayPath));
   args.insertOrAssign(k_CrystalStructuresArrayPath_Key, std::make_any<DataPath>(Constants::k_CrystalStructuresArrayPath));

--- a/src/Plugins/OrientationAnalysis/test/RotateEulerRefFrameTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/RotateEulerRefFrameTest.cpp
@@ -107,7 +107,7 @@ TEST_CASE("OrientationAnalysis::RotateEulerRefFrame", "[OrientationAnalysis]")
 
     // Create default Parameters for the filter.
     args.insertOrAssign(RotateEulerRefFrameFilter::k_RotationAxisAngle_Key, std::make_any<VectorFloat32Parameter::ValueType>(std::vector<float32>{1.0F, 1.0F, 1.0F, 30.0F}));
-    args.insertOrAssign(RotateEulerRefFrameFilter::k_CellEulerAnglesArrayPath_Key, std::make_any<DataPath>(k_EulerAnglesDataPath));
+    args.insertOrAssign(RotateEulerRefFrameFilter::k_EulerAnglesArrayPath_Key, std::make_any<DataPath>(k_EulerAnglesDataPath));
 
     // Preflight the filter and check result
     auto preflightResult = filter.preflight(dataStructure, args);

--- a/src/complex/Filter/Output.hpp
+++ b/src/complex/Filter/Output.hpp
@@ -115,18 +115,14 @@ struct COMPLEX_EXPORT DataObjectModification
 
   enum class ModifiedType : uint64
   {
-    DataArrayModified = 0,
-    DataArrayPossiblyDeleted = 1,
-    AttributeMatrixModified = 2,
-    DataGroupModified = 3,
-    AttributeMatrixPossiblyDeleted = 4,
-    DataGroupPossiblyDeleted = 5,
-    GeometryModified = 6,
-    GeometryPossiblyDeleted = 7
+    Modified = 0,
+    PossiblyDeleted = 1,
+    Unknown = 2,
   };
 
   DataPath modifiedPath;
-  ModifiedType modifiedType;
+  ModifiedType modifiedType = ModifiedType::Unknown;
+  DataObject::Type dataObjectType = DataObject::Type::Unknown;
 };
 
 /**

--- a/src/complex/Filter/Output.hpp
+++ b/src/complex/Filter/Output.hpp
@@ -108,12 +108,29 @@ private:
 };
 
 /**
+ * @brief
+ */
+struct COMPLEX_EXPORT DataModifiedAction
+{
+
+  enum class ModifiedType : uint64
+  {
+    DataArrayModified = 0,
+    DataArrayPossiblyDeleted = 1,
+  };
+
+  DataPath m_ModifiedPath;
+  ModifiedType m_ModifiedType;
+};
+
+/**
  * @brief Container for IDataActions
  */
 struct COMPLEX_EXPORT OutputActions
 {
   std::vector<AnyDataAction> actions = {};
   std::vector<AnyDataAction> deferredActions = {};
+  std::vector<DataModifiedAction> modifiedActions = {};
 
   OutputActions() = default;
 
@@ -137,6 +154,11 @@ struct COMPLEX_EXPORT OutputActions
   {
     static_assert(std::is_base_of_v<IDataAction, T>, "OutputActions::appendDeferredAction requires T to be derived from IDataAction");
     deferredActions.emplace_back(std::move(action));
+  }
+
+  void appendModifiedAction(const DataPath& dataPath, DataModifiedAction::ModifiedType modifiedType)
+  {
+    modifiedActions.emplace_back(DataModifiedAction{dataPath, modifiedType});
   }
 
   static Result<> ApplyActions(nonstd::span<const AnyDataAction> actions, DataStructure& dataStructure, IDataAction::Mode mode);

--- a/src/complex/Filter/Output.hpp
+++ b/src/complex/Filter/Output.hpp
@@ -110,17 +110,23 @@ private:
 /**
  * @brief
  */
-struct COMPLEX_EXPORT DataModifiedAction
+struct COMPLEX_EXPORT DataObjectModification
 {
 
   enum class ModifiedType : uint64
   {
     DataArrayModified = 0,
     DataArrayPossiblyDeleted = 1,
+    AttributeMatrixModified = 2,
+    DataGroupModified = 3,
+    AttributeMatrixPossiblyDeleted = 4,
+    DataGroupPossiblyDeleted = 5,
+    GeometryModified = 6,
+    GeometryPossiblyDeleted = 7
   };
 
-  DataPath m_ModifiedPath;
-  ModifiedType m_ModifiedType;
+  DataPath modifiedPath;
+  ModifiedType modifiedType;
 };
 
 /**
@@ -130,7 +136,7 @@ struct COMPLEX_EXPORT OutputActions
 {
   std::vector<AnyDataAction> actions = {};
   std::vector<AnyDataAction> deferredActions = {};
-  std::vector<DataModifiedAction> modifiedActions = {};
+  std::vector<DataObjectModification> modifiedActions = {};
 
   OutputActions() = default;
 
@@ -156,9 +162,9 @@ struct COMPLEX_EXPORT OutputActions
     deferredActions.emplace_back(std::move(action));
   }
 
-  void appendModifiedAction(const DataPath& dataPath, DataModifiedAction::ModifiedType modifiedType)
+  void appendDataObjectModificationNotification(const DataPath& dataPath, DataObjectModification::ModifiedType modifiedType)
   {
-    modifiedActions.emplace_back(DataModifiedAction{dataPath, modifiedType});
+    modifiedActions.push_back(DataObjectModification{dataPath, modifiedType});
   }
 
   static Result<> ApplyActions(nonstd::span<const AnyDataAction> actions, DataStructure& dataStructure, IDataAction::Mode mode);

--- a/src/complex/Pipeline/PipelineFilter.cpp
+++ b/src/complex/Pipeline/PipelineFilter.cpp
@@ -159,14 +159,9 @@ bool PipelineFilter::preflight(DataStructure& data, RenamedPaths& renamedPaths, 
     }
   }
 
-  for(const auto& action : result.outputActions.value().modifiedActions)
-  {
-    newModifiedPaths.emplace_back(action.m_ModifiedPath);
-  }
-
   // Do not clear the created paths unless the preflight succeeded
   m_CreatedPaths = newCreatedPaths;
-  m_ModifiedPaths = newModifiedPaths;
+  m_DataModifiedActions = result.outputActions.value().modifiedActions;
 
   setPreflightStructure(data);
   sendFilterFaultMessage(m_Index, getFaultState());
@@ -227,9 +222,9 @@ std::vector<DataPath> PipelineFilter::getCreatedPaths() const
   return m_CreatedPaths;
 }
 
-std::vector<DataPath> PipelineFilter::getModifiedPaths() const
+std::vector<DataObjectModification> PipelineFilter::getDataObjectModificationNotifications() const
 {
-  return m_ModifiedPaths;
+  return m_DataModifiedActions;
 }
 
 namespace

--- a/src/complex/Pipeline/PipelineFilter.hpp
+++ b/src/complex/Pipeline/PipelineFilter.hpp
@@ -147,6 +147,12 @@ public:
   std::vector<DataPath> getCreatedPaths() const;
 
   /**
+   * @brief Returns a vector of DataPaths that would be modified when executing the node
+   * @return std::vector<DataPath>
+   */
+  std::vector<DataPath> getModifiedPaths() const;
+
+  /**
    * @brief Returns a collection of warnings returned by the target filter.
    * This collection is cleared when the node is preflighted or executed.
    * @return std::vector<complex::Warning>
@@ -220,5 +226,6 @@ private:
   std::vector<complex::Error> m_Errors;
   std::vector<IFilter::PreflightValue> m_PreflightValues;
   std::vector<DataPath> m_CreatedPaths;
+  std::vector<DataPath> m_ModifiedPaths;
 };
 } // namespace complex

--- a/src/complex/Pipeline/PipelineFilter.hpp
+++ b/src/complex/Pipeline/PipelineFilter.hpp
@@ -150,7 +150,7 @@ public:
    * @brief Returns a vector of DataPaths that would be modified when executing the node
    * @return std::vector<DataPath>
    */
-  std::vector<DataPath> getModifiedPaths() const;
+  std::vector<DataObjectModification> getDataObjectModificationNotifications() const;
 
   /**
    * @brief Returns a collection of warnings returned by the target filter.
@@ -226,6 +226,6 @@ private:
   std::vector<complex::Error> m_Errors;
   std::vector<IFilter::PreflightValue> m_PreflightValues;
   std::vector<DataPath> m_CreatedPaths;
-  std::vector<DataPath> m_ModifiedPaths;
+  std::vector<DataObjectModification> m_DataModifiedActions;
 };
 } // namespace complex

--- a/src/complex/Utilities/FilterUtilities.cpp
+++ b/src/complex/Utilities/FilterUtilities.cpp
@@ -23,4 +23,18 @@ Result<> CreateOutputDirectories(const fs::path& outputPath)
   }
   return {};
 }
+
+// -----------------------------------------------------------------------------
+void AppendDataModifiedActions(const DataStructure& dataStructure, std::vector<DataModifiedAction>& modifiedActions, const DataPath& parentPath, const std::vector<DataPath>& ignoredDataPaths)
+{
+  std::optional<std::vector<DataPath>> result = complex::GetAllChildArrayDataPaths(dataStructure, parentPath, ignoredDataPaths);
+  if(result.has_value())
+  {
+    for(const auto& child : result.value())
+    {
+      modifiedActions.emplace_back(DataModifiedAction{child, DataModifiedAction::ModifiedType::DataArrayModified});
+    }
+  }
+}
+
 } // namespace complex

--- a/src/complex/Utilities/FilterUtilities.cpp
+++ b/src/complex/Utilities/FilterUtilities.cpp
@@ -28,14 +28,14 @@ Result<> CreateOutputDirectories(const fs::path& outputPath)
 void AppendDataObjectModifications(const DataStructure& dataStructure, std::vector<DataObjectModification>& modifiedActions, const DataPath& parentPath, const std::vector<DataPath>& ignoredDataPaths)
 {
   std::optional<std::vector<DataPath>> result = complex::GetAllChildArrayDataPaths(dataStructure, parentPath, ignoredDataPaths);
-  if(result->empty())
+  if(!result)
   {
     return;
   }
 
   for(const auto& child : result.value())
   {
-    modifiedActions.push_back(DataObjectModification{child, DataObjectModification::ModifiedType::DataArrayModified});
+    modifiedActions.push_back(DataObjectModification{child, DataObjectModification::ModifiedType::Modified, dataStructure.getDataRef(child).getDataObjectType()});
   }
 }
 

--- a/src/complex/Utilities/FilterUtilities.cpp
+++ b/src/complex/Utilities/FilterUtilities.cpp
@@ -25,15 +25,17 @@ Result<> CreateOutputDirectories(const fs::path& outputPath)
 }
 
 // -----------------------------------------------------------------------------
-void AppendDataModifiedActions(const DataStructure& dataStructure, std::vector<DataModifiedAction>& modifiedActions, const DataPath& parentPath, const std::vector<DataPath>& ignoredDataPaths)
+void AppendDataObjectModifications(const DataStructure& dataStructure, std::vector<DataObjectModification>& modifiedActions, const DataPath& parentPath, const std::vector<DataPath>& ignoredDataPaths)
 {
   std::optional<std::vector<DataPath>> result = complex::GetAllChildArrayDataPaths(dataStructure, parentPath, ignoredDataPaths);
-  if(result.has_value())
+  if(result->empty())
   {
-    for(const auto& child : result.value())
-    {
-      modifiedActions.emplace_back(DataModifiedAction{child, DataModifiedAction::ModifiedType::DataArrayModified});
-    }
+    return;
+  }
+
+  for(const auto& child : result.value())
+  {
+    modifiedActions.push_back(DataObjectModification{child, DataObjectModification::ModifiedType::DataArrayModified});
   }
 }
 

--- a/src/complex/Utilities/FilterUtilities.hpp
+++ b/src/complex/Utilities/FilterUtilities.hpp
@@ -4,6 +4,8 @@
 #include "complex/Common/Result.hpp"
 #include "complex/Common/Types.hpp"
 #include "complex/complex_export.hpp"
+#include <complex/Filter/Output.hpp>
+#include <complex/Utilities/DataGroupUtilities.hpp>
 
 #include <filesystem>
 #include <stdexcept>
@@ -195,4 +197,13 @@ COMPLEX_EXPORT Result<> CreateOutputDirectories(const fs::path& outputPath);
  */
 COMPLEX_EXPORT std::vector<char> CreateDelimitersVector(bool tabAsDelimiter, bool semicolonAsDelimiter, bool commaAsDelimiter, bool spaceAsDelimiter);
 
+/**
+ * @brief This will create DataModifiedActions for each child of the parent path given
+ * @param dataStructure The DataStructure object
+ * @param modifiedActions The std::vector<> of DataModifiedAction
+ * @param parentPath The parent path
+ * @param ignoredDataPaths And specific DataPath to ignore.
+ */
+COMPLEX_EXPORT void AppendDataModifiedActions(const DataStructure& dataStructure, std::vector<DataModifiedAction>& modifiedActions, const DataPath& parentPath,
+                                              const std::vector<DataPath>& ignoredDataPaths);
 } // namespace complex

--- a/src/complex/Utilities/FilterUtilities.hpp
+++ b/src/complex/Utilities/FilterUtilities.hpp
@@ -204,6 +204,6 @@ COMPLEX_EXPORT std::vector<char> CreateDelimitersVector(bool tabAsDelimiter, boo
  * @param parentPath The parent path
  * @param ignoredDataPaths And specific DataPath to ignore.
  */
-COMPLEX_EXPORT void AppendDataModifiedActions(const DataStructure& dataStructure, std::vector<DataModifiedAction>& modifiedActions, const DataPath& parentPath,
-                                              const std::vector<DataPath>& ignoredDataPaths);
+COMPLEX_EXPORT void AppendDataObjectModifications(const DataStructure& dataStructure, std::vector<DataObjectModification>& modifiedActions, const DataPath& parentPath,
+                                                  const std::vector<DataPath>& ignoredDataPaths);
 } // namespace complex


### PR DESCRIPTION
These additions allow a user interface to show to the user which arrays (if any) are being modified by the filter.

For example, the "Minimum Size" filter will most likely modify the Feature Ids array and then _every_ array in the feature attribute matrix. These additions will store information about these modifications in the IDataActions vector which is communicated to the user interface.

Each filter will need to be reviewed for existing array modifications and then updated with code to add the DataModifiedAction during prefilight. There are probably only a handful of these filters to update. Hopefully.