### PR TITLE
BUG: ReadEspritDataFile - If spacing is zero, reset to 1.0

### DIFF
--- a/src/Plugins/OrientationAnalysis/docs/ReadH5EspritDataFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ReadH5EspritDataFilter.md
@@ -30,6 +30,10 @@ If the data has come from a TSL acquisition system and the settings of the acqui
 
 The user also may want to assign un-indexed pixels to be ignored by flagging them as "bad". The {ref}`Threshold Objects <ComplexCore/MultiThresholdObjects:Description>` Filter can be used to define this *mask* by thresholding on values such as *MAD* > xx.
 
++ Note: If the X Step or Y Step within the HDF5 file for a scan is ZERO, those values will be set to 1.0 when the filter runs. This is needed
+as the user has no effective way to fix the HDF5 file. If the user needs a different
+spacing value, the user can utilize the {ref}`Set Origin and Spacing<ComplexCore/SetImageGeomOriginScalingFilter:Description>` filter.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EspritDataFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EspritDataFilter.cpp
@@ -65,7 +65,7 @@ Parameters ReadH5EspritDataFilter::parameters() const
   Parameters params;
   // Create the parameter descriptors that are needed for this filter
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
-  params.insert(std::make_unique<OEMEbsdScanSelectionParameter>(k_SelectedScanNames_Key, "Scan Names", "The name of the scan in the .h5 file. EDAX can store multiple scans in a single file",
+  params.insert(std::make_unique<OEMEbsdScanSelectionParameter>(k_SelectedScanNames_Key, "Scan Names", "The name of the scan in the .h5 file. Esprit can store multiple scans in a single file",
                                                                 OEMEbsdScanSelectionParameter::ValueType{},
                                                                 /* OEMEbsdScanSelectionParameter::AllowedManufacturers{EbsdLib::OEM::Bruker, EbsdLib::OEM::DREAM3D},*/
                                                                 OEMEbsdScanSelectionParameter::EbsdReaderType::Esprit, OEMEbsdScanSelectionParameter::ExtensionsType{".h5", ".hdf5"}));
@@ -134,7 +134,10 @@ IFilter::PreflightResult ReadH5EspritDataFilter::preflightImpl(const DataStructu
   const std::vector<usize> tupleDims = {dims[2], dims[1], dims[0]};
   {
     CreateImageGeometryAction::SpacingType spacing = {static_cast<float32>(reader->getXStep()), static_cast<float32>(reader->getYStep()), pZSpacingValue};
-
+    for(float& value : spacing)
+    {
+      value = (value == 0.0f ? 1.0f : value);
+    }
     auto createDataGroupAction = std::make_unique<CreateImageGeometryAction>(pImageGeometryNameValue, dims, pOriginValue, spacing, pCellAttributeMatrixNameValue);
     resultOutputActions.value().appendAction(std::move(createDataGroupAction));
   }

--- a/src/Plugins/OrientationAnalysis/test/ReadH5EspritDataTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/ReadH5EspritDataTest.cpp
@@ -62,7 +62,7 @@ TEST_CASE("OrientationAnalysis::ReadH5EspritDataFilter: Valid Filter Execution",
   const auto& imageGeom = dataStructure.getDataRefAs<ImageGeom>(DataPath({ImageGeom::k_TypeName}));
   const auto& exemplarImageGeom = exemplarDataStructure.getDataRefAs<ImageGeom>(DataPath({k_ExemplarDataContainer}));
   REQUIRE(imageGeom.getDimensions() == exemplarImageGeom.getDimensions());
-  REQUIRE(imageGeom.getSpacing() == exemplarImageGeom.getSpacing());
+  REQUIRE(imageGeom.getSpacing() == FloatVec3{1.0f, 1.0f, 1.0f});
   REQUIRE(imageGeom.getOrigin() == exemplarImageGeom.getOrigin());
   REQUIRE(imageGeom.getUnits() == IGeometry::LengthUnit::Micrometer);
 


### PR DESCRIPTION
Some Esprit HDF5 files have their x and y step values set to 0.0. If these are found, the filter will just reset them to 1.0 to avoid strange import behavior.