### PR TITLE
ENH: CLI Reader Bounding Box

### DIFF
--- a/wrapping/python/plugins/DataAnalysisToolkit/CliReaderFilter.py
+++ b/wrapping/python/plugins/DataAnalysisToolkit/CliReaderFilter.py
@@ -127,9 +127,12 @@ class CliReaderFilter:
       bounding_box_coords = min_max_x_coords+min_max_y_coords+min_max_z_coords
 
     try:
-      layer_features, layer_heights, hatch_labels = parse_file(Path(cli_file_path), bounding_box=bounding_box_coords)
+      result = parse_file(Path(cli_file_path), bounding_box=bounding_box_coords)
+      if result.invalid():
+        return nx.Result(errors=result.errors)
+      layer_features, layer_heights, hatch_labels = result.value
     except Exception as e:
-      return nx.Result([nx.Error(-1000, f"An error occurred while parsing the CLI file '{cli_file_path}': {e}")])
+      return nx.Result([nx.Error(-2010, f"An error occurred while parsing the CLI file '{cli_file_path}': {e}")])
 
     start_vertices = []
     end_vertices = []

--- a/wrapping/python/plugins/DataAnalysisToolkit/CliReaderFilter.py
+++ b/wrapping/python/plugins/DataAnalysisToolkit/CliReaderFilter.py
@@ -2,13 +2,16 @@
 
 import simplnx as nx
 import numpy as np
+import sys
 from typing import List, Dict
 from pathlib import Path
 from DataAnalysisToolkit.utilities.cli_tools import parse_file, parse_geometry_array_names
 
 class CliReaderFilter:
   CLI_FILE_PATH = 'cli_file_path'
-  USE_BOUNDING_BOX_MASK = 'use_bounding_box_mask'
+  MASK_X_DIMENSION = 'mask_x_dimension'
+  MASK_Y_DIMENSION = 'mask_y_dimension'
+  MASK_Z_DIMENSION = 'mask_z_dimension'
   MIN_MAX_X_COORDS = 'min_max_x_coords'
   MIN_MAX_Y_COORDS = 'min_max_y_coords'
   MIN_MAX_Z_COORDS = 'min_max_z_coords'
@@ -44,10 +47,12 @@ class CliReaderFilter:
 
     params.insert(nx.Parameters.Separator("Parameters"))
     params.insert(nx.FileSystemPathParameter(CliReaderFilter.CLI_FILE_PATH, 'Input CLI File', 'The path to the input CLI file that will be read.', '', {'.cli'}, nx.FileSystemPathParameter.PathType.InputFile))
