### PR TITLE
Added DataStructure::getDataAsUnsafe functions

### DIFF
--- a/src/simplnx/DataStructure/BaseGroup.cpp
+++ b/src/simplnx/DataStructure/BaseGroup.cpp
@@ -39,6 +39,11 @@ DataObject::Type BaseGroup::getDataObjectType() const
   return Type::BaseGroup;
 }
 
+bool BaseGroup::isGroup() const
+{
+  return true;
+}
+
 BaseGroup::GroupType BaseGroup::getGroupType() const
 {
   return GroupType::BaseGroup;

--- a/src/simplnx/DataStructure/BaseGroup.hpp
+++ b/src/simplnx/DataStructure/BaseGroup.hpp
@@ -83,6 +83,12 @@ public:
   DataObject::Type getDataObjectType() const override;
 
   /**
+   * @brief Returns true if this object is derived from BaseGroup.
+   * @return bool
+   */
+  bool isGroup() const override;
+
+  /**
    * @brief Returns an enumeration of the class or subclass GroupType. Used for quick comparison or type deduction
    * @return
    */

--- a/src/simplnx/DataStructure/DataObject.cpp
+++ b/src/simplnx/DataStructure/DataObject.cpp
@@ -91,6 +91,11 @@ DataObject::Type DataObject::getDataObjectType() const
   return Type::DataObject;
 }
 
+bool DataObject::isGroup() const
+{
+  return false;
+}
+
 void DataObject::setId(IdType newId)
 {
   m_Id = newId;

--- a/src/simplnx/DataStructure/DataObject.hpp
+++ b/src/simplnx/DataStructure/DataObject.hpp
@@ -85,6 +85,12 @@ public:
   virtual Type getDataObjectType() const;
 
   /**
+   * @brief Returns true if this object is derived from BaseGroup.
+   * @return bool
+   */
+  virtual bool isGroup() const;
+
+  /**
    * @brief The IdType alias serves as an ID type for DataObjects within their
    * respective DataStructure.
    */

--- a/src/simplnx/DataStructure/DataStructure.cpp
+++ b/src/simplnx/DataStructure/DataStructure.cpp
@@ -272,40 +272,33 @@ DataObject* DataStructure::getData(const std::optional<DataObject::IdType>& iden
   return iter->second.lock().get();
 }
 
-DataObject* traversePath(DataObject* obj, const DataPath& path, usize index)
-{
-  if(path.getLength() == index)
-  {
-    return obj;
-  }
-  auto col = dynamic_cast<BaseGroup*>(obj);
-  if(col == nullptr)
-  {
-    return nullptr;
-  }
-  DataObject* child = (*col)[path[index]];
-  return traversePath(child, path, index + 1);
-}
-
 DataObject* DataStructure::getData(const DataPath& path)
 {
   if(path.empty())
   {
     return nullptr;
   }
-  auto topLevel = getTopLevelData();
-  for(DataObject* obj : topLevel)
+  DataObject* targetObject = m_RootGroup[path[0]];
+  for(usize index = 1; index < path.getLength(); index++)
   {
-    if(obj == nullptr)
+    if(targetObject == nullptr)
     {
-      continue;
+      return nullptr;
     }
-    if(obj->getName() == path[0])
+    if(!targetObject->isGroup())
     {
-      return traversePath(obj, path, 1);
+      return nullptr;
     }
+    auto* groupObject = static_cast<BaseGroup*>(targetObject);
+    DataObject* childObject = (*groupObject)[path[index]];
+    if(childObject == nullptr)
+    {
+      return nullptr;
+    }
+    targetObject = childObject;
   }
-  return nullptr;
+
+  return targetObject;
 }
 
 DataObject& DataStructure::getDataRef(const DataPath& path)
@@ -364,20 +357,27 @@ const DataObject* DataStructure::getData(const DataPath& path) const
   {
     return nullptr;
   }
-
-  auto topLevel = getTopLevelData();
-  for(DataObject* obj : topLevel)
+  const DataObject* targetObject = m_RootGroup[path[0]];
+  for(usize index = 1; index < path.getLength(); index++)
   {
-    if(obj == nullptr)
+    if(targetObject == nullptr)
     {
-      continue;
+      return nullptr;
     }
-    if(obj->getName() == path[0])
+    if(!targetObject->isGroup())
     {
-      return traversePath(obj, path, 1);
+      return nullptr;
     }
+    const auto* groupObject = static_cast<const BaseGroup*>(targetObject);
+    const DataObject* childObject = (*groupObject)[path[index]];
+    if(childObject == nullptr)
+    {
+      return nullptr;
+    }
+    targetObject = childObject;
   }
-  return nullptr;
+
+  return targetObject;
 }
 
 const DataObject& DataStructure::getDataRef(const DataPath& path) const

