### PR TITLE
ENH/BUG: Add DataStructure::validateGeometries() method

### DIFF
--- a/src/Plugins/ITKImageProcessing/docs/ITKBinaryProjectionImage.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKBinaryProjectionImage.md
@@ -13,6 +13,11 @@ filter is provided with some specialized filters which implement different proje
 
 This class was contributed to the Insight Journal by Gaetan Lehmann. The original paper can be found at <https://www.insight-journal.org/browse/publication/71>
 
+## IMPORTANT NOTE
+
+This filter will change the dimensionality of the Image Geometry that the data is tied to. This has the side effect of also
+changing **every** Data Array that is store in the same AttributeMatrix as the input and output data array.
+
 ### Author
 
  Gaetan Lehmann. Biologie du Developpement et de la Reproduction, INRA de Jouy-en-Josas, France.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/FlyingEdges3D.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/FlyingEdges3D.cpp
@@ -21,6 +21,7 @@ struct ExecuteFlyingEdgesFunctor
     normAM.resizeTuples(normals.getTupleShape());
 
     flyingEdges.pass4();
+    triangleGeom.getFaceAttributeMatrix()->resizeTuples({triangleGeom.getNumberOfFaces()});
   }
 };
 } // namespace

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedTriangles.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedTriangles.cpp
@@ -136,6 +136,7 @@ Result<> RemoveFlaggedTriangles::operator()()
   // define new sizing
   size = VertexListIndices.size();
   reducedTriangle.resizeVertexList(size); // resize accordingly
+  reducedTriangle.getVertexAttributeMatrix()->resizeTuples({size});
 
   // load reduced Geometry Vertex list according to used vertices
   Point3Df coords = {0.0f, 0.0f, 0.0f};
@@ -153,6 +154,7 @@ Result<> RemoveFlaggedTriangles::operator()()
   // Set up preprocessing conditions (allocation for parallelization)
   size = newTrianglesIndexList.size();
   reducedTriangle.resizeFaceList(size); // resize accordingly
+  reducedTriangle.getFaceAttributeMatrix()->resizeTuples({size});
 
   // parse triangles and reassign indexes to match new vertex list
   ParallelDataAlgorithm dataAlg;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateFeatureArrayFromElementArray.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateFeatureArrayFromElementArray.cpp
@@ -189,9 +189,11 @@ Result<> CreateFeatureArrayFromElementArray::executeImpl(DataStructure& dataStru
   // Resize the created array to the proper size
   usize featureIdsMaxIdx = std::distance(featureIds.begin(), std::max_element(featureIds.cbegin(), featureIds.cend()));
   usize maxValue = featureIds[featureIdsMaxIdx];
+  auto& cellFeatureAttrMat = dataStructure.getDataRefAs<AttributeMatrix>(pCellFeatureAttributeMatrixPathValue);
 
   auto& createdArrayStore = createdArray.getIDataStoreRefAs<IDataStore>();
   createdArrayStore.resizeTuples(std::vector<usize>{maxValue + 1});
+  cellFeatureAttrMat.resizeTuples(std::vector<usize>{maxValue + 1});
 
   return ExecuteDataFunction(CopyCellDataFunctor{}, selectedCellArray.getDataType(), dataStructure, pSelectedCellArrayPathValue, pFeatureIdsArrayPathValue, createdArrayPath, shouldCancel);
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MapPointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MapPointCloudToRegularGridFilter.cpp
@@ -179,6 +179,7 @@ void createRegularGrid(DataStructure& data, const Arguments& args)
   image->setDimensions(iDims);
   image->setSpacing(iRes[0], iRes[1], iRes[2]);
   image->setOrigin(iOrigin[0], iOrigin[1], iOrigin[2]);
+  image->getCellData()->resizeTuples({iDims[2], iDims[1], iDims[0]});
 }
 } // namespace
 

--- a/src/Plugins/SimplnxCore/test/CreateFeatureArrayFromElementArrayTest.cpp
+++ b/src/Plugins/SimplnxCore/test/CreateFeatureArrayFromElementArrayTest.cpp
@@ -26,8 +26,9 @@ void testElementArray(const DataPath& cellDataPath)
   DataStructure dataStructure = UnitTest::LoadDataStructure(baseDataFilePath);
   DataPath smallIn100Group({nx::core::Constants::k_DataContainer});
 
+  // This section creates the needed AttributeMatrix of size 1. The filter should be resizing as needed.
   {
-    auto* computedFeatureData = AttributeMatrix::Create(dataStructure, k_Computed_CellData, std::vector<usize>{81}, dataStructure.getId(smallIn100Group));
+    AttributeMatrix::Create(dataStructure, k_Computed_CellData, std::vector<usize>{1}, dataStructure.getId(smallIn100Group));
   }
 
   DataPath featureIdsDataPath = smallIn100Group.createChildPath(nx::core::Constants::k_CellData).createChildPath(k_FeatureIDs);

