### PR TITLE
Fixed shallow copy in python bindings function

### DIFF
--- a/wrapping/python/CxPybind/CxPybind/CxPybind.hpp
+++ b/wrapping/python/CxPybind/CxPybind/CxPybind.hpp
@@ -587,7 +587,8 @@ protected:
       Parameters params = parameters();
       auto shouldCancelProxy = std::make_shared<AtomicBoolProxy>(shouldCancel);
       auto guard = MakeAtomicBoolProxyGuard(shouldCancelProxy);
-      auto result = m_Object.attr("preflight_impl")(data, ConvertArgsToDict(Internals::Instance(), params, args), messageHandler, shouldCancelProxy).cast<PreflightResult>();
+      auto result = m_Object.attr("preflight_impl")(py::cast(data, py::return_value_policy::reference), ConvertArgsToDict(Internals::Instance(), params, args), messageHandler, shouldCancelProxy)
+                        .cast<PreflightResult>();
       return result;
     } catch(const py::error_already_set& pyException)
     {
@@ -606,7 +607,10 @@ protected:
       Parameters params = parameters();
       auto shouldCancelProxy = std::make_shared<AtomicBoolProxy>(shouldCancel);
       auto guard = MakeAtomicBoolProxyGuard(shouldCancelProxy);
-      auto result = m_Object.attr("execute_impl")(data, ConvertArgsToDict(Internals::Instance(), params, args), /* pipelineNode,*/ messageHandler, shouldCancelProxy).cast<Result<>>();
+      auto result =
+          m_Object
+              .attr("execute_impl")(py::cast(data, py::return_value_policy::reference), ConvertArgsToDict(Internals::Instance(), params, args), /* pipelineNode,*/ messageHandler, shouldCancelProxy)
+              .cast<Result<>>();
       return result;
     } catch(const py::error_already_set& pyException)
     {


### PR DESCRIPTION
* Changed the python bindings for `preflight_impl` and `execute_impl` to pass `DataStructure` by reference
* Fixed issue with unintentional shallow copy occuring preventing
some changes from being propogated (i.e. StringArray)