### PR TITLE
Fixed C++20 issue with template id in constructor starting in gcc 11

### DIFF
--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
@@ -70,7 +70,7 @@ template <class T>
 class TSpecificCompareFunctor : public SegmentFeatures::CompareFunctor
 {
 public:
-  CX_DEFAULT_CONSTRUCTORS(TSpecificCompareFunctor<T>)
+  CX_DEFAULT_CONSTRUCTORS(TSpecificCompareFunctor)
 
   using DataArrayType = DataArray<T>;
   using DataStoreType = AbstractDataStore<T>;

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -33,7 +33,7 @@
         "zlib",
         "zstd"
       ],
-      "baseline": "e2836a9d0b7a26d5063b5e5a51a1b10b1246f4e8"
+      "baseline": "ed3fc6a2a4acac755b8006db8752496c585b830c"
     }
   ]
 }


### PR DESCRIPTION
- See [C++20 DR 2237](https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#2237)
- Only made error starting in gcc 11
- gcc 14 switches to a warning `-Wtemplate-id-cdtor`
- EbsdLib also had this issue which 1.0.30 resolves