### PR TITLE
FILTER : ExtractPipelineToFile

### DIFF
--- a/src/Plugins/SimplnxCore/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/CMakeLists.txt
@@ -43,6 +43,7 @@ set(FilterList
   ExecuteProcessFilter
   ExtractComponentAsArrayFilter
   ExtractInternalSurfacesFromTriangleGeometry
+  ExtractPipelineToFileFilter
   ExtractVertexGeometryFilter
   FeatureFaceCurvatureFilter
   FillBadDataFilter

--- a/src/Plugins/SimplnxCore/docs/ExtractPipelineToFileFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ExtractPipelineToFileFilter.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This **Filter** reads the pipeline from an hdf5 file with the .dream3d extension and writes it back out to a json formatted pipeline file with the appropriate extension based on whether the pipeline is a legacy pipeline or not. (.json extension for legacy and .d3dpipeline extension otherwise) 
+This **Filter** reads the pipeline from an hdf5 file with the .dream3d extension and writes it back out to a json formatted pipeline file with the appropriate extension based on whether the pipeline is a DREAM.3D version 6 (.json) or DREAM3D-NX version 7 (.d3dpipeline) formatted pipeline.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/ExtractPipelineToFileFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ExtractPipelineToFileFilter.md
@@ -1,0 +1,15 @@
+# Extract DREAM.3D Pipeline To File
+
+## Description
+
+This **Filter** reads the pipeline from an hdf5 file with the .dream3d extension and writes it back out to a json formatted pipeline file with the appropriate extension based on whether the pipeline is a legacy pipeline or not. (.json extension for legacy and .d3dpipeline extension otherwise) 
+
+% Auto generated parameter table will be inserted here
+
+## Example Pipelines
+
+ExtractPipelineToFile
+
+## License & Copyright
+
+Please see the description file distributed with this plugin.

--- a/src/Plugins/SimplnxCore/pipelines/ExtractPipelineToFile.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/ExtractPipelineToFile.d3dpipeline
@@ -1,0 +1,21 @@
+{
+  "isDisabled": false,
+  "name": "ExtractPipelineToFile.d3dpipeline",
+  "pinnedParams": [],
+  "pipeline": [
+    {
+      "args": {
+        "import_file_data": "Data/Output/Reconstruction/SmallIN100_Final.dream3d",
+        "output_file": "Data/Output/Reconstruction/SmallIN100_Final_Pipeline.d3dpipeline"
+      },
+      "comments": "",
+      "filter": {
+        "name": "nx::core::ExtractPipelineToFileFilter",
+        "uuid": "27203c99-9975-4528-88cc-42b270165d79"
+      },
+      "isDisabled": false
+    }
+  ],
+  "version": 1,
+  "workflowParams": []
+}

--- a/src/Plugins/SimplnxCore/pipelines/ExtractPipelineToFile.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/ExtractPipelineToFile.d3dpipeline
@@ -5,8 +5,8 @@
   "pipeline": [
     {
       "args": {
-        "import_file_data": "Data/Output/Reconstruction/SmallIN100_Final.dream3d",
-        "output_file": "Data/Output/Reconstruction/SmallIN100_Final_Pipeline.d3dpipeline"
+        "input_file_path": "Data/Output/Reconstruction/SmallIN100_Final.dream3d",
+        "output_file_path": "Data/Output/Reconstruction/SmallIN100_Final_Pipeline.d3dpipeline"
       },
       "comments": "",
       "filter": {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.cpp
@@ -1,0 +1,120 @@
+#include "ExtractPipelineToFileFilter.hpp"
+
+#include "simplnx/Common/AtomicFile.hpp"
+#include "simplnx/Common/StringLiteral.hpp"
+#include "simplnx/Parameters/FileSystemPathParameter.hpp"
+#include "simplnx/Parameters/StringParameter.hpp"
+#include "simplnx/Pipeline/Pipeline.hpp"
+#include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
+
+#include "simplnx/Utilities/SIMPLConversion.hpp"
+
+#include <nlohmann/json.hpp>
+
+namespace
+{
+constexpr nx::core::StringLiteral k_ImportedPipeline = "Imported Pipeline";
+} // namespace
+
+namespace nx::core
+{
+//------------------------------------------------------------------------------
+std::string ExtractPipelineToFileFilter::name() const
+{
+  return FilterTraits<ExtractPipelineToFileFilter>::name;
+}
+
+//------------------------------------------------------------------------------
+std::string ExtractPipelineToFileFilter::className() const
+{
+  return FilterTraits<ExtractPipelineToFileFilter>::className;
+}
+
+//------------------------------------------------------------------------------
+Uuid ExtractPipelineToFileFilter::uuid() const
+{
+  return FilterTraits<ExtractPipelineToFileFilter>::uuid;
+}
+
+//------------------------------------------------------------------------------
+std::string ExtractPipelineToFileFilter::humanName() const
+{
+  return "Extract DREAM.3D Pipeline To File";
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> ExtractPipelineToFileFilter::defaultTags() const
+{
+  return {className(), "IO", "Input", "Read", "Import", "Output", "Write", "Export"};
+}
+
+//------------------------------------------------------------------------------
+Parameters ExtractPipelineToFileFilter::parameters() const
+{
+  Parameters params;
+  params.insertSeparator(Parameters::Separator{"Input Parameters"});
+  params.insert(std::make_unique<FileSystemPathParameter>(k_ImportFileData, "Import File Path", "The DREAM.3D file path the pipeline should be taken from", FileSystemPathParameter::ValueType{},
+                                                          FileSystemPathParameter::ExtensionsType{".dream3d"}, FileSystemPathParameter::PathType::InputFile));
+  params.insertSeparator(Parameters::Separator{"Output Parameters"});
+  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputDir, "Output Directory", "The directory in which to save the extracted pipeline file", FileSystemPathParameter::ValueType{},
+                                                          FileSystemPathParameter::ExtensionsType{}, FileSystemPathParameter::PathType::OutputDir));
+  params.insert(std::make_unique<StringParameter>(k_OutputFileName, "Output File Name", "The directory in which to save the extracted pipeline file", ""));
+  return params;
+}
+
+//------------------------------------------------------------------------------
+IFilter::UniquePointer ExtractPipelineToFileFilter::clone() const
+{
+  return std::make_unique<ExtractPipelineToFileFilter>();
+}
+
+//------------------------------------------------------------------------------
+IFilter::PreflightResult ExtractPipelineToFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
+                                                                    const std::atomic_bool& shouldCancel) const
+{
+  if(args.value<StringParameter::ValueType>(k_OutputFileName).empty())
+  {
+    return {nonstd::make_unexpected(std::vector<Error>{Error{-2580, "Output file name cannot be empty."}})};
+  }
+  OutputActions actions;
+  return {std::move(actions)};
+}
+
+//------------------------------------------------------------------------------
+Result<> ExtractPipelineToFileFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                                                  const std::atomic_bool& shouldCancel) const
+{
+  const auto importFile = args.value<FileSystemPathParameter::ValueType>(k_ImportFileData);
+  auto outputDir = args.value<FileSystemPathParameter::ValueType>(k_OutputDir);
+  auto outputFileName = args.value<StringParameter::ValueType>(k_OutputFileName);
+
+  Result<nlohmann::json> pipelineResult = DREAM3D::ImportPipelineJsonFromFile(importFile);
+  if(pipelineResult.invalid())
+  {
+    return ConvertResult<nlohmann::json>(std::move(pipelineResult));
+  }
+  const nlohmann::json pipelineJson = pipelineResult.value();
+  const bool isLegacy = pipelineJson.contains(nx::core::Pipeline::k_SIMPLPipelineBuilderKey);
+
+  std::string extension = isLegacy ? Pipeline::k_SIMPLExtension : Pipeline::k_Extension;
+  std::string outputPath = outputDir.string() + "/" + outputFileName + extension;
+  AtomicFile atomicFile(outputPath, false);
+  {
+    const fs::path exportFilePath = atomicFile.tempFilePath();
+    std::ofstream fOut(exportFilePath.string(), std::ofstream::out); // test name resolution and create file
+    if(!fOut.is_open())
+    {
+      return MakeErrorResult(-2581, fmt::format("Error opening output path {}", exportFilePath.string()));
+    }
+
+    fOut << pipelineJson.dump(2);
+  }
+  atomicFile.commit();
+  return {};
+}
+
+Result<Arguments> ExtractPipelineToFileFilter::FromSIMPLJson(const nlohmann::json& json)
+{
+  return {};
+}
+} // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.cpp
@@ -45,7 +45,7 @@ std::string ExtractPipelineToFileFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ExtractPipelineToFileFilter::defaultTags() const
 {
-  return {className(), "IO", "Input", "Read", "Import", "Output", "Write", "Export"};
+  return {className(), "IO", "Input", "Read", "Import", "Output", "Write", "Export", "Pipeline", "JSON"};
 }
 
 //------------------------------------------------------------------------------
@@ -53,10 +53,10 @@ Parameters ExtractPipelineToFileFilter::parameters() const
 {
   Parameters params;
   params.insertSeparator(Parameters::Separator{"Input Parameters"});
-  params.insert(std::make_unique<FileSystemPathParameter>(k_ImportFileData, "Import File Path", "The DREAM.3D file path the pipeline should be taken from", FileSystemPathParameter::ValueType{},
-                                                          FileSystemPathParameter::ExtensionsType{".dream3d"}, FileSystemPathParameter::PathType::InputFile));
+  params.insert(std::make_unique<FileSystemPathParameter>(k_ImportFileData, "Input DREAM3D File Path", "The file path to the .dream3d that holds the pipeline to be extracted.",
+                                                          FileSystemPathParameter::ValueType{}, FileSystemPathParameter::ExtensionsType{".dream3d"}, FileSystemPathParameter::PathType::InputFile));
   params.insertSeparator(Parameters::Separator{"Output Parameters"});
-  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputFile, "Output File Path", "The file path in which to save the extracted pipeline file", FileSystemPathParameter::ValueType{},
+  params.insert(std::make_unique<FileSystemPathParameter>(k_OutputFile, "Output File Path", "The file path in which to save the extracted pipeline", FileSystemPathParameter::ValueType{},
                                                           FileSystemPathParameter::ExtensionsType{Pipeline::k_Extension, Pipeline::k_SIMPLExtension}, FileSystemPathParameter::PathType::OutputFile));
   return params;
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.hpp
@@ -28,8 +28,7 @@ public:
 
   // Parameter Keys
   static inline constexpr StringLiteral k_ImportFileData = "import_file_data";
-  static inline constexpr StringLiteral k_OutputDir = "output_dir";
-  static inline constexpr StringLiteral k_OutputFileName = "output_file_name";
+  static inline constexpr StringLiteral k_OutputFile = "output_file";
 
   /**
    * @brief Reads SIMPL json and converts it simplnx Arguments.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.hpp
@@ -27,8 +27,8 @@ public:
   ExtractPipelineToFileFilter& operator=(ExtractPipelineToFileFilter&&) noexcept = delete;
 
   // Parameter Keys
-  static inline constexpr StringLiteral k_ImportFileData = "import_file_data";
-  static inline constexpr StringLiteral k_OutputFile = "output_file";
+  static inline constexpr StringLiteral k_ImportFileData = "input_file_path";
+  static inline constexpr StringLiteral k_OutputFile = "output_file_path";
 
   /**
    * @brief Reads SIMPL json and converts it simplnx Arguments.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "SimplnxCore/SimplnxCore_export.hpp"
+
+#include "simplnx/Filter/Arguments.hpp"
+#include "simplnx/Filter/FilterTraits.hpp"
+#include "simplnx/Filter/IFilter.hpp"
+#include "simplnx/Filter/Parameters.hpp"
+
+namespace nx::core
+{
+/**
+ * @class ExtractPipelineToFileFilter
+ * @brief The ExtractPipelineToFileFilter is an IFilter class designed to extract the pipeline data
+ * from a target DREAM.3D file and export it out to it's own file.
+ */
+class SIMPLNXCORE_EXPORT ExtractPipelineToFileFilter : public IFilter
+{
+public:
+  ExtractPipelineToFileFilter() = default;
+  ~ExtractPipelineToFileFilter() noexcept override = default;
+
+  ExtractPipelineToFileFilter(const ExtractPipelineToFileFilter&) = delete;
+  ExtractPipelineToFileFilter(ExtractPipelineToFileFilter&&) noexcept = delete;
+
+  ExtractPipelineToFileFilter& operator=(const ExtractPipelineToFileFilter&) = delete;
+  ExtractPipelineToFileFilter& operator=(ExtractPipelineToFileFilter&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_ImportFileData = "import_file_data";
+  static inline constexpr StringLiteral k_OutputDir = "output_dir";
+  static inline constexpr StringLiteral k_OutputFileName = "output_file_name";
+
+  /**
+   * @brief Reads SIMPL json and converts it simplnx Arguments.
+   * @param json
+   * @return Result<Arguments>
+   */
+  static Result<Arguments> FromSIMPLJson(const nlohmann::json& json);
+
+  /**
+   * @brief Returns the name of the filter class.
+   * @return std::string
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the C++ classname of this filter.
+   * @return std::string
+   */
+  std::string className() const override;
+
+  /**
+   * @brief Returns the ExtractPipelineToFileFilter class's UUID.
+   * @return Uuid
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief Returns the human readable name of the filter.
+   * @return std::string
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
+   * @brief Returns a collection of the filter's parameters (i.e. its inputs)
+   * @return Parameters
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief Returns a copy of the filter as a std::unique_ptr.
+   * @return UniquePointer
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief Classes that implement IFilter must provide this function for preflight.
+   * Runs after the filter runs the checks in its parameters.
+   * @param dataStructure
+   * @param args
+   * @param messageHandler
+   * @return Result<OutputActions>
+   */
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+
+  /**
+   * @brief Classes that implement IFilter must provide this function for execute.
+   * Runs after the filter applies the OutputActions from preflight.
+   * @param dataStructure
+   * @param args
+   * @param pipelineNode
+   * @param messageHandler
+   * @return Result<>
+   */
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                       const std::atomic_bool& shouldCancel) const override;
+};
+} // namespace nx::core
+
+SIMPLNX_DEF_FILTER_TRAITS(nx::core, ExtractPipelineToFileFilter, "27203c99-9975-4528-88cc-42b270165d79");

--- a/src/Plugins/SimplnxCore/test/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/test/CMakeLists.txt
@@ -43,6 +43,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   ExecuteProcessTest.cpp
   ExtractComponentAsArrayTest.cpp
   ExtractInternalSurfacesFromTriangleGeometryTest.cpp
+  ExtractPipelineToFileTest.cpp
   ExtractVertexGeometryTest.cpp
   FeatureFaceCurvatureTest.cpp
   FillBadDataTest.cpp
@@ -69,7 +70,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   FindVolFractionsTest.cpp
   GenerateColorTableTest.cpp
   GenerateVectorColorsTest.cpp
-    GeneratePythonSkeletonTest.cpp
+  GeneratePythonSkeletonTest.cpp
   IdentifySampleTest.cpp
   FlyingEdges3DTest.cpp
   ImageGeomTest.cpp

--- a/src/Plugins/SimplnxCore/test/ExtractPipelineToFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ExtractPipelineToFileTest.cpp
@@ -45,6 +45,8 @@ TEST_CASE("SimplnxCore::ExtractPipelineToFileFilter : Valid Execution", "[Simpln
   SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
 
   REQUIRE(fs::exists(k_JsonOutputFile));
+
+  fs::remove(k_JsonOutputFile);
 }
 
 TEST_CASE("SimplnxCore::ExtractPipelineToFileFilter : Valid Execution - incorrect output extension", "[SimplnxCore][ExtractPipelineToFileFilter]")
@@ -71,6 +73,8 @@ TEST_CASE("SimplnxCore::ExtractPipelineToFileFilter : Valid Execution - incorrec
 
   REQUIRE(preflightResult.outputActions.warnings().front().code == -2581);
   REQUIRE(fs::exists(k_JsonOutputFile));
+
+  fs::remove(k_JsonOutputFile);
 }
 
 TEST_CASE("SimplnxCore::ExtractPipelineToFileFilter : Invalid Execution - missing output extension", "[SimplnxCore][ExtractPipelineToFileFilter]")
@@ -106,12 +110,14 @@ TEST_CASE("SimplnxCore::ExtractPipelineToFileFilter : Invalid Execution - invali
   ExtractPipelineToFileFilter filter;
 
   auto testInvalidInputFile = fs::path(fmt::format("{}/TestDataStructureNoPipeline.dream3d", unit_test::k_BinaryTestOutputDir));
-  DataStructure testDataStructure = UnitTest::CreateDataStructure();
-  auto fileWriterResult = nx::core::HDF5::FileWriter::CreateFile(testInvalidInputFile);
-  REQUIRE(fileWriterResult.valid());
-  nx::core::HDF5::FileWriter fileWriter = std::move(fileWriterResult.value());
-  auto writeResult = HDF5::DataStructureWriter::WriteFile(dataStructure, fileWriter);
-  REQUIRE(writeResult.valid());
+  {
+    DataStructure testDataStructure = UnitTest::CreateDataStructure();
+    auto fileWriterResult = nx::core::HDF5::FileWriter::CreateFile(testInvalidInputFile);
+    REQUIRE(fileWriterResult.valid());
+    nx::core::HDF5::FileWriter fileWriter = std::move(fileWriterResult.value());
+    auto writeResult = HDF5::DataStructureWriter::WriteFile(dataStructure, fileWriter);
+    REQUIRE(writeResult.valid());
+  }
 
   fs::path outputFilePath(fmt::format("{}/TestDataStructureNoPipeline{}", unit_test::k_BinaryTestOutputDir, Pipeline::k_SIMPLExtension.str()));
 
@@ -128,4 +134,6 @@ TEST_CASE("SimplnxCore::ExtractPipelineToFileFilter : Invalid Execution - invali
   SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result)
 
   REQUIRE(!fs::exists(k_JsonOutputFile));
+
+  fs::remove(testInvalidInputFile);
 }

--- a/src/Plugins/SimplnxCore/test/ExtractPipelineToFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ExtractPipelineToFileTest.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Parameters/FileSystemPathParameter.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
+#include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
 
 #include <catch2/catch.hpp>
 
@@ -14,23 +15,117 @@ namespace fs = std::filesystem;
 using namespace nx::core;
 using namespace nx::core::Constants;
 
-TEST_CASE("SimplnxCore::ExtractPipelineToFileFilter", "[SimplnxCore][ExtractPipelineToFileFilter]")
+namespace
 {
-  //// Instantiate the filter, a DataStructure object and an Arguments Object
-  // DataStructure dataStructure;
-  // Arguments args;
-  // ExtractPipelineToFileFilter filter;
-  //
-  //// Create default Parameters for the filter.
-  // args.insertOrAssign(ExtractPipelineToFileFilter::k_ImportFileData, std::make_any<FileSystemPathParameter::ValueType>(fs::path(inputFile)));
-  // args.insertOrAssign(ExtractPipelineToFileFilter::k_OutputDir, std::make_any<FileSystemPathParameter::ValueType>(outputDir));
-  // args.insertOrAssign(ExtractPipelineToFileFilter::k_OutputFileName, std::make_any<std::string>(outputFileName));
-  //
-  //// Preflight the filter and check result
-  // auto preflightResult = filter.preflight(dataStructure, args);
-  // SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-  //
-  //// Execute the filter and check the result
-  // auto executeResult = filter.execute(dataStructure, args);
-  // SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+fs::path k_OutputFileName(fmt::format("{}/Small_IN100_Pipeline", unit_test::k_BinaryTestOutputDir));
+fs::path k_JsonOutputFile(k_OutputFileName.string() + Pipeline::k_SIMPLExtension.str());
+fs::path k_NXOutputFile(k_OutputFileName.string() + Pipeline::k_Extension.str());
+} // namespace
+
+TEST_CASE("SimplnxCore::ExtractPipelineToFileFilter : Valid Execution", "[SimplnxCore][ExtractPipelineToFileFilter]")
+{
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  DataStructure dataStructure;
+  Arguments args;
+  ExtractPipelineToFileFilter filter;
+
+  const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_CMakeExecutable, nx::core::unit_test::k_TestFilesDir, "Small_IN100_dream3d.tar.gz", "Small_IN100.dream3d");
+  auto exemplarDream3dFile = fs::path(fmt::format("{}/Small_IN100.dream3d", unit_test::k_TestFilesDir));
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ExtractPipelineToFileFilter::k_ImportFileData, std::make_any<FileSystemPathParameter::ValueType>(exemplarDream3dFile));
+  args.insertOrAssign(ExtractPipelineToFileFilter::k_OutputFile, std::make_any<FileSystemPathParameter::ValueType>(k_JsonOutputFile));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+
+  REQUIRE(fs::exists(k_JsonOutputFile));
+}
+
+TEST_CASE("SimplnxCore::ExtractPipelineToFileFilter : Valid Execution - incorrect output extension", "[SimplnxCore][ExtractPipelineToFileFilter]")
+{
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  DataStructure dataStructure;
+  Arguments args;
+  ExtractPipelineToFileFilter filter;
+
+  const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_CMakeExecutable, nx::core::unit_test::k_TestFilesDir, "Small_IN100_dream3d.tar.gz", "Small_IN100.dream3d");
+  auto exemplarDream3dFile = fs::path(fmt::format("{}/Small_IN100.dream3d", unit_test::k_TestFilesDir));
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ExtractPipelineToFileFilter::k_ImportFileData, std::make_any<FileSystemPathParameter::ValueType>(exemplarDream3dFile));
+  args.insertOrAssign(ExtractPipelineToFileFilter::k_OutputFile, std::make_any<FileSystemPathParameter::ValueType>(k_NXOutputFile));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+
+  REQUIRE(preflightResult.outputActions.warnings().front().code == -2581);
+  REQUIRE(fs::exists(k_JsonOutputFile));
+}
+
+TEST_CASE("SimplnxCore::ExtractPipelineToFileFilter : Invalid Execution - missing output extension", "[SimplnxCore][ExtractPipelineToFileFilter]")
+{
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  DataStructure dataStructure;
+  Arguments args;
+  ExtractPipelineToFileFilter filter;
+
+  const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_CMakeExecutable, nx::core::unit_test::k_TestFilesDir, "Small_IN100_dream3d.tar.gz", "Small_IN100.dream3d");
+  auto exemplarDream3dFile = fs::path(fmt::format("{}/Small_IN100.dream3d", unit_test::k_TestFilesDir));
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ExtractPipelineToFileFilter::k_ImportFileData, std::make_any<FileSystemPathParameter::ValueType>(exemplarDream3dFile));
+  args.insertOrAssign(ExtractPipelineToFileFilter::k_OutputFile, std::make_any<FileSystemPathParameter::ValueType>(k_OutputFileName));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions)
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result)
+
+  REQUIRE(!fs::exists(k_JsonOutputFile));
+}
+
+TEST_CASE("SimplnxCore::ExtractPipelineToFileFilter : Invalid Execution - invalid input file format", "[SimplnxCore][ExtractPipelineToFileFilter]")
+{
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  DataStructure dataStructure;
+  Arguments args;
+  ExtractPipelineToFileFilter filter;
+
+  auto testInvalidInputFile = fs::path(fmt::format("{}/TestDataStructureNoPipeline.dream3d", unit_test::k_BinaryTestOutputDir));
+  DataStructure testDataStructure = UnitTest::CreateDataStructure();
+  auto fileWriterResult = nx::core::HDF5::FileWriter::CreateFile(testInvalidInputFile);
+  REQUIRE(fileWriterResult.valid());
+  nx::core::HDF5::FileWriter fileWriter = std::move(fileWriterResult.value());
+  auto writeResult = HDF5::DataStructureWriter::WriteFile(dataStructure, fileWriter);
+  REQUIRE(writeResult.valid());
+
+  fs::path outputFilePath(fmt::format("{}/TestDataStructureNoPipeline{}", unit_test::k_BinaryTestOutputDir, Pipeline::k_SIMPLExtension.str()));
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ExtractPipelineToFileFilter::k_ImportFileData, std::make_any<FileSystemPathParameter::ValueType>(testInvalidInputFile));
+  args.insertOrAssign(ExtractPipelineToFileFilter::k_OutputFile, std::make_any<FileSystemPathParameter::ValueType>(outputFilePath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions)
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result)
+
+  REQUIRE(!fs::exists(k_JsonOutputFile));
 }

