### PR TITLE
BUG: Fix HDF5 implicit copy crashes.

### DIFF
--- a/cmake/Utility.cmake
+++ b/cmake/Utility.cmake
@@ -73,12 +73,19 @@ function(simplnx_enable_warnings)
       set(SHADOW_WARNING "shadow-all")
     endif()
 
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+      set(CLANG_WARNINGS
+        -Werror=implicit-exception-spec-mismatch # Wimplicit-exception-spec-mismatch: function previously declared with an explicit/implicit exception specification redeclared with an implicit/explicit exception specification
+      )
+    endif()
+
     target_compile_options(${ARG_TARGET}
       PRIVATE
         # Warning to error
         -Werror=parentheses # Wparentheses: Warn if parentheses are omitted in certain contexts, such as when there is an assignment in a context where a truth value is expected, or when operators are nested whose precedence people often get confused about
         -Werror=return-type # Wreturn-type: Warn about any "return" statement with no return value in a function whose return type is not "void"
         -Werror=${SHADOW_WARNING} # Wshadow: Warn whenever a local variable or type declaration shadows another variable, parameter, type, class member (in C++), or instance variable (in Objective-C) or whenever a built-in function is shadowed.
+        ${CLANG_WARNINGS}
     )
   
   endif()

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/AttributeIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/AttributeIO.cpp
@@ -31,7 +31,22 @@ AttributeIO::AttributeIO(IdType objectId, const std::string& attrName)
   HDF_ERROR_HANDLER_ON
 }
 
-AttributeIO::~AttributeIO()
+AttributeIO::AttributeIO(AttributeIO&& other) noexcept
+{
+  m_ObjectId = std::exchange(other.m_ObjectId, 0);
+  m_AttributeId = std::exchange(other.m_AttributeId, 0);
+  m_AttributeName = std::move(other.m_AttributeName);
+}
+
+AttributeIO& AttributeIO::operator=(AttributeIO&& other) noexcept
+{
+  m_ObjectId = std::exchange(other.m_ObjectId, 0);
+  m_AttributeId = std::exchange(other.m_AttributeId, 0);
+  m_AttributeName = std::move(other.m_AttributeName);
+  return *this;
+}
+
+AttributeIO::~AttributeIO() noexcept
 {
   closeHdf5();
 }

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/AttributeIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/AttributeIO.hpp
@@ -38,12 +38,15 @@ public:
   AttributeIO(IdType objectId, const std::string& attrName);
 
   AttributeIO(const AttributeIO& other) = delete;
-  AttributeIO(AttributeIO&& other) noexcept = default;
+  AttributeIO(AttributeIO&& other) noexcept;
+
+  AttributeIO& operator=(const AttributeIO& other) = delete;
+  AttributeIO& operator=(AttributeIO&& other) noexcept;
 
   /**
    * @brief Releases the wrapped HDF5 attribute.
    */
-  virtual ~AttributeIO();
+  ~AttributeIO() noexcept;
 
   /**
    * @brief Returns true if the AttributeIO has a valid target.
@@ -167,9 +170,6 @@ public:
   template <typename T>
   Result<> writeVector(const DimsVector& dims, const std::vector<T>& vector);
 
-  AttributeIO& operator=(const AttributeIO& other) = delete;
-  AttributeIO& operator=(AttributeIO&& other) noexcept = delete;
-
 protected:
   /**
    * @brief Closes the HDF5 ID and resets it to 0.
@@ -186,7 +186,7 @@ protected:
 private:
   IdType m_ObjectId = 0;
   IdType m_AttributeId = 0;
-  const std::string m_AttributeName;
+  std::string m_AttributeName;
 };
 
 extern template SIMPLNX_EXPORT int8_t AttributeIO::readAsValue<int8_t>() const;

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
@@ -12,9 +12,7 @@
 
 namespace nx::core::HDF5
 {
-DatasetIO::DatasetIO()
-{
-}
+DatasetIO::DatasetIO() = default;
 
 DatasetIO::DatasetIO(IdType parentId, const std::string& datasetName)
 : ObjectIO(parentId)

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
@@ -27,7 +27,7 @@ DatasetIO::DatasetIO(DatasetIO&& other) noexcept
 {
 }
 
-DatasetIO::~DatasetIO()
+DatasetIO::~DatasetIO() noexcept
 {
   closeHdf5();
 }

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
@@ -38,10 +38,13 @@ public:
 
   DatasetIO(DatasetIO&& other) noexcept;
 
+  DatasetIO& operator=(const DatasetIO& rhs) = delete;
+  DatasetIO& operator=(DatasetIO&& rhs) noexcept;
+
   /**
    * @brief Releases the HDF5 dataset.
    */
