### PR TITLE
Fixed cmake syntax warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ target_compile_definitions(simplnx PUBLIC "H5_USE_110_API")
 
 target_compile_options(simplnx
   PUBLIC
-    $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang,Intel>:"-ffp-contract=off">
+    $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang,Intel>:-ffp-contract=off>
 )
 
 if(SIMPLNX_ENABLE_MULTICORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,10 +209,10 @@ endif()
 # Force HDF5 1.10 API
 target_compile_definitions(simplnx PUBLIC "H5_USE_110_API")
 
-target_compile_options( simplnx PUBLIC
-  $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang,Intel>: "-ffp-contract=off">
- )
-
+target_compile_options(simplnx
+  PUBLIC
+    $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang,Intel>:"-ffp-contract=off">
+)
 
 if(SIMPLNX_ENABLE_MULTICORE)
   target_compile_definitions(simplnx PUBLIC "SIMPLNX_ENABLE_MULTICORE")


### PR DESCRIPTION
* Argument not separated from preceding token by whitespace