### PR TITLE
PYTHON: Add helper methods to be able to easily create all the geometries.

### DIFF
--- a/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
+++ b/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
@@ -1525,11 +1525,9 @@ PYBIND11_MODULE(simplnx, mod)
   manualImportFinder.def("contains_module", &ManualImportFinder::containsModule, "mod_name"_a);
 
   // Geometry Helper Methods
-  py::module_ sub = mod.def_submodule("ArrayHandlingType", "How existing arrays will be handled when creating the new geometry.");
-  sub.attr("CopyArray") = CreateGeometryFilter::k_CopyArray;
-  sub.attr("MoveArray") = CreateGeometryFilter::k_MoveArray;
+  py::module_ sub = mod.def_submodule("CreateGeometry", "Submodule that contains the CreateGeometry utility methods.");
 
-  mod.def(
+  sub.def(
       "create_image_geometry",
       [](DataStructure& ds, const DataPath& geometryPath, const std::vector<uint64>& dims, const std::vector<float32>& origin, const std::vector<float32>& spacing,
          const std::string& cellAttrMatrixName) {
@@ -1548,10 +1546,10 @@ PYBIND11_MODULE(simplnx, mod)
       },
       "data_structure"_a, "geometry_path"_a, "dimensions"_a, "origin"_a, "spacing"_a, "cell_attr_matrix_name"_a = "Cell Data");
 
-  mod.def(
+  sub.def(
       "create_rect_grid_geometry",
       [](DataStructure& ds, const DataPath& geometryPath, const DataPath& xBoundsPath, const DataPath& yBoundsPath, const DataPath& zBoundsPath, const std::string& cellAttrMatrixName,
-         ChoicesParameter::ValueType arrayHandling) {
+         ArrayHandlingType arrayHandling) {
         CreateGeometryFilter filter;
         Arguments args;
 
@@ -1561,40 +1559,40 @@ PYBIND11_MODULE(simplnx, mod)
         args.insertOrAssign(CreateGeometryFilter::k_YBoundsPath_Key, std::make_any<DataPath>(yBoundsPath));
         args.insertOrAssign(CreateGeometryFilter::k_ZBoundsPath_Key, std::make_any<DataPath>(zBoundsPath));
         args.insertOrAssign(CreateGeometryFilter::k_CellAttributeMatrixName_Key, std::make_any<std::string>(cellAttrMatrixName));
-        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(arrayHandling));
+        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(arrayHandling)));
 
         IFilter::ExecuteResult executeResult = filter.execute(ds, args);
         return executeResult.result;
       },
-      "data_structure"_a, "geometry_path"_a, "x_bounds_path"_a, "y_bounds_path"_a, "z_bounds_path"_a, "cell_attr_matrix_name"_a = "Cell Data", "array_handling"_a = CreateGeometryFilter::k_CopyArray);
+      "data_structure"_a, "geometry_path"_a, "x_bounds_path"_a, "y_bounds_path"_a, "z_bounds_path"_a, "cell_attr_matrix_name"_a = "Cell Data", "array_handling"_a = ArrayHandlingType::Copy);
 
-  mod.def(
+  sub.def(
       "create_vertex_geometry",
-      [](DataStructure& ds, const DataPath& geometryPath, const DataPath& verticesPath, const std::string& vertexAttrMatrixName, ChoicesParameter::ValueType arrayHandling) {
+      [](DataStructure& ds, const DataPath& geometryPath, const DataPath& verticesPath, const std::string& vertexAttrMatrixName, ArrayHandlingType arrayHandling) {
         CreateGeometryFilter filter;
         Arguments args;
 
         args.insertOrAssign(CreateGeometryFilter::k_GeometryType_Key, std::make_any<ChoicesParameter::ValueType>(CreateGeometryFilter::k_VertexGeometry));
         args.insertOrAssign(CreateGeometryFilter::k_GeometryPath_Key, std::make_any<DataPath>(geometryPath));
-        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(arrayHandling));
+        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(arrayHandling)));
         args.insertOrAssign(CreateGeometryFilter::k_VertexListPath_Key, std::make_any<DataPath>(verticesPath));
         args.insertOrAssign(CreateGeometryFilter::k_VertexAttributeMatrixName_Key, std::make_any<std::string>(vertexAttrMatrixName));
 
         IFilter::ExecuteResult executeResult = filter.execute(ds, args);
         return executeResult.result;
       },
-      "data_structure"_a, "geometry_path"_a, "vertices_path"_a, "vertex_attr_matrix_name"_a = "Vertex Data", "array_handling"_a = CreateGeometryFilter::k_CopyArray);
+      "data_structure"_a, "geometry_path"_a, "vertices_path"_a, "vertex_attr_matrix_name"_a = "Vertex Data", "array_handling"_a = ArrayHandlingType::Copy);
 
-  mod.def(
+  sub.def(
       "create_edge_geometry",
       [](DataStructure& ds, const DataPath& geometryPath, const DataPath& verticesPath, const DataPath& edgeListPath, const std::string& vertexAttrMatrixName, const std::string& edgeAttrMatrixName,
-         ChoicesParameter::ValueType arrayHandling) {
+         ArrayHandlingType arrayHandling) {
         CreateGeometryFilter filter;
         Arguments args;
 
         args.insertOrAssign(CreateGeometryFilter::k_GeometryType_Key, std::make_any<ChoicesParameter::ValueType>(CreateGeometryFilter::k_EdgeGeometry));
         args.insertOrAssign(CreateGeometryFilter::k_GeometryPath_Key, std::make_any<DataPath>(geometryPath));
-        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(arrayHandling));
+        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(arrayHandling)));
         args.insertOrAssign(CreateGeometryFilter::k_VertexListPath_Key, std::make_any<DataPath>(verticesPath));
         args.insertOrAssign(CreateGeometryFilter::k_VertexAttributeMatrixName_Key, std::make_any<std::string>(vertexAttrMatrixName));
         args.insertOrAssign(CreateGeometryFilter::k_EdgeListPath_Key, std::make_any<DataPath>(edgeListPath));
@@ -1604,18 +1602,18 @@ PYBIND11_MODULE(simplnx, mod)
         return executeResult.result;
       },
       "data_structure"_a, "geometry_path"_a, "vertices_path"_a, "edge_list_path"_a, "vertex_attr_matrix_name"_a = "Vertex Data", "edge_attr_matrix_name"_a = "Edge Data",
-      "array_handling"_a = CreateGeometryFilter::k_CopyArray);
+      "array_handling"_a = ArrayHandlingType::Copy);
 
-  mod.def(
+  sub.def(
       "create_triangle_geometry",
       [](DataStructure& ds, const DataPath& geometryPath, const DataPath& verticesPath, const DataPath& triangleListPath, const std::string& vertexAttrMatrixName,
-         const std::string& faceAttrMatrixName, ChoicesParameter::ValueType arrayHandling) {
+         const std::string& faceAttrMatrixName, ArrayHandlingType arrayHandling) {
         CreateGeometryFilter filter;
         Arguments args;
 
         args.insertOrAssign(CreateGeometryFilter::k_GeometryType_Key, std::make_any<ChoicesParameter::ValueType>(CreateGeometryFilter::k_TriangleGeometry));
         args.insertOrAssign(CreateGeometryFilter::k_GeometryPath_Key, std::make_any<DataPath>(geometryPath));
-        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(arrayHandling));
+        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(arrayHandling)));
         args.insertOrAssign(CreateGeometryFilter::k_VertexListPath_Key, std::make_any<DataPath>(verticesPath));
         args.insertOrAssign(CreateGeometryFilter::k_VertexAttributeMatrixName_Key, std::make_any<std::string>(vertexAttrMatrixName));
         args.insertOrAssign(CreateGeometryFilter::k_TriangleListPath_Key, std::make_any<DataPath>(triangleListPath));
