### PR TITLE
BUG/ENH: StringUtilities Split Function Updates

### DIFF
--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/PythonPluginTemplateFile.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/PythonPluginTemplateFile.hpp
@@ -73,7 +73,7 @@ inline Result<> InsertFilterNameInPluginFiles(const std::filesystem::path& plugi
     buffer << file.rdbuf();
     std::string content = buffer.str();
     file.close();
-    std::vector<std::string> lines = nx::core::StringUtilities::split_2(content, "\n", true);
+    std::vector<std::string> lines = nx::core::StringUtilities::split(content, "\n", true);
     if(lines.back().empty())
     {
       lines.pop_back();
@@ -117,7 +117,7 @@ inline Result<> InsertFilterNameInPluginFiles(const std::filesystem::path& plugi
     buffer << file.rdbuf();
     std::string content = buffer.str();
     file.close();
-    std::vector<std::string> lines = nx::core::StringUtilities::split_2(content, "\n", true);
+    std::vector<std::string> lines = nx::core::StringUtilities::split(content, "\n", true);
     if(lines.back().empty())
     {
       lines.pop_back();

--- a/src/simplnx/Utilities/StringUtilities.hpp
+++ b/src/simplnx/Utilities/StringUtilities.hpp
@@ -214,45 +214,6 @@ inline std::vector<std::string> split(std::string_view str, char delim)
   return optimized_split<false>(str, delims);
 }
 
-/**
- *
- * @param input
- * @param delimiter
- * @param consecutiveDelimiters
- * @return
- */
-inline std::vector<std::string> split_2(std::string_view input, nonstd::span<const char> delimiter, bool consecutiveDelimiters)
-{
-  std::vector<std::string> result;
-  std::string current;
-  for(char ch : input)
-  {
-    if(ch == delimiter[0])
-    {
-      // If consecutive delimiters should lead to empty strings, or if the current string is not empty,
-      // we add the current string (which could be empty) to the result.
-      if(consecutiveDelimiters || !current.empty())
-      {
-        result.push_back(current);
-        current.clear(); // Reset current for the next word.
-      }
-      // If consecutiveDelimiters is false, we simply skip this part,
-      // which avoids adding an empty string for consecutive delimiters.
-    }
-    else
-    {
-      current += ch;
-    }
-  }
-  // Add the last word to the result if it's not empty, or if the last character was a delimiter
-  // and consecutiveDelimiters is true.
-  if(!current.empty() || (consecutiveDelimiters && !input.empty() && input.back() == delimiter[0]))
-  {
-    result.push_back(current);
-  }
-  return result;
-}
-
 inline std::string join(nonstd::span<std::string_view> vec, std::string_view delim)
 {
   return fmt::format("{}", fmt::join(vec, delim));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(simplnx_test
   ParametersTest.cpp
   PipelineSaveTest.cpp
   UuidTest.cpp
+  StringUtilitiesTest.cpp
 )
 
 target_link_libraries(simplnx_test

--- a/test/StringUtilitiesTest.cpp
+++ b/test/StringUtilitiesTest.cpp
@@ -1,0 +1,21 @@
+#include "simplnx/Utilities/StringUtilities.hpp"
+#include "simplnx/unit_test/simplnx_test_dirs.hpp"
+
+#include <catch2/catch.hpp>
+
+#include string
+
+using namespace nx::core;
+
+TEST_CASE("Utility Function Test: split(str, char)")
+{
+  // Case 1
+  std::string inputStr = "This|Is|A|Baseline|Test";
+
+  std::vector<std::string> result1 = StringUtilities::split(inputStr, '|');
+
+  REQUIRE(result1.size() == 5);
+
+  // Case 2
+  inputStr
+}

--- a/test/StringUtilitiesTest.cpp
+++ b/test/StringUtilitiesTest.cpp
@@ -14,24 +14,21 @@ TEST_CASE("Utility Function Test: split(str, char)")
 
   std::vector<std::string> result = StringUtilities::split(inputStr, '|');
 
-  REQUIRE(result.size() == 5);
-  // Expected: {"This","Is","A","Baseline","Test"}
+  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 
   // Case 2
   inputStr = "|This|Is|A|Baseline|Test|"
 
   result = StringUtilities::split(inputStr, '|');
 
-  REQUIRE(result.size() == 5);
-  // Expected: {"This","Is","A","Baseline","Test"}
+  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 
   // Case 3
   inputStr = "|This|Is||A||Baseline|Test||"
 
   result = StringUtilities::split(inputStr, '|');
 
-  REQUIRE(result.size() == 5);
-  // Expected: {"This","Is","A","Baseline","Test"}
+  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 }
 
 TEST_CASE("Utility Function Test: split(str, char, bool)")
@@ -41,46 +38,40 @@ TEST_CASE("Utility Function Test: split(str, char, bool)")
 
   std::vector<std::string> result = StringUtilities::split(inputStr, '|', false);
 
-  REQUIRE(result.size() == 5);
-  // Expected: {"This","Is","A","Baseline","Test"}
+  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 
   // Case 2
   inputStr = "|This|Is|A|Baseline|Test|"
 
   result = StringUtilities::split(inputStr, '|', false);
 
-  REQUIRE(result.size() == 5);
-  // Expected: {"This","Is","A","Baseline","Test"}
+  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 
   // Case 3
   inputStr = "|This|Is||A||Baseline|Test||"
 
   result = StringUtilities::split(inputStr, '|', false);
 
-  REQUIRE(result.size() == 5);
-  // Expected: {"This","Is","A","Baseline","Test"}
+  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 
   // Case 4
   std::string inputStr = "This|Is|A|Baseline|Test";
 
   std::vector<std::string> result = StringUtilities::split(inputStr, '|', true);
 
-  REQUIRE(result.size() == 5);
-  // Expected: {"This","Is","A","Baseline","Test"}
+  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 
   // Case 5
   inputStr = "|This|Is|A|Baseline|Test|"
 
   result = StringUtilities::split(inputStr, '|', true);
 
-  REQUIRE(result.size() == 6);
-  // Expected: {"This","Is","A","Baseline","Test",""}
+  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test",""});
 
   // Case 6
   inputStr = "|This|Is||A||Baseline|Test||"
 
   result = StringUtilities::split(inputStr, '|', true);
 
-  REQUIRE(result.size() == 9);
-  // Expected: {"This","Is","","A","","Baseline","Test","",""}
+  REQUIRE(result == std::vector<std::string>{"This","Is","","A","","Baseline","Test","",""});
 }

--- a/test/StringUtilitiesTest.cpp
+++ b/test/StringUtilitiesTest.cpp
@@ -15,6 +15,7 @@ TEST_CASE("Utility Function Test: split(str, char)")
   std::vector<std::string> result = StringUtilities::split(inputStr, '|');
 
   REQUIRE(result.size() == 5);
+  // Expected: {"This","Is","A","Baseline","Test"}
 
   // Case 2
   inputStr = "|This|Is|A|Baseline|Test|"
@@ -22,6 +23,7 @@ TEST_CASE("Utility Function Test: split(str, char)")
   result = StringUtilities::split(inputStr, '|');
 
   REQUIRE(result.size() == 5);
+  // Expected: {"This","Is","A","Baseline","Test"}
 
   // Case 3
   inputStr = "|This|Is||A||Baseline|Test||"
@@ -29,6 +31,7 @@ TEST_CASE("Utility Function Test: split(str, char)")
   result = StringUtilities::split(inputStr, '|');
 
   REQUIRE(result.size() == 5);
+  // Expected: {"This","Is","A","Baseline","Test"}
 }
 
 TEST_CASE("Utility Function Test: split(str, char, bool)")
@@ -39,6 +42,7 @@ TEST_CASE("Utility Function Test: split(str, char, bool)")
   std::vector<std::string> result = StringUtilities::split(inputStr, '|', false);
 
   REQUIRE(result.size() == 5);
+  // Expected: {"This","Is","A","Baseline","Test"}
 
   // Case 2
   inputStr = "|This|Is|A|Baseline|Test|"
@@ -46,6 +50,7 @@ TEST_CASE("Utility Function Test: split(str, char, bool)")
   result = StringUtilities::split(inputStr, '|', false);
 
   REQUIRE(result.size() == 5);
+  // Expected: {"This","Is","A","Baseline","Test"}
 
   // Case 3
   inputStr = "|This|Is||A||Baseline|Test||"
@@ -53,6 +58,7 @@ TEST_CASE("Utility Function Test: split(str, char, bool)")
   result = StringUtilities::split(inputStr, '|', false);
 
   REQUIRE(result.size() == 5);
+  // Expected: {"This","Is","A","Baseline","Test"}
 
   // Case 4
   std::string inputStr = "This|Is|A|Baseline|Test";
@@ -60,6 +66,7 @@ TEST_CASE("Utility Function Test: split(str, char, bool)")
   std::vector<std::string> result = StringUtilities::split(inputStr, '|', true);
 
   REQUIRE(result.size() == 5);
+  // Expected: {"This","Is","A","Baseline","Test"}
 
   // Case 5
   inputStr = "|This|Is|A|Baseline|Test|"
@@ -67,11 +74,13 @@ TEST_CASE("Utility Function Test: split(str, char, bool)")
   result = StringUtilities::split(inputStr, '|', true);
 
   REQUIRE(result.size() == 6);
+  // Expected: {"This","Is","A","Baseline","Test",""}
 
   // Case 6
   inputStr = "|This|Is||A||Baseline|Test||"
 
   result = StringUtilities::split(inputStr, '|', true);
 
-  REQUIRE(result.size() == 8);
+  REQUIRE(result.size() == 9);
+  // Expected: {"This","Is","","A","","Baseline","Test","",""}
 }

--- a/test/StringUtilitiesTest.cpp
+++ b/test/StringUtilitiesTest.cpp
@@ -66,7 +66,7 @@ TEST_CASE("Utility Function Test: split(str, char, bool)")
 
   result = StringUtilities::split(inputStr, '|', true);
 
-  REQUIRE(result.size() == 5);
+  REQUIRE(result.size() == 6);
 
   // Case 6
   inputStr = "|This|Is||A||Baseline|Test||"

--- a/test/StringUtilitiesTest.cpp
+++ b/test/StringUtilitiesTest.cpp
@@ -12,10 +12,66 @@ TEST_CASE("Utility Function Test: split(str, char)")
   // Case 1
   std::string inputStr = "This|Is|A|Baseline|Test";
 
-  std::vector<std::string> result1 = StringUtilities::split(inputStr, '|');
+  std::vector<std::string> result = StringUtilities::split(inputStr, '|');
 
-  REQUIRE(result1.size() == 5);
+  REQUIRE(result.size() == 5);
 
   // Case 2
-  inputStr
+  inputStr = "|This|Is|A|Baseline|Test|"
+
+  result = StringUtilities::split(inputStr, '|');
+
+  REQUIRE(result.size() == 5);
+
+  // Case 3
+  inputStr = "|This|Is||A||Baseline|Test||"
+
+  result = StringUtilities::split(inputStr, '|');
+
+  REQUIRE(result.size() == 5);
+}
+
+TEST_CASE("Utility Function Test: split(str, char, bool)")
+{
+  // Case 1
+  std::string inputStr = "This|Is|A|Baseline|Test";
+
+  std::vector<std::string> result = StringUtilities::split(inputStr, '|', false);
+
+  REQUIRE(result.size() == 5);
+
+  // Case 2
+  inputStr = "|This|Is|A|Baseline|Test|"
+
+  result = StringUtilities::split(inputStr, '|', false);
+
+  REQUIRE(result.size() == 5);
+
+  // Case 3
+  inputStr = "|This|Is||A||Baseline|Test||"
+
+  result = StringUtilities::split(inputStr, '|', false);
+
+  REQUIRE(result.size() == 5);
+
+  // Case 4
+  std::string inputStr = "This|Is|A|Baseline|Test";
+
+  std::vector<std::string> result = StringUtilities::split(inputStr, '|', true);
+
+  REQUIRE(result.size() == 5);
+
+  // Case 5
+  inputStr = "|This|Is|A|Baseline|Test|"
+
+  result = StringUtilities::split(inputStr, '|', true);
+
+  REQUIRE(result.size() == 5);
+
+  // Case 6
+  inputStr = "|This|Is||A||Baseline|Test||"
+
+  result = StringUtilities::split(inputStr, '|', true);
+
+  REQUIRE(result.size() == 8);
 }