-  virtual ~DatasetIO();
+  ~DatasetIO() noexcept override;
 
   /**
    * @brief Returns true if the DatasetIO has a valid target. Otherwise,
@@ -259,9 +262,6 @@ public:
     auto properties = CreateDatasetChunkProperties(chunkDimensions);
     createOrOpenDataset<T>(dimensions, properties);
   }
-
-  DatasetIO& operator=(const DatasetIO& rhs) = delete;
-  DatasetIO& operator=(DatasetIO&& rhs) noexcept;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/FileIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/FileIO.cpp
@@ -115,10 +115,7 @@ hid_t createOrOpenFile(const std::filesystem::path& filepath)
   return H5Fcreate(filepath.string().c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 }
 
-FileIO::FileIO()
-: GroupIO()
-{
-}
+FileIO::FileIO() = default;
 
 FileIO::FileIO(const std::filesystem::path& filepath)
 : GroupIO(0, createOrOpenFile(filepath))
@@ -128,14 +125,6 @@ FileIO::FileIO(const std::filesystem::path& filepath)
 FileIO::FileIO(IdType fileId)
 : GroupIO(0, fileId)
 {
-}
-
-FileIO::FileIO(FileIO&& rhs) noexcept
-: GroupIO()
-{
-  auto rhsId = rhs.getId();
-  setId(rhsId);
-  rhs.setId(-1);
 }
 
 FileIO::~FileIO() noexcept

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp
@@ -67,12 +67,15 @@ public:
    * @brief Move constructor.
    * @param rhs
    */
-  FileIO(FileIO&& rhs) noexcept;
+  FileIO(FileIO&& rhs) noexcept = default;
+
+  FileIO& operator=(const FileIO& rhs) = delete;
+  FileIO& operator=(FileIO&& rhs) noexcept = default;
 
   /**
    * @brief Releases the HDF5 file ID.
    */
-  virtual ~FileIO() noexcept;
+  ~FileIO() noexcept override;
 
   /**
    * @brief Returns the HDF5 file name. Returns an empty string if the file
@@ -80,9 +83,6 @@ public:
    * @return std::string
    */
   std::string getName() const override;
-
-  FileIO& operator=(const FileIO& rhs) = delete;
-  FileIO& operator=(FileIO&& rhs) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/GroupIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/GroupIO.hpp
@@ -24,10 +24,13 @@ public:
   GroupIO(const GroupIO& other) = delete;
   GroupIO(GroupIO&& other) noexcept = default;
 
+  GroupIO& operator=(const GroupIO& other) = delete;
+  GroupIO& operator=(GroupIO&& other) noexcept = default;
+
   /**
    * @brief Releases the wrapped HDF5 group.
    */
-  virtual ~GroupIO() noexcept;
+  ~GroupIO() noexcept override;
 
   /**
    * @brief Attempts to open a nested HDF5 group with the specified name.
@@ -137,9 +140,6 @@ public:
    * @return bool
    */
   bool isDataset(const std::string& childName) const;
-
-  GroupIO& operator=(const GroupIO& other) = delete;
-  GroupIO& operator=(GroupIO&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/ObjectIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/ObjectIO.cpp
@@ -26,6 +26,21 @@ ObjectIO::ObjectIO(IdType parentId, const std::string& targetName)
   m_Id = H5Oopen(parentId, targetName.c_str(), H5P_DEFAULT);
 }
 