--- a/src/Plugins/SimplnxCore/test/FlyingEdges3DTest.cpp
+++ b/src/Plugins/SimplnxCore/test/FlyingEdges3DTest.cpp
@@ -59,6 +59,11 @@ TEST_CASE("SimplnxCore::Image Contouring Valid Execution", "[SimplnxCore][Flying
     auto preflightResult = filter.preflight(dataStructure, args);
     SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
 
+    // This is in here because the exemplar face attribute matrix is not sized correctly. This will
+    // correct that value allowing the test to proceed normally.
+    auto& exemplarContourTriGeom = dataStructure.getDataRefAs<TriangleGeom>(ContourTest::k_ExemplarContourPath);
+    exemplarContourTriGeom.getFaceAttributeMatrixRef().resizeTuples({70});
+
     // Execute the filter and check the result
     auto executeResult = filter.execute(dataStructure, args);
     SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);

--- a/src/Plugins/SimplnxCore/test/LabelTriangleGeometryTest.cpp
+++ b/src/Plugins/SimplnxCore/test/LabelTriangleGeometryTest.cpp
@@ -2,6 +2,7 @@
 
 #include "SimplnxCore/Filters/LabelTriangleGeometryFilter.hpp"
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
+#include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 using namespace nx::core;
@@ -41,11 +42,16 @@ TEST_CASE("SimplnxCore::LabelTriangleGeometryFilter: Valid Filter Execution", "[
 
     // Preflight the filter and check result
     auto preflightResult = filter.preflight(dataStructure, args);
-    REQUIRE(preflightResult.outputActions.valid());
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+    // This is in here because the exemplar face attribute matrix is not sized correctly. This will
+    // correct that value allowing the test to proceed normally.
+    auto& exemplarContourTriGeom = dataStructure.getDataRefAs<TriangleGeom>(k_TriangleGeomPath);
+    exemplarContourTriGeom.getVertexAttributeMatrix()->resizeTuples({144});
 
     // Execute the filter and check the result
     auto executeResult = filter.execute(dataStructure, args);
-    REQUIRE(executeResult.result.valid());
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
 
   DataStructure exemplarDataStructure = UnitTest::LoadDataStructure(k_ExemplarDataFilePath);

--- a/src/Plugins/SimplnxCore/test/RemoveFlaggedTrianglesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/RemoveFlaggedTrianglesTest.cpp
@@ -2,6 +2,7 @@
 
 #include "SimplnxCore/Filters/RemoveFlaggedTrianglesFilter.hpp"
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
+#include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 using namespace nx::core;
@@ -44,11 +45,17 @@ TEST_CASE("SimplnxCore::RemoveFlaggedTrianglesFilter: Valid Filter Execution", "
 
     // Preflight the filter and check result
     auto preflightResult = filter.preflight(dataStructure, args);
-    REQUIRE(preflightResult.outputActions.valid());
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+    // This is in here because the exemplar face attribute matrix is not sized correctly. This will
+    // correct that value allowing the test to proceed normally.
+    auto& exemplarContourTriGeom = dataStructure.getDataRefAs<TriangleGeom>(k_TriangleGeomPath);
+    exemplarContourTriGeom.getVertexAttributeMatrix()->resizeTuples({144});
+    exemplarContourTriGeom.getFaceAttributeMatrix()->resizeTuples({276});
 
     // Execute the filter and check the result
     auto executeResult = filter.execute(dataStructure, args);
-    REQUIRE(executeResult.result.valid());
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
 
   DataStructure exemplarDataStructure = UnitTest::LoadDataStructure(k_ExemplarDataFilePath);

--- a/src/simplnx/DataStructure/AttributeMatrix.cpp
+++ b/src/simplnx/DataStructure/AttributeMatrix.cpp
@@ -119,3 +119,19 @@ void AttributeMatrix::resizeTuples(ShapeType tupleShape)
     array->resizeTuples(m_TupleShape);
   }
 }
+
+Result<> AttributeMatrix::validate() const
+{
+  Result<> result;
+  auto childArrays = findAllChildrenOfType<IArray>();
+  usize numTuples = getNumTuples();
+  for(const auto& array : childArrays)
+  {
+    if(array->getNumberOfTuples() != numTuples)
+    {
+      result = MergeResults(result, MakeErrorResult(-4701, fmt::format("AttributeMatrix '{}' has {} tuples but the contained IArray objet '{}' has {} total tuples.", getName(), numTuples,
+                                                                       array->getName(), array->getNumberOfTuples())));
+    }
+  }
+  return result;
+}

