### PR TITLE
BUG: Ensure Sphinx is installed during the conda build process.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -54,6 +54,10 @@ requirements:
     - tbb
     - tbb-devel
     - zlib
+    - sphinx
+    - myst-parser
+    - sphinx-markdown-tables
+    - sphinx_rtd_theme
   run:
     - python
     - numpy

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -57,6 +57,10 @@ requirements:
     - tbb
     - tbb-devel
     - zlib
+    - sphinx
+    - myst-parser
+    - sphinx-markdown-tables
+    - sphinx_rtd_theme
   run:
     - python
     - numpy


### PR DESCRIPTION
This allows the documentation to be built


