### PR TITLE
BUG/ENH: Atomic File Rework

### DIFF
--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertHexGridToSquareGrid.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertHexGridToSquareGrid.cpp
@@ -31,7 +31,6 @@ public:
   , m_SqrYStep(spacingXY.at(1))
   {
   }
-  ~Converter() noexcept = default;
 
   Converter(const Converter&) = delete;            // Copy Constructor Default Implemented
   Converter(Converter&&) = delete;                 // Move Constructor Not Implemented
@@ -354,7 +353,9 @@ Result<> ConvertHexGridToSquareGrid::operator()()
 {
   if(!m_InputValues->MultiFile)
   {
-    return ::Converter(getCancel(), m_InputValues->OutputPath, m_InputValues->OutputFilePrefix, m_InputValues->XYSpacing)(m_InputValues->InputPath);
+    auto converter = ::Converter(getCancel(), m_InputValues->OutputPath, m_InputValues->OutputFilePrefix, m_InputValues->XYSpacing);
+    converter(m_InputValues->InputPath);
+    return converter.commitAllFiles();
   }
 
   // Now generate all the file names the user is asking for and populate the table
@@ -420,6 +421,8 @@ Result<> ConvertHexGridToSquareGrid::operator()()
       return result;
     }
   }
+
+  result = MergeResults(converter.commitAllFiles(), result);
 
   return result;
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EbsdToH5Ebsd.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EbsdToH5Ebsd.cpp
@@ -51,12 +51,11 @@ Result<> EbsdToH5Ebsd::operator()()
     }
   }
 
-  AtomicFile atomicFile(absPath.string(), false);
-
-  auto dirResult = atomicFile.getResult();
-  if(dirResult.invalid())
+  AtomicFile atomicFile(absPath.string());
+  auto creationResult = atomicFile.getResult();
+  if(creationResult.invalid())
   {
-    return dirResult;
+    return creationResult;
   }
 
   // Scope file writer in code block to get around file lock on windows (enforce destructor order)
@@ -323,6 +322,9 @@ Result<> EbsdToH5Ebsd::operator()()
     }
   }
 
-  atomicFile.commit();
+  if(!atomicFile.commit())
+  {
+    return atomicFile.getResult();
+  }
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteAbaqusHexahedron.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteAbaqusHexahedron.cpp
@@ -370,6 +370,15 @@ Result<> WriteAbaqusHexahedron::operator()()
   fileList.push_back(std::make_unique<AtomicFile>(m_InputValues->OutputPath.string() + "/" + m_InputValues->FilePrefix + "_elset.inp"));
   fileList.push_back(std::make_unique<AtomicFile>(m_InputValues->OutputPath.string() + "/" + m_InputValues->FilePrefix + ".inp"));
 