--- a/test/StringUtilitiesTest.cpp
+++ b/test/StringUtilitiesTest.cpp
@@ -14,21 +14,21 @@ TEST_CASE("Utility Function Test: split(str, char)")
 
   std::vector<std::string> result = StringUtilities::split(inputStr, '|');
 
-  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
+  REQUIRE(result == std::vector<std::string>{"This", "Is", "A", "Baseline", "Test"});
 
   // Case 2
   inputStr = "|This|Is|A|Baseline|Test|";
 
   result = StringUtilities::split(inputStr, '|');
 
-  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
+  REQUIRE(result == std::vector<std::string>{"This", "Is", "A", "Baseline", "Test"});
 
   // Case 3
   inputStr = "||This|Is||A||Baseline|Test||";
 
   result = StringUtilities::split(inputStr, '|');
 
-  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
+  REQUIRE(result == std::vector<std::string>{"This", "Is", "A", "Baseline", "Test"});
 }
 
 TEST_CASE("Utility Function Test: split(str, char, bool)")
@@ -39,42 +39,42 @@ TEST_CASE("Utility Function Test: split(str, char, bool)")
 
   std::vector<std::string> result = StringUtilities::split(inputStr, k_Delimiter, false);
 
-  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
+  REQUIRE(result == std::vector<std::string>{"This", "Is", "A", "Baseline", "Test"});
 
   // Case 2
   inputStr = "|This|Is|A|Baseline|Test|";
 
   result = StringUtilities::split(inputStr, k_Delimiter, false);
 