--- a/src/simplnx/DataStructure/DataStructure.hpp
+++ b/src/simplnx/DataStructure/DataStructure.hpp
@@ -146,6 +146,21 @@ public:
 
   /**
    * @brief Returns a pointer to the DataObject with the specified IdType.
+   * If no such object exists, this method returns nullptr.
+   * PERFORMS NO CHECKS ON THE TYPE OF DATAOBJECT RETURNED
+   * ONLY USE WHEN THE TYPE IS ALREADY GUARENTEED TO BE T
+   * @param identifier
+   * @return T*
+   */
+  template <class T>
+  T* getDataAsUnsafe(DataObject::IdType identifier)
+  {
+    static_assert(std::is_base_of_v<DataObject, T>);
+    return static_cast<T*>(getData(identifier));
+  }
+
+  /**
+   * @brief Returns a pointer to the DataObject with the specified IdType.
    * If no such object exists, or no ID is provided, this method returns nullptr.
    * @param identifier
    * @return DataObject*
@@ -164,6 +179,22 @@ public:
     static_assert(std::is_base_of_v<DataObject, T>);
     auto* object = getData(identifier);
     return dynamic_cast<T*>(object);
+  }
+
+  /**
+   * @brief Returns a pointer to the DataObject with the specified IdType.
+   * If no such object exists, or no ID is provided, this method returns nullptr.
+   * PERFORMS NO CHECKS ON THE TYPE OF DATAOBJECT RETURNED
+   * ONLY USE WHEN THE TYPE IS ALREADY GUARENTEED TO BE T
+   * @param identifier
+   * @return T*
+   */
+  template <class T>
+  T* getDataAsUnsafe(const std::optional<DataObject::IdType>& identifier)
+  {
+    static_assert(std::is_base_of_v<DataObject, T>);
+    auto* object = getData(identifier);
+    return static_cast<T*>(object);
   }
 
   /**
@@ -204,6 +235,21 @@ public:
   }
 
   /**
+   * @brief Returns a pointer to the DataObject at the given DataPath. If no
+   * DataObject is found, this method returns nullptr.
+   * PERFORMS NO CHECKS ON THE TYPE OF DATAOBJECT RETURNED
+   * ONLY USE WHEN THE TYPE IS ALREADY GUARENTEED TO BE T
+   * @param path
+   * @return T*
+   */
+  template <class T>
+  T* getDataAsUnsafe(const DataPath& path)
+  {
+    static_assert(std::is_base_of_v<DataObject, T>);
+    return static_cast<T*>(getData(path));
+  }
+
+  /**
    * @brief Returns a reference to the DataObject at the given DataPath. If no
    * DataObject is found, this method throws std::out_of_range.
    * @param path
@@ -217,6 +263,21 @@ public:
   }
 
   /**
+   * @brief Returns a reference to the DataObject at the given DataPath. If no
+   * DataObject is found, this method throws std::out_of_range.
+   * PERFORMS NO CHECKS ON THE TYPE OF DATAOBJECT RETURNED
+   * ONLY USE WHEN THE TYPE IS ALREADY GUARENTEED TO BE T
+   * @param path
+   * @return T&
+   */
+  template <class T>
+  T& getDataRefAsUnsafe(const DataPath& path)
+  {
+    static_assert(std::is_base_of_v<DataObject, T>);
+    return static_cast<T&>(getDataRef(path));
+  }
+
+  /**
    * @brief Returns a reference to the DataObject with the given identifier. If no
    * DataObject is found, this method throws std::out_of_range.
    * @param identifier
@@ -227,6 +288,21 @@ public:
   {
     static_assert(std::is_base_of_v<DataObject, T>);
     return dynamic_cast<T&>(getDataRef(identifier));
+  }
+
+  /**
+   * @brief Returns a reference to the DataObject with the given identifier. If no
+   * DataObject is found, this method throws std::out_of_range.
+   * PERFORMS NO CHECKS ON THE TYPE OF DATAOBJECT RETURNED
+   * ONLY USE WHEN THE TYPE IS ALREADY GUARENTEED TO BE T
+   * @param identifier
+   * @return T&
+   */
+  template <class T>
+  T& getDataRefAsUnsafe(DataObject::IdType identifier)
+  {
+    static_assert(std::is_base_of_v<DataObject, T>);
+    return static_cast<T&>(getDataRef(identifier));
   }
 
   /**
@@ -248,6 +324,21 @@ public:
   {
     static_assert(std::is_base_of_v<DataObject, T>);
     return dynamic_cast<T*>(getData(path));
+  }
+
+  /**
+   * @brief Returns a pointer to the DataObject found at the specified
+   * LinkedPath. If no such DataObject is found, this method returns nullptr.
+   * PERFORMS NO CHECKS ON THE TYPE OF DATAOBJECT RETURNED
+   * ONLY USE WHEN THE TYPE IS ALREADY GUARENTEED TO BE T
+   * @param path
+   * @return T*
+   */
+  template <class T>
+  T* getDataAsUnsafe(const LinkedPath& path)
+  {
+    static_assert(std::is_base_of_v<DataObject, T>);
+    return static_cast<T*>(getData(path));
   }
 
   /**
@@ -273,6 +364,21 @@ public:
 
   /**
    * @brief Returns a pointer to the DataObject with the specified IdType.
+   * If no such object exists, this method returns nullptr.
+   * PERFORMS NO CHECKS ON THE TYPE OF DATAOBJECT RETURNED
+   * ONLY USE WHEN THE TYPE IS ALREADY GUARENTEED TO BE T
+   * @param identifier
+   * @return const T*
+   */
+  template <class T>
+  const T* getDataAsUnsafe(DataObject::IdType identifier) const
+  {
+    static_assert(std::is_base_of_v<DataObject, T>);
+    return static_cast<const T*>(getData(identifier));
+  }
+
+  /**
+   * @brief Returns a pointer to the DataObject with the specified IdType.
    * If no such object exists, or no ID is provided, this method returns nullptr.
    * @param identifier
    * @return const DataObject*
@@ -290,6 +396,21 @@ public:
   {
     static_assert(std::is_base_of_v<DataObject, T>);
     return dynamic_cast<const T*>(getData(identifier));
+  }
+
+  /**
+   * @brief Returns a pointer to the DataObject with the specified IdType.
+   * If no such object exists, or no ID is provided, this method returns nullptr.
+   * PERFORMS NO CHECKS ON THE TYPE OF DATAOBJECT RETURNED
+   * ONLY USE WHEN THE TYPE IS ALREADY GUARENTEED TO BE T
+   * @param identifier
+   * @return const T*
+   */
+  template <class T>
+  const T* getDataAsUnsafe(const std::optional<DataObject::IdType>& identifier) const
+  {
+    static_assert(std::is_base_of_v<DataObject, T>);
+    return static_cast<const T*>(getData(identifier));
   }
 
   /**
@@ -333,6 +454,20 @@ public:
   }
 
   /**
+   * @brief Returns a pointer to the DataObject at the given DataPath.
+   * PERFORMS NO CHECKS ON THE TYPE OF DATAOBJECT RETURNED
+   * ONLY USE WHEN THE TYPE IS ALREADY GUARENTEED TO BE T
+   * @param path
+   * @return const T*
+   */
+  template <class T>
+  const T* getDataAsUnsafe(const DataPath& path) const
+  {
+    static_assert(std::is_base_of_v<DataObject, T>);
+    return static_cast<const T*>(getData(path));
+  }
+
+  /**
    * @brief Returns a reference to the DataObject at the given DataPath.
    *
    * @throws std::out_of_range if path does not exist
@@ -349,6 +484,21 @@ public:
   }
 
   /**
+   * @brief Returns a reference to the DataObject at the given DataPath.
+   * PERFORMS NO CHECKS ON THE TYPE OF DATAOBJECT RETURNED
+   * ONLY USE WHEN THE TYPE IS ALREADY GUARENTEED TO BE T
+   * @throws std::out_of_range if path does not exist
+   * @param path
+   * @return const T&
+   */
+  template <class T>
+  const T& getDataRefAsUnsafe(const DataPath& path) const
+  {
+    static_assert(std::is_base_of_v<DataObject, T>);
+    return static_cast<const T&>(getDataRef(path));
+  }
+
+  /**
    * @brief Returns a reference to the DataObject with the given identifier. If no
    * DataObject is found, this method throws std::out_of_range.
    * @param identifier
@@ -359,6 +509,21 @@ public:
   {
     static_assert(std::is_base_of_v<DataObject, T>);
     return dynamic_cast<const T&>(getDataRef(identifier));
+  }
+
+  /**
+   * @brief Returns a reference to the DataObject with the given identifier. If no
+   * DataObject is found, this method throws std::out_of_range.
+   * PERFORMS NO CHECKS ON THE TYPE OF DATAOBJECT RETURNED
+   * ONLY USE WHEN THE TYPE IS ALREADY GUARENTEED TO BE T
+   * @param identifier
+   * @return T&
+   */
+  template <class T>
+  const T& getDataRefAsUnsafe(DataObject::IdType identifier) const
+  {
+    static_assert(std::is_base_of_v<DataObject, T>);
+    return static_cast<const T&>(getDataRef(identifier));
   }
 
   /**
@@ -380,6 +545,21 @@ public:
   {
     static_assert(std::is_base_of_v<DataObject, T>);
     return dynamic_cast<const T*>(getData(path));
+  }
+
+  /**
+   * @brief Returns a pointer to the DataObject found at the specified
+   * LinkedPath. If no such DataObject is found, this method returns nullptr.
+   * PERFORMS NO CHECKS ON THE TYPE OF DATAOBJECT RETURNED
+   * ONLY USE WHEN THE TYPE IS ALREADY GUARENTEED TO BE T
+   * @param path
+   * @return const T*
+   */
+  template <class T>
+  const T* getDataAsUnsafe(const LinkedPath& path) const
+  {
+    static_assert(std::is_base_of_v<DataObject, T>);
+    return static_cast<const T*>(getData(path));
   }
 
   /**


### PR DESCRIPTION
- Added replaced recursive implementation of `DataStructure::getData` with an iterative one
- Added `DataObject::isGroup` to remove need for `dynamic_cast` in `DataStructure::getData`