-    params.insert_linkable_parameter(nx.BoolParameter(CliReaderFilter.USE_BOUNDING_BOX_MASK, 'Use Bounding Box Mask', 'Determines whether or not to use a bounding box to mask out any part of the dataset that is outside the bounding box.', False))
-    params.insert(nx.VectorFloat64Parameter(CliReaderFilter.MIN_MAX_X_COORDS, 'X Min/Max', 'The minimum and maximum X coordinate for the bounding box mask.', [0.0, 100.0], ['X Min', 'X Max']))
-    params.insert(nx.VectorFloat64Parameter(CliReaderFilter.MIN_MAX_Y_COORDS, 'Y Min/Max', 'The minimum and maximum Y coordinate for the bounding box mask.', [0.0, 100.0], ['Y Min', 'Y Max']))
-    params.insert(nx.VectorFloat64Parameter(CliReaderFilter.MIN_MAX_Z_COORDS, 'Z Min/Max', 'The minimum and maximum Z coordinate for the bounding box mask.', [0.0, 100.0], ['Z Min', 'Z Max']))
+    params.insert_linkable_parameter(nx.BoolParameter(CliReaderFilter.MASK_X_DIMENSION, 'Mask X Dimension', 'Determines whether or not to use X bounds to mask out any part of the dataset that is outside the bounds in the X dimension.', False))
+    params.insert(nx.VectorFloat64Parameter(CliReaderFilter.MIN_MAX_X_COORDS, 'X Min/Max', 'The minimum and maximum X coordinate for the X bounds.', [0.0, 100.0], ['X Min', 'X Max']))
+    params.insert_linkable_parameter(nx.BoolParameter(CliReaderFilter.MASK_Y_DIMENSION, 'Mask Y Dimension', 'Determines whether or not to use Y bounds to mask out any part of the dataset that is outside the bounds in the Y dimension.', False))
+    params.insert(nx.VectorFloat64Parameter(CliReaderFilter.MIN_MAX_Y_COORDS, 'Y Min/Max', 'The minimum and maximum Y coordinate for the Y bounds.', [0.0, 100.0], ['Y Min', 'Y Max']))
+    params.insert_linkable_parameter(nx.BoolParameter(CliReaderFilter.MASK_Z_DIMENSION, 'Mask Z Dimension', 'Determines whether or not to use Z bounds to mask out any part of the dataset that is outside the bounds in the Z dimension.', False))
+    params.insert(nx.VectorFloat64Parameter(CliReaderFilter.MIN_MAX_Z_COORDS, 'Z Min/Max', 'The minimum and maximum Z coordinate for the Z bounds.', [0.0, 100.0], ['Z Min', 'Z Max']))
     params.insert(nx.Parameters.Separator("Created Data Objects"))
     params.insert(nx.DataGroupCreationParameter(CliReaderFilter.OUTPUT_EDGE_GEOM_PATH, 'Output Edge Geometry', 'The path to the newly created edge geometry.', nx.DataPath("[Edge Geometry]")))
     params.insert(nx.DataObjectNameParameter(CliReaderFilter.OUTPUT_VERTEX_ATTRMAT_NAME, 'Output Vertex Attribute Matrix Name', 'The name of the newly created vertex attribute matrix.', 'Vertex Data'))
@@ -56,9 +61,9 @@ class CliReaderFilter:
     params.insert(nx.DataObjectNameParameter(CliReaderFilter.SHARED_VERTICES_ARRAY_NAME, 'Shared Vertices Array Name', 'The name of the newly created shared vertices array.', 'Shared Vertices'))
     params.insert(nx.DataObjectNameParameter(CliReaderFilter.SHARED_EDGES_ARRAY_NAME, 'Shared Edges Array Name', 'The name of the newly created shared edges array.', 'Shared Edges'))
 
-    params.link_parameters(CliReaderFilter.USE_BOUNDING_BOX_MASK, CliReaderFilter.MIN_MAX_X_COORDS, True)
-    params.link_parameters(CliReaderFilter.USE_BOUNDING_BOX_MASK, CliReaderFilter.MIN_MAX_Y_COORDS, True)
-    params.link_parameters(CliReaderFilter.USE_BOUNDING_BOX_MASK, CliReaderFilter.MIN_MAX_Z_COORDS, True)
+    params.link_parameters(CliReaderFilter.MASK_X_DIMENSION, CliReaderFilter.MIN_MAX_X_COORDS, True)
+    params.link_parameters(CliReaderFilter.MASK_Y_DIMENSION, CliReaderFilter.MIN_MAX_Y_COORDS, True)
+    params.link_parameters(CliReaderFilter.MASK_Z_DIMENSION, CliReaderFilter.MIN_MAX_Z_COORDS, True)
 
     return params
 
@@ -70,17 +75,18 @@ class CliReaderFilter:
     output_feature_attrmat_name: str = args[CliReaderFilter.OUTPUT_FEATURE_ATTRMAT_NAME]
     shared_vertices_array_name: str = args[CliReaderFilter.SHARED_VERTICES_ARRAY_NAME]
     shared_edges_array_name: str = args[CliReaderFilter.SHARED_EDGES_ARRAY_NAME]