@@ -1625,18 +1623,18 @@ PYBIND11_MODULE(simplnx, mod)
         return executeResult.result;
       },
       "data_structure"_a, "geometry_path"_a, "vertices_path"_a, "triangle_list_path"_a, "vertex_attr_matrix_name"_a = "Vertex Data", "face_attr_matrix_name"_a = "Face Data",
-      "array_handling"_a = CreateGeometryFilter::k_CopyArray);
+      "array_handling"_a = ArrayHandlingType::Copy);
 
-  mod.def(
+  sub.def(
       "create_quad_geometry",
       [](DataStructure& ds, const DataPath& geometryPath, const DataPath& verticesPath, const DataPath& quadListPath, const std::string& vertexAttrMatrixName, const std::string& faceAttrMatrixName,
-         ChoicesParameter::ValueType arrayHandling) {
+         ArrayHandlingType arrayHandling) {
         CreateGeometryFilter filter;
         Arguments args;
 
         args.insertOrAssign(CreateGeometryFilter::k_GeometryType_Key, std::make_any<ChoicesParameter::ValueType>(CreateGeometryFilter::k_QuadGeometry));
         args.insertOrAssign(CreateGeometryFilter::k_GeometryPath_Key, std::make_any<DataPath>(geometryPath));
-        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(arrayHandling));
+        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(arrayHandling)));
         args.insertOrAssign(CreateGeometryFilter::k_VertexListPath_Key, std::make_any<DataPath>(verticesPath));
         args.insertOrAssign(CreateGeometryFilter::k_VertexAttributeMatrixName_Key, std::make_any<std::string>(vertexAttrMatrixName));
         args.insertOrAssign(CreateGeometryFilter::k_QuadrilateralListPath_Key, std::make_any<DataPath>(quadListPath));
@@ -1646,18 +1644,18 @@ PYBIND11_MODULE(simplnx, mod)
         return executeResult.result;
       },
       "data_structure"_a, "geometry_path"_a, "vertices_path"_a, "quad_list_path"_a, "vertex_attr_matrix_name"_a = "Vertex Data", "face_attr_matrix_name"_a = "Quad Data",
-      "array_handling"_a = CreateGeometryFilter::k_CopyArray);
+      "array_handling"_a = ArrayHandlingType::Copy);
 
-  mod.def(
+  sub.def(
       "create_tetrahedral_geometry",
       [](DataStructure& ds, const DataPath& geometryPath, const DataPath& verticesPath, const DataPath& tetrahedralListPath, const std::string& vertexAttrMatrixName,
-         const std::string& cellAttrMatrixName, ChoicesParameter::ValueType arrayHandling) {
+         const std::string& cellAttrMatrixName, ArrayHandlingType arrayHandling) {
         CreateGeometryFilter filter;
         Arguments args;
 
         args.insertOrAssign(CreateGeometryFilter::k_GeometryType_Key, std::make_any<ChoicesParameter::ValueType>(CreateGeometryFilter::k_TetGeometry));
         args.insertOrAssign(CreateGeometryFilter::k_GeometryPath_Key, std::make_any<DataPath>(geometryPath));
-        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(arrayHandling));
+        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(arrayHandling)));
         args.insertOrAssign(CreateGeometryFilter::k_VertexListPath_Key, std::make_any<DataPath>(verticesPath));
         args.insertOrAssign(CreateGeometryFilter::k_VertexAttributeMatrixName_Key, std::make_any<std::string>(vertexAttrMatrixName));
         args.insertOrAssign(CreateGeometryFilter::k_TetrahedralListPath_Key, std::make_any<DataPath>(tetrahedralListPath));
@@ -1667,18 +1665,18 @@ PYBIND11_MODULE(simplnx, mod)
         return executeResult.result;
       },
       "data_structure"_a, "geometry_path"_a, "vertices_path"_a, "tetrahedral_list_path"_a, "vertex_attr_matrix_name"_a = "Vertex Data", "cell_attr_matrix_name"_a = "Cell Data",
-      "array_handling"_a = CreateGeometryFilter::k_CopyArray);
+      "array_handling"_a = ArrayHandlingType::Copy);
 
-  mod.def(
+  sub.def(
       "create_hexahedral_geometry",
       [](DataStructure& ds, const DataPath& geometryPath, const DataPath& verticesPath, const DataPath& hexahedralListPath, const std::string& vertexAttrMatrixName,
-         const std::string& cellAttrMatrixName, ChoicesParameter::ValueType arrayHandling) {
+         const std::string& cellAttrMatrixName, ArrayHandlingType arrayHandling) {
         CreateGeometryFilter filter;
         Arguments args;
 
         args.insertOrAssign(CreateGeometryFilter::k_GeometryType_Key, std::make_any<ChoicesParameter::ValueType>(CreateGeometryFilter::k_HexGeometry));
         args.insertOrAssign(CreateGeometryFilter::k_GeometryPath_Key, std::make_any<DataPath>(geometryPath));
-        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(arrayHandling));
+        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(arrayHandling)));
         args.insertOrAssign(CreateGeometryFilter::k_VertexListPath_Key, std::make_any<DataPath>(verticesPath));
         args.insertOrAssign(CreateGeometryFilter::k_VertexAttributeMatrixName_Key, std::make_any<std::string>(vertexAttrMatrixName));
         args.insertOrAssign(CreateGeometryFilter::k_HexahedralListPath_Key, std::make_any<DataPath>(hexahedralListPath));
@@ -1688,5 +1686,5 @@ PYBIND11_MODULE(simplnx, mod)
         return executeResult.result;
       },
       "data_structure"_a, "geometry_path"_a, "vertices_path"_a, "hexahedral_list_path"_a, "vertex_attr_matrix_name"_a = "Vertex Data", "cell_attr_matrix_name"_a = "Cell Data",
-      "array_handling"_a = CreateGeometryFilter::k_CopyArray);
+      "array_handling"_a = ArrayHandlingType::Copy);
 }

--- a/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
+++ b/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
@@ -425,6 +425,8 @@ PYBIND11_MODULE(simplnx, mod)
     }
     return fmt::format("<simplnx.Result(errors={}, warnings={})>", errors, self.warnings());
   });
+  result.def("valid", &Result<>::valid);
+  result.def("invalid", &Result<>::invalid);
 
   py::enum_<NumericType> numericType(mod, "NumericType");
   numericType.value("int8", NumericType::int8);
@@ -529,8 +531,7 @@ PYBIND11_MODULE(simplnx, mod)
   parameters.def("insert_linkable_parameter", &PyInsertLinkableParameter<ChoicesParameter>);
   parameters.def("link_parameters", [](Parameters& self, std::string groupKey, std::string childKey, BoolParameter::ValueType value) { self.linkParameters(groupKey, childKey, value); });
   parameters.def("link_parameters", [](Parameters& self, std::string groupKey, std::string childKey, ChoicesParameter::ValueType value) { self.linkParameters(groupKey, childKey, value); });
-  parameters.def(
-      "__getitem__", [](Parameters& self, std::string_view key) { return self.at(key).get(); }, py::return_value_policy::reference_internal);
+  parameters.def("__getitem__", [](Parameters& self, std::string_view key) { return self.at(key).get(); }, py::return_value_policy::reference_internal);
 
   py::class_<IArrayThreshold, std::shared_ptr<IArrayThreshold>> iArrayThreshold(mod, "IArrayThreshold");
 
@@ -1366,12 +1367,10 @@ PYBIND11_MODULE(simplnx, mod)
       "path"_a);
   pipeline.def_property("name", &Pipeline::getName, &Pipeline::setName);
   pipeline.def("execute", &ExecutePipeline);
-  pipeline.def(
-      "__getitem__", [](Pipeline& self, Pipeline::index_type index) { return self.at(index); }, py::return_value_policy::reference_internal);
+  pipeline.def("__getitem__", [](Pipeline& self, Pipeline::index_type index) { return self.at(index); }, py::return_value_policy::reference_internal);
   pipeline.def("__len__", &Pipeline::size);
   pipeline.def("size", &Pipeline::size);