+ObjectIO::ObjectIO(ObjectIO&& other) noexcept
+{
+  m_Id = std::exchange(other.m_Id, 0);
+  m_ParentId = std::exchange(other.m_ParentId, 0);
+  m_SharedParentPtr = std::move(other.m_SharedParentPtr);
+}
+
+ObjectIO& ObjectIO::operator=(ObjectIO&& other) noexcept
+{
+  m_Id = std::exchange(other.m_Id, 0);
+  m_ParentId = std::exchange(other.m_ParentId, 0);
+  m_SharedParentPtr = std::move(other.m_SharedParentPtr);
+  return *this;
+}
+
 ObjectIO::~ObjectIO() noexcept
 {
   closeHdf5();

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/ObjectIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/ObjectIO.hpp
@@ -27,7 +27,10 @@ public:
   ObjectIO(IdType parentId, const std::string& targetName);
 
   ObjectIO(const ObjectIO& other) = delete;
-  ObjectIO(ObjectIO&& other) noexcept = default;
+  ObjectIO(ObjectIO&& other) noexcept;
+
+  ObjectIO& operator=(const ObjectIO& other) = delete;
+  ObjectIO& operator=(ObjectIO&& other) noexcept;
 
   /**
    * @brief Releases the wrapped HDF5 object.
@@ -130,9 +133,6 @@ public:
    * @return AttributeIO
    */
   AttributeIO createAttribute(const std::string& name);
-
-  ObjectIO& operator=(const ObjectIO& other) = delete;
-  ObjectIO& operator=(ObjectIO&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Readers/AttributeReader.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Readers/AttributeReader.cpp
@@ -26,6 +26,19 @@ AttributeReader::AttributeReader(IdType objectId, const std::string& attrName)
   HDF_ERROR_HANDLER_ON
 }
 
+AttributeReader::AttributeReader(AttributeReader&& other) noexcept
+{
+  m_ObjectId = std::exchange(other.m_ObjectId, 0);
+  m_AttributeId = std::exchange(other.m_AttributeId, 0);
+}
+
+AttributeReader& AttributeReader::operator=(AttributeReader&& other) noexcept
+{
+  m_ObjectId = std::exchange(other.m_ObjectId, 0);
+  m_AttributeId = std::exchange(other.m_AttributeId, 0);
+  return *this;
+}
+
 AttributeReader::~AttributeReader() noexcept
 {
   closeHdf5();

--- a/src/simplnx/Utilities/Parsing/HDF5/Readers/AttributeReader.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Readers/AttributeReader.hpp
@@ -37,12 +37,15 @@ public:
   AttributeReader(IdType objectId, const std::string& attrName);
 
   AttributeReader(const AttributeReader& other) = delete;
-  AttributeReader(AttributeReader&& other) noexcept = default;
+  AttributeReader(AttributeReader&& other) noexcept;
+
+  AttributeReader& operator=(const AttributeReader& other) = delete;
+  AttributeReader& operator=(AttributeReader&& other) noexcept;
 
   /**
    * @brief Releases the wrapped HDF5 attribute.
    */
-  virtual ~AttributeReader() noexcept;
+  ~AttributeReader() noexcept;
 
   /**
    * @brief Returns true if the AttributeReader has a valid target.
@@ -148,9 +151,6 @@ public:
    * @return std::string
    */
   std::string readAsString() const;
-
-  AttributeReader& operator=(const AttributeReader& other) = delete;
-  AttributeReader& operator=(AttributeReader&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Readers/DatasetReader.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Readers/DatasetReader.cpp
@@ -10,16 +10,14 @@
 
 namespace nx::core::HDF5
 {
-DatasetReader::DatasetReader()
-{
-}
+DatasetReader::DatasetReader() = default;
 
 DatasetReader::DatasetReader(IdType parentId, const std::string& dataName)
 : ObjectReader(parentId, H5Dopen(parentId, dataName.c_str(), H5P_DEFAULT))
 {
 }
 
-DatasetReader::~DatasetReader()
+DatasetReader::~DatasetReader() noexcept
 {
   closeHdf5();
 }

--- a/src/simplnx/Utilities/Parsing/HDF5/Readers/DatasetReader.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Readers/DatasetReader.hpp
@@ -30,10 +30,13 @@ public:
   DatasetReader(const DatasetReader& other) = delete;
   DatasetReader(DatasetReader&& other) noexcept = default;
 
+  DatasetReader& operator=(const DatasetReader& other) = delete;
+  DatasetReader& operator=(DatasetReader&& other) noexcept = default;
+
   /**
    * @brief Releases the HDF5 dataset.
    */
-  virtual ~DatasetReader();
+  ~DatasetReader() noexcept override;
 
   /**
    * @brief Returns the dataspace's HDF5 ID. Returns 0 if the attribute is
@@ -124,9 +127,6 @@ public:
   std::vector<hsize_t> getDimensions() const;
 
   std::string getFilterName() const;
-
-  DatasetReader& operator=(const DatasetReader& other) = delete;
-  DatasetReader& operator=(DatasetReader&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Readers/FileReader.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Readers/FileReader.hpp
@@ -29,10 +29,13 @@ public:
   FileReader(const FileReader& other) = delete;
   FileReader(FileReader&& other) noexcept = default;
 
+  FileReader& operator=(const FileReader& other) = delete;
+  FileReader& operator=(FileReader&& other) noexcept = default;
+
   /**
    * @brief Releases the HDF5 file ID.
    */
-  virtual ~FileReader() noexcept;
+  ~FileReader() noexcept override;
 
   /**
    * @brief Returns the HDF5 file name. Returns an empty string if the file
@@ -40,9 +43,6 @@ public:
    * @return std::string
    */
   std::string getName() const override;
-
-  FileReader& operator=(const FileReader& other) = delete;
-  FileReader& operator=(FileReader&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Readers/GroupReader.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Readers/GroupReader.hpp
@@ -22,10 +22,13 @@ public:
   GroupReader(const GroupReader& other) = delete;
   GroupReader(GroupReader&& other) noexcept = default;
 
+  GroupReader& operator=(const GroupReader& other) = delete;
+  GroupReader& operator=(GroupReader&& other) noexcept = default;
+
   /**
    * @brief Releases the wrapped HDF5 group.
    */
-  virtual ~GroupReader() noexcept;
+  ~GroupReader() noexcept override;
 
   /**
    * @brief Attempts to open a nested HDF5 group with the specified name.
@@ -89,9 +92,6 @@ public:
    * @return bool
    */
   bool isDataset(const std::string& childName) const;
-
-  GroupReader& operator=(const GroupReader& other) = delete;
-  GroupReader& operator=(GroupReader&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Readers/ObjectReader.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Readers/ObjectReader.cpp
@@ -25,6 +25,19 @@ ObjectReader::ObjectReader(IdType parentId, const std::string& targetName)
   m_Id = H5Oopen(parentId, targetName.c_str(), H5P_DEFAULT);
 }
 
+ObjectReader::ObjectReader(ObjectReader&& other) noexcept
+{
+  m_Id = std::exchange(other.m_Id, 0);
+  m_ParentId = std::exchange(other.m_ParentId, 0);
+}
+
+ObjectReader& ObjectReader::operator=(ObjectReader&& other) noexcept
+{
+  m_Id = std::exchange(other.m_Id, 0);
+  m_ParentId = std::exchange(other.m_ParentId, 0);
+  return *this;
+}
+
 ObjectReader::~ObjectReader() noexcept
 {
   closeHdf5();

--- a/src/simplnx/Utilities/Parsing/HDF5/Readers/ObjectReader.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Readers/ObjectReader.hpp
@@ -25,7 +25,10 @@ public:
   ObjectReader(IdType parentId, const std::string& targetName);
 
   ObjectReader(const ObjectReader& other) = delete;
-  ObjectReader(ObjectReader&& other) noexcept = default;
+  ObjectReader(ObjectReader&& other) noexcept;
+
+  ObjectReader& operator=(const ObjectReader& other) = delete;
+  ObjectReader& operator=(ObjectReader&& other) noexcept;
 
   /**
    * @brief Releases the wrapped HDF5 object.
@@ -98,9 +101,6 @@ public:
    * @return AttributeReader
    */
   AttributeReader getAttributeByIdx(size_t idx) const;
-
-  ObjectReader& operator=(const ObjectReader& other) = delete;
-  ObjectReader& operator=(ObjectReader&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/AttributeWriter.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/AttributeWriter.cpp
@@ -11,9 +11,7 @@
 
 namespace nx::core::HDF5
 {
-AttributeWriter::AttributeWriter()
-{
-}
+AttributeWriter::AttributeWriter() = default;
 
 AttributeWriter::AttributeWriter(IdType objectId, const std::string& attributeName)
 : m_ObjectId(objectId)
@@ -21,7 +19,20 @@ AttributeWriter::AttributeWriter(IdType objectId, const std::string& attributeNa
 {
 }
 
-AttributeWriter::~AttributeWriter() = default;
+AttributeWriter::AttributeWriter(AttributeWriter&& other) noexcept
+{
+  m_ObjectId = std::exchange(other.m_ObjectId, 0);
+  m_AttributeName = std::move(other.m_AttributeName);
+}
+
+AttributeWriter& AttributeWriter::operator=(AttributeWriter&& other) noexcept
+{
+  m_ObjectId = std::exchange(other.m_ObjectId, 0);
+  m_AttributeName = std::move(other.m_AttributeName);
+  return *this;
+}
+
+AttributeWriter::~AttributeWriter() noexcept = default;
 
 nx::core::Result<> AttributeWriter::findAndDeleteAttribute()
 {

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/AttributeWriter.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/AttributeWriter.hpp
@@ -32,12 +32,15 @@ public:
   AttributeWriter(IdType objectId, const std::string& attributeName);
 
   AttributeWriter(const AttributeWriter& other) = delete;
-  AttributeWriter(AttributeWriter&& other) noexcept = default;
+  AttributeWriter(AttributeWriter&& other) noexcept;
+
+  AttributeWriter& operator=(const AttributeWriter& other) = delete;
+  AttributeWriter& operator=(AttributeWriter&& other) noexcept;
 
   /**
    * @brief Default destructor
    */
-  virtual ~AttributeWriter();
+  ~AttributeWriter() noexcept;
 
   /**
    * @brief Returns true if the AttributeReader has a valid target.
@@ -207,9 +210,6 @@ public:
     return returnError;
   }
 
-  AttributeWriter& operator=(const AttributeWriter& other) = delete;
-  AttributeWriter& operator=(AttributeWriter&& other) noexcept = delete;
-
 protected:
   /**
    * @brief Finds and deletes any existing attribute with the current name.
@@ -219,7 +219,7 @@ protected:
   Result<> findAndDeleteAttribute();
 
 private:
-  const IdType m_ObjectId = 0;
-  const std::string m_AttributeName;
+  IdType m_ObjectId = 0;
+  std::string m_AttributeName;
 };
 } // namespace nx::core::HDF5

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/DatasetWriter.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/DatasetWriter.cpp
@@ -10,10 +10,7 @@
 
 namespace nx::core::HDF5
 {
-DatasetWriter::DatasetWriter()
-: ObjectWriter()
-{
-}
+DatasetWriter::DatasetWriter() = default;
 
 DatasetWriter::DatasetWriter(IdType parentId, const std::string& datasetName)
 : ObjectWriter(parentId)
@@ -27,7 +24,25 @@ DatasetWriter::DatasetWriter(IdType parentId, const std::string& datasetName)
 #endif
 }
 
-DatasetWriter::~DatasetWriter()
+DatasetWriter::DatasetWriter(DatasetWriter&& other) noexcept
+: ObjectWriter(std::move(other))
+, m_DatasetName(std::move(other.m_DatasetName))
+{
+}
+
+DatasetWriter& DatasetWriter::operator=(DatasetWriter&& other) noexcept
+{
+  setParentId(other.getParentId());
+  setId(other.getId());
+  m_DatasetName = std::move(other.m_DatasetName);
+
+  other.setId(0);
+  other.setParentId(0);
+
+  return *this;
+}
+
+DatasetWriter::~DatasetWriter() noexcept
 {
   closeHdf5();
 }

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/DatasetWriter.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/DatasetWriter.hpp
@@ -29,12 +29,15 @@ public:
   DatasetWriter(IdType parentId, const std::string& datasetName);
 
   DatasetWriter(const DatasetWriter& other) = delete;
-  DatasetWriter(DatasetWriter&& other) noexcept = default;
+  DatasetWriter(DatasetWriter&& other) noexcept;
+
+  DatasetWriter& operator=(const DatasetWriter& other) = delete;
+  DatasetWriter& operator=(DatasetWriter&& other) noexcept;
 
   /**
    * @brief Default destructor
    */
-  virtual ~DatasetWriter();
+  ~DatasetWriter() noexcept override;
 
   /**
    * @brief Returns true if the DatasetWriter has a valid target. Otherwise,
@@ -206,9 +209,6 @@ public:
    */
   IdType getPListId() const;
 
-  DatasetWriter& operator=(const DatasetWriter& other) = delete;
-  DatasetWriter& operator=(DatasetWriter&& other) noexcept = delete;
-
 protected:
   /**
    * @brief Finds and deletes any existing attribute with the current name.
@@ -248,6 +248,6 @@ protected:
   void closeHdf5() override;
 
 private:
-  const std::string m_DatasetName;
+  std::string m_DatasetName;
 };
 } // namespace nx::core::HDF5

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/FileWriter.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/FileWriter.cpp
@@ -51,14 +51,6 @@ Result<FileWriter> FileWriter::WrapHdf5FileId(IdType fileId)
 
 FileWriter::FileWriter() = default;
 
-FileWriter::FileWriter(FileWriter&& rhs) noexcept
-: GroupWriter()
-{
-  auto rhsId = rhs.getId();
-  setId(rhsId);
-  rhs.setId(-1);
-}
-
 FileWriter::FileWriter(const std::filesystem::path& filepath)
 : GroupWriter(0, H5Fcreate(filepath.string().c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT))
 {
@@ -75,7 +67,7 @@ FileWriter::FileWriter(IdType fileId)
 {
 }
 
-FileWriter::~FileWriter()
+FileWriter::~FileWriter() noexcept
 {
   closeHdf5();
 }

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/FileWriter.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/FileWriter.hpp
@@ -46,12 +46,15 @@ public:
    * @brief Move constructor.
    * @param rhs
    */
-  FileWriter(FileWriter&& rhs) noexcept;
+  FileWriter(FileWriter&& rhs) noexcept = default;
+
+  FileWriter& operator=(const FileWriter& rhs) = delete;
+  FileWriter& operator=(FileWriter&& rhs) noexcept = default;
 
   /**
    * @brief Closes the HDF5 file.
    */
-  ~FileWriter() override;
+  ~FileWriter() noexcept override;
 
   /**
    * @brief Returns the HDF5 file name. Returns an empty string if the writer
@@ -59,9 +62,6 @@ public:
    * @return std::string
    */
   std::string getName() const override;
-
-  FileWriter& operator=(const FileWriter& rhs) = delete;
-  FileWriter& operator=(FileWriter&& rhs) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/GroupWriter.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/GroupWriter.cpp
@@ -8,10 +8,7 @@
 
 namespace nx::core::HDF5
 {
-GroupWriter::GroupWriter()
-: ObjectWriter()
-{
-}
+GroupWriter::GroupWriter() = default;
 
 GroupWriter::GroupWriter(IdType parentId, IdType objectId)
 : ObjectWriter(parentId, objectId)
@@ -36,7 +33,7 @@ GroupWriter::GroupWriter(IdType parentId, const std::string& groupName)
   }
 }
 
-GroupWriter::~GroupWriter()
+GroupWriter::~GroupWriter() noexcept
 {
   closeHdf5();
 }

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/GroupWriter.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/GroupWriter.hpp
@@ -27,10 +27,13 @@ public:
   GroupWriter(const GroupWriter& other) = delete;
   GroupWriter(GroupWriter&& other) noexcept = default;
 
+  GroupWriter& operator=(const GroupWriter& other) = delete;
+  GroupWriter& operator=(GroupWriter&& other) noexcept = default;
+
   /**
    * @brief Closes the HDF5 group.
    */
-  virtual ~GroupWriter();
+  ~GroupWriter() noexcept override;
 
   /**
    * @brief Returns true if the GroupWriter is valid. Returns false otherwise.
@@ -64,9 +67,6 @@ public:
    * @return Result<>
    */
   Result<> createLink(const std::string& objectPath);
-
-  GroupWriter& operator=(const GroupWriter& other) = delete;
-  GroupWriter& operator=(GroupWriter&& other) noexcept = default;
 
 protected:
   /**

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/ObjectWriter.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/ObjectWriter.cpp
@@ -7,9 +7,7 @@
 namespace nx::core::HDF5
 {
 
-ObjectWriter::ObjectWriter()
-{
-}
+ObjectWriter::ObjectWriter() = default;
 
 ObjectWriter::ObjectWriter(IdType parentId, IdType objectId)
 : m_ParentId(parentId)
@@ -17,7 +15,20 @@ ObjectWriter::ObjectWriter(IdType parentId, IdType objectId)
 {
 }
 
-ObjectWriter::~ObjectWriter() = default;
+ObjectWriter::ObjectWriter(ObjectWriter&& other) noexcept
+{
+  m_Id = std::exchange(other.m_Id, 0);
+  m_ParentId = std::exchange(other.m_ParentId, 0);
+}
+
+ObjectWriter& ObjectWriter::operator=(ObjectWriter&& other) noexcept
+{
+  m_Id = std::exchange(other.m_Id, 0);
+  m_ParentId = std::exchange(other.m_ParentId, 0);
+  return *this;
+}
+
+ObjectWriter::~ObjectWriter() noexcept = default;
 
 IdType ObjectWriter::getFileId() const
 {
@@ -27,6 +38,11 @@ IdType ObjectWriter::getFileId() const
   }
 
   return H5Iget_file_id(getParentId());
+}
+
+void ObjectWriter::setParentId(IdType parentId)
+{
+  m_ParentId = parentId;
 }
 
 IdType ObjectWriter::getParentId() const

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/ObjectWriter.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/ObjectWriter.hpp
@@ -26,12 +26,15 @@ public:
   ObjectWriter(IdType parentId, IdType objectId = 0);
 
   ObjectWriter(const ObjectWriter& other) = delete;
-  ObjectWriter(ObjectWriter&& other) noexcept = default;
+  ObjectWriter(ObjectWriter&& other) noexcept;
+
+  ObjectWriter& operator=(const ObjectWriter& other) = delete;
+  ObjectWriter& operator=(ObjectWriter&& other) noexcept;
 
   /**
    * @brief Releases the wrapped HDF5 object.
    */
-  virtual ~ObjectWriter();
+  virtual ~ObjectWriter() noexcept;
 
   /**
    * @brief Returns true if the ObjectWriter has a valid target. Otherwise,
@@ -93,14 +96,18 @@ public:
    */
   AttributeWriter createAttribute(const std::string& name);
 
-  ObjectWriter& operator=(const ObjectWriter& other) = delete;
-  ObjectWriter& operator=(ObjectWriter&& other) noexcept = default;
-
 protected:
   /**
    * @brief Closes the HDF5 ID and resets it to 0.
    */
   virtual void closeHdf5() = 0;
+
+  /**
+   * @brief Sets a new parent ID.
+   * This method should only be used in the move operations of derived classes.
+   * @param parentId
+   */
+  void setParentId(IdType parentId);
 
 private:
   IdType m_ParentId = 0;


### PR DESCRIPTION
Some HDF5 classes didn't get the changes meant to fix #916. This PR fixes those ones and adds a unit test.