--- a/src/simplnx/DataStructure/AttributeMatrix.hpp
+++ b/src/simplnx/DataStructure/AttributeMatrix.hpp
@@ -137,6 +137,13 @@ public:
    */
   void resizeTuples(ShapeType tupleShape);
 
+  /**
+   * @brief Validates that every IArray held by this attribute matrix have the same number
+   * of tuples that the attribute matrix requires.
+   * @return Result<> object.
+   */
+  Result<> validate() const;
+
 protected:
   /**
    * @brief Creates the AttributeMatrix for the target DataStructure and with the

--- a/src/simplnx/DataStructure/DataStructure.cpp
+++ b/src/simplnx/DataStructure/DataStructure.cpp
@@ -1035,4 +1035,22 @@ Result<> DataStructure::validateGeometries() const
   return result;
 }
 
+Result<> DataStructure::validateAttributeMatrices() const
+{
+  Result<> result;
+  for(const auto& dataObject : m_DataObjects)
+  {
+    auto dataObjectType = dataObject.second.lock()->getDataObjectType();
+    if(dataObjectType == DataObject::Type::AttributeMatrix)
+    {
+      auto* attrMatPtr = dynamic_cast<AttributeMatrix*>(dataObject.second.lock().get());
+      if(nullptr != attrMatPtr)
+      {
+        result = MergeResults(attrMatPtr->validate(), result);
+      }
+    }
+  }
+  return result;
+}
+
 } // namespace nx::core

--- a/src/simplnx/DataStructure/DataStructure.cpp
+++ b/src/simplnx/DataStructure/DataStructure.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Core/Application.hpp"
 #include "simplnx/DataStructure/BaseGroup.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/DataStructure/Geometry/IGeometry.hpp"
 #include "simplnx/DataStructure/IDataArray.hpp"
 #include "simplnx/DataStructure/INeighborList.hpp"
 #include "simplnx/DataStructure/LinkedPath.hpp"
@@ -1014,4 +1015,24 @@ Result<> DataStructure::transferDataArraysOoc()
 
   return result;
 }
+
+Result<> DataStructure::validateGeometries() const
+{
+  /** There is an assumption about the range of the DataObject::Type enumeration. That assumption
+   * is backed up by a static_assert test case for the unit tests. If the enumeration is changed
+   * the compile will fail if the unit tests are enabled. Which they are on all the CI machines.
+   */
+  Result<> result;
+  for(const auto& dataObject : m_RootGroup)
+  {
+    auto dataObjectType = dataObject.second->getDataObjectType();
+    if(dataObjectType >= DataObject::Type::IGeometry && dataObjectType <= DataObject::Type::TetrahedralGeom)
+    {
+      auto* geomPtr = dynamic_cast<IGeometry*>(dataObject.second.get());
+      result = MergeResults(geomPtr->validateGeometry(), result);
+    }
+  }
+  return result;
+}
+
 } // namespace nx::core

--- a/src/simplnx/DataStructure/DataStructure.cpp
+++ b/src/simplnx/DataStructure/DataStructure.cpp
@@ -1029,7 +1029,7 @@ Result<> DataStructure::validateGeometries() const
     if(dataObjectType >= DataObject::Type::IGeometry && dataObjectType <= DataObject::Type::TetrahedralGeom)
     {
       auto* geomPtr = dynamic_cast<IGeometry*>(dataObject.second.get());
-      result = MergeResults(geomPtr->validateGeometry(), result);
+      result = MergeResults(geomPtr->validate(), result);
     }
   }
   return result;

--- a/src/simplnx/DataStructure/DataStructure.cpp
+++ b/src/simplnx/DataStructure/DataStructure.cpp
@@ -1040,13 +1040,17 @@ Result<> DataStructure::validateAttributeMatrices() const
   Result<> result;
   for(const auto& dataObject : m_DataObjects)
   {
-    auto dataObjectType = dataObject.second.lock()->getDataObjectType();
-    if(dataObjectType == DataObject::Type::AttributeMatrix)
+    auto dataObjectSharedPtr = dataObject.second.lock();
+    if(dataObjectSharedPtr.get() != nullptr)
     {
-      auto* attrMatPtr = dynamic_cast<AttributeMatrix*>(dataObject.second.lock().get());
-      if(nullptr != attrMatPtr)
+      auto dataObjectType = dataObjectSharedPtr->getDataObjectType();
+      if(dataObjectType == DataObject::Type::AttributeMatrix)
       {
-        result = MergeResults(attrMatPtr->validate(), result);
+        auto* attrMatPtr = dynamic_cast<AttributeMatrix*>(dataObject.second.lock().get());
+        if(nullptr != attrMatPtr)
+        {
+          result = MergeResults(attrMatPtr->validate(), result);
+        }
       }
     }
   }