-  pipeline.def(
-      "__iter__", [](Pipeline& self) { return py::make_iterator(self.begin(), self.end()); }, py::keep_alive<0, 1>());
+  pipeline.def("__iter__", [](Pipeline& self) { return py::make_iterator(self.begin(), self.end()); }, py::keep_alive<0, 1>());
   pipeline.def(
       "insert",
       [internals](Pipeline& self, Pipeline::index_type index, const IFilter& filter, const py::dict& args) {
@@ -1385,10 +1384,8 @@ PYBIND11_MODULE(simplnx, mod)
   pipeline.def("remove", &Pipeline::removeAt, "index"_a);
 
   pipelineFilter.def("get_args", [internals](PipelineFilter& self) { return ConvertArgsToDict(*internals, self.getParameters(), self.getArguments()); });
-  pipelineFilter.def(
-      "set_args", [internals](PipelineFilter& self, py::dict& args) { self.setArguments(ConvertDictToArgs(*internals, self.getParameters(), args)); }, "args"_a);
-  pipelineFilter.def(
-      "get_filter", [](PipelineFilter& self) { return self.getFilter(); }, py::return_value_policy::reference_internal);
+  pipelineFilter.def("set_args", [internals](PipelineFilter& self, py::dict& args) { self.setArguments(ConvertDictToArgs(*internals, self.getParameters(), args)); }, "args"_a);
+  pipelineFilter.def("get_filter", [](PipelineFilter& self) { return self.getFilter(); }, py::return_value_policy::reference_internal);
   pipelineFilter.def(
       "name",
       [](const PipelineFilter& self) {

--- a/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
+++ b/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
@@ -531,7 +531,8 @@ PYBIND11_MODULE(simplnx, mod)
   parameters.def("insert_linkable_parameter", &PyInsertLinkableParameter<ChoicesParameter>);
   parameters.def("link_parameters", [](Parameters& self, std::string groupKey, std::string childKey, BoolParameter::ValueType value) { self.linkParameters(groupKey, childKey, value); });
   parameters.def("link_parameters", [](Parameters& self, std::string groupKey, std::string childKey, ChoicesParameter::ValueType value) { self.linkParameters(groupKey, childKey, value); });
-  parameters.def("__getitem__", [](Parameters& self, std::string_view key) { return self.at(key).get(); }, py::return_value_policy::reference_internal);
+  parameters.def(
+      "__getitem__", [](Parameters& self, std::string_view key) { return self.at(key).get(); }, py::return_value_policy::reference_internal);
 
   py::class_<IArrayThreshold, std::shared_ptr<IArrayThreshold>> iArrayThreshold(mod, "IArrayThreshold");
 
@@ -1367,10 +1368,12 @@ PYBIND11_MODULE(simplnx, mod)
       "path"_a);
   pipeline.def_property("name", &Pipeline::getName, &Pipeline::setName);
   pipeline.def("execute", &ExecutePipeline);
-  pipeline.def("__getitem__", [](Pipeline& self, Pipeline::index_type index) { return self.at(index); }, py::return_value_policy::reference_internal);
+  pipeline.def(
+      "__getitem__", [](Pipeline& self, Pipeline::index_type index) { return self.at(index); }, py::return_value_policy::reference_internal);
   pipeline.def("__len__", &Pipeline::size);
   pipeline.def("size", &Pipeline::size);
-  pipeline.def("__iter__", [](Pipeline& self) { return py::make_iterator(self.begin(), self.end()); }, py::keep_alive<0, 1>());
+  pipeline.def(
+      "__iter__", [](Pipeline& self) { return py::make_iterator(self.begin(), self.end()); }, py::keep_alive<0, 1>());
   pipeline.def(
       "insert",
       [internals](Pipeline& self, Pipeline::index_type index, const IFilter& filter, const py::dict& args) {
@@ -1384,8 +1387,10 @@ PYBIND11_MODULE(simplnx, mod)
   pipeline.def("remove", &Pipeline::removeAt, "index"_a);
 
   pipelineFilter.def("get_args", [internals](PipelineFilter& self) { return ConvertArgsToDict(*internals, self.getParameters(), self.getArguments()); });
-  pipelineFilter.def("set_args", [internals](PipelineFilter& self, py::dict& args) { self.setArguments(ConvertDictToArgs(*internals, self.getParameters(), args)); }, "args"_a);
-  pipelineFilter.def("get_filter", [](PipelineFilter& self) { return self.getFilter(); }, py::return_value_policy::reference_internal);
+  pipelineFilter.def(
+      "set_args", [internals](PipelineFilter& self, py::dict& args) { self.setArguments(ConvertDictToArgs(*internals, self.getParameters(), args)); }, "args"_a);
+  pipelineFilter.def(
+      "get_filter", [](PipelineFilter& self) { return self.getFilter(); }, py::return_value_policy::reference_internal);
   pipelineFilter.def(
       "name",
       [](const PipelineFilter& self) {

--- a/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
+++ b/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
@@ -7,6 +7,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/stl/filesystem.h>
 
+#include "SimplnxCore/Filters/CreateGeometryFilter.hpp"
 #include "SimplnxCore/SimplnxCoreFilterBinding.hpp"
 #include "SimplnxCore/SimplnxCorePlugin.hpp"
 
@@ -1520,4 +1521,170 @@ PYBIND11_MODULE(simplnx, mod)
   manualImportFinder.def("clear", &ManualImportFinder::clear);
   manualImportFinder.def("contains_path", &ManualImportFinder::containsPath, "path"_a);
   manualImportFinder.def("contains_module", &ManualImportFinder::containsModule, "mod_name"_a);
+
+  // Geometry Helper Methods
+  py::module_ sub = mod.def_submodule("ArrayHandlingType", "How existing arrays will be handled when creating the new geometry.");
+  sub.attr("CopyArray") = CreateGeometryFilter::k_CopyArray;
+  sub.attr("MoveArray") = CreateGeometryFilter::k_MoveArray;
+
+  mod.def(
+      "create_image_geometry",
+      [](DataStructure& ds, const DataPath& geometryPath, const std::vector<uint64>& dims, const std::vector<float32>& origin, const std::vector<float32>& spacing,
+         const std::string& cellAttrMatrixName) {
+        CreateGeometryFilter filter;
+        Arguments args;
+
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryType_Key, std::make_any<ChoicesParameter::ValueType>(CreateGeometryFilter::k_ImageGeometry));
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryPath_Key, std::make_any<DataPath>(geometryPath));
+        args.insertOrAssign(CreateGeometryFilter::k_Dimensions_Key, std::make_any<VectorUInt64Parameter::ValueType>(dims));
+        args.insertOrAssign(CreateGeometryFilter::k_Origin_Key, std::make_any<VectorFloat32Parameter::ValueType>(origin));
+        args.insertOrAssign(CreateGeometryFilter::k_Spacing_Key, std::make_any<VectorFloat32Parameter::ValueType>(spacing));
+        args.insertOrAssign(CreateGeometryFilter::k_CellAttributeMatrixName_Key, std::make_any<std::string>(cellAttrMatrixName));
+
+        IFilter::ExecuteResult executeResult = filter.execute(ds, args);
+        return executeResult.result;
+      },
+      "data_structure"_a, "geometry_path"_a, "dimensions"_a, "origin"_a, "spacing"_a, "cell_attr_matrix_name"_a = "Cell Data");
+
+  mod.def(
+      "create_rect_grid_geometry",
+      [](DataStructure& ds, const DataPath& geometryPath, const DataPath& xBoundsPath, const DataPath& yBoundsPath, const DataPath& zBoundsPath, const std::string& cellAttrMatrixName,
+         ChoicesParameter::ValueType arrayHandling) {
+        CreateGeometryFilter filter;
+        Arguments args;
+
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryType_Key, std::make_any<ChoicesParameter::ValueType>(CreateGeometryFilter::k_RectGridGeometry));
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryPath_Key, std::make_any<DataPath>(geometryPath));
+        args.insertOrAssign(CreateGeometryFilter::k_XBoundsPath_Key, std::make_any<DataPath>(xBoundsPath));
+        args.insertOrAssign(CreateGeometryFilter::k_YBoundsPath_Key, std::make_any<DataPath>(yBoundsPath));
+        args.insertOrAssign(CreateGeometryFilter::k_ZBoundsPath_Key, std::make_any<DataPath>(zBoundsPath));
+        args.insertOrAssign(CreateGeometryFilter::k_CellAttributeMatrixName_Key, std::make_any<std::string>(cellAttrMatrixName));
+        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(arrayHandling));
+
+        IFilter::ExecuteResult executeResult = filter.execute(ds, args);
+        return executeResult.result;
+      },
+      "data_structure"_a, "geometry_path"_a, "x_bounds_path"_a, "y_bounds_path"_a, "z_bounds_path"_a, "cell_attr_matrix_name"_a = "Cell Data", "array_handling"_a = CreateGeometryFilter::k_CopyArray);
+
+  mod.def(
+      "create_vertex_geometry",
+      [](DataStructure& ds, const DataPath& geometryPath, const DataPath& verticesPath, const std::string& vertexAttrMatrixName, ChoicesParameter::ValueType arrayHandling) {
+        CreateGeometryFilter filter;
+        Arguments args;
+
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryType_Key, std::make_any<ChoicesParameter::ValueType>(CreateGeometryFilter::k_VertexGeometry));
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryPath_Key, std::make_any<DataPath>(geometryPath));
+        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(arrayHandling));
+        args.insertOrAssign(CreateGeometryFilter::k_VertexListPath_Key, std::make_any<DataPath>(verticesPath));
+        args.insertOrAssign(CreateGeometryFilter::k_VertexAttributeMatrixName_Key, std::make_any<std::string>(vertexAttrMatrixName));
+
+        IFilter::ExecuteResult executeResult = filter.execute(ds, args);
+        return executeResult.result;
+      },
+      "data_structure"_a, "geometry_path"_a, "vertices_path"_a, "vertex_attr_matrix_name"_a = "Vertex Data", "array_handling"_a = CreateGeometryFilter::k_CopyArray);
+
+  mod.def(
+      "create_edge_geometry",
+      [](DataStructure& ds, const DataPath& geometryPath, const DataPath& verticesPath, const DataPath& edgeListPath, const std::string& vertexAttrMatrixName, const std::string& edgeAttrMatrixName,
+         ChoicesParameter::ValueType arrayHandling) {
+        CreateGeometryFilter filter;
+        Arguments args;
+
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryType_Key, std::make_any<ChoicesParameter::ValueType>(CreateGeometryFilter::k_EdgeGeometry));
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryPath_Key, std::make_any<DataPath>(geometryPath));
+        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(arrayHandling));
+        args.insertOrAssign(CreateGeometryFilter::k_VertexListPath_Key, std::make_any<DataPath>(verticesPath));
+        args.insertOrAssign(CreateGeometryFilter::k_VertexAttributeMatrixName_Key, std::make_any<std::string>(vertexAttrMatrixName));
+        args.insertOrAssign(CreateGeometryFilter::k_EdgeListPath_Key, std::make_any<DataPath>(edgeListPath));
+        args.insertOrAssign(CreateGeometryFilter::k_EdgeAttributeMatrixName_Key, std::make_any<std::string>(edgeAttrMatrixName));
+
+        IFilter::ExecuteResult executeResult = filter.execute(ds, args);
+        return executeResult.result;
+      },
+      "data_structure"_a, "geometry_path"_a, "vertices_path"_a, "edge_list_path"_a, "vertex_attr_matrix_name"_a = "Vertex Data", "edge_attr_matrix_name"_a = "Edge Data",
+      "array_handling"_a = CreateGeometryFilter::k_CopyArray);
+
+  mod.def(
+      "create_triangle_geometry",
+      [](DataStructure& ds, const DataPath& geometryPath, const DataPath& verticesPath, const DataPath& triangleListPath, const std::string& vertexAttrMatrixName,
+         const std::string& faceAttrMatrixName, ChoicesParameter::ValueType arrayHandling) {
+        CreateGeometryFilter filter;
+        Arguments args;
+
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryType_Key, std::make_any<ChoicesParameter::ValueType>(CreateGeometryFilter::k_TriangleGeometry));
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryPath_Key, std::make_any<DataPath>(geometryPath));
+        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(arrayHandling));
+        args.insertOrAssign(CreateGeometryFilter::k_VertexListPath_Key, std::make_any<DataPath>(verticesPath));
+        args.insertOrAssign(CreateGeometryFilter::k_VertexAttributeMatrixName_Key, std::make_any<std::string>(vertexAttrMatrixName));
+        args.insertOrAssign(CreateGeometryFilter::k_TriangleListPath_Key, std::make_any<DataPath>(triangleListPath));
+        args.insertOrAssign(CreateGeometryFilter::k_FaceAttributeMatrixName_Key, std::make_any<std::string>(faceAttrMatrixName));
+
+        IFilter::ExecuteResult executeResult = filter.execute(ds, args);
+        return executeResult.result;
+      },
+      "data_structure"_a, "geometry_path"_a, "vertices_path"_a, "triangle_list_path"_a, "vertex_attr_matrix_name"_a = "Vertex Data", "face_attr_matrix_name"_a = "Face Data",
+      "array_handling"_a = CreateGeometryFilter::k_CopyArray);
+
+  mod.def(
+      "create_quad_geometry",
+      [](DataStructure& ds, const DataPath& geometryPath, const DataPath& verticesPath, const DataPath& quadListPath, const std::string& vertexAttrMatrixName, const std::string& faceAttrMatrixName,
+         ChoicesParameter::ValueType arrayHandling) {
+        CreateGeometryFilter filter;
+        Arguments args;
+
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryType_Key, std::make_any<ChoicesParameter::ValueType>(CreateGeometryFilter::k_QuadGeometry));
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryPath_Key, std::make_any<DataPath>(geometryPath));
+        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(arrayHandling));
+        args.insertOrAssign(CreateGeometryFilter::k_VertexListPath_Key, std::make_any<DataPath>(verticesPath));
+        args.insertOrAssign(CreateGeometryFilter::k_VertexAttributeMatrixName_Key, std::make_any<std::string>(vertexAttrMatrixName));
+        args.insertOrAssign(CreateGeometryFilter::k_QuadrilateralListPath_Key, std::make_any<DataPath>(quadListPath));
+        args.insertOrAssign(CreateGeometryFilter::k_FaceAttributeMatrixName_Key, std::make_any<std::string>(faceAttrMatrixName));
+
+        IFilter::ExecuteResult executeResult = filter.execute(ds, args);
+        return executeResult.result;
+      },
+      "data_structure"_a, "geometry_path"_a, "vertices_path"_a, "quad_list_path"_a, "vertex_attr_matrix_name"_a = "Vertex Data", "face_attr_matrix_name"_a = "Quad Data",
+      "array_handling"_a = CreateGeometryFilter::k_CopyArray);
+
+  mod.def(
+      "create_tetrahedral_geometry",
+      [](DataStructure& ds, const DataPath& geometryPath, const DataPath& verticesPath, const DataPath& tetrahedralListPath, const std::string& vertexAttrMatrixName,
+         const std::string& cellAttrMatrixName, ChoicesParameter::ValueType arrayHandling) {
+        CreateGeometryFilter filter;
+        Arguments args;
+
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryType_Key, std::make_any<ChoicesParameter::ValueType>(CreateGeometryFilter::k_TetGeometry));
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryPath_Key, std::make_any<DataPath>(geometryPath));
+        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(arrayHandling));
+        args.insertOrAssign(CreateGeometryFilter::k_VertexListPath_Key, std::make_any<DataPath>(verticesPath));
+        args.insertOrAssign(CreateGeometryFilter::k_VertexAttributeMatrixName_Key, std::make_any<std::string>(vertexAttrMatrixName));
+        args.insertOrAssign(CreateGeometryFilter::k_TetrahedralListPath_Key, std::make_any<DataPath>(tetrahedralListPath));
+        args.insertOrAssign(CreateGeometryFilter::k_CellAttributeMatrixName_Key, std::make_any<std::string>(cellAttrMatrixName));
+
+        IFilter::ExecuteResult executeResult = filter.execute(ds, args);
+        return executeResult.result;
+      },
+      "data_structure"_a, "geometry_path"_a, "vertices_path"_a, "tetrahedral_list_path"_a, "vertex_attr_matrix_name"_a = "Vertex Data", "cell_attr_matrix_name"_a = "Cell Data",
+      "array_handling"_a = CreateGeometryFilter::k_CopyArray);
+
+  mod.def(
+      "create_hexahedral_geometry",
+      [](DataStructure& ds, const DataPath& geometryPath, const DataPath& verticesPath, const DataPath& hexahedralListPath, const std::string& vertexAttrMatrixName,
+         const std::string& cellAttrMatrixName, ChoicesParameter::ValueType arrayHandling) {
+        CreateGeometryFilter filter;
+        Arguments args;
+
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryType_Key, std::make_any<ChoicesParameter::ValueType>(CreateGeometryFilter::k_HexGeometry));
+        args.insertOrAssign(CreateGeometryFilter::k_GeometryPath_Key, std::make_any<DataPath>(geometryPath));
+        args.insertOrAssign(CreateGeometryFilter::k_ArrayHandling_Key, std::make_any<ChoicesParameter::ValueType>(arrayHandling));
+        args.insertOrAssign(CreateGeometryFilter::k_VertexListPath_Key, std::make_any<DataPath>(verticesPath));
+        args.insertOrAssign(CreateGeometryFilter::k_VertexAttributeMatrixName_Key, std::make_any<std::string>(vertexAttrMatrixName));
+        args.insertOrAssign(CreateGeometryFilter::k_HexahedralListPath_Key, std::make_any<DataPath>(hexahedralListPath));
+        args.insertOrAssign(CreateGeometryFilter::k_CellAttributeMatrixName_Key, std::make_any<std::string>(cellAttrMatrixName));
+
+        IFilter::ExecuteResult executeResult = filter.execute(ds, args);
+        return executeResult.result;
+      },
+      "data_structure"_a, "geometry_path"_a, "vertices_path"_a, "hexahedral_list_path"_a, "vertex_attr_matrix_name"_a = "Vertex Data", "cell_attr_matrix_name"_a = "Cell Data",
+      "array_handling"_a = CreateGeometryFilter::k_CopyArray);
 }

