### PR TITLE
ENH: Fix compile warnings in FilterUtilities. Init array in DataStore when resizing

### DIFF
--- a/src/simplnx/Common/TypesUtility.hpp
+++ b/src/simplnx/Common/TypesUtility.hpp
@@ -4,7 +4,19 @@
 #include "simplnx/Common/TypeTraits.hpp"
 #include "simplnx/Common/Types.hpp"
 
+#if defined(__clang__) && defined(__clang_major__) && defined(__APPLE__)
+#if __clang_major__ > 14
 #include <bit>
+namespace bs = std;
+#else
+#include "Bit.hpp"
+namespace bs = nx::core;
+#endif
+#else
+#include <bit>
+namespace bs = std;
+#endif
+
 #include <optional>
 #include <stdexcept>
 #include <vector>
@@ -21,19 +33,19 @@ constexpr T GetMudflap() noexcept
 {
   if constexpr(sizeof(T) == 1)
   {
-    return std::bit_cast<T>(static_cast<uint8>(0xAB));
+    return bs::bit_cast<T>(static_cast<uint8>(0xAB));
   }
   if constexpr(sizeof(T) == 2)
   {
-    return std::bit_cast<T>(static_cast<uint16>(0xABAB));
+    return bs::bit_cast<T>(static_cast<uint16>(0xABAB));
   }
   if constexpr(sizeof(T) == 4)
   {
-    return std::bit_cast<T>(static_cast<uint32>(0xABABABAB));
+    return bs::bit_cast<T>(static_cast<uint32>(0xABABABAB));
   }
   if constexpr(sizeof(T) == 8)
   {
-    return std::bit_cast<T>(static_cast<uint64>(0xABABABABABABABAB));
+    return bs::bit_cast<T>(static_cast<uint64>(0xABABABABABABABAB));
   }
 }
 

--- a/src/simplnx/Common/TypesUtility.hpp
+++ b/src/simplnx/Common/TypesUtility.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <stdexcept>
 #include <vector>
+#include <bit>
 
 namespace nx::core
 {

--- a/src/simplnx/Common/TypesUtility.hpp
+++ b/src/simplnx/Common/TypesUtility.hpp
@@ -10,6 +10,33 @@
 
 namespace nx::core
 {
+
+/**
+ * @brief Returns the templated value for the byte pattern 0xAB based on the byte count of the template parameter
+ * @tparam T
+ * @return
+ */
+template <typename T>
+constexpr T GetMudflap() noexcept
+{
+  if constexpr(sizeof(T) == 1)
+  {
+    return std::bit_cast<T>(static_cast<uint8>(0xAB));
+  }
+  if constexpr(sizeof(T) == 2)
+  {
+    return std::bit_cast<T>(static_cast<uint16>(0xABAB));
+  }
+  if constexpr(sizeof(T) == 4)
+  {
+    return std::bit_cast<T>(static_cast<uint32>(0xABABABAB));
+  }
+  if constexpr(sizeof(T) == 8)
+  {
+    return std::bit_cast<T>(static_cast<uint64>(0xABABABABABABABAB));
+  }
+}
+
 /**
  * @brief Returns the NumericType associated with T.
  * @tparam T

--- a/src/simplnx/Common/TypesUtility.hpp
+++ b/src/simplnx/Common/TypesUtility.hpp
@@ -4,14 +4,13 @@
 #include "simplnx/Common/TypeTraits.hpp"
 #include "simplnx/Common/Types.hpp"
 
+#include <bit>
 #include <optional>
 #include <stdexcept>
 #include <vector>
-#include <bit>
 
 namespace nx::core
 {
-
 /**
  * @brief Returns the templated value for the byte pattern 0xAB based on the byte count of the template parameter
  * @tparam T

--- a/src/simplnx/Utilities/FilterUtilities.hpp
+++ b/src/simplnx/Utilities/FilterUtilities.hpp
@@ -2,6 +2,7 @@
 
 #include "ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Common/Result.hpp"
+#include "simplnx/Common/TypeTraits.hpp"
 #include "simplnx/Common/Types.hpp"
 #include "simplnx/Filter/IFilter.hpp"
 #include "simplnx/Filter/Output.hpp"
@@ -94,6 +95,9 @@ auto RunTemplateClass(DataType dataType, ArgsT&&... args)
       return ClassT<float64>(std::forward<ArgsT>(args)...)();
     }
   }
+  std::stringstream ss;
+  ss << "FilterUtilities::RunTemplateClass<> Error: dataType did not match any known type. DataType was " << to_underlying(dataType);
+  throw std::runtime_error(ss.str());
 }
 
 template <class FuncT, class... ArgsT>

--- a/src/simplnx/Utilities/FilterUtilities.hpp
+++ b/src/simplnx/Utilities/FilterUtilities.hpp
@@ -95,9 +95,7 @@ auto RunTemplateClass(DataType dataType, ArgsT&&... args)
       return ClassT<float64>(std::forward<ArgsT>(args)...)();
     }
   }
-  std::stringstream ss;
-  ss << "FilterUtilities::RunTemplateClass<> Error: dataType did not match any known type. DataType was " << to_underlying(dataType);
-  throw std::runtime_error(ss.str());
+  throw std::runtime_error(fmt::format("FilterUtilities::RunTemplateClass<> Error: dataType did not match any known type. DataType was {}", DataTypeToString(dataType)));
 }
 
 template <class FuncT, class... ArgsT>

--- a/src/simplnx/Utilities/FilterUtilities.hpp
+++ b/src/simplnx/Utilities/FilterUtilities.hpp
@@ -3,6 +3,7 @@
 #include "ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Common/Result.hpp"
 #include "simplnx/Common/TypeTraits.hpp"
+#include "simplnx/Common/TypeUtilities.hpp"
 #include "simplnx/Common/Types.hpp"
 #include "simplnx/Common/TypesUtility.hpp"
 #include "simplnx/Filter/IFilter.hpp"

--- a/src/simplnx/Utilities/FilterUtilities.hpp
+++ b/src/simplnx/Utilities/FilterUtilities.hpp
@@ -3,7 +3,6 @@
 #include "ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Common/Result.hpp"
 #include "simplnx/Common/TypeTraits.hpp"
-#include "simplnx/Common/TypeUtilities.hpp"
 #include "simplnx/Common/Types.hpp"
 #include "simplnx/Common/TypesUtility.hpp"
 #include "simplnx/Filter/IFilter.hpp"

--- a/src/simplnx/Utilities/FilterUtilities.hpp
+++ b/src/simplnx/Utilities/FilterUtilities.hpp
@@ -4,6 +4,7 @@
 #include "simplnx/Common/Result.hpp"
 #include "simplnx/Common/TypeTraits.hpp"
 #include "simplnx/Common/Types.hpp"
+#include "simplnx/Common/TypesUtility.hpp"
 #include "simplnx/Filter/IFilter.hpp"
 #include "simplnx/Filter/Output.hpp"
 #include "simplnx/simplnx_export.hpp"


### PR DESCRIPTION
FilterUtilities had a function without a return statement

- DataStore did not attempt to initialize the array with any value. This leads to difficulty debugging when the values are random or happening randomly (if the re-allocation happens to be in the same place as a once-valid array.

This change attempts to allow for the initialization value to be used. In case *no* initialization value is passed into the constructor then a default 0xABAB byte pattern is used instead. 