--- a/src/simplnx/DataStructure/DataStructure.hpp
+++ b/src/simplnx/DataStructure/DataStructure.hpp
@@ -724,9 +724,21 @@ public:
    * the matching Attribute Matrix must also have the same number of tuples. For example if there is
    * an Edge Geometry that has 10 edges and the EdgeData AttributeMatrix does **NOT** have 10 tuples total,
    * then a Result<> with errors will be returned.
-   * @return
+   *
+   * @return Result<> object
    */
   Result<> validateGeometries() const;
+
+  /**
+   * @brief This method will validate that each AttributeMatrix is valid.
+   *
+   * The validation criteria is that for the Attribute Matrix itself: Every contained IArray
+   * object must have the same number of Tuples as every other IArray object and the
+   * AttributeMatrix itself must also have the same total number of tuples.
+   *
+   * @return Result<> object
+   */
+  Result<> validateAttributeMatrices() const;
 
 protected:
   /**

--- a/src/simplnx/DataStructure/DataStructure.hpp
+++ b/src/simplnx/DataStructure/DataStructure.hpp
@@ -717,6 +717,17 @@ public:
    */
   Result<> transferDataArraysOoc();
 
+  /**
+   * @brief This method will validate that each Geometry is valid based on a specific set of criteria
+   *
+   * The criteria used for validation is that for Node based geometries, for each of the "Shared-List" type of arrays,
+   * the matching Attribute Matrix must also have the same number of tuples. For example if there is
+   * an Edge Geometry that has 10 edges and the EdgeData AttributeMatrix does **NOT** have 10 tuples total,
+   * then a Result<> with errors will be returned.
+   * @return
+   */
+  Result<> validateGeometries() const;
+
 protected:
   /**
    * @brief Returns a new ID for use constructing a DataObject.

--- a/src/simplnx/DataStructure/Geometry/IGeometry.hpp
+++ b/src/simplnx/DataStructure/Geometry/IGeometry.hpp
@@ -179,6 +179,12 @@ public:
    */
   static std::string LengthUnitToString(LengthUnit unit);
 
+  /**
+   * @brief validates that linkages between shared node lists and their associated Attribute Matrix is correct.
+   * @return A Result<> object possibly with error code and message.
+   */
+  virtual Result<> validateGeometry() const = 0;
+
 protected:
   IGeometry(DataStructure& dataStructure, std::string name);
 

--- a/src/simplnx/DataStructure/Geometry/IGeometry.hpp
+++ b/src/simplnx/DataStructure/Geometry/IGeometry.hpp
@@ -183,7 +183,7 @@ public:
    * @brief validates that linkages between shared node lists and their associated Attribute Matrix is correct.
    * @return A Result<> object possibly with error code and message.
    */
-  virtual Result<> validateGeometry() const = 0;
+  virtual Result<> validate() const = 0;
 
 protected:
   IGeometry(DataStructure& dataStructure, std::string name);

--- a/src/simplnx/DataStructure/Geometry/IGridGeometry.cpp
+++ b/src/simplnx/DataStructure/Geometry/IGridGeometry.cpp
@@ -90,7 +90,7 @@ void IGridGeometry::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdTy
   }
 }
 
-Result<> IGridGeometry::validateGeometry() const
+Result<> IGridGeometry::validate() const
 {
   // Validate the next lower dimension geometry
   Result<> result;

--- a/src/simplnx/DataStructure/Geometry/IGridGeometry.hpp
+++ b/src/simplnx/DataStructure/Geometry/IGridGeometry.hpp
@@ -212,6 +212,12 @@ public:
    */
   void setCellData(OptionalId id);
 
+  /**
+   * @brief validates that linkages between shared node lists and their associated Attribute Matrix is correct.
+   * @return A Result<> object possibly with error code and message.
+   */
+  Result<> validateGeometry() const override;
+
 protected:
   IGridGeometry(DataStructure& dataStructure, std::string name);
 

--- a/src/simplnx/DataStructure/Geometry/IGridGeometry.hpp
+++ b/src/simplnx/DataStructure/Geometry/IGridGeometry.hpp
@@ -216,7 +216,7 @@ public:
    * @brief validates that linkages between shared node lists and their associated Attribute Matrix is correct.
    * @return A Result<> object possibly with error code and message.
    */
-  Result<> validateGeometry() const override;
+  Result<> validate() const override;
 
 protected:
   IGridGeometry(DataStructure& dataStructure, std::string name);

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry0D.cpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry0D.cpp
@@ -253,7 +253,7 @@ void INodeGeometry0D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, Id
   }
 }
 