+  for(auto& file : fileList)
+  {
+    auto creationResult = file->getResult();
+    if(creationResult.invalid())
+    {
+      return creationResult;
+    }
+  }
+
   int32 err = writeNodes(this, fileList[0]->tempFilePath().string(), cDims.data(), origin.data(), spacing.data(), getCancel()); // Nodes file
   if(err < 0)
   {
@@ -432,7 +441,10 @@ Result<> WriteAbaqusHexahedron::operator()()
 
   for(auto& file : fileList)
   {
-    file->commit();
+    if(!file->commit())
+    {
+      return file->getResult();
+    }
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.cpp
@@ -129,7 +129,12 @@ Result<> ExtractPipelineToFileFilter::executeImpl(DataStructure& dataStructure, 
   {
     outputFile.replace_extension(extension);
   }
-  AtomicFile atomicFile(outputFile.string(), false);
+  AtomicFile atomicFile(outputFile.string());
+  auto creationResult = atomicFile.getResult();
+  if(creationResult.invalid())
+  {
+    return creationResult;
+  }
   {
     const fs::path exportFilePath = atomicFile.tempFilePath();
     std::ofstream fOut(exportFilePath.string(), std::ofstream::out); // test name resolution and create file
@@ -140,7 +145,11 @@ Result<> ExtractPipelineToFileFilter::executeImpl(DataStructure& dataStructure, 
 
     fOut << pipelineJson.dump(2);
   }
-  atomicFile.commit();
+  if(!atomicFile.commit())
+  {
+    return atomicFile.getResult();
+  }
+
   return {};
 }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoRectilinearCoordinateFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoRectilinearCoordinateFilter.cpp
@@ -97,7 +97,12 @@ Result<> WriteAvizoRectilinearCoordinateFilter::executeImpl(DataStructure& dataS
 {
   AvizoWriterInputValues inputValues;
 
-  AtomicFile atomicFile(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key), true);
+  AtomicFile atomicFile(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
+  auto creationResult = atomicFile.getResult();
+  if(creationResult.invalid())
+  {
+    return creationResult;
+  }
 
   inputValues.OutputFile = atomicFile.tempFilePath();
   inputValues.WriteBinaryFile = filterArgs.value<bool>(k_WriteBinaryFile_Key);
@@ -106,7 +111,14 @@ Result<> WriteAvizoRectilinearCoordinateFilter::executeImpl(DataStructure& dataS
   inputValues.Units = filterArgs.value<StringParameter::ValueType>(k_Units_Key);
 
   auto result = WriteAvizoRectilinearCoordinate(dataStructure, messageHandler, shouldCancel, &inputValues)();
-  atomicFile.setAutoCommit(result.valid());
+  if(result.valid())
+  {
+    if(!atomicFile.commit())
+    {
+      return atomicFile.getResult();
+    }
+  }
+
   return result;
 }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteFeatureDataCSVFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteFeatureDataCSVFilter.cpp
@@ -96,6 +96,11 @@ Result<> WriteFeatureDataCSVFilter::executeImpl(DataStructure& dataStructure, co
                                                 const std::atomic_bool& shouldCancel) const
 {
   AtomicFile atomicFile(filterArgs.value<FileSystemPathParameter::ValueType>(k_FeatureDataFile_Key));
+  auto creationResult = atomicFile.getResult();
+  if(creationResult.invalid())
+  {
+    return creationResult;
+  }
 
   auto pOutputFilePath = atomicFile.tempFilePath();
   auto pWriteNeighborListDataValue = filterArgs.value<bool>(k_WriteNeighborListData_Key);
@@ -155,7 +160,10 @@ Result<> WriteFeatureDataCSVFilter::executeImpl(DataStructure& dataStructure, co
     OStreamUtilities::PrintDataSetsToSingleFile(fout, arrayPaths, dataStructure, messageHandler, shouldCancel, delimiter, true, true, false, "Feature_ID", neighborPaths, pWriteNumFeaturesLineValue);
   }
 
-  atomicFile.commit();
+  if(!atomicFile.commit())
+  {
+    return atomicFile.getResult();
+  }
   return {};
 }
 

--- a/src/simplnx/Common/AtomicFile.hpp
+++ b/src/simplnx/Common/AtomicFile.hpp
@@ -38,8 +38,8 @@ public:
 private:
   fs::path m_FilePath;
   fs::path m_TempFilePath;
+  Result<> m_Result;
   bool m_AutoCommit = false;
-  Result<> m_Result = {};
 
   Result<> createOutputDirectories();
 };

--- a/src/simplnx/Common/AtomicFile.hpp
+++ b/src/simplnx/Common/AtomicFile.hpp
@@ -16,30 +16,57 @@ namespace fs = std::filesystem;
  * @brief The AtomicFile class accepts a filepath which it stores and
  * used to create a temporary file. This temporary can be written to in place
  * of the original file path. Upon commit() the temporary file will be moved to
- * the end location passed in originally. By enabling autoCommit the temporary file
- * will be swapped upon object destruction. The temporary file will always be deleted
+ * the end location passed in originally. The temporary file will always be deleted
  * upon object destruction.
  */
 class SIMPLNX_EXPORT AtomicFile
 {
 public:
-  explicit AtomicFile(const std::string& filename, bool autoCommit = false);
-  explicit AtomicFile(fs::path&& filename, bool autoCommit = false);
+  /**
+   * @brief Constructs the object and stores errors !!!CHECK getResult()!!!
+   */
+  explicit AtomicFile(const std::string& filename);
+  /**
+   * @brief Constructs the object and stores errors !!!CHECK getResult()!!!
+   */
+  explicit AtomicFile(fs::path&& filename);
 
   ~AtomicFile();
 
-  fs::path tempFilePath() const;
-  void commit() const;
-  void setAutoCommit(bool value);
-  bool getAutoCommit() const;
+  /**
+   * @brief Fetches the file path object to work from
+   * @return fs::path the working file path modifications should be made to
+   */
+  [[nodiscard]] fs::path tempFilePath() const;
+
+  /**
+   * @brief Attempts to move the temp file to its final path !!!CHECK getResult() IF FALSE!!!
+   * @return bool - if false you MUST call getResult() to error codes
+   */
+  [[nodiscard]] bool commit();
+
+  /**
+   * @brief Purges the temporary file
+   */
   void removeTempFile() const;
-  Result<> getResult() const;
+
+  /**
+   * @brief Fetch for amalgamated error codes !!!call clearResult() To Reset Errors/Warnings!!!
+   * @return Result<> The result object containing all collected errors
+   */
+  [[nodiscard]] Result<> getResult() const;
+
+  /**
+   * @brief Empties the result container
+   */
+  void clearResult();
 
 private:
+  void updateResult(Result<>&& result);
+  void initialize();
   fs::path m_FilePath;
   fs::path m_TempFilePath;
   Result<> m_Result;
-  bool m_AutoCommit = false;
 
   Result<> createOutputDirectories();
 };

--- a/src/simplnx/Utilities/FileUtilities.cpp
+++ b/src/simplnx/Utilities/FileUtilities.cpp
@@ -5,11 +5,29 @@
 #include <filesystem>
 #include <fstream>
 
+#ifdef _WIN32
+#include <io.h>
+#define FSPP_ACCESS_FUNC_NAME _access
+#else
+#include <unistd.h>
+#define FSPP_ACCESS_FUNC_NAME access
+#endif
+
 namespace fs = std::filesystem;
+
+namespace
+{
+#ifdef _WIN32
+constexpr int k_CheckWritable = 2;
+#else
+constexpr int k_CheckWritable = W_OK;
+#endif
+
+constexpr int k_HasAccess = 0;
+}; // namespace
 
 namespace nx::core::FileUtilities
 {
-
 int64 LinesInFile(const std::string& filepath)
 {
   const usize BUFFER_SIZE = 16384;
@@ -139,4 +157,69 @@ Result<> ValidateCSVFile(const std::string& filePath)
   return {};
 }
 
+//-----------------------------------------------------------------------------
+bool HasWriteAccess(const std::string& path)
+{
+  return FSPP_ACCESS_FUNC_NAME(path.c_str(), k_CheckWritable) == k_HasAccess;
+}
+
+//-----------------------------------------------------------------------------
+Result<> ValidateDirectoryWritePermission(const fs::path& path, bool isFile)
+{
+  if(path.empty())
+  {
+    return MakeErrorResult(-16, "ValidateDirectoryWritePermission() error: given path was empty.");
+  }
+
+  auto checkedPath = path;
+  if(isFile)
+  {
+    checkedPath = checkedPath.parent_path();
+  }
+  // We now have the parent directory. Let us see if *any* part of the path exists
+
+  // If the path is relative, then make it absolute
+  if(!checkedPath.is_absolute())
+  {
+    try
+    {
+      checkedPath = fs::absolute(checkedPath);
+    } catch(const std::filesystem::filesystem_error& error)
+    {
+      return MakeErrorResult(-15, fmt::format("ValidateDirectoryWritePermission() threw an error: '{}'", error.what()));
+    }
+  }
+
+  auto rootPath = checkedPath.root_path();
+
+  // The idea here is to start walking up from the deepest directory and hopefully
+  // find an existing directory. If we get to the top if the path and we are still
+  // empty then:
+  //  On unix based systems not sure if it would happen. Even if the user set a path
+  // to another drive that didn't exist, at some point you hit the '/' and then you
+  // can try to create the directories.
+  //  On Windows the user put in a bogus drive letter which is just a hard failure
+  // because we can't make up a new drive letter.
+  while(!fs::exists(checkedPath) && checkedPath != rootPath)
+  {
+    checkedPath = checkedPath.parent_path();
+  }
+
+  if(checkedPath.empty())
+  {
+    return MakeErrorResult(-19, "ValidateDirectoryWritePermission() resolved path was empty");
+  }
+
+  if(!fs::exists(checkedPath))
+  {
+    return MakeErrorResult(-11, fmt::format("ValidateDirectoryWritePermission() error: The drive does not exist on this system: '{}'", checkedPath.string()));
+  }
+
+  // We should be at the top of the tree with an existing directory.
+  if(HasWriteAccess(checkedPath.string()))
+  {
+    return {};
+  }
+  return MakeErrorResult(-8, fmt::format("User does not have write permissions to path '{}'", path.string()));
+}
 } // namespace nx::core::FileUtilities

--- a/src/simplnx/Utilities/FileUtilities.hpp
+++ b/src/simplnx/Utilities/FileUtilities.hpp
@@ -31,13 +31,14 @@
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 #pragma once
 
-#include <string>
-
 #include "simplnx/Common/Result.hpp"
 
-namespace nx::core
-{
-namespace FileUtilities
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace nx::core::FileUtilities
 {
 
 /**
@@ -53,5 +54,18 @@ SIMPLNX_EXPORT int64 LinesInFile(const std::string& filepath);
  * @return
  */
 SIMPLNX_EXPORT Result<> ValidateCSVFile(const std::string& filePath);
-} // namespace FileUtilities
-} // namespace nx::core
+
+/**
+ * @brief
+ * @param filePath
+ * @return
+ */
+SIMPLNX_EXPORT bool HasWriteAccess(const std::string& path);
+
+/**
+ * @brief
+ * @param filePath
+ * @return
+ */
+SIMPLNX_EXPORT Result<> ValidateDirectoryWritePermission(const fs::path& path, bool isFile);
+} // namespace nx::core::FileUtilities

--- a/src/simplnx/Utilities/OStreamUtilities.hpp
+++ b/src/simplnx/Utilities/OStreamUtilities.hpp
@@ -10,9 +10,7 @@
 #include "simplnx/DataStructure/StringArray.hpp"
 #include "simplnx/Filter/IFilter.hpp"
 
-namespace nx::core
-{
-namespace OStreamUtilities
+namespace nx::core::OStreamUtilities
 {
 /**
  * @brief enum for accepted output delimiters in DREAM3D
@@ -47,9 +45,10 @@ SIMPLNX_EXPORT std::string DelimiterToString(uint64 delim);
  * @param includeHeaders The boolean that determines if headers are printed | leave blank if binary is end output
  * @param componentsPerLine The amount of elements to be inserted before newline character | leave blank if binary is end output
  */
-SIMPLNX_EXPORT void PrintDataSetsToMultipleFiles(const std::vector<DataPath>& objectPaths, DataStructure& dataStructure, const std::string& directoryPath, const IFilter::MessageHandler& mesgHandler,
-                                                 const std::atomic_bool& shouldCancel, const std::string& fileExtension = ".txt", bool exportToBinary = false, const std::string& delimiter = "",
-                                                 bool includeIndex = false, bool includeHeaders = false, size_t componentsPerLine = 0);
+SIMPLNX_EXPORT Result<> PrintDataSetsToMultipleFiles(const std::vector<DataPath>& objectPaths, DataStructure& dataStructure, const std::string& directoryPath,
+                                                     const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, const std::string& fileExtension = ".txt",
+                                                     bool exportToBinary = false, const std::string& delimiter = "", bool includeIndex = false, bool includeHeaders = false,
+                                                     size_t componentsPerLine = 0);
 
 /**
  * @brief [Single Output][Custom OStream] | Writes one IArray child to some OStream
@@ -85,6 +84,4 @@ SIMPLNX_EXPORT void PrintSingleDataObject(std::ostream& outputStrm, const DataPa
 SIMPLNX_EXPORT void PrintDataSetsToSingleFile(std::ostream& outputStrm, const std::vector<DataPath>& objectPaths, DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler,
                                               const std::atomic_bool& shouldCancel, const std::string& delimiter = "", bool includeIndex = false, bool includeHeaders = false,
                                               bool writeFirstIndex = true, const std::string& indexName = "Index", const std::vector<DataPath>& neighborLists = {}, bool writeNumOfFeatures = false);
-} // namespace OStreamUtilities
-
-} // namespace nx::core
+} // namespace nx::core::OStreamUtilities


### PR DESCRIPTION
- Removed Autocommit
- Added Additional Documentation
- Revamped Atomic File code to be safer and consolidated
- Updated multiple filters that use Atomic File to cut down extraneous copies of potentially large result objects
- Defined new writer code paradigm that makes heavy use of error checking at multiple stages
- Updated all existing writers to reflect the new paradigm

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the simplnx repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start simplnx commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `simplnx/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `simplnx/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [x] 1 Unit test to test output from the filter against known exemplar set of data
- [x] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [x] No commented out code (rare exceptions to this is allowed..)
- [x] No API changes were made (or the changes have been approved)
- [x] No major design changes were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added license to new files (if any)
- [x] Added example pipelines that use the filter
- [x] Classes and methods are properly documented


<!-- **Thanks for contributing to simplnx!** -->
