### PR TITLE
ENH: GeneratePythonFilter-Crashing fixed, Generation Fixed, headers split

### DIFF
--- a/src/Plugins/SimplnxCore/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/CMakeLists.txt
@@ -318,6 +318,7 @@ set(PLUGIN_EXTRA_SOURCES
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/CeilOperator.cpp"
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/AvizoWriter.hpp"
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/AvizoWriter.cpp"
+    "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/PythonPluginTemplateFile.hpp"
 
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/SurfaceNets/MMCellFlag.cpp"
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/SurfaceNets/MMCellFlag.h"
@@ -348,11 +349,24 @@ source_group(TREE "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}" PREFIX ${PLU
 # the template file to use the contents of those files. This should allow easier
 # updating of those template files.
 file(READ "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/PythonFilterTemplate.py" PYTHON_FILTER_TEMPLATE)
-file(READ "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/PythonPluginInitTemplate.py" PYTHON_PLUGIN_INIT_TEMPLATE)
-file(READ "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/PythonPluginTemplate.py" PYTHON_PLUGIN_TEMPLATE)
+string(HEX ${PYTHON_FILTER_TEMPLATE} PYTHON_FILTER_TEMPLATE)
+string(REGEX REPLACE "([0-9a-f][0-9a-f])" "0x\\0," PYTHON_FILTER_TEMPLATE ${PYTHON_FILTER_TEMPLATE})
+string(APPEND PYTHON_FILTER_TEMPLATE "0x00")
 
-configure_file("${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/PythonPluginTemplateFile.in.hpp"
-                "${${PLUGIN_NAME}_BINARY_DIR}/utils/PythonPluginTemplateFile.hpp")
+
+file(READ "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/PythonPluginInitTemplate.py" PYTHON_PLUGIN_INIT_TEMPLATE)
+string(HEX ${PYTHON_PLUGIN_INIT_TEMPLATE} PYTHON_PLUGIN_INIT_TEMPLATE)
+string(REGEX REPLACE "([0-9a-f][0-9a-f])" "0x\\0," PYTHON_PLUGIN_INIT_TEMPLATE ${PYTHON_PLUGIN_INIT_TEMPLATE})
+string(APPEND PYTHON_PLUGIN_INIT_TEMPLATE "0x00")
+
+file(READ "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/PythonPluginTemplate.py" PYTHON_PLUGIN_TEMPLATE)
+string(HEX ${PYTHON_PLUGIN_TEMPLATE} PYTHON_PLUGIN_TEMPLATE)
+string(REGEX REPLACE "([0-9a-f][0-9a-f])" "0x\\0," PYTHON_PLUGIN_TEMPLATE ${PYTHON_PLUGIN_TEMPLATE})
+string(APPEND PYTHON_PLUGIN_TEMPLATE "0x00")
+
+
+cmpConfigureFileWithMD5Check(CONFIGURED_TEMPLATE_PATH "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/PythonPluginSourceTemplate.in.hpp"
+                              GENERATED_FILE_PATH "${${PLUGIN_NAME}_BINARY_DIR}/generated/${PLUGIN_NAME}/utils/PythonPluginSourceTemplate.hpp")
 
 #------------------------------------------------------------------------------
 # If there are additional include directories that are needed for this plugin

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/PythonPluginSourceTemplate.in.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/PythonPluginSourceTemplate.in.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+/**
+ * This file is auto-generated during CMake time. Any changes made to the generated file
+ * will be over written the next time CMake runs a configure.
+ */
+
+#include <string>
+
+namespace nx::core
+{
+
+// clang-format off
+static const char k_PythonFilterTemplateCharArray[] = {@PYTHON_FILTER_TEMPLATE@};
+// clang-format on
+
+inline const std::string PythonFilterTemplate()
+{
+  return {k_PythonFilterTemplateCharArray};
+}
+
+// clang-format off
+static const char k_PluginPythonFileCharArray[] = {@PYTHON_PLUGIN_TEMPLATE@};
+// clang-format on
+
+inline const std::string PluginPythonFile()
+{
+  return {k_PluginPythonFileCharArray};
+}
+
+// clang-format off
+static const char k_PluginInitPythonFileCharArray[] = {@PYTHON_PLUGIN_INIT_TEMPLATE@};
+// clang-format on
+
+inline const std::string PluginInitPythonFile()
+{
+  return {k_PluginInitPythonFileCharArray};
+}
+
+}; // namespace nx::core

--- a/wrapping/python/plugins/DataAnalysisToolkit/NPSortArray.py
+++ b/wrapping/python/plugins/DataAnalysisToolkit/NPSortArray.py
@@ -1,0 +1,97 @@
+
+from typing import List
+
+import simplnx as nx
+
+import numpy as np
+
+class NPSortArray:
+  """
+  This section should contain the 'keys' that store each parameter. The value of the key should be snake_case. The name
+  of the value should be ALL_CAPITOL_KEY
+  """
+  INPUT_ARRAY_KEY = 'input_array_path'
+
+  def uuid(self) -> nx.Uuid:
+    """This returns the UUID of the filter. Each filter has a unique UUID value
+    :return: The Filter's Uuid value
+    :rtype: string
+    """
+    return nx.Uuid('ae37de34-4ead-4202-9a49-6c222cbd88a8')
+
+  def human_name(self) -> str:
+    """This returns the name of the filter as a user of DREAM3DNX would see it
+    :return: The filter's human name
+    :rtype: string
+    """
+    return 'Sort Data Array (Numpy)'
+
+  def class_name(self) -> str:
+    """The returns the name of the class that implements the filter
+    :return: The name of the implementation class
+    :rtype: string
+    """
+    return 'NPSortArray'
+
+  def name(self) -> str:
+    """The returns the name of filter
+    :return: The name of the filter
+    :rtype: string
+    """
+    return 'NPSortArray'
+
+  def default_tags(self) -> List[str]:
+    """This returns the default tags for this filter
+    :return: The default tags for the filter
+    :rtype: list
+    """
+    return ['python']
+
+  def clone(self):
+    """Clones the filter
+    :return: A new instance of the filter
+    :rtype:  NPSortArray
+    """
+    return NPSortArray()
+
+  def parameters(self) -> nx.Parameters:
+    """This function defines the parameters that are needed by the filter. Parameters collect the values from the user
+       or through a pipeline file.
+    """
+    params = nx.Parameters()
+
+    params.insert(nx.ArraySelectionParameter(NPSortArray.INPUT_ARRAY_KEY, 'Input Data Array', 'The input array to sort.', nx.DataPath(), nx.get_all_data_types()))
+
+    return params
+
+  def preflight_impl(self, data_structure: nx.DataStructure, args: dict, message_handler: nx.IFilter.MessageHandler, should_cancel: nx.AtomicBoolProxy) -> nx.IFilter.PreflightResult:
+    """This method preflights the filter and should ensure that all inputs are sanity checked as best as possible. Array
+    sizes can be checked if the arrays are actually know at preflight time. Some filters will not be able to report output
+    array sizes during preflight (segmentation filters for example).
+    :returns:
+    :rtype: nx.IFilter.PreflightResult
+    """
+
+#    message_handler(nx.IFilter.Message(nx.IFilter.Message.Type.Info, f'Preflight: {value}'))
+    return nx.IFilter.PreflightResult()
+
+  def execute_impl(self, data_structure: nx.DataStructure, args: dict, message_handler: nx.IFilter.MessageHandler, should_cancel: nx.AtomicBoolProxy) -> nx.IFilter.ExecuteResult:
+    """ This method actually executes the filter algorithm and reports results.
+    :returns:
+    :rtype: nx.IFilter.ExecuteResult
+    """
+    # Extract the DataPath from the arguments
+    input_data_arr_path: nx.DataPath = args[NPSortArray.INPUT_ARRAY_KEY]
+    # Use the DataPath to get a numpy view of the DataArray at that DataPath
+    input_array_view = data_structure[input_data_arr_path].npview()
+
+    # Treat the view like a single dimensional array
+    # The entire array is sorted from first element to last element. 
+    input_array_view = input_array_view.reshape(-1)
+
+    # Sort the actual Data Array in place
+    input_array_view.sort()
+        
+    return nx.Result()
+
+

--- a/wrapping/python/plugins/DataAnalysisToolkit/Plugin.py
+++ b/wrapping/python/plugins/DataAnalysisToolkit/Plugin.py
@@ -1,7 +1,16 @@
+
+"""
+Insert documentation here.
+"""
+
 from DataAnalysisToolkit.CalculateHistogramFilter import CalculateHistogramFilter
 from DataAnalysisToolkit.InterpolateGridDataFilter import InterpolateGridDataFilter
 from DataAnalysisToolkit.CliReaderFilter import CliReaderFilter
 from DataAnalysisToolkit.ContourDetectionFilter import ContourDetectionFilter
+from DataAnalysisToolkit.NPSortArray import NPSortArray
+
+# FILTER_INCLUDE_INSERT
+
 import simplnx as nx
 
 class DataAnalysisToolkit:
@@ -21,4 +30,6 @@ class DataAnalysisToolkit:
     return 'BlueQuartz Software'
 
   def get_filters(self):
-    return [CalculateHistogramFilter, InterpolateGridDataFilter, CliReaderFilter, ContourDetectionFilter]
+    return [CalculateHistogramFilter,InterpolateGridDataFilter,CliReaderFilter,NPSortArray,ContourDetectionFilter] # FILTER_NAME_INSERT
+
+

--- a/wrapping/python/plugins/DataAnalysisToolkit/__init__.py
+++ b/wrapping/python/plugins/DataAnalysisToolkit/__init__.py
@@ -1,10 +1,17 @@
+
 from DataAnalysisToolkit.Plugin import DataAnalysisToolkit
+
 from DataAnalysisToolkit.CalculateHistogramFilter import CalculateHistogramFilter
 from DataAnalysisToolkit.InterpolateGridDataFilter import InterpolateGridDataFilter
 from DataAnalysisToolkit.CliReaderFilter import CliReaderFilter
 from DataAnalysisToolkit.ContourDetectionFilter import ContourDetectionFilter
+from DataAnalysisToolkit.NPSortArray import NPSortArray
+
+# FILTER_INCLUDE_INSERT
 
 def get_plugin():
   return DataAnalysisToolkit()
 
-__all__ = ['DataAnalysisToolkit', 'CalculateHistogramFilter', 'InterpolateGridDataFilter', 'CliReaderFilter', 'ContourDetectionFilter', 'get_plugin']
+__all__ = ['DataAnalysisToolkit','CalculateHistogramFilter', 'InterpolateGridDataFilter', 'CliReaderFilter', 'get_plugin', 'ContourDetectionFilter', 'NPSortArray'] # FILTER_NAME_INSERT
+
+


### PR DESCRIPTION
- Crash when adding a filter to an existing plugin
- Generation fixed when adding a filter to an existing plugin
- Split the constant strings from the header into their own header file which allows easier debugging of the sources