-Result<> INodeGeometry0D::validateGeometry() const
+Result<> INodeGeometry0D::validate() const
 {
   Result<> result;
   usize numVerts = getNumberOfVertices();

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry0D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry0D.hpp
@@ -177,7 +177,7 @@ public:
    * @brief validates that linkages between shared node lists and their associated Attribute Matrix is correct.
    * @return A Result<> object possibly with error code and message.
    */
-  Result<> validateGeometry() const override;
+  Result<> validate() const override;
 
 protected:
   INodeGeometry0D(DataStructure& dataStructure, std::string name);

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry0D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry0D.hpp
@@ -173,6 +173,12 @@ public:
    */
   void setVertexAttributeMatrix(const AttributeMatrix& attributeMatrix);
 
+  /**
+   * @brief validates that linkages between shared node lists and their associated Attribute Matrix is correct.
+   * @return A Result<> object possibly with error code and message.
+   */
+  Result<> validateGeometry() const override;
+
 protected:
   INodeGeometry0D(DataStructure& dataStructure, std::string name);
 

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry1D.cpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry1D.cpp
@@ -275,10 +275,10 @@ void INodeGeometry1D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, Id
   }
 }
 
-Result<> INodeGeometry1D::validateGeometry() const
+Result<> INodeGeometry1D::validate() const
 {
   // Validate the next lower dimension geometry
-  Result<> result = INodeGeometry0D::validateGeometry();
+  Result<> result = INodeGeometry0D::validate();
 
   usize numTuples = getNumberOfEdges();
   const AttributeMatrix* amPtr = getEdgeAttributeMatrix();

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry1D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry1D.hpp
@@ -207,7 +207,7 @@ public:
    * @brief validates that linkages between shared node lists and their associated Attribute Matrix is correct.
    * @return A Result<> object possibly with error code and message.
    */
-  Result<> validateGeometry() const override;
+  Result<> validate() const override;
 
 protected:
   INodeGeometry1D(DataStructure& dataStructure, std::string name);

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry1D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry1D.hpp
@@ -203,6 +203,12 @@ public:
   void setElementCentroidsId(const std::optional<IdType>& centroidsId);
   void setElementSizesId(const std::optional<IdType>& sizesId);
 
+  /**
+   * @brief validates that linkages between shared node lists and their associated Attribute Matrix is correct.
+   * @return A Result<> object possibly with error code and message.
+   */
+  Result<> validateGeometry() const override;
+
 protected:
   INodeGeometry1D(DataStructure& dataStructure, std::string name);
 

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry2D.cpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry2D.cpp
@@ -224,10 +224,10 @@ void INodeGeometry2D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, Id
   }
 }
 