--- a/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
+++ b/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
@@ -1170,7 +1170,8 @@ PYBIND11_MODULE(simplnx, mod)
 
   BindParameterConstructor(calculatorParameter);
 
-  choicesParameter.def(py::init<const std::string&, const std::string&, const std::string&, ChoicesParameter::ValueType, const ChoicesParameter::Choices&>());
+  choicesParameter.def(py::init<const std::string&, const std::string&, const std::string&, ChoicesParameter::ValueType, const ChoicesParameter::Choices&>(), "name"_a, "human_name"_a, "help_text"_a,
+                       "default_value"_a, "choices"_a);
 
   BindParameterConstructor(dataGroupCreationParameter);
 

--- a/wrapping/python/docs/source/User_API.rst
+++ b/wrapping/python/docs/source/User_API.rst
@@ -29,6 +29,223 @@ Error & Warning Reporting
       else:
          print("No errors running the ConvertOrientations")
 
+Creating Geometries
+------------------
+
+All the `simplnx` geometries can be created in Python using the following helper methods:
+
++ create_image_geometry
++ create_rect_grid_geometry
++ create_vertex_geometry
++ create_edge_geometry
++ create_triangle_geometry
++ create_quad_geometry
++ create_tetrahedral_geometry
++ create_hexahedral_geometry
+
+The submodule `ArrayHandlingType` defines how existing arrays will be handled when creating a new geometry. It includes the following attributes:
+
+- **CopyArray**: The existing arrays will be copied into the new geometry.
+- **MoveArray**: The existing arrays will be moved into the new geometry.
+
+Creating An Image Geometry
+##########################
+
+To create an image geometry, use the `create_image_geometry` method. This method requires the following parameters:
+
+- `data_structure`: The data structure where the geometry will be created.
+- `geometry_path`: The :ref:`DataPath <DataPath>` where the geometry will be stored.
+- `dimensions`: A list of dimensions for the image.
+- `origin`: The origin coordinates of the image.
+- `spacing`: The spacing between elements in the image.
+- `cell_attr_matrix_name` (optional): The name of the cell attribute matrix. Defaults to "Cell Data".
+
+Example usage:
+
+.. code:: python
+
+   import simplnx as nx
+
+   # Create an image geometry
+   result: nx.Result = nx.create_image_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Image Geometry"]), dimensions=[100, 150, 200], origin=[0, 5, -2], spacing=[0.5, 0.5, 0.5], cell_attr_matrix_name='Image Data')
+   if result.valid():
+      image_geom = data_structure[nx.DataPath(["Image Geometry"])]
+      print("Image Geometry Created!")
+
+
+Creating A Rectilinear Grid Geometry
+####################################
+
+To create a rectilinear grid geometry, use the ``create_rect_grid_geometry`` method. This method requires the following parameters:
+
+- **data_structure**: The data structure where the geometry will be created.
+- **geometry_path**: The :ref:`DataPath <DataPath>` where the geometry will be stored.
+- **x_bounds_path**: The :ref:`DataPath <DataPath>` to the X bounds array.
+- **y_bounds_path**: The :ref:`DataPath <DataPath>` to the Y bounds array.
+- **z_bounds_path**: The :ref:`DataPath <DataPath>` to the Z bounds array.
+- **cell_attr_matrix_name** (optional): The name of the cell attribute matrix. Defaults to "Cell Data".
+- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.CopyArray``.
+
+Example usage:
+
+.. code-block:: python
+
+   import simplnx as nx
+
+   # Create a rect grid geometry
+   result = nx.create_rect_grid_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Rect Grid Geometry"]), x_bounds_path=nx.DataPath(["Foo"]), y_bounds_path=nx.DataPath(["Y Bounds"]), z_bounds_path=nx.DataPath(["Z Bounds"]), cell_attr_matrix_name='Cell Data', array_handling=nx.ArrayHandlingType.CopyArray)
+   if result.valid():
+      rect_grid_geom = data_structure[nx.DataPath(["Rect Grid Geometry"])]
+      print("Rect Grid Geometry Created!")
+
+Creating A Vertex Geometry
+##########################
+
+To create a vertex geometry, use the ``create_vertex_geometry`` method. This method requires the following parameters:
+
+- **data_structure**: The data structure where the geometry will be created.
+- **geometry_path**: The :ref:`DataPath <DataPath>` where the geometry will be stored.
+- **vertices_path**: The :ref:`DataPath <DataPath>` to the vertices array.
+- **vertex_attr_matrix_name** (optional): The name of the vertex attribute matrix. Defaults to "Vertex Data".
+- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.CopyArray``.
+
+Example usage:
+
+.. code-block:: python
+
+   import simplnx as nx
+
+   # Create a vertex geometry
+   result = nx.create_vertex_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Vertex Geometry"]), vertices_path=nx.DataPath("Vertices"), vertex_attr_matrix_name='Vertex Data', array_handling=nx.ArrayHandlingType.CopyArray)
+   if result.valid():
+      vertex_geom = data_structure[nx.DataPath("Vertex Geometry")]
+      print("Vertex Geometry Created!")
+
+Creating An Edge Geometry
+#########################
+
+To create an edge geometry, use the ``create_edge_geometry`` method. This method requires the following parameters:
+
+- **data_structure**: The data structure where the geometry will be created.
+- **geometry_path**: The :ref:`DataPath <DataPath>` where the geometry will be stored.
+- **vertices_path**: The :ref:`DataPath <DataPath>` to the vertices array.
+- **edge_list_path**: The :ref:`DataPath <DataPath>` to the edge list array.
+- **vertex_attr_matrix_name** (optional): The name of the vertex attribute matrix. Defaults to "Vertex Data".
+- **edge_attr_matrix_name** (optional): The name of the edge attribute matrix. Defaults to "Edge Data".
+- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.CopyArray``.
+
+Example usage:
+
+.. code-block:: python
+
+   import simplnx as nx
+
+   # Create an edge geometry
+   result = nx.create_edge_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Edge Geometry"]), vertices_path=nx.DataPath("Vertices"), edge_list_path=nx.DataPath("Edge List"), vertex_attr_matrix_name='Vertex Data', edge_attr_matrix_name='Edge Data', array_handling=nx.ArrayHandlingType.CopyArray)
+   if result.valid():
+      edge_geom = data_structure[nx.DataPath("Edge Geometry")]
+      print("Edge Geometry Created!")
+
+Creating A Triangle Geometry
+############################
+
+To create a triangle geometry, use the ``create_triangle_geometry`` method. This method requires the following parameters:
+
+- **data_structure**: The data structure where the geometry will be created.
+- **geometry_path**: The :ref:`DataPath <DataPath>` where the geometry will be stored.
+- **vertices_path**: The :ref:`DataPath <DataPath>` to the vertices array.
+- **triangle_list_path**: The :ref:`DataPath <DataPath>` to the triangle list array.
+- **vertex_attr_matrix_name** (optional): The name of the vertex attribute matrix. Defaults to "Vertex Data".
+- **face_attr_matrix_name** (optional): The name of the face attribute matrix. Defaults to "Face Data".
+- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.CopyArray``.
+
+Example usage:
+
+.. code-block:: python
+
+   import simplnx as nx
+
+   # Create a triangle geometry
+   result = nx.create_triangle_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Triangle Geometry"]), vertices_path=nx.DataPath("Vertices"), triangle_list_path=nx.DataPath("Triangle List"), vertex_attr_matrix_name='Vertex Data', face_attr_matrix_name='Face Data', array_handling=nx.ArrayHandlingType.CopyArray)
+   if result.valid():
+      triangle_geom = data_structure[nx.DataPath("Triangle Geometry")]
+      print("Triangle Geometry Created!")
+
+Creating A Quadrilateral Geometry
+#################################
+
+To create a quadrilateral geometry, use the ``create_quad_geometry`` method. This method requires the following parameters:
+
+- **data_structure**: The data structure where the geometry will be created.
+- **geometry_path**: The :ref:`DataPath <DataPath>` where the geometry will be stored.
+- **vertices_path**: The :ref:`DataPath <DataPath>` to the vertices array.
+- **quad_list_path**: The :ref:`DataPath <DataPath>` to the quadrilateral list array.
+- **vertex_attr_matrix_name** (optional): The name of the vertex attribute matrix. Defaults to "Vertex Data".
+- **face_attr_matrix_name** (optional): The name of the face attribute matrix. Defaults to "Quad Data".
+- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.CopyArray``.
+
+Example usage:
+
+.. code-block:: python
+
+   import simplnx as nx
+
+   # Create a quad geometry
+   result = nx.create_quad_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Quad Geometry"]), vertices_path=nx.DataPath("Vertices"), quad_list_path=nx.DataPath("Quad List"), vertex_attr_matrix_name='Vertex Data', face_attr_matrix_name='Quad Data', array_handling=nx.ArrayHandlingType.CopyArray)
+   if result.valid():
+      quad_geom = data_structure[nx.DataPath("Quad Geometry")]
+      print("Quad Geometry Created!")
+
+Creating A Tetrahedral Geometry
+###############################
+
+To create a tetrahedral geometry, use the ``create_tetrahedral_geometry`` method. This method requires the following parameters:
+
+- **data_structure**: The data structure where the geometry will be created.
+- **geometry_path**: The :ref:`DataPath <DataPath>` where the geometry will be stored.
+- **vertices_path**: The :ref:`DataPath <DataPath>` to the vertices array.
+- **tetrahedral_list_path**: The :ref:`DataPath <DataPath>` to the tetrahedral list array.
+- **vertex_attr_matrix_name** (optional): The name of the vertex attribute matrix. Defaults to "Vertex Data".
+- **cell_attr_matrix_name** (optional): The name of the cell attribute matrix. Defaults to "Cell Data".
+- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.CopyArray``.
+
+Example usage:
+
+.. code-block:: python
+
+   import simplnx as nx
+
+   # Create a tetrahedral geometry
+   result = nx.create_tetrahedral_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Tetrahedral Geometry"]), vertices_path=nx.DataPath("Vertices"), tetrahedral_list_path=nx.DataPath("Tetrahedral List"), vertex_attr_matrix_name='Vertex Data', cell_attr_matrix_name='Cell Data', array_handling=nx.ArrayHandlingType.CopyArray)
+   if result.valid():
+      tetrahedral_geom = data_structure[nx.DataPath("Tetrahedral Geometry")]
+      print("Tetrahedral Geometry Created!")
+
+Creating A Hexahedral Geometry
+##############################
+
+To create a hexahedral geometry, use the ``create_hexahedral_geometry`` method. This method requires the following parameters:
+
+- **data_structure**: The data structure where the geometry will be created.
+- **geometry_path**: The :ref:`DataPath <DataPath>` where the geometry will be stored.
+- **vertices_path**: The :ref:`DataPath <DataPath>` to the vertices array.
+- **hexahedral_list_path**: The :ref:`DataPath <DataPath>` to the hexahedral list array.
+- **vertex_attr_matrix_name** (optional): The name of the vertex attribute matrix. Defaults to "Vertex Data".
+- **cell_attr_matrix_name** (optional): The name of the cell attribute matrix. Defaults to "Cell Data".
+- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.CopyArray``.
+
+Example usage:
+
+.. code-block:: python
+
+   import simplnx as nx
+
+   # Create a hexahedral geometry
+   result = nx.create_hexahedral_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Hexahedral Geometry"]), vertices_path=nx.DataPath("Vertices"), hexahedral_list_path=nx.DataPath("Hexahedral List"), vertex_attr_matrix_name='Vertex Data', cell_attr_matrix_name='Cell Data', array_handling=nx.ArrayHandlingType.CopyArray)
+   if result.valid():
+      hexahedral_geom = data_structure[nx.DataPath("Hexahedral Geometry")]
+      print("Hexahedral Geometry Created!")
+
 General Parameters 
 ------------------
 

