### PR TITLE
BUG: ArraySelection Parameters linked to ChoiceParameter cannot be empty

### DIFF
--- a/src/simplnx/Filter/Parameters.cpp
+++ b/src/simplnx/Filter/Parameters.cpp
@@ -127,7 +127,11 @@ bool Parameters::isParameterActive(std::string_view key, const Arguments& args) 
 
     const IParameter* groupParameter = at(groupKey).get();
 
-    isActive |= func(*groupParameter, value, associatedValue);
+    isActive = func(*groupParameter, value, associatedValue);
+    if(isActive)
+    {
+      break;
+    }
   }
 
   return isActive;


### PR DESCRIPTION
- If an Array Selection Parameter is linked to a choice parameter the validate() function is called regardless whether the proper choice that activates that parameter is selected. This commit fixes the bug and restores the intended behavior.