-Result<> INodeGeometry2D::validateGeometry() const
+Result<> INodeGeometry2D::validate() const
 {
   // Validate the next lower dimension geometry
-  Result<> result = INodeGeometry1D::validateGeometry();
+  Result<> result = INodeGeometry1D::validate();
 
   usize numTuples = getNumberOfFaces();
   const AttributeMatrix* amPtr = getFaceAttributeMatrix();

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry2D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry2D.hpp
@@ -195,7 +195,7 @@ public:
    * @brief validates that linkages between shared node lists and their associated Attribute Matrix is correct.
    * @return A Result<> object possibly with error code and message.
    */
-  Result<> validateGeometry() const override;
+  Result<> validate() const override;
 
 protected:
   INodeGeometry2D(DataStructure& dataStructure, std::string name);

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry2D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry2D.hpp
@@ -191,6 +191,12 @@ public:
    */
   void setFaceAttributeMatrix(const AttributeMatrix& attributeMatrix);
 
+  /**
+   * @brief validates that linkages between shared node lists and their associated Attribute Matrix is correct.
+   * @return A Result<> object possibly with error code and message.
+   */
+  Result<> validateGeometry() const override;
+
 protected:
   INodeGeometry2D(DataStructure& dataStructure, std::string name);
 

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry3D.cpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry3D.cpp
@@ -26,21 +26,39 @@ void INodeGeometry3D::setPolyhedronListId(const OptionalId& polyListId)
 
 INodeGeometry3D::SharedFaceList* INodeGeometry3D::getPolyhedra()
 {
+  if(!m_PolyhedronListId.has_value())
+  {
+    return nullptr;
+  }
   return getDataStructureRef().getDataAs<SharedFaceList>(m_PolyhedronListId);
 }
 
 const INodeGeometry3D::SharedFaceList* INodeGeometry3D::getPolyhedra() const
 {
+  if(!m_PolyhedronListId.has_value())
+  {
+    return nullptr;
+  }
   return getDataStructureRef().getDataAs<SharedFaceList>(m_PolyhedronListId);
 }
 
 INodeGeometry3D::SharedFaceList& INodeGeometry3D::getPolyhedraRef()
 {
+  if(!m_PolyhedronListId.has_value())
+  {
+    throw std::runtime_error(
+        fmt::format("INodeGeometry1D::{} threw runtime exception. The geometry with name '{}' does not have a shared polyhedra list assigned.\n  {}:{}", __func__, getName(), __FILE__, __LINE__));
+  }
   return getDataStructureRef().getDataRefAs<SharedFaceList>(m_PolyhedronListId.value());
 }
 
 const INodeGeometry3D::SharedFaceList& INodeGeometry3D::getPolyhedraRef() const
 {
+  if(!m_PolyhedronListId.has_value())
+  {
+    throw std::runtime_error(
+        fmt::format("INodeGeometry1D::{} threw runtime exception. The geometry with name '{}' does not have a shared polyhedra list assigned.\n  {}:{}", __func__, getName(), __FILE__, __LINE__));
+  }
   return getDataStructureRef().getDataRefAs<SharedFaceList>(m_PolyhedronListId.value());
 }
 
@@ -61,8 +79,8 @@ void INodeGeometry3D::resizePolyhedraList(usize size)
 
 usize INodeGeometry3D::getNumberOfPolyhedra() const
 {
-  const auto& polyhedra = getPolyhedraRef();
-  return polyhedra.getNumberOfTuples();
+  const auto* polyhedraPtr = getPolyhedra();
+  return polyhedraPtr == nullptr ? 0 : polyhedraPtr->getNumberOfTuples();
 }
 
 void INodeGeometry3D::setCellPointIds(usize polyhedraId, nonstd::span<usize> vertexIds)
@@ -145,21 +163,39 @@ void INodeGeometry3D::setPolyhedraDataId(const OptionalId& polyDataId)
 
 AttributeMatrix* INodeGeometry3D::getPolyhedraAttributeMatrix()
 {
+  if(!m_PolyhedronAttributeMatrixId.has_value())
+  {
+    return nullptr;
+  }
   return getDataStructureRef().getDataAs<AttributeMatrix>(m_PolyhedronAttributeMatrixId);
 }
 
 const AttributeMatrix* INodeGeometry3D::getPolyhedraAttributeMatrix() const
 {
+  if(!m_PolyhedronAttributeMatrixId.has_value())
+  {
+    return nullptr;
+  }
   return getDataStructureRef().getDataAs<AttributeMatrix>(m_PolyhedronAttributeMatrixId);
 }
 
 AttributeMatrix& INodeGeometry3D::getPolyhedraAttributeMatrixRef()
 {
+  if(!m_PolyhedronAttributeMatrixId.has_value())
+  {
+    throw std::runtime_error(
+        fmt::format("INodeGeometry1D::{} threw runtime exception. The geometry with name '{}' does not have a polyhedra attribute matrix assigned.\n  {}:{}", __func__, getName(), __FILE__, __LINE__));
+  }
   return getDataStructureRef().getDataRefAs<AttributeMatrix>(m_PolyhedronAttributeMatrixId.value());
 }
 
 const AttributeMatrix& INodeGeometry3D::getPolyhedraAttributeMatrixRef() const
 {
+  if(!m_PolyhedronAttributeMatrixId.has_value())
+  {
+    throw std::runtime_error(
+        fmt::format("INodeGeometry1D::{} threw runtime exception. The geometry with name '{}' does not have a polyhedra attribute matrix assigned.\n  {}:{}", __func__, getName(), __FILE__, __LINE__));
+  }
   return getDataStructureRef().getDataRefAs<AttributeMatrix>(m_PolyhedronAttributeMatrixId.value());
 }
 
@@ -197,5 +233,26 @@ void INodeGeometry3D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, Id
     m_PolyhedronAttributeMatrixId = nx::core::VisitDataStructureId(m_PolyhedronAttributeMatrixId, updatedId, visited, 1);
     m_UnsharedFaceListId = nx::core::VisitDataStructureId(m_UnsharedFaceListId, updatedId, visited, 2);
   }
+}
+
+Result<> INodeGeometry3D::validateGeometry() const
+{
+  // Validate the next lower dimension geometry
+  Result<> result = INodeGeometry2D::validateGeometry();
+
+  usize numTuples = getNumberOfPolyhedra();
+  const AttributeMatrix* amPtr = getPolyhedraAttributeMatrix();
+  if(nullptr == amPtr)
+  {
+    return result;
+  }
+  usize amNumTuples = amPtr->getNumTuples();
+
+  if(numTuples != amNumTuples)
+  {
+    return MergeResults(
+        result, MakeErrorResult(-4501, fmt::format("Hex/Tet Geometry '{}' has {} cells but the cell Attribute Matrix '{}' has {} total tuples.", getName(), numTuples, amPtr->getName(), amNumTuples)));
+  }
+  return result;
 }
 } // namespace nx::core

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry3D.cpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry3D.cpp
@@ -235,10 +235,10 @@ void INodeGeometry3D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, Id
   }
 }
 