-  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
+  REQUIRE(result == std::vector<std::string>{"This", "Is", "A", "Baseline", "Test"});
 
   // Case 3
   inputStr = "||This|Is||A||Baseline|Test||";
 
   result = StringUtilities::split(inputStr, k_Delimiter, false);
 
-  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
+  REQUIRE(result == std::vector<std::string>{"This", "Is", "A", "Baseline", "Test"});
 
   // Case 4
   inputStr = "This|Is|A|Baseline|Test";
 
   result = StringUtilities::split(inputStr, k_Delimiter, true);
 
-  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
+  REQUIRE(result == std::vector<std::string>{"This", "Is", "A", "Baseline", "Test"});
 
   // Case 5
   inputStr = "|This|Is|A|Baseline|Test|";
 
   result = StringUtilities::split(inputStr, k_Delimiter, true);
 
-  REQUIRE(result == std::vector<std::string>{"","This","Is","A","Baseline","Test",""});
+  REQUIRE(result == std::vector<std::string>{"", "This", "Is", "A", "Baseline", "Test", ""});
 
   // Case 6
   inputStr = "||This|Is||A||Baseline|Test||";
 
   result = StringUtilities::split(inputStr, k_Delimiter, true);
 
-  REQUIRE(result == std::vector<std::string>{"","","This","Is","","A","","Baseline","Test","",""});
+  REQUIRE(result == std::vector<std::string>{"", "", "This", "Is", "", "A", "", "Baseline", "Test", "", ""});
 }
 
 TEST_CASE("Utility Function Test: specific_split(str, char, StringUtilities::SplitType)")