-    use_bounding_box_mask: bool = args[CliReaderFilter.USE_BOUNDING_BOX_MASK]
+    mask_x_dimension: bool = args[CliReaderFilter.MASK_X_DIMENSION]
+    mask_y_dimension: bool = args[CliReaderFilter.MASK_Y_DIMENSION]
+    mask_z_dimension: bool = args[CliReaderFilter.MASK_Z_DIMENSION]
     min_max_x_coords: list = args[CliReaderFilter.MIN_MAX_X_COORDS]
     min_max_y_coords: list = args[CliReaderFilter.MIN_MAX_Y_COORDS]
     min_max_z_coords: list = args[CliReaderFilter.MIN_MAX_Z_COORDS]
     
-    if use_bounding_box_mask:
-      if min_max_x_coords[0] > min_max_x_coords[1]:
-        return nx.IFilter.PreflightResult(nx.OutputActions(), [nx.Error(-9100, f"Invalid Bounding Box Mask: The minimum X coordinate ({min_max_x_coords[0]}) is larger than the maximum X coordinate ({min_max_x_coords[1]}).")])
-      if min_max_y_coords[0] > min_max_y_coords[1]:
+    if mask_x_dimension and min_max_x_coords[0] > min_max_x_coords[1]:
+      return nx.IFilter.PreflightResult(nx.OutputActions(), [nx.Error(-9100, f"Invalid Bounding Box Mask: The minimum X coordinate ({min_max_x_coords[0]}) is larger than the maximum X coordinate ({min_max_x_coords[1]}).")])
+    if mask_y_dimension and min_max_y_coords[0] > min_max_y_coords[1]:
         return nx.IFilter.PreflightResult(nx.OutputActions(), [nx.Error(-9101, f"Invalid Bounding Box Mask: The minimum Y coordinate ({min_max_y_coords[0]}) is larger than the maximum Y coordinate ({min_max_y_coords[1]}).")])
-      if min_max_z_coords[0] > min_max_z_coords[1]:
+    if mask_z_dimension and min_max_z_coords[0] > min_max_z_coords[1]:
         return nx.IFilter.PreflightResult(nx.OutputActions(), [nx.Error(-9102, f"Invalid Bounding Box Mask: The minimum Z coordinate ({min_max_z_coords[0]}) is larger than the maximum Z coordinate ({min_max_z_coords[1]}).")])
 
     # Here we create the Edge Geometry (and the 2 internal Attribute Matrix to hold vertex and edge data arrays.)
@@ -117,14 +123,20 @@ class CliReaderFilter:
     output_edge_geom_path: nx.DataPath = args[CliReaderFilter.OUTPUT_EDGE_GEOM_PATH]
     output_edge_attrmat_name: str = args[CliReaderFilter.OUTPUT_EDGE_ATTRMAT_NAME]
     output_feature_attrmat_name: str = args[CliReaderFilter.OUTPUT_FEATURE_ATTRMAT_NAME]
-    use_bounding_box_mask: bool = args[CliReaderFilter.USE_BOUNDING_BOX_MASK]
+    mask_x_dimension: bool = args[CliReaderFilter.MASK_X_DIMENSION]
+    mask_y_dimension: bool = args[CliReaderFilter.MASK_Y_DIMENSION]
+    mask_z_dimension: bool = args[CliReaderFilter.MASK_Z_DIMENSION]
     min_max_x_coords: list = args[CliReaderFilter.MIN_MAX_X_COORDS]
     min_max_y_coords: list = args[CliReaderFilter.MIN_MAX_Y_COORDS]
     min_max_z_coords: list = args[CliReaderFilter.MIN_MAX_Z_COORDS]
 
