### PR TITLE
Moved Result handling outside of AtomicFile

### DIFF
--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EbsdToH5Ebsd.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EbsdToH5Ebsd.cpp
@@ -51,12 +51,12 @@ Result<> EbsdToH5Ebsd::operator()()
     }
   }
 
-  AtomicFile atomicFile(absPath.string());
-  auto creationResult = atomicFile.getResult();
-  if(creationResult.invalid())
+  auto atomicFileResult = AtomicFile::Create(absPath);
+  if(atomicFileResult.invalid())
   {
-    return creationResult;
+    return ConvertResult(std::move(atomicFileResult));
   }
+  AtomicFile atomicFile = std::move(atomicFileResult.value());
 
   // Scope file writer in code block to get around file lock on windows (enforce destructor order)
   {
@@ -322,9 +322,10 @@ Result<> EbsdToH5Ebsd::operator()()
     }
   }
 
-  if(!atomicFile.commit())
+  Result<> commitResult = atomicFile.commit();
+  if(commitResult.invalid())
   {
-    return atomicFile.getResult();
+    return commitResult;
   }
   return {};
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDGMTFileFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDGMTFileFilter.cpp
@@ -124,12 +124,12 @@ IFilter::PreflightResult WriteGBCDGMTFileFilter::preflightImpl(const DataStructu
 Result<> WriteGBCDGMTFileFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                              const std::atomic_bool& shouldCancel) const
 {
-  AtomicFile atomicFile(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
-  auto creationResult = atomicFile.getResult();
-  if(creationResult.invalid())
+  auto atomicFileResult = AtomicFile::Create(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
+  if(atomicFileResult.invalid())
   {
-    return creationResult;
+    return ConvertResult(std::move(atomicFileResult));
   }
+  AtomicFile atomicFile = std::move(atomicFileResult.value());
 
   WriteGBCDGMTFileInputValues inputValues;
 
@@ -142,9 +142,10 @@ Result<> WriteGBCDGMTFileFilter::executeImpl(DataStructure& dataStructure, const
   auto result = WriteGBCDGMTFile(dataStructure, messageHandler, shouldCancel, &inputValues)();
   if(result.valid())
   {
-    if(!atomicFile.commit())
+    Result<> commitResult = atomicFile.commit();
+    if(commitResult.invalid())
     {
-      return atomicFile.getResult();
+      return commitResult;
     }
   }
   return result;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteAbaqusHexahedron.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteAbaqusHexahedron.cpp
@@ -96,7 +96,8 @@ int32 writeNodes(WriteAbaqusHexahedron* filter, const std::string& fileName, usi
           int64 milliDiff = std::chrono::duration_cast<std::chrono::milliseconds>(now - initialTime).count();
           if(milliDiff > 1000)
           {
-            std::string percentage = "Writing Nodes (File 1/5) " + StringUtilities::number(static_cast<int32>((float32)(nodeIndex) / (float32)(totalPoints) * 100)) + "% Completed ";
+            std::string percentage =
+                "Writing Nodes (File 1/5) " + StringUtilities::number(static_cast<int32>(static_cast<float32>(nodeIndex) / static_cast<float32>(totalPoints) * 100.0f)) + "% Completed ";
             float32 timeDiff = ((float32)nodeIndex / (float32)(milliDiff));
             int64 estimatedTime = (float32)(totalPoints - nodeIndex) / timeDiff;
             std::string timeRemaining = " || Est. Time Remain: " + format_duration(std::chrono::milliseconds(estimatedTime));
@@ -160,7 +161,8 @@ int32 writeElems(WriteAbaqusHexahedron* filter, const std::string& fileName, con
           int64 milliDiff = std::chrono::duration_cast<std::chrono::milliseconds>(now - initialTime).count();
           if(milliDiff > 1000)
           {
-            std::string percentage = "Writing Elements (File 2/5) " + StringUtilities::number(static_cast<int32>((float32)(index) / (float32)(totalPoints) * 100)) + "% Completed ";
+            std::string percentage =
+                "Writing Elements (File 2/5) " + StringUtilities::number(static_cast<int32>(static_cast<float32>(index) / static_cast<float32>(totalPoints) * 100.0f)) + "% Completed ";
             float32 timeDiff = ((float32)index / (float32)(milliDiff));
             int64 estimatedTime = (float32)(totalPoints - index) / timeDiff;
             std::string timeRemaining = " || Est. Time Remain: " + format_duration(std::chrono::milliseconds(estimatedTime));
@@ -240,7 +242,8 @@ int32 writeElset(WriteAbaqusHexahedron* filter, const std::string& fileName, siz
       int64 milliDiff = std::chrono::duration_cast<std::chrono::milliseconds>(now - initialTime).count();
       if(milliDiff > 1000)
       {
-        std::string percentage = "Writing Element Sets (File 4/5) " + StringUtilities::number(static_cast<int>((float32)(voxelId) / (float32)(maxGrainId) * 100)) + "% Completed ";
+        std::string percentage =
+            "Writing Element Sets (File 4/5) " + StringUtilities::number(static_cast<int32>(static_cast<float32>(voxelId) / static_cast<float32>(maxGrainId) * 100.0f)) + "% Completed ";
         float32 timeDiff = ((float32)voxelId / (float32)(milliDiff));
         auto estimatedTime = static_cast<int64>((float32)(maxGrainId - voxelId) / timeDiff);
         std::string timeRemaining = " || Est. Time Remain: " + format_duration(std::chrono::milliseconds(estimatedTime));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoRectilinearCoordinateFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoRectilinearCoordinateFilter.cpp
@@ -97,12 +97,12 @@ Result<> WriteAvizoRectilinearCoordinateFilter::executeImpl(DataStructure& dataS
 {
   AvizoWriterInputValues inputValues;
 
-  AtomicFile atomicFile(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
-  auto creationResult = atomicFile.getResult();
-  if(creationResult.invalid())
+  auto atomicFileResult = AtomicFile::Create(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
+  if(atomicFileResult.invalid())
   {
-    return creationResult;
+    return ConvertResult(std::move(atomicFileResult));
   }
+  AtomicFile atomicFile = std::move(atomicFileResult.value());
 
   inputValues.OutputFile = atomicFile.tempFilePath();
   inputValues.WriteBinaryFile = filterArgs.value<bool>(k_WriteBinaryFile_Key);
@@ -113,9 +113,10 @@ Result<> WriteAvizoRectilinearCoordinateFilter::executeImpl(DataStructure& dataS
   auto result = WriteAvizoRectilinearCoordinate(dataStructure, messageHandler, shouldCancel, &inputValues)();
   if(result.valid())
   {
-    if(!atomicFile.commit())
+    Result<> commitResult = atomicFile.commit();
+    if(commitResult.invalid())
     {
-      return atomicFile.getResult();
+      return commitResult;
     }
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteLosAlamosFFTFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteLosAlamosFFTFilter.cpp
@@ -108,12 +108,12 @@ IFilter::PreflightResult WriteLosAlamosFFTFilter::preflightImpl(const DataStruct
 Result<> WriteLosAlamosFFTFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                               const std::atomic_bool& shouldCancel) const
 {
-  AtomicFile atomicFile(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
-  auto creationResult = atomicFile.getResult();
-  if(creationResult.invalid())
+  auto atomicFileResult = AtomicFile::Create(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
+  if(atomicFileResult.invalid())
   {
-    return creationResult;
+    return ConvertResult(std::move(atomicFileResult));
   }
+  AtomicFile atomicFile = std::move(atomicFileResult.value());
 
   WriteLosAlamosFFTInputValues inputValues;
 
@@ -126,9 +126,10 @@ Result<> WriteLosAlamosFFTFilter::executeImpl(DataStructure& dataStructure, cons
   auto result = WriteLosAlamosFFT(dataStructure, messageHandler, shouldCancel, &inputValues)();
   if(result.valid())
   {
-    if(!atomicFile.commit())
+    Result<> commitResult = atomicFile.commit();
+    if(commitResult.invalid())
     {
-      return atomicFile.getResult();
+      return commitResult;
     }
   }
   return result;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteVtkStructuredPointsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteVtkStructuredPointsFilter.cpp
@@ -113,12 +113,12 @@ IFilter::PreflightResult WriteVtkStructuredPointsFilter::preflightImpl(const Dat
 Result<> WriteVtkStructuredPointsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                                      const std::atomic_bool& shouldCancel) const
 {
-  AtomicFile atomicFile(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
-  auto creationResult = atomicFile.getResult();
-  if(creationResult.invalid())
+  auto atomicFileResult = AtomicFile::Create(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
+  if(atomicFileResult.invalid())
   {
-    return creationResult;
+    return ConvertResult(std::move(atomicFileResult));
   }
+  AtomicFile atomicFile = std::move(atomicFileResult.value());
 
   WriteVtkStructuredPointsInputValues inputValues;
 
@@ -130,9 +130,10 @@ Result<> WriteVtkStructuredPointsFilter::executeImpl(DataStructure& dataStructur
   auto result = WriteVtkStructuredPoints(dataStructure, messageHandler, shouldCancel, &inputValues)();
   if(result.valid())
   {
-    if(!atomicFile.commit())
+    Result<> commitResult = atomicFile.commit();
+    if(commitResult.invalid())
     {
-      return atomicFile.getResult();
+      return commitResult;
     }
   }
   return result;

--- a/src/simplnx/Common/AtomicFile.cpp
+++ b/src/simplnx/Common/AtomicFile.cpp
@@ -9,40 +9,77 @@
 
 using namespace nx::core;
 
+namespace fs = std::filesystem;
+
 namespace
 {
-constexpr std::array<char, 62> chars = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U',
-                                        'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
-std::string randomDirName()
+constexpr std::array<char, 62> k_Chars = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U',
+                                          'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
+std::string CreateRandomDirName()
 {
   std::mt19937_64 gen(static_cast<std::mt19937_64::result_type>(std::chrono::steady_clock::now().time_since_epoch().count()));
-  std::uniform_int_distribution<uint32> dist(0, chars.size() - 1);
+  std::uniform_int_distribution<uint32> dist(0, k_Chars.size() - 1);
 
-  std::string randomDir = "";
+  std::string randomDir;
   for(uint32 i = 0; i < 24; i++)
   {
-    randomDir += chars[dist(gen)];
+    randomDir += k_Chars[dist(gen)];
   }
   return randomDir;
 }
 } // namespace
 
-AtomicFile::AtomicFile(const std::string& filename)
-: m_FilePath(fs::path(filename))
-, m_Result({})
+Result<AtomicFile> AtomicFile::Create(fs::path filename)
 {
-  initialize();
+  AtomicFile atomicFile(std::move(filename));
+
+  // If the path is relative, then make it absolute
+  if(!atomicFile.m_FilePath.is_absolute())
+  {
+    try
+    {
+      atomicFile.m_FilePath = fs::absolute(atomicFile.m_FilePath);
+    } catch(const std::filesystem::filesystem_error& error)
+    {
+      return MakeErrorResult<AtomicFile>(-15780, fmt::format("When attempting to create an absolute path, AtomicFile encountered the following error: '{}'", error.what()));
+    }
+  }
+
+  // Validate write permissions
+  { // Scope to avoid accessing result after it's no longer guaranteed by the move
+    auto result = FileUtilities::ValidateDirectoryWritePermission(atomicFile.m_FilePath, true);
+    if(result.invalid())
+    {
+      return ConvertInvalidResult<AtomicFile>(std::move(result));
+    }
+  }
+
+  atomicFile.m_TempFilePath = fs::path(fmt::format("{}/{}/{}", atomicFile.m_FilePath.parent_path().string(), ::CreateRandomDirName(), atomicFile.m_FilePath.filename().string()));
+  { // Scope to avoid accessing result after it's no longer guaranteed by the move
+    // Make sure any directory path is also available as the user may have just typed
+    // in a path without actually creating the full path
+    auto result = CreateOutputDirectories(atomicFile.m_TempFilePath.parent_path());
+    if(result.invalid())
+    {
+      return ConvertInvalidResult<AtomicFile>(std::move(result));
+    }
+  }
+
+  return {std::move(atomicFile)};
 }
 
-AtomicFile::AtomicFile(fs::path&& filepath)
+AtomicFile::AtomicFile(fs::path filepath)
 : m_FilePath(std::move(filepath))
-, m_Result({})
 {
-  initialize();
 }
 
-AtomicFile::~AtomicFile()
+AtomicFile::~AtomicFile() noexcept
 {
+  if(m_TempFilePath.empty())
+  {
+    return;
+  }
+
   if(fs::exists(m_TempFilePath) || fs::exists(m_TempFilePath.parent_path()))
   {
     removeTempFile();
@@ -54,12 +91,11 @@ fs::path AtomicFile::tempFilePath() const
   return m_TempFilePath;
 }
 
-bool AtomicFile::commit()
+Result<> AtomicFile::commit()
 {
   if(!fs::exists(m_TempFilePath))
   {
-    updateResult(MakeErrorResult(-15780, m_TempFilePath.string() + " does not exist"));
-    return false;
+    return MakeErrorResult(-15780, m_TempFilePath.string() + " does not exist");
   }
 
   try
@@ -67,69 +103,13 @@ bool AtomicFile::commit()
     fs::rename(m_TempFilePath, m_FilePath);
   } catch(const std::filesystem::filesystem_error& error)
   {
-    updateResult(MakeErrorResult(-15780, fmt::format("When attempting to move the temp file to the end absolute path, AtomicFile encountered the following error on rename(): '{}'", error.what())));
-    return false;
+    return MakeErrorResult(-15780, fmt::format("When attempting to move the temp file to the end absolute path, AtomicFile encountered the following error on rename(): '{}'", error.what()));
   }
 
-  return true;
+  return {};
 }
 
 void AtomicFile::removeTempFile() const
 {
   fs::remove_all(m_TempFilePath.parent_path());
-}
-
-Result<> AtomicFile::getResult() const
-{
-  return m_Result;
-}
-
-Result<> AtomicFile::createOutputDirectories()
-{
-  // Make sure any directory path is also available as the user may have just typed
-  // in a path without actually creating the full path
-  return CreateOutputDirectories(m_TempFilePath.parent_path());
-}
-
-void AtomicFile::clearResult()
-{
-  m_Result = {};
-}
-
-void AtomicFile::updateResult(Result<>&& result)
-{
-  m_Result = MergeResults(m_Result, result);
-}
-
-void AtomicFile::initialize()
-{
-  // If the path is relative, then make it absolute
-  if(!m_FilePath.is_absolute())
-  {
-    try
-    {
-      m_FilePath = fs::absolute(m_FilePath);
-    } catch(const std::filesystem::filesystem_error& error)
-    {
-      updateResult(MakeErrorResult(-15780, fmt::format("When attempting to create an absolute path, AtomicFile encountered the following error: '{}'", error.what())));
-    }
-  }
-
-  // Validate write permissions
-  { // Scope to avoid accessing result after it's no longer guaranteed by the move
-    auto result = FileUtilities::ValidateDirectoryWritePermission(m_FilePath, true);
-    if(result.invalid())
-    {
-      updateResult(std::move(result));
-    }
-  }
-
-  m_TempFilePath = fs::path(fmt::format("{}/{}/{}", m_FilePath.parent_path().string(), ::randomDirName(), m_FilePath.filename().string()));
-  { // Scope to avoid accessing result after it's no longer guaranteed by the move
-    auto result = createOutputDirectories();
-    if(result.invalid())
-    {
-      updateResult(std::move(result));
-    }
-  }
 }

--- a/src/simplnx/Common/AtomicFile.hpp
+++ b/src/simplnx/Common/AtomicFile.hpp
@@ -9,8 +9,6 @@
 
 namespace nx::core
 {
-namespace fs = std::filesystem;
-
 /**
  * @class AtomicFile
  * @brief The AtomicFile class accepts a filepath which it stores and
@@ -22,52 +20,40 @@ namespace fs = std::filesystem;
 class SIMPLNX_EXPORT AtomicFile
 {
 public:
-  /**
-   * @brief Constructs the object and stores errors !!!CHECK getResult()!!!
-   */
-  explicit AtomicFile(const std::string& filename);
-  /**
-   * @brief Constructs the object and stores errors !!!CHECK getResult()!!!
-   */
-  explicit AtomicFile(fs::path&& filename);
+  ~AtomicFile() noexcept;
 
-  ~AtomicFile();
+  AtomicFile(const AtomicFile&) = delete;
+  AtomicFile(AtomicFile&&) noexcept = default;
+
+  AtomicFile& operator=(const AtomicFile&) = delete;
+  AtomicFile& operator=(AtomicFile&&) noexcept = default;
+
+  static Result<AtomicFile> Create(std::filesystem::path filename);
 
   /**
    * @brief Fetches the file path object to work from
    * @return fs::path the working file path modifications should be made to
    */
-  [[nodiscard]] fs::path tempFilePath() const;
+  [[nodiscard]] std::filesystem::path tempFilePath() const;
 
   /**
-   * @brief Attempts to move the temp file to its final path !!!CHECK getResult() IF FALSE!!!
-   * @return bool - if false you MUST call getResult() to error codes
+   * @brief Attempts to move the temp file to its final path
+   * @return Result<>
    */
-  [[nodiscard]] bool commit();
+  [[nodiscard]] Result<> commit();
 
   /**
    * @brief Purges the temporary file
    */
   void removeTempFile() const;
 
-  /**
-   * @brief Fetch for amalgamated error codes !!!call clearResult() To Reset Errors/Warnings!!!
-   * @return Result<> The result object containing all collected errors
-   */
-  [[nodiscard]] Result<> getResult() const;
-
-  /**
-   * @brief Empties the result container
-   */
-  void clearResult();
-
 private:
-  void updateResult(Result<>&& result);
-  void initialize();
-  fs::path m_FilePath;
-  fs::path m_TempFilePath;
-  Result<> m_Result;
+  /**
+   * @brief Constructs the object.
+   */
+  explicit AtomicFile(std::filesystem::path filename);
 
-  Result<> createOutputDirectories();
+  std::filesystem::path m_FilePath;
+  std::filesystem::path m_TempFilePath;
 };
 } // namespace nx::core

--- a/src/simplnx/Common/Result.hpp
+++ b/src/simplnx/Common/Result.hpp
@@ -175,8 +175,7 @@ Result<T> ConvertResultTo(Result<>&& fromResult, T&& value)
 template <class ToT, class FromT>
 Result<ToT> ConvertInvalidResult(Result<FromT>&& result)
 {
-  Result<ToT> convertedResult;
-  convertedResult.m_Expected = nonstd::make_unexpected(std::move(result.errors()));
+  Result<ToT> convertedResult{std::move(nonstd::make_unexpected(std::move(result.errors())))};
   convertedResult.warnings() = std::move(result.warnings());
 
   return convertedResult;


### PR DESCRIPTION
- `AtomicFile` now has a `Create` method which returns `Result<AtomicFile>` instead of a public constructor
  - This result should be checked before using the `AtomicFile` which is in place of the stored `Result` variable
- `AtomicFile::commit()` nows also returns a `Result<>` instead a bool
- Fixed issue with `ConvertInvalidResult` regarding non default constructible types
- `AtomicFile` is now move only