### PR TITLE
BUG: Add Additional Edge Case Checks for Split Function

### DIFF
--- a/src/simplnx/DataStructure/DataPath.cpp
+++ b/src/simplnx/DataStructure/DataPath.cpp
@@ -43,6 +43,10 @@ std::optional<DataPath> DataPath::FromString(std::string_view inputPath, char de
   {
     return DataPath{};
   }
+  if(inputPath.size() == 1 && inputPath[0] == delimiter)
+  {
+    return DataPath{};
+  }
   auto parts = StringUtilities::split(inputPath, delimiter);
   if(parts.empty())
   {

--- a/src/simplnx/Utilities/StringUtilities.hpp
+++ b/src/simplnx/Utilities/StringUtilities.hpp
@@ -93,6 +93,10 @@ using SplitAllowEmptyRightAnalyze = SplitTypeOptions<true, false, true>;
 template <class SplitTypeOptionsV = SplitIgnoreEmpty>
 inline std::vector<std::string> optimized_split(std::string_view str, nonstd::span<const char> delimiters)
 {
+  if(str.empty())
+  {
+    return {};
+  }
   auto endPos = str.end();
   auto startPos = str.begin();
 
@@ -140,6 +144,12 @@ inline std::vector<std::string> optimized_split(std::string_view str, nonstd::sp
   }
 
   tokens.shrink_to_fit();
+
+  // No Delimiters found
+  if(tokens.empty())
+  {
+    tokens.emplace_back(str);
+  }
 
   return tokens;
 }

--- a/test/StringUtilitiesTest.cpp
+++ b/test/StringUtilitiesTest.cpp
@@ -7,6 +7,69 @@
 
 using namespace nx::core;
 
+TEST_CASE("Empty Input Utility Function Test: split(str, char), split(str, char, bool), specific_split(str, char, StringUtilities::SplitType)")
+{
+  std::string emptyInput = "";
+  std::string noDelimiterInput = "ThisIsABaselineTest";
+
+  std::vector<std::string> result;
+  std::array<char, 1> k_Delimiter = {'|'};
+
+  // Case 1
+  result = StringUtilities::split(emptyInput, k_Delimiter[0]);
+
+  REQUIRE(result.empty());
+
+  result = StringUtilities::split(noDelimiterInput, k_Delimiter[0]);
+
+  REQUIRE(result == std::vector<std::string>{noDelimiterInput});
+
+  // Case 2
+  result = StringUtilities::split(emptyInput, k_Delimiter, true);
+
+  REQUIRE(result.empty());
+
+  result = StringUtilities::split(noDelimiterInput, k_Delimiter, true);
+
+  REQUIRE(result == std::vector<std::string>{noDelimiterInput});
+
+  // Case 4
+  result = StringUtilities::specific_split(emptyInput, k_Delimiter, StringUtilities::SplitType::OnlyConsecutive);
+
+  REQUIRE(result.empty());
+
+  result = StringUtilities::specific_split(noDelimiterInput, k_Delimiter, StringUtilities::SplitType::OnlyConsecutive);
+
+  REQUIRE(result == std::vector<std::string>{noDelimiterInput});
+
+  // Case 5
+  result = StringUtilities::specific_split(emptyInput, k_Delimiter, StringUtilities::SplitType::NoStripIgnoreConsecutive);
+
+  REQUIRE(result.empty());
+
+  result = StringUtilities::specific_split(noDelimiterInput, k_Delimiter, StringUtilities::SplitType::NoStripIgnoreConsecutive);
+
+  REQUIRE(result == std::vector<std::string>{noDelimiterInput});
+
+  // Case 6
+  result = StringUtilities::specific_split(emptyInput, k_Delimiter, StringUtilities::SplitType::AllowEmptyLeftAnalyze);
+
+  REQUIRE(result.empty());
+
+  result = StringUtilities::specific_split(noDelimiterInput, k_Delimiter, StringUtilities::SplitType::AllowEmptyLeftAnalyze);
+
+  REQUIRE(result == std::vector<std::string>{noDelimiterInput});
+
+  // Case 7
+  result = StringUtilities::specific_split(emptyInput, k_Delimiter, StringUtilities::SplitType::AllowEmptyRightAnalyze);
+
+  REQUIRE(result.empty());
+
+  result = StringUtilities::specific_split(noDelimiterInput, k_Delimiter, StringUtilities::SplitType::AllowEmptyRightAnalyze);
+
+  REQUIRE(result == std::vector<std::string>{noDelimiterInput});
+}
+
 TEST_CASE("Utility Function Test: split(str, char)")
 {
   // Case 1


### PR DESCRIPTION
- Now handles empty input by returning an empty vector
- Now handles no delimiters by returning a vector containing the whole input string
- New test cases for additional control paths
- Updated DataPath `FromString` to explicitly handle root paths

## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `simplnx/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `simplnx/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to simplnx!** -->