--- a/src/Plugins/SimplnxCore/test/ExtractPipelineToFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ExtractPipelineToFileTest.cpp
@@ -1,0 +1,36 @@
+#include "SimplnxCore/Filters/ExtractPipelineToFileFilter.hpp"
+#include "SimplnxCore/SimplnxCore_test_dirs.hpp"
+
+#include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
+#include "simplnx/Parameters/FileSystemPathParameter.hpp"
+#include "simplnx/UnitTest/UnitTestCommon.hpp"
+
+#include <catch2/catch.hpp>
+
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+using namespace nx::core;
+using namespace nx::core::Constants;
+
+TEST_CASE("SimplnxCore::ExtractPipelineToFileFilter", "[SimplnxCore][ExtractPipelineToFileFilter]")
+{
+  //// Instantiate the filter, a DataStructure object and an Arguments Object
+  // DataStructure dataStructure;
+  // Arguments args;
+  // ExtractPipelineToFileFilter filter;
+  //
+  //// Create default Parameters for the filter.
+  // args.insertOrAssign(ExtractPipelineToFileFilter::k_ImportFileData, std::make_any<FileSystemPathParameter::ValueType>(fs::path(inputFile)));
+  // args.insertOrAssign(ExtractPipelineToFileFilter::k_OutputDir, std::make_any<FileSystemPathParameter::ValueType>(outputDir));
+  // args.insertOrAssign(ExtractPipelineToFileFilter::k_OutputFileName, std::make_any<std::string>(outputFileName));
+  //
+  //// Preflight the filter and check result
+  // auto preflightResult = filter.preflight(dataStructure, args);
+  // SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+  //
+  //// Execute the filter and check the result
+  // auto executeResult = filter.execute(dataStructure, args);
+  // SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+}

--- a/src/simplnx/Pipeline/Pipeline.hpp
+++ b/src/simplnx/Pipeline/Pipeline.hpp
@@ -33,6 +33,7 @@ public:
   using const_iterator = collection_type::const_iterator;
 
   static constexpr StringLiteral k_Extension = ".d3dpipeline";
+  static constexpr StringLiteral k_SIMPLExtension = ".json";
   static constexpr StringLiteral k_SIMPLPipelineBuilderKey = "PipelineBuilder";
 
   /**


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the simplnx repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start simplnx commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `simplnx/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `simplnx/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [ ] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to simplnx!** -->
