### PR TITLE
Updated vcpkg baseline for fmt 10.1.1

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -28,7 +28,7 @@
         "zlib",
         "zstd"
       ],
-      "baseline": "510e7f37bda3d7bf05b39cadd7eb2e74d3291e87"
+      "baseline": "29602a9d88e4c918904a0bd0fab83c5289700908"
     }
   ]
 }


### PR DESCRIPTION
* The fmt update fixes a deprecated warning on msvc