### PR TITLE
COMP: Clang v14 -ffp-contract=off compiler option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,11 @@ endif()
 # Force HDF5 1.10 API
 target_compile_definitions(simplnx PUBLIC "H5_USE_110_API")
 
+target_compile_options( simplnx PUBLIC
+  $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang,Intel>: "-ffp-contract=off">
+ )
+
+
 if(SIMPLNX_ENABLE_MULTICORE)
   target_compile_definitions(simplnx PUBLIC "SIMPLNX_ENABLE_MULTICORE")
   target_link_libraries(simplnx PUBLIC TBB::tbb)

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -32,7 +32,7 @@
         "zlib",
         "zstd"
       ],
-      "baseline": "5154386f1d47afc0bab1fb7de42078e88488dc56"
+      "baseline": "13dcb0971a538726d6c5cd0ccea1b8ab536a81af"
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -74,7 +74,7 @@
       "dependencies": [
         {
           "name": "ebsdlib",
-          "version>=": "1.0.26"
+          "version>=": "1.0.27"
         }
       ]
     },


### PR DESCRIPTION
https://stackoverflow.com/questions/73985098/clang-14-0-0-floating-point-optimizations

This change was changing results from some of the orientation representation functions. This change will ensure that the results are consistent across the various versions of Clang that are supported.