### PR TITLE
Fix HDF5 implicit copy

### DIFF
--- a/src/simplnx/Utilities/Parsing/HDF5/IO/AttributeIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/AttributeIO.hpp
@@ -37,6 +37,9 @@ public:
    */
   AttributeIO(IdType objectId, const std::string& attrName);
 
+  AttributeIO(const AttributeIO& other) = delete;
+  AttributeIO(AttributeIO&& other) noexcept = default;
+
   /**
    * @brief Releases the wrapped HDF5 attribute.
    */
@@ -163,6 +166,9 @@ public:
    */
   template <typename T>
   Result<> writeVector(const DimsVector& dims, const std::vector<T>& vector);
+
+  AttributeIO& operator=(const AttributeIO& other) = delete;
+  AttributeIO& operator=(AttributeIO&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
@@ -24,7 +24,7 @@ DatasetIO::DatasetIO(IdType parentId, const std::string& datasetName)
 }
 
 DatasetIO::DatasetIO(DatasetIO&& other) noexcept
-: ObjectIO(other)
+: ObjectIO(std::move(other))
 , m_DatasetName(std::move(other.m_DatasetName))
 {
 }

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp
@@ -61,6 +61,8 @@ public:
    */
   FileIO(IdType fileId);
 
+  FileIO(const FileIO& rhs) = delete;
+
   /**
    * @brief Move constructor.
    * @param rhs
@@ -78,6 +80,9 @@ public:
    * @return std::string
    */
   std::string getName() const override;
+
+  FileIO& operator=(const FileIO& rhs) = delete;
+  FileIO& operator=(FileIO&& rhs) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/GroupIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/GroupIO.hpp
@@ -21,6 +21,9 @@ public:
    */
   GroupIO(IdType parentId, const std::string& groupName);
 
+  GroupIO(const GroupIO& other) = delete;
+  GroupIO(GroupIO&& other) noexcept = default;
+
   /**
    * @brief Releases the wrapped HDF5 group.
    */
@@ -134,6 +137,9 @@ public:
    * @return bool
    */
   bool isDataset(const std::string& childName) const;