-    bounding_box_coords = None
-    if use_bounding_box_mask:
-      bounding_box_coords = min_max_x_coords+min_max_y_coords+min_max_z_coords
+    bounding_box_coords = [-sys.float_info.max, sys.float_info.max] * 3
+    if mask_x_dimension:
+      bounding_box_coords[0:2] = min_max_x_coords
+    if mask_y_dimension:
+      bounding_box_coords[2:4] = min_max_y_coords
+    if mask_z_dimension:
+      bounding_box_coords[4:6] = min_max_z_coords
 
     try:
       result = parse_file(Path(cli_file_path), bounding_box=bounding_box_coords)

--- a/wrapping/python/plugins/DataAnalysisToolkit/common/Result.py
+++ b/wrapping/python/plugins/DataAnalysisToolkit/common/Result.py
@@ -1,0 +1,59 @@
+from typing import Generic, TypeVar, List
+import simplnx as nx
+
+T = TypeVar('T')
+
+class Result(Generic[T]):
+    """A class to represent a result that might be a value or an error."""
+    def __init__(self, value: T = None, errors: List[nx.Error] = None, warnings: List[nx.Warning] = None):
+        if errors and value is not None:
+            raise ValueError("Cannot create a Result with both errors and a value.")
+
+        self.value = value
+        self.errors = errors if errors else []
+        self.warnings = warnings if warnings else []
+
+    def valid(self) -> bool:
+        """Check if the Result is valid (i.e., has no errors)."""
+        return not self.errors
+
+    def invalid(self) -> bool:
+        """Check if the Result is invalid (i.e., has errors)."""
+        return self.errors
+
+def make_error_result(code: int, message: str) -> Result:
+    return Result(errors=[nx.Error(code, message)])
+
+def make_warning_result(code: int, message: str) -> Result:
+    return Result(warnings=[nx.Warning(code, message)])
+
+def convert_result_to_void(result: Result) -> Result[None]:
+    """Convert a Result of any type to a Result of type None, preserving errors and warnings."""
+    return Result(None, result.errors, result.warnings)
+
+
+def merge_results(first: Result, second: Result) -> Result:
+    """Merge two Results into one, combining their errors and warnings."""
+    merged_errors = first.errors + second.errors
+    merged_warnings = first.warnings + second.warnings
+    # Assuming we're merging results without values; adjust as needed for your use case
+    return Result(None, merged_errors, merged_warnings)
+
+
+# Example usage
+if __name__ == "__main__":
+    # Create an error and a warning
+    error = nx.Error(1, "An error occurred")
+    warning = nx.Warning(1, "This is a warning")
+
+    # Create a valid result and an invalid one
+    valid_result = Result(value="Success")
+    invalid_result = Result(errors=[error])
+
+    # Check if results are valid
+    print("Valid result is valid:", valid_result.valid())
+    print("Invalid result is valid:", invalid_result.valid())
+
+    # Merge results
+    merged_result = merge_results(valid_result, invalid_result)
+    print("Merged result has", len(merged_result.errors), "errors and", len(merged_result.warnings), "warnings.")

--- a/wrapping/python/plugins/DataAnalysisToolkit/docs/CliReaderFilter.md
+++ b/wrapping/python/plugins/DataAnalysisToolkit/docs/CliReaderFilter.md
@@ -8,15 +8,25 @@ IO (Input)
 
 **Read CLI File** is a Python-based *simplnx* filter designed to read and process CLI (Common Layer Interface) files, typically used in additive manufacturing and 3D printing for representing slices of a 3D model.
 
-This filter extracts geometric and attribute data from CLI files and organizes the data into the *simplnx* data structure by creating an edge geometry out of the imported data.
+This filter extracts geometric and attribute data from CLI files and organizes the data into the *simplnx* data structure by creating an edge geometry out of the imported data. It provides options to selectively mask the dataset based on X, Y, and Z dimensions to focus on specific parts of the model.
+
+*Note*: If any edges in the dataset straddle the specified mask bounds, this filter will return an error.
 
 ### Parameters
 
 - `Input CLI File`: Filesystem path to the input CLI file.
