### PR TITLE
VCPKG: Add Default registry and add OpenSSL as an option

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,5 +1,9 @@
 {
-  "default-registry": null,
+  "default-registry": {
+    "kind": "git",
+    "repository": "https://github.com/microsoft/vcpkg",
+    "baseline": "8eb57355a4ffb410a2e94c07b4dca2dffbee8e50"
+  },
   "registries": [
     {
       "kind": "git",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -85,6 +85,14 @@
           "name": "blosc"
         }
       ]
+    },
+    "ssl": {
+      "description": "Use OpenSSL",
+      "dependencies": [
+        {
+          "name": "openssl"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
This is needed for licensing on the NX side of things. This is off by default.