+
+  GroupIO& operator=(const GroupIO& other) = delete;
+  GroupIO& operator=(GroupIO&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/ObjectIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/ObjectIO.hpp
@@ -26,6 +26,9 @@ public:
    */
   ObjectIO(IdType parentId, const std::string& targetName);
 
+  ObjectIO(const ObjectIO& other) = delete;
+  ObjectIO(ObjectIO&& other) noexcept = default;
+
   /**
    * @brief Releases the wrapped HDF5 object.
    */
@@ -127,6 +130,9 @@ public:
    * @return AttributeIO
    */
   AttributeIO createAttribute(const std::string& name);
+
+  ObjectIO& operator=(const ObjectIO& other) = delete;
+  ObjectIO& operator=(ObjectIO&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Readers/AttributeReader.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Readers/AttributeReader.hpp
@@ -36,6 +36,9 @@ public:
    */
   AttributeReader(IdType objectId, const std::string& attrName);
 
+  AttributeReader(const AttributeReader& other) = delete;
+  AttributeReader(AttributeReader&& other) noexcept = default;
+
   /**
    * @brief Releases the wrapped HDF5 attribute.
    */
@@ -145,6 +148,9 @@ public:
    * @return std::string
    */
   std::string readAsString() const;
+
+  AttributeReader& operator=(const AttributeReader& other) = delete;
+  AttributeReader& operator=(AttributeReader&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Readers/DatasetReader.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Readers/DatasetReader.hpp
@@ -27,6 +27,9 @@ public:
    */
   DatasetReader(IdType parentId, const std::string& dataName);
 
+  DatasetReader(const DatasetReader& other) = delete;
+  DatasetReader(DatasetReader&& other) noexcept = default;
+
   /**
    * @brief Releases the HDF5 dataset.
    */
@@ -121,6 +124,9 @@ public:
   std::vector<hsize_t> getDimensions() const;
 
   std::string getFilterName() const;
+
+  DatasetReader& operator=(const DatasetReader& other) = delete;
+  DatasetReader& operator=(DatasetReader&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Readers/FileReader.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Readers/FileReader.hpp
@@ -26,6 +26,9 @@ public:
    */
   FileReader(IdType fileId);
 
+  FileReader(const FileReader& other) = delete;
+  FileReader(FileReader&& other) noexcept = default;
+
   /**
    * @brief Releases the HDF5 file ID.
    */
@@ -37,6 +40,9 @@ public:
    * @return std::string
    */
   std::string getName() const override;
+
+  FileReader& operator=(const FileReader& other) = delete;
+  FileReader& operator=(FileReader&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Readers/GroupReader.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Readers/GroupReader.hpp
@@ -19,6 +19,9 @@ public:
    */
   GroupReader(IdType parentId, const std::string& groupName);
 
+  GroupReader(const GroupReader& other) = delete;
+  GroupReader(GroupReader&& other) noexcept = default;
+
   /**
    * @brief Releases the wrapped HDF5 group.
    */
@@ -86,6 +89,9 @@ public:
    * @return bool
    */
   bool isDataset(const std::string& childName) const;
+
+  GroupReader& operator=(const GroupReader& other) = delete;
+  GroupReader& operator=(GroupReader&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Readers/ObjectReader.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Readers/ObjectReader.hpp
@@ -24,6 +24,9 @@ public:
    */
   ObjectReader(IdType parentId, const std::string& targetName);
 
+  ObjectReader(const ObjectReader& other) = delete;
+  ObjectReader(ObjectReader&& other) noexcept = default;
+
   /**
    * @brief Releases the wrapped HDF5 object.
    */
@@ -95,6 +98,9 @@ public:
    * @return AttributeReader
    */
   AttributeReader getAttributeByIdx(size_t idx) const;
+
+  ObjectReader& operator=(const ObjectReader& other) = delete;
+  ObjectReader& operator=(ObjectReader&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/AttributeWriter.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/AttributeWriter.hpp
@@ -31,6 +31,9 @@ public:
    */
   AttributeWriter(IdType objectId, const std::string& attributeName);
 
+  AttributeWriter(const AttributeWriter& other) = delete;
+  AttributeWriter(AttributeWriter&& other) noexcept = default;
+
   /**
    * @brief Default destructor
    */
@@ -203,6 +206,9 @@ public:
 
     return returnError;
   }
+
+  AttributeWriter& operator=(const AttributeWriter& other) = delete;
+  AttributeWriter& operator=(AttributeWriter&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/DatasetWriter.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/DatasetWriter.cpp
@@ -27,6 +27,8 @@ DatasetWriter::DatasetWriter(IdType parentId, const std::string& datasetName)
 #endif
 }
 
+DatasetWriter::DatasetWriter(DatasetWriter&& other) noexcept = default;
+
 DatasetWriter::~DatasetWriter()
 {
   closeHdf5();

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/DatasetWriter.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/DatasetWriter.cpp
@@ -27,8 +27,6 @@ DatasetWriter::DatasetWriter(IdType parentId, const std::string& datasetName)
 #endif
 }
 
-DatasetWriter::DatasetWriter(DatasetWriter&& other) noexcept = default;
-
 DatasetWriter::~DatasetWriter()
 {
   closeHdf5();

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/DatasetWriter.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/DatasetWriter.hpp
@@ -28,6 +28,9 @@ public:
    */
   DatasetWriter(IdType parentId, const std::string& datasetName);
 
+  DatasetWriter(const DatasetWriter& other) = delete;
+  DatasetWriter(DatasetWriter&& other) noexcept;
+
   /**
    * @brief Default destructor
    */
@@ -202,6 +205,9 @@ public:
    * @return IdType
    */
   IdType getPListId() const;
+
+  DatasetWriter& operator=(const DatasetWriter& other) = delete;
+  DatasetWriter& operator=(DatasetWriter&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/DatasetWriter.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/DatasetWriter.hpp
@@ -29,7 +29,7 @@ public:
   DatasetWriter(IdType parentId, const std::string& datasetName);
 
   DatasetWriter(const DatasetWriter& other) = delete;
-  DatasetWriter(DatasetWriter&& other) noexcept;
+  DatasetWriter(DatasetWriter&& other) noexcept = default;
 
   /**
    * @brief Default destructor

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/FileWriter.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/FileWriter.hpp
@@ -37,6 +37,12 @@ public:
   FileWriter();
 
   /**
+   * @brief Copy constructor.
+   * @param rhs
+   */
+  FileWriter(const FileWriter& rhs) = delete;
+
+  /**
    * @brief Move constructor.
    * @param rhs
    */
@@ -53,6 +59,9 @@ public:
    * @return std::string
    */
   std::string getName() const override;
+
+  FileWriter& operator=(const FileWriter& rhs) = delete;
+  FileWriter& operator=(FileWriter&& rhs) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/GroupWriter.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/GroupWriter.hpp
@@ -24,6 +24,9 @@ public:
    */
   GroupWriter(IdType parentId, const std::string& objectName);
 
+  GroupWriter(const GroupWriter& other) = delete;
+  GroupWriter(GroupWriter&& other) noexcept = default;
+
   /**
    * @brief Closes the HDF5 group.
    */
@@ -61,6 +64,9 @@ public:
    * @return Result<>
    */
   Result<> createLink(const std::string& objectPath);
+
+  GroupWriter& operator=(const GroupWriter& other) = delete;
+  GroupWriter& operator=(GroupWriter&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/ObjectWriter.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/ObjectWriter.hpp
@@ -25,6 +25,9 @@ public:
    */
   ObjectWriter(IdType parentId, IdType objectId = 0);
 
+  ObjectWriter(const ObjectWriter& other) = delete;
+  ObjectWriter(ObjectWriter&& other) noexcept = default;
+
   /**
    * @brief Releases the wrapped HDF5 object.
    */
@@ -89,6 +92,9 @@ public:
    * @return AttributeWriter
    */
   AttributeWriter createAttribute(const std::string& name);
+
+  ObjectWriter& operator=(const ObjectWriter& other) = delete;
+  ObjectWriter& operator=(ObjectWriter&& other) noexcept = default;
 
 protected:
   /**


### PR DESCRIPTION
* Delete copy constructors in HDF5 parsing classes.
* Fixed DatasetIO move constructor.

fixes #916

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the simplnx repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start simplnx commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `simplnx/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `simplnx/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [ ] 1 Unit test to test output from the filter against known exemplar set of data
- [ ] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [ ] No commented out code (rare exceptions to this is allowed..)
- [ ] No API changes were made (or the changes have been approved)
- [ ] No major design changes were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added license to new files (if any)
- [ ] Added example pipelines that use the filter
- [ ] Classes and methods are properly documented


<!-- **Thanks for contributing to simplnx!** -->