--- a/wrapping/python/docs/source/User_API.rst
+++ b/wrapping/python/docs/source/User_API.rst
@@ -34,24 +34,24 @@ Creating Geometries
 
 All the `simplnx` geometries can be created in Python using the following helper methods:
 
-+ create_image_geometry
-+ create_rect_grid_geometry
-+ create_vertex_geometry
-+ create_edge_geometry
-+ create_triangle_geometry
-+ create_quad_geometry
-+ create_tetrahedral_geometry
-+ create_hexahedral_geometry
++ CreateGeometry.create_image_geometry
++ CreateGeometry.create_rect_grid_geometry
++ CreateGeometry.create_vertex_geometry
++ CreateGeometry.create_edge_geometry
++ CreateGeometry.create_triangle_geometry
++ CreateGeometry.create_quad_geometry
++ CreateGeometry.create_tetrahedral_geometry
++ CreateGeometry.create_hexahedral_geometry
 
-The submodule `ArrayHandlingType` defines how existing arrays will be handled when creating a new geometry. It includes the following attributes:
+The enumeration `ArrayHandlingType` defines how existing arrays will be handled when creating a new geometry. It includes the following values:
 
-- **CopyArray**: The existing arrays will be copied into the new geometry.
-- **MoveArray**: The existing arrays will be moved into the new geometry.
+- **Copy**: The existing arrays will be copied into the new geometry.
+- **Move**: The existing arrays will be moved into the new geometry.
 
 Creating An Image Geometry
 ##########################
 