+- `Mask X Dimension`: Enable this option to apply X bounds, masking out any dataset portions that fall outside the specified X dimension bounds.
+- `X Min/Max`: Minimum and maximum coordinates for the X bounds.
+- `Mask Y Dimension`: Enable this option to apply Y bounds, masking out any dataset portions that fall outside the specified Y dimension bounds.
+- `Y Min/Max`: Minimum and maximum coordinates for the Y bounds.
+- `Mask Z Dimension`: Enable this option to apply Z bounds, masking out any dataset portions that fall outside the specified Z dimension bounds.
+- `Z Min/Max`: Minimum and maximum coordinates for the Z bounds.
 - `Output Edge Geometry`: Path where the edge geometry data will be stored in the data structure.
 - `Output Vertex Attribute Matrix Name`: Name for the output vertex attribute matrix.
 - `Output Edge Attribute Matrix Name`: Name for the output edge attribute matrix.
 - `Output Feature Attribute Matrix Name`: Name for the output feature attribute matrix.
+- `Shared Vertices Array Name`: Name of the shared vertices array created.
+- `Shared Edges Array Name`: Name of the shared edges array created.
 
 ## Example Pipelines
 
@@ -26,4 +36,4 @@ Please see the description file distributed with this **Plugin**
 
 ## DREAM3D-NX Help
 
