### PR TITLE
BUG FIX: Find Array Statistics

### DIFF
--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/FindArrayStatistics.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/FindArrayStatistics.cpp
@@ -447,20 +447,17 @@ public:
       featureSources[featureId - start].push_back(source[tupleIndex]);
     }
 
-    auto& medianArray = m_MedianArray->getDataStoreRef();
-    auto& numUniqueValuesArray = m_NumUniqueValuesArray->getDataStoreRef();
-
     for(usize featureSourceIndex = 0; featureSourceIndex < numFeatureSources; featureSourceIndex++)
     {
       if(m_FindMedian)
       {
         const float32 val = StatisticsCalculations::findMedian(featureSources[featureSourceIndex]);
-        medianArray.setValue(featureSourceIndex + start, val);
+        m_MedianArray->setValue(featureSourceIndex + start, val);
       }
       if(m_FindNumUniqueValues)
       {
         const auto val = StatisticsCalculations::findNumUniqueValues(featureSources[featureSourceIndex]);
-        numUniqueValuesArray.setValue(featureSourceIndex + start, val);
+        m_NumUniqueValuesArray->setValue(featureSourceIndex + start, val);
       }
     }
   }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FindArrayStatisticsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FindArrayStatisticsFilter.cpp
@@ -352,7 +352,7 @@ IFilter::PreflightResult FindArrayStatisticsFilter::preflightImpl(const DataStru
     featureIdsPtr = dataStructure.getDataAs<Int32Array>(pFeatureIdsArrayPathValue);
     if(featureIdsPtr == nullptr)
     {
-      return {MakeErrorResult<OutputActions>(-57205, fmt::format("Could not find feature ids array at path '{}' ", pFeatureIdsArrayPathValue.toString())), {}};
+      return {MakeErrorResult<OutputActions>(-57204, fmt::format("Could not find feature ids array at path '{}' ", pFeatureIdsArrayPathValue.toString())), {}};
     }
     inputDataArrayPaths.push_back(pFeatureIdsArrayPathValue);
 
@@ -364,11 +364,11 @@ IFilter::PreflightResult FindArrayStatisticsFilter::preflightImpl(const DataStru
     const auto* maskPtr = dataStructure.getDataAs<IDataArray>(pMaskArrayPathValue);
     if(maskPtr == nullptr)
     {
-      return {MakeErrorResult<OutputActions>(-57207, fmt::format("Could not find mask array at path '{}' ", pMaskArrayPathValue.toString())), {}};
+      return {MakeErrorResult<OutputActions>(-57205, fmt::format("Could not find mask array at path '{}' ", pMaskArrayPathValue.toString())), {}};
     }
     if(maskPtr->getDataType() != DataType::boolean && maskPtr->getDataType() != DataType::uint8)
     {
-      return {MakeErrorResult<OutputActions>(-57207, fmt::format("Mask array must be of type Boolean or UInt8")), {}};
+      return {MakeErrorResult<OutputActions>(-57206, fmt::format("Mask array must be of type Boolean or UInt8")), {}};
     }
     inputDataArrayPaths.push_back(pMaskArrayPathValue);
   }
@@ -377,25 +377,35 @@ IFilter::PreflightResult FindArrayStatisticsFilter::preflightImpl(const DataStru
   {
     if(!pFindMeanValue || !pFindStdDeviationValue)
     {
-      return {MakeErrorResult<OutputActions>(-57208, fmt::format(R"(To standardize data, the "Find Mean" and "Find Standard Deviation" options must also be checked)")), {}};
+      return {MakeErrorResult<OutputActions>(-57207, fmt::format(R"(To standardize data, the "Find Mean" and "Find Standard Deviation" options must also be checked)")), {}};
     }
+  }
+
+  if(pFindMedianValue && !pFindLengthValue)
+  {
+    return {MakeErrorResult<OutputActions>(-57208, fmt::format(R"(To find the median of the data, the "Find Length" option must also be checked)")), {}};
+  }
+
+  if(pFindNumUniqueValuesValue && !pFindLengthValue)
+  {
+    return {MakeErrorResult<OutputActions>(-57209, fmt::format(R"(To find the number of unique values, the "Find Length" option must also be checked)")), {}};
   }
 
   if(pFindHistogramValue && pFindModalBinRanges && !pFindModeValue)
   {
-    return {MakeErrorResult<OutputActions>(-57209, fmt::format(R"(To calculate the modal histogram bin ranges, the "Find Mode" option must also be turned on.)")), {}};
+    return {MakeErrorResult<OutputActions>(-57210, fmt::format(R"(To calculate the modal histogram bin ranges, the "Find Mode" option must also be turned on.)")), {}};
   }
 
   if(pFindModeValue && !ExecuteDataFunction(IsIntegerType{}, inputArrayPtr->getDataType()))
   {
     std::string msg = "Finding the mode requires selecting an input array with an integer data type (int8, uint8, int16, uint16, int32, uint32, int64, uint64).";
-    return {nonstd::make_unexpected(std::vector<Error>{Error{-57209, msg}})};
+    return {nonstd::make_unexpected(std::vector<Error>{Error{-57211, msg}})};
   }
 
   auto tupleValidityCheck = dataStructure.validateNumberOfTuples(inputDataArrayPaths);
   if(!tupleValidityCheck)
   {
-    return {MakeErrorResult<OutputActions>(-57210, fmt::format("The following DataArrays all must have equal number of tuples but this was not satisfied.\n{}", tupleValidityCheck.error()))};
+    return {MakeErrorResult<OutputActions>(-57212, fmt::format("The following DataArrays all must have equal number of tuples but this was not satisfied.\n{}", tupleValidityCheck.error()))};
   }
 
   resultOutputActions.value().actions = CreateCompatibleArrays(dataStructure, filterArgs, numBins, tupleDims).actions;


### PR DESCRIPTION
* Fixed a crashing bug that was occurring whenever Find Median or Find Unique Values is chosen but Find Length is not chosen.  Find Length is required for these, so added a preflight error saying that.
* Fixed a crash that was occurring when only one of Find Median and Find Unique Values was selected.