### PR TITLE
ENH: Added 4 Major Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,7 @@ body:
       label: Version
       description: What version of our software are you running? [Further details may be required during triage process]
       options:
-        - 7.0.x (DREAM3DNX beta)
+        - DREAM3D NX (version 7)
         - NXRunner built from source - Please provide git hash of commit in description
         - other (Please enter in the extended description at the bottom)
     validations:
@@ -41,12 +41,22 @@ body:
       options:
         - Windows 10
         - Windows 11
-        - macOS 10.15 Catalina
         - macOS 11.00 Big Sur
         - macOS 12.00 Monterey
         - macOS 13.00 Ventura
         - Linux - Ubuntu 20.04 LTS
         - Linux - Ubuntu 22.04 LTS
+        - other (Please enter in the extended description at the bottom)
+    validations:
+      required: true
+  - type: dropdown
+    id: hardware-architecture
+    attributes:
+      label: What hardware architecture are you using? [Further details may be required during triage process]
+      options:
+        - x86_64
+        - x64
+        - ARM64
         - other (Please enter in the extended description at the bottom)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,103 @@
+name: Bug Report
+description: File a bug report
+title: "BUG: "
+labels: ["bug", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We're sorry to hear your having trouble with our application. By filling out the following form in its entirety, we will be able to better diagnose the problem and help you reach a resolution. Thank you in advance for taking the time to fill out the form!
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues, known issues in release notes, and documentation.
+          required: true
+  - type: textarea
+    id: brief-description
+    attributes:
+      label: Brief Description of the Issue and Expected Behavior
+      description: Briefly describe the issue you encountered and what you expected to happen.
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running? [Further details may be required during triage process]
+      options:
+        - 7.0.x (DREAM3DNX beta)
+        - NXRunner built from source - Please provide git hash of commit in description
+        - other (Please enter in the extended description at the bottom)
+    validations:
+      required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: What operating system are you seeing the problem on? [Further details may be required during triage process]
+      options:
+        - Windows 10
+        - Windows 11
+        - macOS 10.15 Catalina
+        - macOS 11.00 Big Sur
+        - macOS 12.00 Monterey
+        - macOS 13.00 Ventura
+        - Linux - Ubuntu 20.04 LTS
+        - Linux - Ubuntu 22.04 LTS
+        - other (Please enter in the extended description at the bottom)
+    validations:
+      required: true
+  - type: dropdown
+    id: error-type
+    attributes:
+      label: What section did you encounter the error in? [Further details may be required during triage process]
+      multiple: true
+      options:
+        - GUI client
+        - NXRunner
+        - Visualization
+        - Workflow
+        - Filter Library (or Search Bar)
+        - Filter Parameters
+    validations:
+      required: false
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: Please include the steps to reproduce the behavior in order to help you as efficiently as possible.
+      placeholder: |
+        1. With this config...
+        2. Run '...'
+        3. See error...
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This can be found in the output widget of the interface or the console output of PipelineRunner.
+      render: "Text"
+    validations:
+      required: false
+  - type: textarea
+    id: further-detail
+    attributes:
+      label: Anything else?
+      description: |
+        Links? Pipelines? References? Compiler? Hardware? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you understand that your issue may be closed if you do not remain cordial, do not provide further detail if prompted, or do not engage with responses from the developers in a reasonable time.
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -29,7 +29,7 @@ body:
       label: Version
       description: What version of our software are you running? [Further details may be required during triage process]
       options:
-        - 7.0.x (DREAM3DNX beta)
+        - DREAM3D NX (version 7)
         - NXRunner built from source - Please provide git hash of commit in description
         - other (Please enter in the extended description at the bottom)
     validations:

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -1,0 +1,73 @@
+name: Documentation Report
+description: File a report for additional sections or discrepancies, missing, or comment errors in our documentation.
+title: "DOC: "
+labels: ["documentation", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping to better our documentation! By filling out the following form in its entirety, we will be able to better what needs to be fixed or improved on. Thank you in advance for taking the time to fill out the form!
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues, known issues in release notes, and documentation.
+          required: true
+  - type: textarea
+    id: brief-description
+    attributes:
+      label: Brief Description of the Documentation Issue or Improvement
+      description: Briefly describe the issue you found and what you expected.
+      placeholder: Tell us what you see!
+      value: "The discrepancy can be found at ___ and I think it should be ___"
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running? [Further details may be required during triage process]
+      options:
+        - 7.0.x (DREAM3DNX beta)
+        - NXRunner built from source - Please provide git hash of commit in description
+        - other (Please enter in the extended description at the bottom)
+    validations:
+      required: true
+  - type: dropdown
+    id: error-type
+    attributes:
+      label: What section of the documentation did you encounter the discrepancy in? [Further details may be required during triage process]
+      multiple: true
+      options:
+        - Filter Documentation
+        - Python Bindings Documentation
+        - Release Notes
+        - Acknowledgements
+        - Licensing
+        - README.md
+        - CONTRIBUTING.md
+        - SUPPORT.md
+        - Other - Please provide additional information in the "Anything Else?" Section
+    validations:
+      required: false
+  - type: textarea
+    id: further-detail
+    attributes:
+      label: Anything else?
+      description: |
+        Is this in relation to multilingual support?
+        Is there sections you think should be added to help other users?
+        Is there a missing reference?
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you understand that your issue may be closed if you do not remain cordial, do not provide further detail if prompted, or do not engage with responses from the developers in a reasonable time.
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/functionality_report.yml
+++ b/.github/ISSUE_TEMPLATE/functionality_report.yml
@@ -1,0 +1,77 @@
+name: Request New Functionality
+description: Share your recommendations for new features, filters, and functionality!
+title: "ENH: "
+labels: ["enhancement", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We're excited to hear your visions for our library. By filling out the following form in its entirety, we will be able to get a better understanding of your idea. Thank you in advance for taking the time to fill out the form!
+  - type: checkboxes
+    attributes:
+      label: Is there an existing plan for this?
+      description: Please search to see if a plan already exists for your suggestion. [If so, feel free to comment your support in that discussion/report]
+      options:
+        - label: I have searched the existing discussions, release notes, and documentation.
+          required: true
+  - type: textarea
+    id: brief-description
+    attributes:
+      label: Description of the Feature, Filter, or Functionality?
+      description: Describe your feature in detail or even provide an implementation plan/existing open source library to reference!
+      value: What if complex had...
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running? [Further details may be required during triage process]
+      options:
+        - 7.0.x (DREAM3DNX beta)
+        - NXRunner built from source - Please provide git hash of commit in description
+        - other (Please enter in the extended description at the bottom)
+    validations:
+      required: true
+  - type: dropdown
+    id: suggestion-type
+    attributes:
+      label: What section did you foresee your suggestion falling in? [Further details may be required during triage process]
+      multiple: true
+      options:
+        - Python Bindings
+        - NXRunner
+        - Filter Library (or Search Bar)
+        - Filter Parameters
+        - Infrastructure
+        - External Compatibility
+    validations:
+      required: false
+  - type: textarea
+    id: steps-to-implement
+    attributes:
+      label: High Level Steps To Implement
+      description: Please include the steps to implement the behavior in order to help you as efficiently as possible.
+      placeholder: |
+        1. Based on this paper/library...
+        2. Alter...
+    validations:
+      required: false
+  - type: textarea
+    id: further-detail
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you understand that your issue may be closed if you do not remain cordial, do not provide further detail if prompted, or do not engage with responses from the developers in a reasonable time.
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/performance_report.yml
+++ b/.github/ISSUE_TEMPLATE/performance_report.yml
@@ -29,7 +29,7 @@ body:
       label: Version
       description: What version of our software are you running? [Further details may be required during triage process]
       options:
-        - 7.0.x (DREAM3DNX beta)
+        - DREAM3D NX (version 7)
         - NXRunner built from source - Please provide git hash of commit in description
         - other (Please enter in the extended description at the bottom)
     validations:
@@ -41,12 +41,22 @@ body:
       options:
         - Windows 10
         - Windows 11
-        - macOS 10.15 Catalina
         - macOS 11.00 Big Sur
         - macOS 12.00 Monterey
         - macOS 13.00 Ventura
         - Linux - Ubuntu 20.04 LTS
         - Linux - Ubuntu 22.04 LTS
+        - other (Please enter in the extended description at the bottom)
+    validations:
+      required: true
+  - type: dropdown
+    id: hardware-architecture
+    attributes:
+      label: What hardware architecture are you using? [Further details may be required during triage process]
+      options:
+        - x86_64
+        - x64
+        - ARM64
         - other (Please enter in the extended description at the bottom)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/performance_report.yml
+++ b/.github/ISSUE_TEMPLATE/performance_report.yml
@@ -1,0 +1,100 @@
+name: Performance Report
+description: File a performance report
+title: "PERF: "
+labels: ["performance", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We're sorry to hear your having trouble with our library. By filling out the following form in its entirety, we will be able to better diagnose the problem and help you reach a resolution. Thank you in advance for taking the time to fill out the form!
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the performance issue you encountered.
+      options:
+        - label: I have searched the existing issues, known issues in release notes, and documentation.
+          required: true
+  - type: textarea
+    id: brief-description
+    attributes:
+      label: Brief Description of the Issue and Expected Behavior
+      description: Briefly describe the issue you encountered and what you expected to happen.
+      placeholder: Tell us what you see profiling wise.
+      value: "This profile shows..."
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running? [Further details may be required during triage process]
+      options:
+        - 7.0.x (DREAM3DNX beta)
+        - NXRunner built from source - Please provide git hash of commit in description
+        - other (Please enter in the extended description at the bottom)
+    validations:
+      required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: What operating system are you seeing the problem on? [Further details may be required during triage process]
+      options:
+        - Windows 10
+        - Windows 11
+        - macOS 10.15 Catalina
+        - macOS 11.00 Big Sur
+        - macOS 12.00 Monterey
+        - macOS 13.00 Ventura
+        - Linux - Ubuntu 20.04 LTS
+        - Linux - Ubuntu 22.04 LTS
+        - other (Please enter in the extended description at the bottom)
+    validations:
+      required: true
+  - type: dropdown
+    id: error-type
+    attributes:
+      label: What section did you encounter the deprecated performance in? [Further details may be required during triage process]
+      multiple: true
+      options:
+        - GUI client
+        - NXRunner
+        - Python Bindings
+        - Specific filter
+    validations:
+      required: false
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: Please include the steps to reproduce the behavior in order to help you as efficiently as possible.
+      placeholder: |
+        1. With this config...
+        2. Run '...'
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This can be found in the output widget of the interface or the console output of PipelineRunner.
+      render: "Text"
+    validations:
+      required: false
+  - type: textarea
+    id: further-detail
+    attributes:
+      label: Anything else?
+      description: |
+        Pipeline? Data? References? Compiler? Hardware? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you understand that your issue may be closed if you do not remain cordial, do not provide further detail if prompted, or do not engage with responses from the developers in a reasonable time.
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
These mainly focus on stuff related specifically to complex since we have DREAM3DNX-Issues for most of the more casual GUI users that is found directly through the documentation. The exception to this rule is the bug report since someone may stumble upon this repository with less technical expertise and the main way for interacting with our library is NX GUI. I also opted to leave out the Security report since the default is better than anything I could put together to be honest.

In the future we can set up bots to automatically update these files with new releases and recent commit hashes to save updating them every time and boost usability for the reporter.

One for bugs - bug_report.yml
One for documentation additions or discrepancies - documentation_report.yml
One for new features or enhancements - functionality_report.yml
One for performance issues - performance_report.yml