-If you need help, need to file a bug report or want to request a new feature, please head over to the [DREAM3DNX-Issues](https://github.com/BlueQuartzSoftware/DREAM3DNX-Issues) GItHub site where the community of DREAM3D-NX users can help answer your questions.
+If you need help, need to file a bug report, or want to request a new feature, please head over to the [DREAM3DNX-Issues](https://github.com/BlueQuartzSoftware/DREAM3DNX-Issues) GitHub site where the community of DREAM3D-NX users can help answer your questions.

--- a/wrapping/python/plugins/DataAnalysisToolkit/utilities/cli_tools.py
+++ b/wrapping/python/plugins/DataAnalysisToolkit/utilities/cli_tools.py
@@ -1,9 +1,18 @@
 import numpy as np
 from pathlib import Path
-from typing import List
+from typing import Tuple
+from ..common.Result import Result, make_error_result
 import copy
 
-def mask_coordinates(coords: np.ndarray, z_height: float, units: int, bounding_box: list) -> np.array:
+def read_poly_line(line: str) -> Tuple[int, int, int, np.ndarray]:
+    vals = line.split(",")
+    return int(vals[0]), int(vals[1]), int(vals[2]), np.array(list(map(float, vals[3:])))
+
+def read_hatch_line(line: str) -> Tuple[int, int, np.ndarray]:
+    vals = line.split(",")
+    return int(vals[0]), int(vals[1]), np.array(list(map(float, vals[2:])))
+
+def mask_coordinates(coords: np.ndarray, z_height: float, units: int, bounding_box: list) -> Result[np.array]:
     x_min, x_max, y_min, y_max, z_min, z_max = bounding_box
     
     coords = coords.reshape((coords.size // 4, 4))
@@ -15,48 +24,51 @@ def mask_coordinates(coords: np.ndarray, z_height: float, units: int, bounding_b
     y2 = coords[:, 3] * units
     z_height = z_height * units
 
+    # Check for violations of bounding box condition
+    x1_inside = (x1 >= x_min) & (x1 <= x_max)
+    y1_inside = (y1 >= y_min) & (y1 <= y_max)
+    z_inside = (z_height >= z_min) & (z_height <= z_max)
+    x2_inside = (x2 >= x_min) & (x2 <= x_max)
+    y2_inside = (y2 >= y_min) & (y2 <= y_max)
+
+    # Check for cases where either x1, y1, or z1 is inside the bounding box while the other is outside
+    if np.any(x1_inside & y1_inside & z_inside & (~x2_inside | ~y2_inside)):
+        idx = np.where(x1_inside & y1_inside & z_inside & (~x2_inside | ~y2_inside))[0][0]
+        return make_error_result(code=-1100, message=f"Point ({x1[idx]}, {y1[idx]}, {z_height}) is inside the bounding box while point ({x2[idx]}, {y2[idx]}, {z_height}) is outside.")
+    if np.any(x2_inside & y2_inside & z_inside & (~x1_inside | ~y1_inside)):
+        idx = np.where(x2_inside & y2_inside & z_inside & (~x1_inside | ~y1_inside))[0][0]
+        return make_error_result(code=-1101, message=f"Point ({x2[idx]}, {y2[idx]}, {z_height}) is inside the bounding box while point ({x1[idx]}, {y1[idx]}, {z_height}) is outside.")
+        
     # Creating boolean masks for points inside the bounding box
-    mask = ((x1 >= x_min) & (x1 <= x_max) & (y1 >= y_min) & (y1 <= y_max) &
-            (x2 >= x_min) & (x2 <= x_max) & (y2 >= y_min) & (y2 <= y_max) &
-            (z_height >= z_min) & (z_height <= z_max))
+    mask = ((x1_inside & y1_inside & z_inside) & (x2_inside & y2_inside & z_inside))
 
     # Filtering numpy array based on the mask
     filtered_array = coords[mask]
     filtered_array = filtered_array.reshape((np.prod(filtered_array.shape)))
 
-    return filtered_array
+    return Result(value=filtered_array)
 
 class Polyline(object):
-    def __init__(self, line, layer_id, z_height, data: dict, units=1.0, bounding_box: list = None):
+    def __init__(self, layer_id, z_height, data: dict, poly_id, dir, n, xvals, yvals) -> Result:
         self.layer_id = layer_id
-        self.z_height = z_height * units
-        vals = line.split(",")
-        self.poly_id = int(vals[0])
-        self.dir = int(vals[1])
-        self.n = int(vals[2])
-        coords = np.array(list(map(float, vals[3:])))
-        if bounding_box is not None:
-            coords = mask_coordinates(coords, z_height, units, bounding_box)
-            self.n = coords.size // 4
-        self.xvals = coords[0::2] * units
-        self.yvals = coords[1::2] * units
+        self.z_height = z_height
+        self.poly_id = poly_id
+        self.dir = dir
+        self.n = n
+        self.xvals = xvals
+        self.yvals = yvals
         self.data = data
         
 class Hatches(object):
-    def __init__(self, line, layer_id, z_height, data: dict, units=1.0, bounding_box: list = None):
+    def __init__(self, layer_id, z_height, data: dict, hatch_id, n, start_xvals, start_yvals, end_xvals, end_yvals):
         self.layer_id = layer_id
-        self.z_height = z_height * units
-        vals = line.split(",")
-        self.hatch_id = int(vals[0])
-        self.n = int(vals[1])
-        coords = np.array(list(map(float, vals[2:])))
-        if bounding_box is not None:
-            coords: np.ndarray = mask_coordinates(coords, z_height, units, bounding_box)
-            self.n = coords.size // 4
-        self.start_xvals = coords[0::4] * units
-        self.start_yvals = coords[1::4] * units
-        self.end_xvals   = coords[2::4] * units
-        self.end_yvals   = coords[3::4] * units
+        self.hatch_id = hatch_id
+        self.n = n
+        self.z_height = z_height
+        self.start_xvals = start_xvals
+        self.start_yvals = start_yvals
+        self.end_xvals   = end_xvals
+        self.end_yvals   = end_yvals
         self.data = data
 
 def parse_header(file):
@@ -106,7 +118,7 @@ def parse_geometry_array_names(full_path: Path):
     return array_names, num_of_labels
                 
 
-def parse_geometry(file, units, bounding_box: list = None):
+def parse_geometry(file, units, bounding_box: list = None) -> Result:
     layer_counter = -1 #initialize to -1, increment by one when finding the first layer
     layer_heights = []
     layer_features = []
@@ -134,13 +146,35 @@ def parse_geometry(file, units, bounding_box: list = None):
         elif line.startswith("$$POLYLINE") or line.startswith("$POLYLINE"):
             #Assuming we found the units already!!!
             key, val = line.split("/")
-            new_poly = Polyline(val, layer_counter, layer_heights[-1], copy.copy(data), units, bounding_box)
+            poly_id, dir, n, coords = read_poly_line(val)
+            z_height = layer_heights[-1] * units
+            if bounding_box is not None:
+                coords_result = mask_coordinates(coords, z_height, units, bounding_box)
+                if coords_result.invalid():
+                    return Result(errors=coords_result.errors)
+                coords = coords_result.value
+                n = coords.size // 4
+            xvals = coords[0::2] * units
+            yvals = coords[1::2] * units
+            new_poly = Polyline(layer_counter, z_height, copy.copy(data), poly_id, dir, n, xvals, yvals)
             features.append(new_poly)
     
         elif line.startswith("$$HATCHES") or line.startswith("$HATCHES"):
             #Assuming we found the units already!!!
             key, val = line.split("/")
-            new_hatch = Hatches(val, layer_counter, layer_heights[-1], copy.copy(data), units, bounding_box)
+            hatch_id, n, coords = read_hatch_line(val)
+            z_height = layer_heights[-1]
+            if bounding_box is not None:
+                coords_result = mask_coordinates(coords, z_height, units, bounding_box)
+                if coords_result.invalid():
+                    return Result(errors=coords_result.errors)
+                coords: np.ndarray = coords_result.value
+                n = coords.size // 4
+            start_xvals = coords[0::4] * units
+            start_yvals = coords[1::4] * units
+            end_xvals   = coords[2::4] * units
+            end_yvals   = coords[3::4] * units
+            new_hatch = Hatches(layer_counter, z_height * units, copy.copy(data), hatch_id, n, start_xvals, start_yvals, end_xvals, end_yvals)
             features.append(new_hatch)
         else:
             key, val = line.split("/")
@@ -156,9 +190,9 @@ def parse_geometry(file, units, bounding_box: list = None):
     if features:
         layer_features.append(features)
 
-    return layer_features, layer_heights
+    return Result(value=(layer_features, layer_heights))
 
-def parse_file(full_path: Path, bounding_box: list = None):    
+def parse_file(full_path: Path, bounding_box: list = None) -> Result:    
     layer_heights = None
     layer_features = None
     units = None
@@ -174,16 +208,22 @@ def parse_file(full_path: Path, bounding_box: list = None):
             elif line.startswith("$$GEOMETRYSTART"):
                 if units is None:
                     raise Exception("No $$HEADERSTART tag was found!") 
-                layer_features, layer_heights = parse_geometry(file, units, bounding_box)
+                result = parse_geometry(file, units, bounding_box)
+                if result.invalid():
+                    return Result(errors=result.errors)
+                layer_features, layer_heights = result.value
             line = file.readline().strip()
     
-    return layer_features, layer_heights, hatch_labels
+    return Result(value=(layer_features, layer_heights, hatch_labels))
 
 if __name__ == "__main__":
     full_path = Path("/Users/bluequartz/Downloads/B10.cli")
     
     try:
-        layer_features, layer_heights = parse_file(full_path)
+        result = parse_file(full_path)
+        if result.invalid():
+            print(f"Error: {result.errors[0].message}")
+        layer_features, layer_heights, hatch_labels = result.value
     except Exception as e:
         print(f"An error occurred while parsing the CLI file '{str(full_path)}': {e}")
 


### PR DESCRIPTION
* Add ability to mask incoming CLI data using a bounding box.  There is a checkbox to enable mask bounds for the X, Y, and Z dimensions.  If any dimension's checkbox is turned off, then that dimension will not be masked.
* Filter returns an error when vertex pairs straddle the minimum or maximum bound in any of the dimensions.
* Filter now correctly ignores comments when parsing lines.