@@ -86,30 +86,30 @@ TEST_CASE("Utility Function Test: specific_split(str, char, StringUtilities::Spl
   // Case 1
   result = StringUtilities::specific_split(inputStr, k_Delimiter, StringUtilities::SplitType::AllowAll);
 
-  REQUIRE(result == std::vector<std::string>{"","","This","Is","","A","","Baseline","Test","",""});
+  REQUIRE(result == std::vector<std::string>{"", "", "This", "Is", "", "A", "", "Baseline", "Test", "", ""});
 
   // Case 2
   result = StringUtilities::specific_split(inputStr, k_Delimiter, StringUtilities::SplitType::IgnoreEmpty);
 
-  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
+  REQUIRE(result == std::vector<std::string>{"This", "Is", "A", "Baseline", "Test"});
 
   // Case 3
   result = StringUtilities::specific_split(inputStr, k_Delimiter, StringUtilities::SplitType::NoStripIgnoreConsecutive);
 
-  REQUIRE(result == std::vector<std::string>{"","This","Is","A","Baseline","Test",""});
+  REQUIRE(result == std::vector<std::string>{"", "This", "Is", "A", "Baseline", "Test", ""});
 
   // Case 4
   result = StringUtilities::specific_split(inputStr, k_Delimiter, StringUtilities::SplitType::OnlyConsecutive);
 
-  REQUIRE(result == std::vector<std::string>{"","This","Is","","A","","Baseline","Test",""});
+  REQUIRE(result == std::vector<std::string>{"", "This", "Is", "", "A", "", "Baseline", "Test", ""});
 
   // Case 5
   result = StringUtilities::specific_split(inputStr, k_Delimiter, StringUtilities::SplitType::AllowEmptyLeftAnalyze);
 
-  REQUIRE(result == std::vector<std::string>{"","","This","Is","","A","","Baseline","Test",""});
+  REQUIRE(result == std::vector<std::string>{"", "", "This", "Is", "", "A", "", "Baseline", "Test", ""});
 
   // Case 5
   result = StringUtilities::specific_split(inputStr, k_Delimiter, StringUtilities::SplitType::AllowEmptyRightAnalyze);
 
-  REQUIRE(result == std::vector<std::string>{"","This","Is","","A","","Baseline","Test","", ""});
+  REQUIRE(result == std::vector<std::string>{"", "This", "Is", "", "A", "", "Baseline", "Test", "", ""});
 }