-To create an image geometry, use the `create_image_geometry` method. This method requires the following parameters:
+To create an image geometry, use the `CreateGeometry.create_image_geometry` method. This method requires the following parameters:
 
 - `data_structure`: The data structure where the geometry will be created.
 - `geometry_path`: The :ref:`DataPath <DataPath>` where the geometry will be stored.
@@ -67,7 +67,7 @@ Example usage:
    import simplnx as nx
 
    # Create an image geometry
-   result: nx.Result = nx.create_image_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Image Geometry"]), dimensions=[100, 150, 200], origin=[0, 5, -2], spacing=[0.5, 0.5, 0.5], cell_attr_matrix_name='Image Data')
+   result: nx.Result = nx.CreateGeometry.create_image_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Image Geometry"]), dimensions=[100, 150, 200], origin=[0, 5, -2], spacing=[0.5, 0.5, 0.5], cell_attr_matrix_name='Image Data')
    if result.valid():
       image_geom = data_structure[nx.DataPath(["Image Geometry"])]
       print("Image Geometry Created!")
@@ -76,7 +76,7 @@ Example usage:
 Creating A Rectilinear Grid Geometry
 ####################################
 
-To create a rectilinear grid geometry, use the ``create_rect_grid_geometry`` method. This method requires the following parameters:
+To create a rectilinear grid geometry, use the `CreateGeometry.create_rect_grid_geometry` method. This method requires the following parameters:
 
 - **data_structure**: The data structure where the geometry will be created.
 - **geometry_path**: The :ref:`DataPath <DataPath>` where the geometry will be stored.
