### PR TITLE
BUG: CliObsever output bug, create_directories() error message

### DIFF
--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApproximatePointCloudHull.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApproximatePointCloudHull.cpp
@@ -290,6 +290,10 @@ Result<> ApproximatePointCloudHull::executeImpl(DataStructure& data, const Argum
 
   auto* hull = data.getDataAs<VertexGeom>(hullVertexGeomPath);
   hull->resizeVertexList(tmpVerts.size() / 3);
+  if(hull->getVertexAttributeMatrix() != nullptr)
+  {
+    hull->getVertexAttributeMatrix()->resizeTuples({tmpVerts.size() / 3});
+  }
   auto* hullVerts = hull->getVertices();
   auto tmpVertData = tmpVerts.data();
   for(usize i = 0; i < hull->getNumberOfVertices() * 3; i++)

--- a/src/nxrunner/src/CliObserver.cpp
+++ b/src/nxrunner/src/CliObserver.cpp
@@ -39,7 +39,7 @@ PipelineObserver::PipelineObserver(Pipeline* pipeline)
       {
         std::cout << "[" << currentFilterIndex << "] Error(s) Encountered during filter execution. Fault state= " << static_cast<int32_t>(state) << std::endl;
       }
-      if(state != nx::core::FaultState::Warnings)
+      if(state == nx::core::FaultState::Warnings)
       {
         std::cout << "[" << currentFilterIndex << "] Warning(s) Encountered during filter execution. Fault state= " << static_cast<int32_t>(state) << std::endl;
       }

--- a/src/simplnx/Utilities/FilterUtilities.cpp
+++ b/src/simplnx/Utilities/FilterUtilities.cpp
@@ -18,7 +18,7 @@ Result<> CreateOutputDirectories(const fs::path& outputPath)
     // /tmp/foo but what was created was /private/tmp/foo. This logic should fix that issue.
     if(!fs::create_directories(outputPath, errorCode) && !fs::exists(outputPath))
     {
-      return MakeErrorResult(-4010, fmt::format("Unable to create output directory {}. Error code from operating system is {}", outputPath.string(), errorCode.value()));
+      return MakeErrorResult(-4010, fmt::format("Unable to create output directory {}. Error code from operating system is {}", outputPath.string(), errorCode.value(), errorCode.message()));
     }
   }
   return {};


### PR DESCRIPTION
- CliObserver was always printing warnings even if there were none.
- If std::file_system::create_directories() returned an error, the error message was not included in the Result<> warning
- ApproximatePointCloudHull: Resize created vertex attribute matrix to match vertex geometry