--- a/test/StringUtilitiesTest.cpp
+++ b/test/StringUtilitiesTest.cpp
@@ -3,7 +3,7 @@
 
 #include <catch2/catch.hpp>
 
-#include string
+#include <string>
 
 using namespace nx::core;
 
@@ -17,14 +17,14 @@ TEST_CASE("Utility Function Test: split(str, char)")
   REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 
   // Case 2
-  inputStr = "|This|Is|A|Baseline|Test|"
+  inputStr = "|This|Is|A|Baseline|Test|";
 
   result = StringUtilities::split(inputStr, '|');
 
   REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 
   // Case 3
-  inputStr = "|This|Is||A||Baseline|Test||"
+  inputStr = "|This|Is||A||Baseline|Test||";
 
   result = StringUtilities::split(inputStr, '|');
 
@@ -33,45 +33,46 @@ TEST_CASE("Utility Function Test: split(str, char)")
 
 TEST_CASE("Utility Function Test: split(str, char, bool)")
 {
+  std::array<char, 1> k_Delimiter = {'|'};
   // Case 1
   std::string inputStr = "This|Is|A|Baseline|Test";
 
-  std::vector<std::string> result = StringUtilities::split(inputStr, '|', false);
+  std::vector<std::string> result = StringUtilities::split(inputStr, k_Delimiter, false);
 
   REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 
   // Case 2
-  inputStr = "|This|Is|A|Baseline|Test|"
+  inputStr = "|This|Is|A|Baseline|Test|";
 
-  result = StringUtilities::split(inputStr, '|', false);
+  result = StringUtilities::split(inputStr, k_Delimiter, false);
 
   REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 
   // Case 3
-  inputStr = "|This|Is||A||Baseline|Test||"
+  inputStr = "|This|Is||A||Baseline|Test||";
 
-  result = StringUtilities::split(inputStr, '|', false);
+  result = StringUtilities::split(inputStr, k_Delimiter, false);
 
   REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 
   // Case 4
-  std::string inputStr = "This|Is|A|Baseline|Test";
+  inputStr = "This|Is|A|Baseline|Test";
 
-  std::vector<std::string> result = StringUtilities::split(inputStr, '|', true);
+  result = StringUtilities::split(inputStr, k_Delimiter, true);
 
   REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 
   // Case 5
-  inputStr = "|This|Is|A|Baseline|Test|"
+  inputStr = "|This|Is|A|Baseline|Test|";
 
-  result = StringUtilities::split(inputStr, '|', true);
+  result = StringUtilities::split(inputStr, k_Delimiter, true);
 
   REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test",""});
 
   // Case 6
-  inputStr = "|This|Is||A||Baseline|Test||"
+  inputStr = "|This|Is||A||Baseline|Test||";
 
-  result = StringUtilities::split(inputStr, '|', true);
+  result = StringUtilities::split(inputStr, k_Delimiter, true);
 
   REQUIRE(result == std::vector<std::string>{"This","Is","","A","","Baseline","Test","",""});
 }