-Result<> INodeGeometry3D::validateGeometry() const
+Result<> INodeGeometry3D::validate() const
 {
   // Validate the next lower dimension geometry
-  Result<> result = INodeGeometry2D::validateGeometry();
+  Result<> result = INodeGeometry2D::validate();
 
   usize numTuples = getNumberOfPolyhedra();
   const AttributeMatrix* amPtr = getPolyhedraAttributeMatrix();

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry3D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry3D.hpp
@@ -192,7 +192,7 @@ public:
    * @brief validates that linkages between shared node lists and their associated Attribute Matrix is correct.
    * @return A Result<> object possibly with error code and message.
    */
-  Result<> validateGeometry() const override;
+  Result<> validate() const override;
 
 protected:
   INodeGeometry3D(DataStructure& dataStructure, std::string name);

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry3D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry3D.hpp
@@ -188,6 +188,12 @@ public:
    */
   void setPolyhedraAttributeMatrix(const AttributeMatrix& attributeMatrix);
 
+  /**
+   * @brief validates that linkages between shared node lists and their associated Attribute Matrix is correct.
+   * @return A Result<> object possibly with error code and message.
+   */
+  Result<> validateGeometry() const override;
+
 protected:
   INodeGeometry3D(DataStructure& dataStructure, std::string name);
 

--- a/src/simplnx/Filter/IFilter.cpp
+++ b/src/simplnx/Filter/IFilter.cpp
@@ -227,6 +227,12 @@ IFilter::ExecuteResult IFilter::execute(DataStructure& dataStructure, const Argu
 
   Result<> validGeometries = MergeResults(dataStructure.validateGeometries(), executeImplResult);
 
+  Result<> validAttributeMatrices = dataStructure.validateAttributeMatrices();
+  if(validAttributeMatrices.invalid())
+  {
+    return ExecuteResult{std::move(validAttributeMatrices), std::move(preflightResult.outputValues) };
+  }
+
   Result<> preflightActionsExecuteResult = MergeResults(std::move(preflightActionsResult), std::move(validGeometries));
 
   if(preflightActionsExecuteResult.invalid())

--- a/src/simplnx/Filter/IFilter.cpp
+++ b/src/simplnx/Filter/IFilter.cpp
@@ -193,10 +193,10 @@ IFilter::PreflightResult IFilter::preflight(const DataStructure& data, const Arg
   return implResult;
 }
 
-IFilter::ExecuteResult IFilter::execute(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineFilter, const MessageHandler& messageHandler,
+IFilter::ExecuteResult IFilter::execute(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineFilter, const MessageHandler& messageHandler,
                                         const std::atomic_bool& shouldCancel) const
 {
-  PreflightResult preflightResult = preflight(data, args, messageHandler, shouldCancel);
+  PreflightResult preflightResult = preflight(dataStructure, args, messageHandler, shouldCancel);
   if(preflightResult.outputActions.invalid())
   {
     return ExecuteResult{ConvertResult(std::move(preflightResult.outputActions)), std::move(preflightResult.outputValues)};
@@ -206,7 +206,7 @@ IFilter::ExecuteResult IFilter::execute(DataStructure& data, const Arguments& ar
 
   Result<> outputActionsResult = ConvertResult(std::move(preflightResult.outputActions));
 
-  Result<> actionsResult = outputActions.applyRegular(data, IDataAction::Mode::Execute);
+  Result<> actionsResult = outputActions.applyRegular(dataStructure, IDataAction::Mode::Execute);
 
   Result<> preflightActionsResult = MergeResults(std::move(outputActionsResult), std::move(actionsResult));
 
@@ -219,20 +219,22 @@ IFilter::ExecuteResult IFilter::execute(DataStructure& data, const Arguments& ar
   // We can discard the warnings since they're already reported in preflight
   auto [resolvedArgs, warnings] = GetResolvedArgs(args, params, *this);
 
-  Result<> executeImplResult = executeImpl(data, resolvedArgs, pipelineFilter, messageHandler, shouldCancel);
+  Result<> executeImplResult = executeImpl(dataStructure, resolvedArgs, pipelineFilter, messageHandler, shouldCancel);
   if(shouldCancel)
   {
     return {MakeErrorResult(-1, "Filter cancelled")};
   }
 
-  Result<> preflightActionsExecuteResult = MergeResults(std::move(preflightActionsResult), std::move(executeImplResult));
+  Result<> validGeometries = MergeResults(dataStructure.validateGeometries(), executeImplResult);
+
+  Result<> preflightActionsExecuteResult = MergeResults(std::move(preflightActionsResult), std::move(validGeometries));
 
   if(preflightActionsExecuteResult.invalid())
   {
     return ExecuteResult{std::move(preflightActionsExecuteResult), std::move(preflightResult.outputValues)};
   }
 
-  Result<> deferredActionsResult = outputActions.applyDeferred(data, IDataAction::Mode::Execute);
+  Result<> deferredActionsResult = outputActions.applyDeferred(dataStructure, IDataAction::Mode::Execute);
 
   Result<> finalResult = MergeResults(std::move(preflightActionsExecuteResult), std::move(deferredActionsResult));
 

--- a/src/simplnx/Filter/IFilter.cpp
+++ b/src/simplnx/Filter/IFilter.cpp
@@ -225,15 +225,9 @@ IFilter::ExecuteResult IFilter::execute(DataStructure& dataStructure, const Argu
     return {MakeErrorResult(-1, "Filter cancelled")};
   }
 
-  Result<> validGeometries = MergeResults(dataStructure.validateGeometries(), executeImplResult);
-
-  Result<> validAttributeMatrices = dataStructure.validateAttributeMatrices();
-  if(validAttributeMatrices.invalid())
-  {
-    return ExecuteResult{std::move(validAttributeMatrices), std::move(preflightResult.outputValues) };
-  }
-
-  Result<> preflightActionsExecuteResult = MergeResults(std::move(preflightActionsResult), std::move(validGeometries));
+  Result<> validGeometryAndAttributeMatrices = MergeResults(dataStructure.validateGeometries(), dataStructure.validateAttributeMatrices());
+  validGeometryAndAttributeMatrices = MergeResults(validGeometryAndAttributeMatrices, executeImplResult);
+  Result<> preflightActionsExecuteResult = MergeResults(std::move(preflightActionsResult), std::move(validGeometryAndAttributeMatrices));
 
   if(preflightActionsExecuteResult.invalid())
   {

--- a/src/simplnx/Filter/IFilter.hpp
+++ b/src/simplnx/Filter/IFilter.hpp
@@ -164,14 +164,14 @@ public:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param data
+   * @param dataStructure
    * @param args
    * @param pipelineNode = nullptr
    * @param messageHandler = {}
    * @param shouldCancel
    * @return ExecuteResult
    */
-  ExecuteResult execute(DataStructure& data, const Arguments& args, const PipelineFilter* pipelineNode = nullptr, const MessageHandler& messageHandler = {},
+  ExecuteResult execute(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode = nullptr, const MessageHandler& messageHandler = {},
                         const std::atomic_bool& shouldCancel = false) const;
 
   /**

--- a/test/DataStructTest.cpp
+++ b/test/DataStructTest.cpp
@@ -43,6 +43,24 @@ constexpr StringLiteral k_SharedPolyhedrons = "SharedPolyhedronList";
 constexpr StringLiteral k_HexGeo = "Hex Geometry";
 } // namespace
 
+TEST_CASE("SimplnxCore::DataObjectType Check")
+{
+  static_assert(DataObject::Type::IGeometry == static_cast<DataObject::Type>(8));
+  static_assert(DataObject::Type::IGridGeometry == static_cast<DataObject::Type>(9));
+  static_assert(DataObject::Type::RectGridGeom == static_cast<DataObject::Type>(10));
+  static_assert(DataObject::Type::ImageGeom == static_cast<DataObject::Type>(11));
+  static_assert(DataObject::Type::INodeGeometry0D == static_cast<DataObject::Type>(12));
+  static_assert(DataObject::Type::VertexGeom == static_cast<DataObject::Type>(13));
+  static_assert(DataObject::Type::INodeGeometry1D == static_cast<DataObject::Type>(14));
+  static_assert(DataObject::Type::EdgeGeom == static_cast<DataObject::Type>(15));
+  static_assert(DataObject::Type::INodeGeometry2D == static_cast<DataObject::Type>(16));
+  static_assert(DataObject::Type::QuadGeom == static_cast<DataObject::Type>(17));
+  static_assert(DataObject::Type::TriangleGeom == static_cast<DataObject::Type>(18));
+  static_assert(DataObject::Type::INodeGeometry3D == static_cast<DataObject::Type>(19));
+  static_assert(DataObject::Type::HexahedralGeom == static_cast<DataObject::Type>(20));
+  static_assert(DataObject::Type::TetrahedralGeom == static_cast<DataObject::Type>(21));
+}
+
 // This test will ensure we don't run into runtime exceptions trying to run the functions
 TEST_CASE("SimplnxCore::exportHierarchyAsGraphViz")
 {


### PR DESCRIPTION
This method is run by IFilter::execute() after the actual filter's executeImpl() is run. The code will validate that the geometry's Attribute Matrices are correctly sized to match the vertex/edge/face/cell shared lists.

Some filters and unit tests bugs were also found and fixed by this update.