@@ -84,7 +84,7 @@ To create a rectilinear grid geometry, use the ``create_rect_grid_geometry`` met
 - **y_bounds_path**: The :ref:`DataPath <DataPath>` to the Y bounds array.
 - **z_bounds_path**: The :ref:`DataPath <DataPath>` to the Z bounds array.
 - **cell_attr_matrix_name** (optional): The name of the cell attribute matrix. Defaults to "Cell Data".
-- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.CopyArray``.
+- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.Copy``.
 
 Example usage:
 
@@ -93,7 +93,7 @@ Example usage:
    import simplnx as nx
 
    # Create a rect grid geometry
-   result = nx.create_rect_grid_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Rect Grid Geometry"]), x_bounds_path=nx.DataPath(["Foo"]), y_bounds_path=nx.DataPath(["Y Bounds"]), z_bounds_path=nx.DataPath(["Z Bounds"]), cell_attr_matrix_name='Cell Data', array_handling=nx.ArrayHandlingType.CopyArray)
+   result = nx.CreateGeometry.create_rect_grid_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Rect Grid Geometry"]), x_bounds_path=nx.DataPath(["Foo"]), y_bounds_path=nx.DataPath(["Y Bounds"]), z_bounds_path=nx.DataPath(["Z Bounds"]), cell_attr_matrix_name='Cell Data', array_handling=nx.ArrayHandlingType.Copy)
    if result.valid():
       rect_grid_geom = data_structure[nx.DataPath(["Rect Grid Geometry"])]
       print("Rect Grid Geometry Created!")
@@ -101,13 +101,13 @@ Example usage:
 Creating A Vertex Geometry
 ##########################
 
-To create a vertex geometry, use the ``create_vertex_geometry`` method. This method requires the following parameters:
+To create a vertex geometry, use the `CreateGeometry.create_vertex_geometry` method. This method requires the following parameters:
 
 - **data_structure**: The data structure where the geometry will be created.
 - **geometry_path**: The :ref:`DataPath <DataPath>` where the geometry will be stored.
 - **vertices_path**: The :ref:`DataPath <DataPath>` to the vertices array.
 - **vertex_attr_matrix_name** (optional): The name of the vertex attribute matrix. Defaults to "Vertex Data".
-- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.CopyArray``.
+- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.Copy``.
 
 Example usage:
 
@@ -116,7 +116,7 @@ Example usage:
    import simplnx as nx
 
    # Create a vertex geometry
-   result = nx.create_vertex_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Vertex Geometry"]), vertices_path=nx.DataPath("Vertices"), vertex_attr_matrix_name='Vertex Data', array_handling=nx.ArrayHandlingType.CopyArray)
+   result = nx.CreateGeometry.create_vertex_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Vertex Geometry"]), vertices_path=nx.DataPath("Vertices"), vertex_attr_matrix_name='Vertex Data', array_handling=nx.ArrayHandlingType.Copy)
    if result.valid():
       vertex_geom = data_structure[nx.DataPath("Vertex Geometry")]
       print("Vertex Geometry Created!")
@@ -124,7 +124,7 @@ Example usage:
 Creating An Edge Geometry
 #########################
 
-To create an edge geometry, use the ``create_edge_geometry`` method. This method requires the following parameters:
+To create an edge geometry, use the `CreateGeometry.create_edge_geometry` method. This method requires the following parameters:
 
 - **data_structure**: The data structure where the geometry will be created.
 - **geometry_path**: The :ref:`DataPath <DataPath>` where the geometry will be stored.
@@ -132,7 +132,7 @@ To create an edge geometry, use the ``create_edge_geometry`` method. This method
 - **edge_list_path**: The :ref:`DataPath <DataPath>` to the edge list array.
 - **vertex_attr_matrix_name** (optional): The name of the vertex attribute matrix. Defaults to "Vertex Data".
 - **edge_attr_matrix_name** (optional): The name of the edge attribute matrix. Defaults to "Edge Data".
-- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.CopyArray``.
+- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.Copy``.
 
 Example usage:
 
@@ -141,7 +141,7 @@ Example usage:
    import simplnx as nx
 
    # Create an edge geometry
-   result = nx.create_edge_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Edge Geometry"]), vertices_path=nx.DataPath("Vertices"), edge_list_path=nx.DataPath("Edge List"), vertex_attr_matrix_name='Vertex Data', edge_attr_matrix_name='Edge Data', array_handling=nx.ArrayHandlingType.CopyArray)
+   result = nx.CreateGeometry.create_edge_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Edge Geometry"]), vertices_path=nx.DataPath("Vertices"), edge_list_path=nx.DataPath("Edge List"), vertex_attr_matrix_name='Vertex Data', edge_attr_matrix_name='Edge Data', array_handling=nx.ArrayHandlingType.Copy)
    if result.valid():
       edge_geom = data_structure[nx.DataPath("Edge Geometry")]
       print("Edge Geometry Created!")
@@ -149,7 +149,7 @@ Example usage:
 Creating A Triangle Geometry
 ############################
 
-To create a triangle geometry, use the ``create_triangle_geometry`` method. This method requires the following parameters:
+To create a triangle geometry, use the `CreateGeometry.create_triangle_geometry` method. This method requires the following parameters:
 
 - **data_structure**: The data structure where the geometry will be created.
 - **geometry_path**: The :ref:`DataPath <DataPath>` where the geometry will be stored.
@@ -157,7 +157,7 @@ To create a triangle geometry, use the ``create_triangle_geometry`` method. This
 - **triangle_list_path**: The :ref:`DataPath <DataPath>` to the triangle list array.
 - **vertex_attr_matrix_name** (optional): The name of the vertex attribute matrix. Defaults to "Vertex Data".
 - **face_attr_matrix_name** (optional): The name of the face attribute matrix. Defaults to "Face Data".
-- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.CopyArray``.
+- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.Copy``.
 
 Example usage:
 
@@ -166,7 +166,7 @@ Example usage:
    import simplnx as nx
 
    # Create a triangle geometry
-   result = nx.create_triangle_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Triangle Geometry"]), vertices_path=nx.DataPath("Vertices"), triangle_list_path=nx.DataPath("Triangle List"), vertex_attr_matrix_name='Vertex Data', face_attr_matrix_name='Face Data', array_handling=nx.ArrayHandlingType.CopyArray)
+   result = nx.CreateGeometry.create_triangle_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Triangle Geometry"]), vertices_path=nx.DataPath("Vertices"), triangle_list_path=nx.DataPath("Triangle List"), vertex_attr_matrix_name='Vertex Data', face_attr_matrix_name='Face Data', array_handling=nx.ArrayHandlingType.Copy)
    if result.valid():
       triangle_geom = data_structure[nx.DataPath("Triangle Geometry")]
       print("Triangle Geometry Created!")
@@ -174,7 +174,7 @@ Example usage:
 Creating A Quadrilateral Geometry
 #################################
 
-To create a quadrilateral geometry, use the ``create_quad_geometry`` method. This method requires the following parameters:
+To create a quadrilateral geometry, use the `CreateGeometry.create_quad_geometry` method. This method requires the following parameters:
 
 - **data_structure**: The data structure where the geometry will be created.
 - **geometry_path**: The :ref:`DataPath <DataPath>` where the geometry will be stored.
@@ -182,7 +182,7 @@ To create a quadrilateral geometry, use the ``create_quad_geometry`` method. Thi
 - **quad_list_path**: The :ref:`DataPath <DataPath>` to the quadrilateral list array.
 - **vertex_attr_matrix_name** (optional): The name of the vertex attribute matrix. Defaults to "Vertex Data".
 - **face_attr_matrix_name** (optional): The name of the face attribute matrix. Defaults to "Quad Data".
-- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.CopyArray``.
+- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.Copy``.
 
 Example usage:
 
@@ -191,7 +191,7 @@ Example usage:
    import simplnx as nx
 
    # Create a quad geometry
-   result = nx.create_quad_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Quad Geometry"]), vertices_path=nx.DataPath("Vertices"), quad_list_path=nx.DataPath("Quad List"), vertex_attr_matrix_name='Vertex Data', face_attr_matrix_name='Quad Data', array_handling=nx.ArrayHandlingType.CopyArray)
+   result = nx.CreateGeometry.create_quad_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Quad Geometry"]), vertices_path=nx.DataPath("Vertices"), quad_list_path=nx.DataPath("Quad List"), vertex_attr_matrix_name='Vertex Data', face_attr_matrix_name='Quad Data', array_handling=nx.ArrayHandlingType.Copy)
    if result.valid():
       quad_geom = data_structure[nx.DataPath("Quad Geometry")]
       print("Quad Geometry Created!")
@@ -199,7 +199,7 @@ Example usage:
 Creating A Tetrahedral Geometry
 ###############################
 
-To create a tetrahedral geometry, use the ``create_tetrahedral_geometry`` method. This method requires the following parameters:
+To create a tetrahedral geometry, use the `CreateGeometry.create_tetrahedral_geometry` method. This method requires the following parameters:
 
 - **data_structure**: The data structure where the geometry will be created.
 - **geometry_path**: The :ref:`DataPath <DataPath>` where the geometry will be stored.
@@ -207,7 +207,7 @@ To create a tetrahedral geometry, use the ``create_tetrahedral_geometry`` method
 - **tetrahedral_list_path**: The :ref:`DataPath <DataPath>` to the tetrahedral list array.
 - **vertex_attr_matrix_name** (optional): The name of the vertex attribute matrix. Defaults to "Vertex Data".
 - **cell_attr_matrix_name** (optional): The name of the cell attribute matrix. Defaults to "Cell Data".
-- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.CopyArray``.
+- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.Copy``.
 
 Example usage:
 
@@ -216,7 +216,7 @@ Example usage:
    import simplnx as nx
 
    # Create a tetrahedral geometry
-   result = nx.create_tetrahedral_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Tetrahedral Geometry"]), vertices_path=nx.DataPath("Vertices"), tetrahedral_list_path=nx.DataPath("Tetrahedral List"), vertex_attr_matrix_name='Vertex Data', cell_attr_matrix_name='Cell Data', array_handling=nx.ArrayHandlingType.CopyArray)
+   result = nx.CreateGeometry.create_tetrahedral_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Tetrahedral Geometry"]), vertices_path=nx.DataPath("Vertices"), tetrahedral_list_path=nx.DataPath("Tetrahedral List"), vertex_attr_matrix_name='Vertex Data', cell_attr_matrix_name='Cell Data', array_handling=nx.ArrayHandlingType.Copy)
    if result.valid():
       tetrahedral_geom = data_structure[nx.DataPath("Tetrahedral Geometry")]
       print("Tetrahedral Geometry Created!")
@@ -224,7 +224,7 @@ Example usage:
 Creating A Hexahedral Geometry
 ##############################
 
-To create a hexahedral geometry, use the ``create_hexahedral_geometry`` method. This method requires the following parameters:
+To create a hexahedral geometry, use the `CreateGeometry.create_hexahedral_geometry` method. This method requires the following parameters:
 
 - **data_structure**: The data structure where the geometry will be created.
 - **geometry_path**: The :ref:`DataPath <DataPath>` where the geometry will be stored.
@@ -232,7 +232,7 @@ To create a hexahedral geometry, use the ``create_hexahedral_geometry`` method. 
 - **hexahedral_list_path**: The :ref:`DataPath <DataPath>` to the hexahedral list array.
 - **vertex_attr_matrix_name** (optional): The name of the vertex attribute matrix. Defaults to "Vertex Data".
 - **cell_attr_matrix_name** (optional): The name of the cell attribute matrix. Defaults to "Cell Data".
-- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.CopyArray``.
+- **array_handling** (optional): Specifies how to handle existing arrays. Defaults to ``ArrayHandlingType.Copy``.
 
 Example usage:
 
@@ -241,7 +241,7 @@ Example usage:
    import simplnx as nx
 
    # Create a hexahedral geometry
-   result = nx.create_hexahedral_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Hexahedral Geometry"]), vertices_path=nx.DataPath("Vertices"), hexahedral_list_path=nx.DataPath("Hexahedral List"), vertex_attr_matrix_name='Vertex Data', cell_attr_matrix_name='Cell Data', array_handling=nx.ArrayHandlingType.CopyArray)
+   result = nx.CreateGeometry.create_hexahedral_geometry(data_structure=data_structure, geometry_path=nx.DataPath(["Hexahedral Geometry"]), vertices_path=nx.DataPath("Vertices"), hexahedral_list_path=nx.DataPath("Hexahedral List"), vertex_attr_matrix_name='Vertex Data', cell_attr_matrix_name='Cell Data', array_handling=nx.ArrayHandlingType.Copy)
    if result.valid():
       hexahedral_geom = data_structure[nx.DataPath("Hexahedral Geometry")]
       print("Hexahedral Geometry Created!")


### PR DESCRIPTION
Adds the following helper methods to be able to easily create all the geometries:

nx.CreateGeometry.create_image_geometry
nx.CreateGeometry.create_rect_grid_geometry
nx.CreateGeometry.create_vertex_geometry
nx.CreateGeometry.create_edge_geometry
nx.CreateGeometry.create_triangle_geometry
nx.CreateGeometry.create_quad_geometry
nx.CreateGeometry.create_tetrahedral_geometry
nx.CreateGeometry.create_hexahedral_geometry

Also adds parameter names to the ChoicesParameter binding.