--- a/test/StringUtilitiesTest.cpp
+++ b/test/StringUtilitiesTest.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Utility Function Test: split(str, char)")
   REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 
   // Case 3
-  inputStr = "|This|Is||A||Baseline|Test||";
+  inputStr = "||This|Is||A||Baseline|Test||";
 
   result = StringUtilities::split(inputStr, '|');
 
@@ -49,7 +49,7 @@ TEST_CASE("Utility Function Test: split(str, char, bool)")
   REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
 
   // Case 3
-  inputStr = "|This|Is||A||Baseline|Test||";
+  inputStr = "||This|Is||A||Baseline|Test||";
 
   result = StringUtilities::split(inputStr, k_Delimiter, false);
 
@@ -67,12 +67,49 @@ TEST_CASE("Utility Function Test: split(str, char, bool)")
 
   result = StringUtilities::split(inputStr, k_Delimiter, true);
 
-  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test",""});
+  REQUIRE(result == std::vector<std::string>{"","This","Is","A","Baseline","Test",""});
 
   // Case 6
-  inputStr = "|This|Is||A||Baseline|Test||";
+  inputStr = "||This|Is||A||Baseline|Test||";
 
   result = StringUtilities::split(inputStr, k_Delimiter, true);
 
-  REQUIRE(result == std::vector<std::string>{"This","Is","","A","","Baseline","Test","",""});
+  REQUIRE(result == std::vector<std::string>{"","","This","Is","","A","","Baseline","Test","",""});
+}
+
+TEST_CASE("Utility Function Test: specific_split(str, char, StringUtilities::SplitType)")
+{
+  std::array<char, 1> k_Delimiter = {'|'};
+  std::string inputStr = "||This|Is||A||Baseline|Test||";
+  std::vector<std::string> result;
+
+  // Case 1
+  result = StringUtilities::specific_split(inputStr, k_Delimiter, StringUtilities::SplitType::AllowAll);
+
+  REQUIRE(result == std::vector<std::string>{"","","This","Is","","A","","Baseline","Test","",""});
+
+  // Case 2
+  result = StringUtilities::specific_split(inputStr, k_Delimiter, StringUtilities::SplitType::IgnoreEmpty);
+
+  REQUIRE(result == std::vector<std::string>{"This","Is","A","Baseline","Test"});
+
+  // Case 3
+  result = StringUtilities::specific_split(inputStr, k_Delimiter, StringUtilities::SplitType::NoStripIgnoreConsecutive);
+
+  REQUIRE(result == std::vector<std::string>{"","This","Is","A","Baseline","Test",""});
+
+  // Case 4
+  result = StringUtilities::specific_split(inputStr, k_Delimiter, StringUtilities::SplitType::OnlyConsecutive);
+
+  REQUIRE(result == std::vector<std::string>{"","This","Is","","A","","Baseline","Test",""});
+
+  // Case 5
+  result = StringUtilities::specific_split(inputStr, k_Delimiter, StringUtilities::SplitType::AllowEmptyLeftAnalyze);
+
+  REQUIRE(result == std::vector<std::string>{"","","This","Is","","A","","Baseline","Test",""});
+
+  // Case 5
+  result = StringUtilities::specific_split(inputStr, k_Delimiter, StringUtilities::SplitType::AllowEmptyRightAnalyze);
+
+  REQUIRE(result == std::vector<std::string>{"","This","Is","","A","","Baseline","Test","", ""});
 }


### PR DESCRIPTION
Added:
- New specific_split() function that offers a wide range of split types depending on how you want to parse a string
- Added considerations to the algorithm/api so the function is parallel safe and works for chunking large strings
- Added ~15 test cases for split functionality

Updated:
- split(string_view, char) now functions as ignoring all empty and now has reduced overhead
- split(string_view, span, bool) now has the option for considering all delimiters or ignoring all empty values with reduced overhead
- the underlying split algorithm now handles edge case code handling generation in separate template instances to ensure it runs as efficiently as possible
- as many ifs as possible have been extracted to outside the parsing loops to be handled in the pre and post iteration to cut down on branch determinism in loop

Fixes: #883

## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `simplnx/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `simplnx/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [ ] Added example pipelines that use the filter
- [ ] Classes and methods are properly documented


<!-- **Thanks for contributing to simplnx!** -->
