### PR TITLE
Update vcpkg baseline for HDF5 1.14.4.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ find_package(nod CONFIG REQUIRED)
 # Find HDF5 and get the path to the DLL libraries and put that into a
 # global property for later install, debugging and packaging
 # -----------------------------------------------------------------------
-find_package(HDF5 MODULE REQUIRED)
+find_package(HDF5 1.14 MODULE REQUIRED)
 get_target_property(hdf5_dll_path hdf5::hdf5 IMPORTED_LOCATION_RELEASE)
 get_filename_component(hdf5_dll_path "${hdf5_dll_path}" DIRECTORY)
 get_property(SIMPLNX_EXTRA_LIBRARY_DIRS GLOBAL PROPERTY SIMPLNX_EXTRA_LIBRARY_DIRS)

--- a/src/simplnx/Utilities/Parsing/HDF5/H5.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/H5.hpp
@@ -12,7 +12,7 @@ namespace nx::core::HDF5
 {
 using IdType = int64;
 using ErrorType = int32;
-using SizeType = unsigned long long;
+using SizeType = uint64;
 
 enum class Type
 {

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -32,7 +32,7 @@
         "zlib",
         "zstd"
       ],
-      "baseline": "8d1ff160df9f35a1f6c3d2e4242ae38228602a7d"
+      "baseline": "91f2503b2158a684bfe6a524b344ad7028de9511"
     }
   ]
 }


### PR DESCRIPTION
* Also includes pybind11 2.12.0 and addition of google benchmark
* Fixed issue with nx::core::HDF5::SizeType on latest HDF5 version
  * Starting with HDF5 1.13 hsize_t changed from `unsigned long long` to `uint64_t` which are considered different types on non-windows platforms