### PR TITLE
ENH: Segment Features Filters are more consistent with memory allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 DREAM3D-NX is a user-friendly and versatile desktop application that leverages the open-source ‘simplnx’ software library to enable users to manipulate, analyze, and visualize multidimensional, multimodal data with ease. With its advanced reconstruction, quantification, meshing, data organization, and visualization capabilities, DREAM3D-NX has emerged as a go-to tool for the materials science community to reconstruct and quantify 3D microstructures. Its flexibility and adaptability make it suitable for a broad range of multidimensional data analysis applications beyond materials science and engineering domain.
 
-`simplnx` is a rewrite of the [SIMPL](https://www.github.com/bluequartzsoftware/simpl) library upon which [DREAM3D](https://www.github.com/bluequartzsoftware/dream3d) is written. This library aims to be fully C++17 compliant, removes the need for Qt5 at the library level and brings more flexible data organization and grouping options. The library is under active development by BlueQuartz Software at the current time.
+`simplnx` is a rewrite of the [SIMPL](https://www.github.com/bluequartzsoftware/simpl) library upon which [DREAM3D](https://www.github.com/bluequartzsoftware/dream3d) is written. This library aims to be fully C++20 compliant, removes the need for Qt5 at the library level and brings more flexible data organization and grouping options. The library is under active development by BlueQuartz Software at the current time.
 
 ## Project Vision
 

--- a/docs/Build_From_Source.md
+++ b/docs/Build_From_Source.md
@@ -22,11 +22,11 @@
 
 ## Prerequisites ##
 
-In order to compile `simplnx` you will need a C++17 compiler suite installed on your computer.
+In order to compile `simplnx` you will need a C++20 compiler suite installed on your computer.
 
 + Compiler
   + Windows Visual Studio 2019 v142 toolset
-  + macOS 12.0 and Xcode 14.2 or higher
+  + macOS 12.5 and Xcode 14.2 or higher
   + Linux with GCC Version 11.0 or higher or clang 14.
 
 ## Install vcpkg ##

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD Reconstruction/(01) Small IN100 Archive.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD Reconstruction/(01) Small IN100 Archive.d3dpipeline
@@ -17,7 +17,7 @@
         },
         "output_file_path": "Data/Output/Reconstruction/Small_IN100.h5ebsd",
         "reference_frame_index": 0,
-        "stacking_orde_index": 1,
+        "stacking_order_index": 1,
         "z_spacing": 0.25
       },
       "filter": {

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.cpp
@@ -58,9 +58,9 @@ Result<> CAxisSegmentFeatures::operator()()
     }
   }
 
-  m_FeatureIdsArray = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsArrayName);
+  m_FeatureIdsArray = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsArrayPath);
   m_FeatureIdsArray->fill(0);
-  auto* active = m_DataStructure.getDataAs<UInt8Array>(m_InputValues->ActiveArrayName);
+  auto* active = m_DataStructure.getDataAs<UInt8Array>(m_InputValues->ActiveArrayPath);
   active->fill(1);
 
   // Generate the random voxel indices that will be used for the seed points to start a new grain growth/agglomeration

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.cpp
@@ -72,7 +72,7 @@ Result<> CAxisSegmentFeatures::operator()()
   }
 
   // Resize the Feature Attribute Matrix
-  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures)};
+  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures + 1)};
   auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->CellFeatureAttributeMatrixPath);
   cellFeaturesAM.resizeTuples(tDims); // This will resize the active array
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.hpp
@@ -21,9 +21,9 @@ struct ORIENTATIONANALYSIS_EXPORT CAxisSegmentFeaturesInputValues
   DataPath CellPhasesArrayPath;
   DataPath MaskArrayPath;
   DataPath CrystalStructuresArrayPath;
-  DataPath FeatureIdsArrayName;
+  DataPath FeatureIdsArrayPath;
   DataPath CellFeatureAttributeMatrixName;
-  DataPath ActiveArrayName;
+  DataPath ActiveArrayPath;
 };
 
 /**

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.hpp
@@ -22,7 +22,7 @@ struct ORIENTATIONANALYSIS_EXPORT CAxisSegmentFeaturesInputValues
   DataPath MaskArrayPath;
   DataPath CrystalStructuresArrayPath;
   DataPath FeatureIdsArrayPath;
-  DataPath CellFeatureAttributeMatrixName;
+  DataPath CellFeatureAttributeMatrixPath;
   DataPath ActiveArrayPath;
 };
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
@@ -52,7 +52,7 @@ Result<> EBSDSegmentFeatures::operator()()
   }
 
   // Resize the Feature Attribute Matrix
-  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures)};
+  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures + 1)};
   auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->CellFeatureAttributeMatrixPath);
   cellFeaturesAM.resizeTuples(tDims); // This will resize the active array
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
@@ -104,9 +104,6 @@ int64_t EBSDSegmentFeatures::getSeed(int32 gnum, int64 nextSeed) const
   if(seed >= 0)
   {
     featureIds->setValue(static_cast<usize>(seed), gnum);
-    //    std::vector<usize> tDims = {static_cast<usize>(gnum) + 1};
-    //    cellFeatureAM.resizeTuples(tDims); // This will resize the actives array
-    //    activeArray[gnum] = 1;
   }
   return seed;
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
@@ -103,8 +103,6 @@ int64_t EBSDSegmentFeatures::getSeed(int32 gnum, int64 nextSeed) const
   }
   if(seed >= 0)
   {
-    //    auto& activeArray = m_DataStructure.getDataAs<UInt8Array>(m_InputValues->activeArrayPath)->getDataStoreRef();
-    //    auto& cellFeatureAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->cellFeatureAttributeMatrixPath);
     featureIds->setValue(static_cast<usize>(seed), gnum);
     //    std::vector<usize> tDims = {static_cast<usize>(gnum) + 1};
     //    cellFeatureAM.resizeTuples(tDims); // This will resize the actives array

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
@@ -21,43 +21,52 @@ EBSDSegmentFeatures::~EBSDSegmentFeatures() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> EBSDSegmentFeatures::operator()()
 {
-  auto* gridGeom = m_DataStructure.getDataAs<IGridGeometry>(m_InputValues->gridGeomPath);
+  auto* gridGeom = m_DataStructure.getDataAs<IGridGeometry>(m_InputValues->ImageGeometryPath);
 
-  m_QuatsArray = m_DataStructure.getDataAs<Float32Array>(m_InputValues->quatsArrayPath);
-  m_CellPhases = m_DataStructure.getDataAs<Int32Array>(m_InputValues->cellPhasesArrayPath);
-  if(m_InputValues->useGoodVoxels)
+  m_QuatsArray = m_DataStructure.getDataAs<Float32Array>(m_InputValues->QuatsArrayPath);
+  m_CellPhases = m_DataStructure.getDataAs<Int32Array>(m_InputValues->CellPhasesArrayPath);
+  if(m_InputValues->UseMask)
   {
     try
     {
-      m_GoodVoxelsArray = std::move(InstantiateMaskCompare(m_DataStructure, m_InputValues->goodVoxelsArrayPath));
+      m_GoodVoxelsArray = std::move(InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath));
     } catch(const std::out_of_range& exception)
     {
       // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from
       // somewhere else that is NOT going through the normal nx::core::IFilter API of Preflight and Execute
-      std::string message = fmt::format("Mask Array DataPath does not exist or is not of the correct type (Bool | UInt8) {}", m_InputValues->goodVoxelsArrayPath.toString());
+      std::string message = fmt::format("Mask Array DataPath does not exist or is not of the correct type (Bool | UInt8) {}", m_InputValues->MaskArrayPath.toString());
       return MakeErrorResult(-485090, message);
     }
   }
-  m_CrystalStructures = m_DataStructure.getDataAs<UInt32Array>(m_InputValues->crystalStructuresArrayPath);
+  m_CrystalStructures = m_DataStructure.getDataAs<UInt32Array>(m_InputValues->CrystalStructuresArrayPath);
 
-  m_FeatureIdsArray = m_DataStructure.getDataAs<Int32Array>(m_InputValues->featureIdsArrayPath);
+  m_FeatureIdsArray = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsArrayPath);
   m_FeatureIdsArray->fill(0); // initialize the output array with zeros
 
+  // Run the segmentation algorithm
   execute(gridGeom);
-
-  auto* activeArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->activeArrayPath);
-  auto totalFeatures = activeArray->getNumberOfTuples();
-  if(totalFeatures < 2)
+  // Sanity check the result.
+  if(this->m_FoundFeatures < 1)
   {
-    return {nonstd::make_unexpected(std::vector<Error>{Error{-87000, "The number of Features was 0 or 1 which means no Features were detected. A threshold value may be set too high"}})};
+    return {MakeErrorResult(-87000, fmt::format("The number of Features is '{}' which means no Features were detected. A threshold value may be set incorrectly", this->m_FoundFeatures))};
   }
+
+  // Resize the Feature Attribute Matrix
+  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures) + 1};
+  auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->CellFeatureAttributeMatrixPath);
+  cellFeaturesAM.resizeTuples(tDims); // This will resize the active array
+
+  // make sure all values are initialized and "re-reserve" index 0
+  auto* activeArray = m_DataStructure.getDataAs<UInt8Array>(m_InputValues->ActiveArrayPath);
+  activeArray->getDataStore()->fill(1);
+  (*activeArray)[0] = 0;
 
   // Randomize the feature Ids for purely visual clarify. Having random Feature Ids
   // allows users visualizing the data to better discern each grain otherwise the coloring
   // would look like a smooth gradient. This is a user input parameter
-  if(m_InputValues->shouldRandomizeFeatureIds)
+  if(m_InputValues->RandomizeFeatureIds)
   {
-    randomizeFeatureIds(m_FeatureIdsArray, totalFeatures);
+    randomizeFeatureIds(m_FeatureIdsArray, this->m_FoundFeatures + 1);
   }
 
   return {};
@@ -78,7 +87,7 @@ int64_t EBSDSegmentFeatures::getSeed(int32 gnum, int64 nextSeed) const
   {
     if(featureIds->getValue(randPoint) == 0) // If the GrainId of the voxel is ZERO then we can use this as a seed point
     {
-      if((!m_InputValues->useGoodVoxels || m_GoodVoxelsArray->isTrue(randPoint)) && cellPhases->getValue(randPoint) > 0)
+      if((!m_InputValues->UseMask || m_GoodVoxelsArray->isTrue(randPoint)) && cellPhases->getValue(randPoint) > 0)
       {
         seed = static_cast<int64>(randPoint);
       }
@@ -94,12 +103,12 @@ int64_t EBSDSegmentFeatures::getSeed(int32 gnum, int64 nextSeed) const
   }
   if(seed >= 0)
   {
-    auto& activeArray = m_DataStructure.getDataAs<UInt8Array>(m_InputValues->activeArrayPath)->getDataStoreRef();
-    auto& cellFeatureAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->cellFeatureAttributeMatrixPath);
+    //    auto& activeArray = m_DataStructure.getDataAs<UInt8Array>(m_InputValues->activeArrayPath)->getDataStoreRef();
+    //    auto& cellFeatureAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->cellFeatureAttributeMatrixPath);
     featureIds->setValue(static_cast<usize>(seed), gnum);
-    std::vector<usize> tDims = {static_cast<usize>(gnum) + 1};
-    cellFeatureAM.resizeTuples(tDims); // This will resize the actives array
-    activeArray[gnum] = 1;
+    //    std::vector<usize> tDims = {static_cast<usize>(gnum) + 1};
+    //    cellFeatureAM.resizeTuples(tDims); // This will resize the actives array
+    //    activeArray[gnum] = 1;
   }
   return seed;
 }
@@ -139,7 +148,7 @@ bool EBSDSegmentFeatures::determineGrouping(int64 referencePoint, int64 neighbor
       OrientationF axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
       w = axisAngle[3];
     }
-    if(w < m_InputValues->misorientationTolerance)
+    if(w < m_InputValues->MisorientationTolerance)
     {
       group = true;
       featureIds[neighborPoint] = gnum;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
@@ -52,7 +52,7 @@ Result<> EBSDSegmentFeatures::operator()()
   }
 
   // Resize the Feature Attribute Matrix
-  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures) + 1};
+  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures)};
   auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->CellFeatureAttributeMatrixPath);
   cellFeaturesAM.resizeTuples(tDims); // This will resize the active array
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.hpp
@@ -22,17 +22,17 @@ namespace nx::core
  */
 struct ORIENTATIONANALYSIS_EXPORT EBSDSegmentFeaturesInputValues
 {
-  float32 misorientationTolerance;
-  bool useGoodVoxels;
-  bool shouldRandomizeFeatureIds;
-  DataPath gridGeomPath;
-  DataPath quatsArrayPath;
-  DataPath cellPhasesArrayPath;
-  DataPath goodVoxelsArrayPath;
-  DataPath crystalStructuresArrayPath;
-  DataPath featureIdsArrayPath;
-  DataPath cellFeatureAttributeMatrixPath;
-  DataPath activeArrayPath;
+  float32 MisorientationTolerance;
+  bool UseMask;
+  bool RandomizeFeatureIds;
+  DataPath ImageGeometryPath;
+  DataPath QuatsArrayPath;
+  DataPath CellPhasesArrayPath;
+  DataPath MaskArrayPath;
+  DataPath CrystalStructuresArrayPath;
+  DataPath FeatureIdsArrayPath;
+  DataPath CellFeatureAttributeMatrixPath;
+  DataPath ActiveArrayPath;
 };
 
 /**

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.cpp
@@ -198,8 +198,8 @@ Result<> CAxisSegmentFeaturesFilter::executeImpl(DataStructure& dataStructure, c
   inputValues.MaskArrayPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
   inputValues.CrystalStructuresArrayPath = filterArgs.value<DataPath>(k_CrystalStructuresArrayPath_Key);
   inputValues.FeatureIdsArrayPath = inputValues.QuatsArrayPath.replaceName(filterArgs.value<std::string>(k_FeatureIdsArrayName_Key));
-  inputValues.CellFeatureAttributeMatrixName = inputValues.ImageGeometryPath.createChildPath(filterArgs.value<std::string>(k_CellFeatureAttributeMatrixName_Key));
-  inputValues.ActiveArrayPath = inputValues.CellFeatureAttributeMatrixName.createChildPath(filterArgs.value<std::string>(k_ActiveArrayName_Key));
+  inputValues.CellFeatureAttributeMatrixPath = inputValues.ImageGeometryPath.createChildPath(filterArgs.value<std::string>(k_CellFeatureAttributeMatrixName_Key));
+  inputValues.ActiveArrayPath = inputValues.CellFeatureAttributeMatrixPath.createChildPath(filterArgs.value<std::string>(k_ActiveArrayName_Key));
 
   return CAxisSegmentFeatures(dataStructure, messageHandler, shouldCancel, &inputValues)();
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.cpp
@@ -17,6 +17,13 @@
 #include "simplnx/Parameters/NumberParameter.hpp"
 
 using namespace nx::core;
+namespace
+{
+constexpr int32 k_MissingGeomError = -440;
+constexpr int32 k_IncorrectInputArray = -600;
+constexpr int32 k_MissingInputArray = -601;
+constexpr int32 k_MissingOrIncorrectGoodVoxelsArray = -602;
+} // namespace
 
 namespace nx::core
 {
@@ -56,11 +63,10 @@ Parameters CAxisSegmentFeaturesFilter::parameters() const
   Parameters params;
   // Create the parameter descriptors that are needed for this filter
   params.insertSeparator(Parameters::Separator{"Input Parameter(s)"});
-  params.insert(std::make_unique<GeometrySelectionParameter>(k_ImageGeometryPath_Key, "Image Geometry", "The path to the input image geometry", DataPath{},
-                                                             GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image}));
+
   params.insert(std::make_unique<Float32Parameter>(k_MisorientationTolerance_Key, "C-Axis Misorientation Tolerance (Degrees)",
                                                    "Tolerance (in degrees) used to determine if neighboring Cells belong to the same Feature", 5.0f));
-  params.insert(std::make_unique<BoolParameter>(k_RandomizeFeatureIds_Key, "Randomize Feature Ids", "Specifies whether to randomize the feature ids", true));
+  params.insert(std::make_unique<BoolParameter>(k_RandomizeFeatureIds_Key, "Randomize Feature Ids", "Specifies whether to randomize the feature ids", false));
 
   params.insertSeparator(Parameters::Separator{"Optional Data Mask"});
   params.insertLinkableParameter(
@@ -69,7 +75,8 @@ Parameters CAxisSegmentFeaturesFilter::parameters() const
                                                           DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::boolean, DataType::uint8}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
 
   params.insertSeparator(Parameters::Separator{"Input Cell Data"});
-  params.insert(std::make_unique<DataObjectNameParameter>(k_FeatureIdsArrayName_Key, "Cell Feature Ids", "Specifies to which Feature each Cell belongs", "FeatureIds"));
+  params.insert(std::make_unique<GeometrySelectionParameter>(k_SelectedImageGeometryPath_Key, "Input Grid Geometry", "DataPath to input Grid Geometry", DataPath{},
+                                                             GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image, IGeometry::Type::RectGrid}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_QuatsArrayPath_Key, "Cell Quaternions", "Specifies the orientation of the Cell in quaternion representation", DataPath{},
                                                           ArraySelectionParameter::AllowedTypes{DataType::float32}, ArraySelectionParameter::AllowedComponentShapes{{4}}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_CellPhasesArrayPath_Key, "Cell Phases", "Specifies to which Ensemble each Cell belongs", DataPath{},
@@ -78,11 +85,17 @@ Parameters CAxisSegmentFeaturesFilter::parameters() const
   params.insertSeparator(Parameters::Separator{"Input Ensemble Data"});
   params.insert(std::make_unique<ArraySelectionParameter>(k_CrystalStructuresArrayPath_Key, "Crystal Structures", "Enumeration representing the crystal structure for each Ensemble", DataPath{},
                                                           ArraySelectionParameter::AllowedTypes{DataType::uint32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
+
+  params.insertSeparator(Parameters::Separator{"Output Cell Data"});
+  params.insert(std::make_unique<DataObjectNameParameter>(k_FeatureIdsArrayName_Key, "Cell Feature Ids", "Specifies to which Feature each Cell belongs", "FeatureIds"));
+
   params.insertSeparator(Parameters::Separator{"Output Feature Data"});
   params.insert(std::make_unique<DataObjectNameParameter>(k_CellFeatureAttributeMatrixName_Key, "Feature Attribute Matrix", "The name of the created feature attribute matrix", "Cell Feature Data"));
-  params.insert(std::make_unique<DataObjectNameParameter>(
-      k_ActiveArrayName_Key, "Active",
-      "Specifies if the Feature is still in the sample (true if the Feature is in the sample and false if it is not). At the end of the Filter, all Features will be Active", "Active"));
+  params.insert(std::make_unique<DataObjectNameParameter>(k_ActiveArrayName_Key, "Active",
+                                                          "The name of the array which specifies if the Feature is still in the sample (true if the Feature is in the sample and false if it is not). "
+                                                          "At the end of the Filter, all Features will be Active",
+                                                          "Active"));
+
   // Associate the Linkable Parameter(s) to the children parameters that they control
   params.linkParameters(k_UseMask_Key, k_MaskArrayPath_Key, true);
 
@@ -96,57 +109,78 @@ IFilter::UniquePointer CAxisSegmentFeaturesFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult CAxisSegmentFeaturesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
+IFilter::PreflightResult CAxisSegmentFeaturesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
                                                                    const std::atomic_bool& shouldCancel) const
 {
-  auto pImageGeometryPath = filterArgs.value<DataPath>(k_ImageGeometryPath_Key);
-  auto pUseGoodVoxelsValue = filterArgs.value<bool>(k_UseMask_Key);
-  auto pQuatsArrayPathValue = filterArgs.value<DataPath>(k_QuatsArrayPath_Key);
-  auto pCellPhasesArrayPathValue = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
-  auto pCrystalStructuresArrayPathValue = filterArgs.value<DataPath>(k_CrystalStructuresArrayPath_Key);
-  auto pFeatureIdsArrayNameValue = filterArgs.value<std::string>(k_FeatureIdsArrayName_Key);
-  auto pCellFeatureAttributeMatrixNameValue = filterArgs.value<std::string>(k_CellFeatureAttributeMatrixName_Key);
-  auto pActiveArrayNameValue = filterArgs.value<std::string>(k_ActiveArrayName_Key);
+  auto pQuatsArrayPathValue = args.value<DataPath>(k_QuatsArrayPath_Key);
+  auto pCellPhasesArrayPathValue = args.value<DataPath>(k_CellPhasesArrayPath_Key);
+  auto pCrystalStructuresArrayPathValue = args.value<DataPath>(k_CrystalStructuresArrayPath_Key);
 
-  const DataPath featureIdsPath = pQuatsArrayPathValue.replaceName(pFeatureIdsArrayNameValue);
-  const DataPath cellFeatureAMPath = pImageGeometryPath.createChildPath(pCellFeatureAttributeMatrixNameValue);
-  const DataPath activePath = cellFeatureAMPath.createChildPath(pActiveArrayNameValue);
-
-  PreflightResult preflightResult;
-  Result<OutputActions> resultOutputActions;
-  std::vector<PreflightValue> preflightUpdatedValues;
-
-  std::vector<DataPath> dataPaths = {pQuatsArrayPathValue, pCellPhasesArrayPathValue};
-  if(pUseGoodVoxelsValue)
+  // Validate the tolerance != 0
+  auto tolerance = args.value<float32>(k_MisorientationTolerance_Key);
+  if(tolerance == 0.0F)
   {
-    dataPaths.push_back(filterArgs.value<DataPath>(k_MaskArrayPath_Key));
+    return {MakeErrorResult<OutputActions>(-655, fmt::format("Misorientation Tolerance cannot equal ZERO.", humanName()))};
   }
 
-  const auto& imageGeo = dataStructure.getDataRefAs<ImageGeom>(pImageGeometryPath);
-  const auto* cellDataAM = imageGeo.getCellData();
+  // Validate the Grid Geometry
+  auto gridGeomPath = args.value<DataPath>(k_SelectedImageGeometryPath_Key);
+  const auto* inputGridGeom = dataStructure.getDataAs<IGridGeometry>(gridGeomPath);
+  DataPath inputCellDataPath = inputGridGeom->getCellDataPath();
+  auto featureIdsPath = inputCellDataPath.createChildPath(args.value<std::string>(k_FeatureIdsArrayName_Key));
+  auto pCellFeatureAttributeMatrixNameValue = gridGeomPath.createChildPath(args.value<std::string>(k_CellFeatureAttributeMatrixName_Key));
+  auto activeArrayPath = pCellFeatureAttributeMatrixNameValue.createChildPath(args.value<std::string>(k_ActiveArrayName_Key));
+
+  std::vector<DataPath> dataPaths;
+
+  dataPaths.push_back(pQuatsArrayPathValue);
+  dataPaths.push_back(pCellPhasesArrayPathValue);
+
+  // Validate the GoodVoxels/Mask Array combination
+  bool useGoodVoxels = args.value<bool>(k_UseMask_Key);
+  DataPath goodVoxelsPath;
+  if(useGoodVoxels)
+  {
+    goodVoxelsPath = args.value<DataPath>(k_MaskArrayPath_Key);
+
+    const auto* goodVoxelsArray = dataStructure.getDataAs<IDataArray>(goodVoxelsPath);
+    if(nullptr == goodVoxelsArray)
+    {
+      return {MakeErrorResult<OutputActions>(k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array is not located at path: '{}'", goodVoxelsPath.toString()))};
+    }
+    if(goodVoxelsArray->getDataType() != DataType::boolean && goodVoxelsArray->getDataType() != DataType::uint8)
+    {
+      return {
+          MakeErrorResult<OutputActions>(k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array at path '{}' is not of the correct type. It must be Bool or UInt8.", goodVoxelsPath.toString()))};
+    }
+    dataPaths.push_back(goodVoxelsPath);
+  }
+
   auto tupleValidityCheck = dataStructure.validateNumberOfTuples(dataPaths);
   if(!tupleValidityCheck)
   {
-    return {MakeErrorResult<OutputActions>(-8630, fmt::format("The following DataArrays all must have equal number of tuples but this was not satisfied.\n{}", tupleValidityCheck.error()))};
+    return {MakeErrorResult<OutputActions>(-651, fmt::format("The following DataArrays all must have equal number of tuples but this was not satisfied.\n{}", tupleValidityCheck.error()))};
   }
 
-  {
-    auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::int32, cellDataAM->getShape(), std::vector<usize>{1}, featureIdsPath);
-    resultOutputActions.value().appendAction(std::move(createArrayAction));
-  }
-  {
-    auto createAttributeMatrixAction = std::make_unique<CreateAttributeMatrixAction>(cellFeatureAMPath, std::vector<usize>{1});
-    resultOutputActions.value().appendAction(std::move(createAttributeMatrixAction));
-  }
-  {
-    auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::uint8, std::vector<usize>{1}, std::vector<usize>{1}, activePath);
-    resultOutputActions.value().appendAction(std::move(createArrayAction));
-  }
+  // Create the Cell Level FeatureIds array
+  const auto& quats = dataStructure.getDataRefAs<Float32Array>(pQuatsArrayPathValue);
+  auto createFeatureIdsAction = std::make_unique<CreateArrayAction>(DataType::int32, quats.getIDataStore()->getTupleShape(), std::vector<usize>{1}, featureIdsPath);
+
+  // Create the Feature Attribute Matrix
+  auto createFeatureGroupAction = std::make_unique<CreateAttributeMatrixAction>(pCellFeatureAttributeMatrixNameValue, std::vector<usize>{1});
+  auto createActiveAction = std::make_unique<CreateArrayAction>(DataType::uint8, std::vector<usize>{1}, std::vector<usize>{1}, activeArrayPath);
+
+  nx::core::Result<OutputActions> resultOutputActions;
+  std::vector<PreflightValue> preflightUpdatedValues;
+
+  resultOutputActions.value().appendAction(std::move(createFeatureGroupAction));
+  resultOutputActions.value().appendAction(std::move(createActiveAction));
+  resultOutputActions.value().appendAction(std::move(createFeatureIdsAction));
 
   resultOutputActions.warnings().push_back(
-      {-8361, "Segmenting features via c-axis mis orientation requires Hexagonal-Low 6/m or Hexagonal-High 6/mmm type crystal structures. Make sure your data is of one of these two types."});
+      {-8361, "Segmenting features via c-axis mis-orientation requires Hexagonal-Low 6/m or Hexagonal-High 6/mmm type crystal structures. Make sure your data is of one of these two types."});
 
-  return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
+  return {resultOutputActions, preflightUpdatedValues};
 }
 
 //------------------------------------------------------------------------------
@@ -155,7 +189,7 @@ Result<> CAxisSegmentFeaturesFilter::executeImpl(DataStructure& dataStructure, c
 {
   CAxisSegmentFeaturesInputValues inputValues;
 
-  inputValues.ImageGeometryPath = filterArgs.value<DataPath>(k_ImageGeometryPath_Key);
+  inputValues.ImageGeometryPath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
   inputValues.MisorientationTolerance = filterArgs.value<float32>(k_MisorientationTolerance_Key) * Constants::k_PiOver180F;
   inputValues.UseMask = filterArgs.value<bool>(k_UseMask_Key);
   inputValues.RandomizeFeatureIds = filterArgs.value<bool>(k_RandomizeFeatureIds_Key);
@@ -163,9 +197,9 @@ Result<> CAxisSegmentFeaturesFilter::executeImpl(DataStructure& dataStructure, c
   inputValues.CellPhasesArrayPath = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
   inputValues.MaskArrayPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
   inputValues.CrystalStructuresArrayPath = filterArgs.value<DataPath>(k_CrystalStructuresArrayPath_Key);
-  inputValues.FeatureIdsArrayName = inputValues.QuatsArrayPath.replaceName(filterArgs.value<std::string>(k_FeatureIdsArrayName_Key));
+  inputValues.FeatureIdsArrayPath = inputValues.QuatsArrayPath.replaceName(filterArgs.value<std::string>(k_FeatureIdsArrayName_Key));
   inputValues.CellFeatureAttributeMatrixName = inputValues.ImageGeometryPath.createChildPath(filterArgs.value<std::string>(k_CellFeatureAttributeMatrixName_Key));
-  inputValues.ActiveArrayName = inputValues.CellFeatureAttributeMatrixName.createChildPath(filterArgs.value<std::string>(k_ActiveArrayName_Key));
+  inputValues.ActiveArrayPath = inputValues.CellFeatureAttributeMatrixName.createChildPath(filterArgs.value<std::string>(k_ActiveArrayName_Key));
 
   return CAxisSegmentFeatures(dataStructure, messageHandler, shouldCancel, &inputValues)();
 }
@@ -193,7 +227,7 @@ Result<Arguments> CAxisSegmentFeaturesFilter::FromSIMPLJson(const nlohmann::json
 
   std::vector<Result<>> results;
 
-  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataContainerSelectionFilterParameterConverter>(args, json, SIMPL::k_QuatsArrayPathKey, k_ImageGeometryPath_Key));
+  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataContainerSelectionFilterParameterConverter>(args, json, SIMPL::k_QuatsArrayPathKey, k_SelectedImageGeometryPath_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::FloatFilterParameterConverter<float32>>(args, json, SIMPL::k_MisorientationToleranceKey, k_MisorientationTolerance_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::LinkedBooleanFilterParameterConverter>(args, json, SIMPL::k_UseGoodVoxelsKey, k_UseMask_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::BooleanFilterParameterConverter>(args, json, SIMPL::k_RandomizeFeatureIdsKey, k_RandomizeFeatureIds_Key));

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.hpp
@@ -24,10 +24,9 @@ public:
   CAxisSegmentFeaturesFilter& operator=(CAxisSegmentFeaturesFilter&&) noexcept = delete;
 
   // Parameter Keys
-  static inline constexpr StringLiteral k_ImageGeometryPath_Key = "input_image_geometry_path";
+  static inline constexpr StringLiteral k_SelectedImageGeometryPath_Key = "input_image_geometry_path";
   static inline constexpr StringLiteral k_MisorientationTolerance_Key = "misorientation_tolerance";
   static inline constexpr StringLiteral k_UseMask_Key = "use_mask";
-  static inline constexpr StringLiteral k_RandomizeFeatureIds_Key = "randomize_feature_ids";
   static inline constexpr StringLiteral k_QuatsArrayPath_Key = "quats_array_path";
   static inline constexpr StringLiteral k_CellPhasesArrayPath_Key = "cell_phases_array_path";
   static inline constexpr StringLiteral k_MaskArrayPath_Key = "mask_array_path";
@@ -35,6 +34,7 @@ public:
   static inline constexpr StringLiteral k_FeatureIdsArrayName_Key = "feature_ids_array_name";
   static inline constexpr StringLiteral k_CellFeatureAttributeMatrixName_Key = "cell_feature_attribute_matrix_name";
   static inline constexpr StringLiteral k_ActiveArrayName_Key = "active_array_name";
+  static inline constexpr StringLiteral k_RandomizeFeatureIds_Key = "randomize_feature_ids";
 
   /**
    * @brief Reads SIMPL json and converts it simplnx Arguments.

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EBSDSegmentFeaturesFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EBSDSegmentFeaturesFilter.cpp
@@ -1,7 +1,7 @@
 #include "EBSDSegmentFeaturesFilter.hpp"
 #include "OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.hpp"
 
-#include "simplnx/Common/Numbers.hpp"
+#include "simplnx/Common/Constants.hpp"
 #include "simplnx/DataStructure/DataPath.hpp"
 #include "simplnx/DataStructure/Geometry/IGridGeometry.hpp"
 #include "simplnx/Filter/Actions/CreateArrayAction.hpp"
@@ -10,10 +10,8 @@
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/DataObjectNameParameter.hpp"
 #include "simplnx/Parameters/GeometrySelectionParameter.hpp"
-
-#include "simplnx/Utilities/SIMPLConversion.hpp"
-
 #include "simplnx/Parameters/NumberParameter.hpp"
+#include "simplnx/Utilities/SIMPLConversion.hpp"
 
 using namespace nx::core;
 
@@ -66,13 +64,13 @@ Parameters EBSDSegmentFeaturesFilter::parameters() const
   params.insertSeparator(Parameters::Separator{"Input Parameter(s)"});
   params.insert(std::make_unique<Float32Parameter>(k_MisorientationTolerance_Key, "Misorientation Tolerance (Degrees)",
                                                    "Tolerance (in degrees) used to determine if neighboring Cells belong to the same Feature", 5.0f));
-  params.insert(std::make_unique<BoolParameter>(k_RandomizeFeatures_Key, "Randomize Feature IDs", "Specifies if feature IDs should be randomized during calculations", false));
+  params.insert(std::make_unique<BoolParameter>(k_RandomizeFeatureIds_Key, "Randomize Feature IDs", "Specifies if feature IDs should be randomized during calculations", false));
+
+  params.insertSeparator(Parameters::Separator{"Optional Data Mask"});
   params.insertLinkableParameter(
       std::make_unique<BoolParameter>(k_UseMask_Key, "Use Mask Array", "Specifies whether to use a boolean array to exclude some Cells from the Feature identification process", false));
   params.insert(std::make_unique<ArraySelectionParameter>(k_MaskArrayPath_Key, "Cell Mask Array", "Path to the data array that specifies if the Cell is to be counted in the algorithm", DataPath(),
                                                           ArraySelectionParameter::AllowedTypes{DataType::boolean, DataType::uint8}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
-  // Associate the Linkable Parameter(s) to the children parameters that they control
-  params.linkParameters(k_UseMask_Key, k_MaskArrayPath_Key, true);
 
   params.insertSeparator(Parameters::Separator{"Input Cell Data"});
   params.insert(std::make_unique<GeometrySelectionParameter>(k_SelectedImageGeometryPath_Key, "Input Grid Geometry", "DataPath to input Grid Geometry", DataPath{},
@@ -88,6 +86,7 @@ Parameters EBSDSegmentFeaturesFilter::parameters() const
 
   params.insertSeparator(Parameters::Separator{"Output Cell Data"});
   params.insert(std::make_unique<DataObjectNameParameter>(k_FeatureIdsArrayName_Key, "Cell Feature Ids", "Specifies to which Feature each Cell belongs.", "FeatureIds"));
+
   params.insertSeparator(Parameters::Separator{"Output Feature Data"});
   params.insert(
       std::make_unique<DataObjectNameParameter>(k_CellFeatureAttributeMatrixName_Key, "Feature Attribute Matrix", "The name of the created cell feature attribute matrix", "Cell Feature Data"));
@@ -95,6 +94,9 @@ Parameters EBSDSegmentFeaturesFilter::parameters() const
                                                           "The name of the array which specifies if the Feature is still in the sample (true if the Feature is in the sample and false if it is not). "
                                                           "At the end of the Filter, all Features will be Active",
                                                           "Active"));
+
+  // Associate the Linkable Parameter(s) to the children parameters that they control
+  params.linkParameters(k_UseMask_Key, k_MaskArrayPath_Key, true);
 
   return params;
 }
@@ -117,14 +119,7 @@ IFilter::PreflightResult EBSDSegmentFeaturesFilter::preflightImpl(const DataStru
   auto tolerance = args.value<float32>(k_MisorientationTolerance_Key);
   if(tolerance == 0.0F)
   {
-    return {nonstd::make_unexpected(std::vector<Error>{Error{-655, fmt::format("Misorientation Tolerance cannot equal ZERO.", humanName())}})};
-  }
-
-  // Validate the Crystal Structures array
-  const auto& crystalStructures = dataStructure.getDataRefAs<UInt32Array>(pCrystalStructuresArrayPathValue);
-  if(crystalStructures.getNumberOfComponents() != 1)
-  {
-    return {nonstd::make_unexpected(std::vector<Error>{Error{k_IncorrectInputArray, "Crystal Structures Input Array must be a 1 component Int32 array"}})};
+    return {MakeErrorResult<OutputActions>(-655, fmt::format("Misorientation Tolerance cannot equal ZERO.", humanName()))};
   }
 
   // Validate the Grid Geometry
@@ -137,20 +132,7 @@ IFilter::PreflightResult EBSDSegmentFeaturesFilter::preflightImpl(const DataStru
 
   std::vector<DataPath> dataPaths;
 
-  // Validate the Quats array
-  const auto& quats = dataStructure.getDataRefAs<Float32Array>(pQuatsArrayPathValue);
-  if(quats.getNumberOfComponents() != 4)
-  {
-    return {nonstd::make_unexpected(std::vector<Error>{Error{k_IncorrectInputArray, "Quaternion Input Array must be a 4 component Float32 array"}})};
-  }
   dataPaths.push_back(pQuatsArrayPathValue);
-
-  // Validate the Phases array
-  const auto& phases = dataStructure.getDataRefAs<Int32Array>(pCellPhasesArrayPathValue);
-  if(phases.getNumberOfComponents() != 1)
-  {
-    return {nonstd::make_unexpected(std::vector<Error>{Error{k_IncorrectInputArray, "Phases Input Array must be a 1 component Int32 array"}})};
-  }
   dataPaths.push_back(pCellPhasesArrayPathValue);
 
   // Validate the GoodVoxels/Mask Array combination
@@ -163,12 +145,12 @@ IFilter::PreflightResult EBSDSegmentFeaturesFilter::preflightImpl(const DataStru
     const auto* goodVoxelsArray = dataStructure.getDataAs<IDataArray>(goodVoxelsPath);
     if(nullptr == goodVoxelsArray)
     {
-      return {nonstd::make_unexpected(std::vector<Error>{Error{k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array is not located at path: '{}'", goodVoxelsPath.toString())}})};
+      return {MakeErrorResult<OutputActions>(k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array is not located at path: '{}'", goodVoxelsPath.toString()))};
     }
     if(goodVoxelsArray->getDataType() != DataType::boolean && goodVoxelsArray->getDataType() != DataType::uint8)
     {
-      return {nonstd::make_unexpected(
-          std::vector<Error>{Error{k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array at path '{}' is not of the correct type. It must be Bool or UInt8.", goodVoxelsPath.toString())}})};
+      return {
+          MakeErrorResult<OutputActions>(k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array at path '{}' is not of the correct type. It must be Bool or UInt8.", goodVoxelsPath.toString()))};
     }
     dataPaths.push_back(goodVoxelsPath);
   }
@@ -179,17 +161,22 @@ IFilter::PreflightResult EBSDSegmentFeaturesFilter::preflightImpl(const DataStru
     return {MakeErrorResult<OutputActions>(-651, fmt::format("The following DataArrays all must have equal number of tuples but this was not satisfied.\n{}", tupleValidityCheck.error()))};
   }
 
-  // Create output DataStructure Items
-  auto createFeatureGroupAction = std::make_unique<CreateAttributeMatrixAction>(pCellFeatureAttributeMatrixNameValue, std::vector<usize>{1});
-  auto createActiveAction = std::make_unique<CreateArrayAction>(DataType::uint8, std::vector<usize>{1}, std::vector<usize>{1}, activeArrayPath);
+  // Create the Cell Level FeatureIds array
+  const auto& quats = dataStructure.getDataRefAs<Float32Array>(pQuatsArrayPathValue);
   auto createFeatureIdsAction = std::make_unique<CreateArrayAction>(DataType::int32, quats.getIDataStore()->getTupleShape(), std::vector<usize>{1}, featureIdsPath);
 
-  OutputActions actions;
-  actions.appendAction(std::move(createFeatureGroupAction));
-  actions.appendAction(std::move(createActiveAction));
-  actions.appendAction(std::move(createFeatureIdsAction));
+  // Create the Feature Attribute Matrix
+  auto createFeatureGroupAction = std::make_unique<CreateAttributeMatrixAction>(pCellFeatureAttributeMatrixNameValue, std::vector<usize>{1});
+  auto createActiveAction = std::make_unique<CreateArrayAction>(DataType::uint8, std::vector<usize>{1}, std::vector<usize>{1}, activeArrayPath);
 
-  return {std::move(actions)};
+  nx::core::Result<OutputActions> resultOutputActions;
+  std::vector<PreflightValue> preflightUpdatedValues;
+
+  resultOutputActions.value().appendAction(std::move(createFeatureGroupAction));
+  resultOutputActions.value().appendAction(std::move(createActiveAction));
+  resultOutputActions.value().appendAction(std::move(createFeatureIdsAction));
+
+  return {resultOutputActions, preflightUpdatedValues};
 }
 
 //------------------------------------------------------------------------------
@@ -198,19 +185,17 @@ Result<> EBSDSegmentFeaturesFilter::executeImpl(DataStructure& dataStructure, co
 {
   EBSDSegmentFeaturesInputValues inputValues;
 
-  // Store the misorientation tolerance as radians
-  inputValues.misorientationTolerance = filterArgs.value<float32>(k_MisorientationTolerance_Key) * static_cast<float>(nx::core::numbers::pi / 180.0f);
-  inputValues.useGoodVoxels = filterArgs.value<bool>(k_UseMask_Key);
-  inputValues.shouldRandomizeFeatureIds = filterArgs.value<bool>(k_RandomizeFeatures_Key);
-  inputValues.gridGeomPath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
-  inputValues.quatsArrayPath = filterArgs.value<DataPath>(k_QuatsArrayPath_Key);
-  inputValues.cellPhasesArrayPath = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
-  inputValues.goodVoxelsArrayPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
-  inputValues.crystalStructuresArrayPath = filterArgs.value<DataPath>(k_CrystalStructuresArrayPath_Key);
-  auto cellDataAMPath = dataStructure.getDataAs<IGridGeometry>(inputValues.gridGeomPath)->getCellDataPath();
-  inputValues.featureIdsArrayPath = cellDataAMPath.createChildPath(filterArgs.value<std::string>(k_FeatureIdsArrayName_Key));
-  inputValues.cellFeatureAttributeMatrixPath = inputValues.gridGeomPath.createChildPath(filterArgs.value<std::string>(k_CellFeatureAttributeMatrixName_Key));
-  inputValues.activeArrayPath = inputValues.cellFeatureAttributeMatrixPath.createChildPath(filterArgs.value<std::string>(k_ActiveArrayName_Key));
+  inputValues.ImageGeometryPath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
+  inputValues.MisorientationTolerance = filterArgs.value<float32>(k_MisorientationTolerance_Key) * Constants::k_PiOver180F;
+  inputValues.UseMask = filterArgs.value<bool>(k_UseMask_Key);
+  inputValues.RandomizeFeatureIds = filterArgs.value<bool>(k_RandomizeFeatureIds_Key);
+  inputValues.QuatsArrayPath = filterArgs.value<DataPath>(k_QuatsArrayPath_Key);
+  inputValues.CellPhasesArrayPath = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
+  inputValues.MaskArrayPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
+  inputValues.CrystalStructuresArrayPath = filterArgs.value<DataPath>(k_CrystalStructuresArrayPath_Key);
+  inputValues.FeatureIdsArrayPath = inputValues.QuatsArrayPath.replaceName(filterArgs.value<std::string>(k_FeatureIdsArrayName_Key));
+  inputValues.CellFeatureAttributeMatrixPath = inputValues.ImageGeometryPath.createChildPath(filterArgs.value<std::string>(k_CellFeatureAttributeMatrixName_Key));
+  inputValues.ActiveArrayPath = inputValues.CellFeatureAttributeMatrixPath.createChildPath(filterArgs.value<std::string>(k_ActiveArrayName_Key));
 
   // Let the Algorithm instance do the work
   return EBSDSegmentFeatures(dataStructure, messageHandler, shouldCancel, &inputValues)();
@@ -242,7 +227,7 @@ Result<Arguments> EBSDSegmentFeaturesFilter::FromSIMPLJson(const nlohmann::json&
 
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::FloatFilterParameterConverter<float32>>(args, json, SIMPL::k_MisorientationToleranceKey, k_MisorientationTolerance_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::LinkedBooleanFilterParameterConverter>(args, json, SIMPL::k_UseGoodVoxelsKey, k_UseMask_Key));
-  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::BooleanFilterParameterConverter>(args, json, SIMPL::k_RandomizeFeatureIdsKey, k_RandomizeFeatures_Key));
+  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::BooleanFilterParameterConverter>(args, json, SIMPL::k_RandomizeFeatureIdsKey, k_RandomizeFeatureIds_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_QuatsArrayPathKey, k_QuatsArrayPath_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_CellPhasesArrayPathKey, k_CellPhasesArrayPath_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_GoodVoxelsArrayPathKey, k_MaskArrayPath_Key));

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EBSDSegmentFeaturesFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EBSDSegmentFeaturesFilter.hpp
@@ -34,7 +34,7 @@ public:
   static inline constexpr StringLiteral k_FeatureIdsArrayName_Key = "feature_ids_array_name";
   static inline constexpr StringLiteral k_CellFeatureAttributeMatrixName_Key = "cell_feature_attribute_matrix_name";
   static inline constexpr StringLiteral k_ActiveArrayName_Key = "active_array_name";
-  static inline constexpr StringLiteral k_RandomizeFeatures_Key = "randomize_features";
+  static inline constexpr StringLiteral k_RandomizeFeatureIds_Key = "randomize_features";
 
   /**
    * @brief Reads SIMPL json and converts it simplnx Arguments.

--- a/src/Plugins/OrientationAnalysis/test/CAxisSegmentFeaturesTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/CAxisSegmentFeaturesTest.cpp
@@ -4,7 +4,6 @@
 
 #include "OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.hpp"
 #include "OrientationAnalysis/OrientationAnalysis_test_dirs.hpp"
-#include "OrientationAnalysisTestUtils.hpp"
 
 #include <filesystem>
 
@@ -53,6 +52,12 @@ TEST_CASE("OrientationAnalysis::CAxisSegmentFeaturesFilter: Valid Filter Executi
     // Execute the filter and check the result
     auto executeResult = filter.execute(dataStructure, args);
     SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+  }
+  {
+    DataPath activeArrayDataPath = k_DataContainerPath.createChildPath(k_ComputedCellFeatureData).createChildPath(k_ActiveName);
+    UInt8Array& actives = dataStructure.getDataRefAs<UInt8Array>(activeArrayDataPath);
+    size_t numFeatures = actives.getNumberOfTuples();
+    REQUIRE(numFeatures == 31228);
   }
 
   // Loop and compare each array from the 'Exemplar Data / CellData' to the 'Data Container / CellData' group

--- a/src/Plugins/OrientationAnalysis/test/CAxisSegmentFeaturesTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/CAxisSegmentFeaturesTest.cpp
@@ -57,7 +57,7 @@ TEST_CASE("OrientationAnalysis::CAxisSegmentFeaturesFilter: Valid Filter Executi
     DataPath activeArrayDataPath = k_DataContainerPath.createChildPath(k_ComputedCellFeatureData).createChildPath(k_ActiveName);
     UInt8Array& actives = dataStructure.getDataRefAs<UInt8Array>(activeArrayDataPath);
     size_t numFeatures = actives.getNumberOfTuples();
-    REQUIRE(numFeatures == 31228);
+    REQUIRE(numFeatures == 31229);
   }
 
   // Loop and compare each array from the 'Exemplar Data / CellData' to the 'Data Container / CellData' group
@@ -65,10 +65,6 @@ TEST_CASE("OrientationAnalysis::CAxisSegmentFeaturesFilter: Valid Filter Executi
     const auto& generatedFeatureIds = dataStructure.getDataRefAs<Int32Array>(k_CellAttributeMatrix.createChildPath(k_ComputedFeatureIds));
     const auto& exemplarFeatureIds = dataStructure.getDataRefAs<Int32Array>(k_FeatureIdsArrayPath);
     UnitTest::CompareDataArrays<int32>(generatedFeatureIds, exemplarFeatureIds);
-
-    const auto& generatedActive = dataStructure.getDataRefAs<UInt8Array>(k_DataContainerPath.createChildPath(k_ComputedCellFeatureData).createChildPath(k_ActiveName));
-    const auto& exemplarActive = dataStructure.getDataRefAs<BoolArray>(k_CellFeatureDataPath.createChildPath(k_ActiveName));
-    REQUIRE(generatedActive.size() == exemplarActive.size());
   }
 }
 

--- a/src/Plugins/OrientationAnalysis/test/CAxisSegmentFeaturesTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/CAxisSegmentFeaturesTest.cpp
@@ -34,7 +34,7 @@ TEST_CASE("OrientationAnalysis::CAxisSegmentFeaturesFilter: Valid Filter Executi
     Arguments args;
 
     // Create default Parameters for the filter.
-    args.insertOrAssign(CAxisSegmentFeaturesFilter::k_ImageGeometryPath_Key, std::make_any<DataPath>(k_DataContainerPath));
+    args.insertOrAssign(CAxisSegmentFeaturesFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_DataContainerPath));
     args.insertOrAssign(CAxisSegmentFeaturesFilter::k_MisorientationTolerance_Key, std::make_any<float32>(5.0f));
     args.insertOrAssign(CAxisSegmentFeaturesFilter::k_UseMask_Key, std::make_any<bool>(true));
     args.insertOrAssign(CAxisSegmentFeaturesFilter::k_RandomizeFeatureIds_Key, std::make_any<bool>(false));
@@ -84,7 +84,7 @@ TEST_CASE("OrientationAnalysis::CAxisSegmentFeaturesFilter: Invalid Filter Execu
   Arguments args;
 
   // Invalid crystal structure type : should fail in execute
-  args.insertOrAssign(CAxisSegmentFeaturesFilter::k_ImageGeometryPath_Key, std::make_any<DataPath>(k_DataContainerPath));
+  args.insertOrAssign(CAxisSegmentFeaturesFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_DataContainerPath));
   args.insertOrAssign(CAxisSegmentFeaturesFilter::k_MisorientationTolerance_Key, std::make_any<float32>(5.0f));
   args.insertOrAssign(CAxisSegmentFeaturesFilter::k_UseMask_Key, std::make_any<bool>(false));
   args.insertOrAssign(CAxisSegmentFeaturesFilter::k_RandomizeFeatureIds_Key, std::make_any<bool>(false));

--- a/src/Plugins/OrientationAnalysis/test/EBSDSegmentFeaturesFilterTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/EBSDSegmentFeaturesFilterTest.cpp
@@ -88,7 +88,7 @@ TEST_CASE("OrientationAnalysis::EBSDSegmentFeatures: Valid Execution", "[Orienta
     DataPath activeArrayDataPath = k_DataContainerPath.createChildPath(k_Grain_Data).createChildPath(k_ActiveName);
     UInt8Array& actives = dataStructure.getDataRefAs<UInt8Array>(activeArrayDataPath);
     size_t numFeatures = actives.getNumberOfTuples();
-    REQUIRE(numFeatures == 5416);
+    REQUIRE(numFeatures == 5417);
   }
   // Loop and compare each array from the 'Exemplar Data / CellData' to the 'Data Container / CellData' group
   {

--- a/src/Plugins/OrientationAnalysis/test/EBSDSegmentFeaturesFilterTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/EBSDSegmentFeaturesFilterTest.cpp
@@ -84,6 +84,12 @@ TEST_CASE("OrientationAnalysis::EBSDSegmentFeatures: Valid Execution", "[Orienta
     SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
 
+  {
+    DataPath activeArrayDataPath = k_DataContainerPath.createChildPath(k_Grain_Data).createChildPath(k_ActiveName);
+    UInt8Array& actives = dataStructure.getDataRefAs<UInt8Array>(activeArrayDataPath);
+    size_t numFeatures = actives.getNumberOfTuples();
+    REQUIRE(numFeatures == 5416);
+  }
   // Loop and compare each array from the 'Exemplar Data / CellData' to the 'Data Container / CellData' group
   {
     const auto& generatedDataArray = dataStructure.getDataRefAs<Int32Array>(k_FeatureIdsArrayPath);

--- a/src/Plugins/OrientationAnalysis/test/EBSDSegmentFeaturesFilterTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/EBSDSegmentFeaturesFilterTest.cpp
@@ -73,7 +73,7 @@ TEST_CASE("OrientationAnalysis::EBSDSegmentFeatures: Valid Execution", "[Orienta
     args.insertOrAssign(EBSDSegmentFeaturesFilter::k_FeatureIdsArrayName_Key, std::make_any<std::string>(k_FeatureIds));
     args.insertOrAssign(EBSDSegmentFeaturesFilter::k_CellFeatureAttributeMatrixName_Key, std::make_any<std::string>(k_Grain_Data));
     args.insertOrAssign(EBSDSegmentFeaturesFilter::k_ActiveArrayName_Key, std::make_any<std::string>(k_ActiveName));
-    args.insertOrAssign(EBSDSegmentFeaturesFilter::k_RandomizeFeatures_Key, std::make_any<bool>(false));
+    args.insertOrAssign(EBSDSegmentFeaturesFilter::k_RandomizeFeatureIds_Key, std::make_any<bool>(false));
 
     // Preflight the filter and check result
     auto preflightResult = filter.preflight(dataStructure, args);

--- a/src/Plugins/OrientationAnalysis/test/MergeTwinsTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/MergeTwinsTest.cpp
@@ -88,7 +88,7 @@ TEST_CASE("Reconstruction::MergeTwinsFilter: Valid Execution", "[Reconstruction]
     Arguments args;
 
     args.insertOrAssign(EBSDSegmentFeaturesFilter::k_MisorientationTolerance_Key, std::make_any<float32>(5.0f));
-    args.insertOrAssign(EBSDSegmentFeaturesFilter::k_RandomizeFeatures_Key, std::make_any<bool>(false));
+    args.insertOrAssign(EBSDSegmentFeaturesFilter::k_RandomizeFeatureIds_Key, std::make_any<bool>(false));
     args.insertOrAssign(EBSDSegmentFeaturesFilter::k_UseMask_Key, std::make_any<bool>(true));
     args.insertOrAssign(EBSDSegmentFeaturesFilter::k_MaskArrayPath_Key, std::make_any<DataPath>(k_MaskArrayPath));
     args.insertOrAssign(EBSDSegmentFeaturesFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_DataContainerPath));

--- a/src/Plugins/OrientationAnalysis/test/OrientationAnalysisTestUtils.hpp
+++ b/src/Plugins/OrientationAnalysis/test/OrientationAnalysisTestUtils.hpp
@@ -171,7 +171,7 @@ inline void ExecuteEbsdSegmentFeatures(DataStructure& dataStructure, const Filte
   args.insertOrAssign(EBSDSegmentFeaturesFilter::k_FeatureIdsArrayName_Key, std::make_any<std::string>(Constants::k_FeatureIds));
   args.insertOrAssign(EBSDSegmentFeaturesFilter::k_CellFeatureAttributeMatrixName_Key, std::make_any<std::string>(Constants::k_Grain_Data));
   args.insertOrAssign(EBSDSegmentFeaturesFilter::k_ActiveArrayName_Key, std::make_any<std::string>(Constants::k_ActiveName));
-  args.insertOrAssign(EBSDSegmentFeaturesFilter::k_RandomizeFeatures_Key, std::make_any<bool>(false));
+  args.insertOrAssign(EBSDSegmentFeaturesFilter::k_RandomizeFeatureIds_Key, std::make_any<bool>(false));
 
   // Preflight the filter and check result
   auto preflightResult = filter->preflight(dataStructure, args);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
@@ -272,9 +272,6 @@ int64_t ScalarSegmentFeatures::getSeed(int32 gnum, int64 nextSeed) const
   if(seed >= 0)
   {
     featureIds->setValue(static_cast<usize>(seed), gnum);
-    //  std::vector<usize> tDims = {static_cast<usize>(gnum) + 1};
-    //  auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->pCellFeaturesPath);
-    //  cellFeaturesAM.resizeTuples(tDims); // This will resize the active array
   }
   return seed;
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
@@ -222,7 +222,7 @@ Result<> ScalarSegmentFeatures::operator()()
   }
 
   // Resize the Feature Attribute Matrix
-  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures) + 1};
+  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures)};
   auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->CellFeatureAttributeMatrixPath);
   cellFeaturesAM.resizeTuples(tDims); // This will resize the active array
 
@@ -284,7 +284,6 @@ bool ScalarSegmentFeatures::determineGrouping(int64 referencepoint, int64 neighb
   {
     CompareFunctor* func = m_CompareFunctor.get();
     return (*func)((usize)(referencepoint), (usize)(neighborpoint), gnum);
-    //     | Functor  ||calling the operator() method of the CompareFunctor Class |
   }
 
   return false;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
@@ -222,7 +222,7 @@ Result<> ScalarSegmentFeatures::operator()()
   }
 
   // Resize the Feature Attribute Matrix
-  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures)};
+  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures + 1)};
   auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->CellFeatureAttributeMatrixPath);
   cellFeaturesAM.resizeTuples(tDims); // This will resize the active array
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
@@ -134,25 +134,26 @@ ScalarSegmentFeatures::~ScalarSegmentFeatures() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ScalarSegmentFeatures::operator()()
 {
-  if(m_InputValues->pUseGoodVoxels)
+  if(m_InputValues->UseMask)
   {
     try
     {
-      m_GoodVoxels = InstantiateMaskCompare(m_DataStructure, m_InputValues->pGoodVoxelsPath);
+      m_GoodVoxels = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
     } catch(const std::out_of_range& exception)
     {
       // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from
       // somewhere else that is NOT going through the normal nx::core::IFilter API of Preflight and Execute
-      std::string message = fmt::format("Mask Array DataPath does not exist or is not of the correct type (Bool | UInt8) {}", m_InputValues->pGoodVoxelsPath.toString());
+      std::string message = fmt::format("Mask Array DataPath does not exist or is not of the correct type (Bool | UInt8) {}", m_InputValues->MaskArrayPath.toString());
       return MakeErrorResult(-54110, message);
     }
   }
 
-  auto* gridGeom = m_DataStructure.getDataAs<IGridGeometry>(m_InputValues->pGridGeomPath);
+  auto* gridGeom = m_DataStructure.getDataAs<IGridGeometry>(m_InputValues->ImageGeometryPath);
 
-  m_FeatureIdsArray = m_DataStructure.getDataAs<Int32Array>(m_InputValues->pFeatureIdsPath);
+  m_FeatureIdsArray = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsArrayPath);
   m_FeatureIdsArray->fill(0); // initialize the output array with zeros
-  IDataArray* inputDataArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->pInputDataPath);
+
+  IDataArray* inputDataArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->InputDataPath);
   size_t inDataPoints = inputDataArray->getNumberOfTuples();
   nx::core::DataType dataType = inputDataArray->getDataType();
 
@@ -161,47 +162,47 @@ Result<> ScalarSegmentFeatures::operator()()
   switch(dataType)
   {
   case nx::core::DataType::int8: {
-    m_CompareFunctor = std::make_shared<::TSpecificCompareFunctor<int8>>(inputDataArray, inDataPoints, static_cast<int8>(m_InputValues->pScalarTolerance), featureIds);
+    m_CompareFunctor = std::make_shared<::TSpecificCompareFunctor<int8>>(inputDataArray, inDataPoints, static_cast<int8>(m_InputValues->ScalarTolerance), featureIds);
     break;
   }
   case nx::core::DataType::uint8: {
-    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<uint8>>(inputDataArray, inDataPoints, static_cast<uint8>(m_InputValues->pScalarTolerance), featureIds);
+    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<uint8>>(inputDataArray, inDataPoints, static_cast<uint8>(m_InputValues->ScalarTolerance), featureIds);
     break;
   }
   case nx::core::DataType::boolean: {
-    m_CompareFunctor = std::make_shared<TSpecificCompareFunctorBool>(inputDataArray, inDataPoints, static_cast<bool>(m_InputValues->pScalarTolerance), featureIds);
+    m_CompareFunctor = std::make_shared<TSpecificCompareFunctorBool>(inputDataArray, inDataPoints, static_cast<bool>(m_InputValues->ScalarTolerance), featureIds);
     break;
   }
   case nx::core::DataType::int16: {
-    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<int16>>(inputDataArray, inDataPoints, static_cast<int16>(m_InputValues->pScalarTolerance), featureIds);
+    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<int16>>(inputDataArray, inDataPoints, static_cast<int16>(m_InputValues->ScalarTolerance), featureIds);
     break;
   }
   case nx::core::DataType::uint16: {
-    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<uint16>>(inputDataArray, inDataPoints, static_cast<uint16>(m_InputValues->pScalarTolerance), featureIds);
+    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<uint16>>(inputDataArray, inDataPoints, static_cast<uint16>(m_InputValues->ScalarTolerance), featureIds);
     break;
   }
   case nx::core::DataType::int32: {
-    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<int32>>(inputDataArray, inDataPoints, static_cast<int32>(m_InputValues->pScalarTolerance), featureIds);
+    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<int32>>(inputDataArray, inDataPoints, static_cast<int32>(m_InputValues->ScalarTolerance), featureIds);
     break;
   }
   case nx::core::DataType::uint32: {
-    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<uint32>>(inputDataArray, inDataPoints, static_cast<uint32>(m_InputValues->pScalarTolerance), featureIds);
+    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<uint32>>(inputDataArray, inDataPoints, static_cast<uint32>(m_InputValues->ScalarTolerance), featureIds);
     break;
   }
   case nx::core::DataType::int64: {
-    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<int64>>(inputDataArray, inDataPoints, static_cast<int64>(m_InputValues->pScalarTolerance), featureIds);
+    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<int64>>(inputDataArray, inDataPoints, static_cast<int64>(m_InputValues->ScalarTolerance), featureIds);
     break;
   }
   case nx::core::DataType::uint64: {
-    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<uint64>>(inputDataArray, inDataPoints, static_cast<uint64>(m_InputValues->pScalarTolerance), featureIds);
+    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<uint64>>(inputDataArray, inDataPoints, static_cast<uint64>(m_InputValues->ScalarTolerance), featureIds);
     break;
   }
   case nx::core::DataType::float32: {
-    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<float32>>(inputDataArray, inDataPoints, static_cast<float32>(m_InputValues->pScalarTolerance), featureIds);
+    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<float32>>(inputDataArray, inDataPoints, static_cast<float32>(m_InputValues->ScalarTolerance), featureIds);
     break;
   }
   case nx::core::DataType::float64: {
-    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<float64>>(inputDataArray, inDataPoints, static_cast<float64>(m_InputValues->pScalarTolerance), featureIds);
+    m_CompareFunctor = std::make_shared<TSpecificCompareFunctor<float64>>(inputDataArray, inDataPoints, static_cast<float64>(m_InputValues->ScalarTolerance), featureIds);
     break;
   }
   default:
@@ -212,29 +213,30 @@ Result<> ScalarSegmentFeatures::operator()()
     m_CompareFunctor = std::shared_ptr<SegmentFeatures::CompareFunctor>(new SegmentFeatures::CompareFunctor()); // The default CompareFunctor which ALWAYS returns false for the comparison
   }
 
-  //  // Add compare function to arguments
-  //  Arguments newArgs = args;
-  //  newArgs.insert(k_CompareFunctKey, compare.get());
-
+  // Run the segmentation algorithm
   execute(gridGeom);
-
-  auto* activeArray = m_DataStructure.getDataAs<UInt8Array>(m_InputValues->pActiveArrayPath);
-  auto totalFeatures = activeArray->getNumberOfTuples();
-  if(totalFeatures < 2)
+  // Sanity check the result.
+  if(this->m_FoundFeatures < 1)
   {
-    return {nonstd::make_unexpected(std::vector<Error>{Error{-87000, "The number of Features was 0 or 1 which means no Features were detected. A threshold value may be set too high"}})};
+    return {MakeErrorResult(-87000, fmt::format("The number of Features is '{}' which means no Features were detected. A threshold value may be set incorrectly", this->m_FoundFeatures))};
   }
 
+  // Resize the Feature Attribute Matrix
+  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures) + 1};
+  auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->CellFeatureAttributeMatrixPath);
+  cellFeaturesAM.resizeTuples(tDims); // This will resize the active array
+
   // make sure all values are initialized and "re-reserve" index 0
+  auto* activeArray = m_DataStructure.getDataAs<UInt8Array>(m_InputValues->ActiveArrayPath);
   activeArray->getDataStore()->fill(1);
   (*activeArray)[0] = 0;
 
   // Randomize the feature Ids for purely visual clarify. Having random Feature Ids
   // allows users visualizing the data to better discern each grain otherwise the coloring
   // would look like a smooth gradient. This is a user input parameter
-  if(m_InputValues->pShouldRandomizeFeatureIds)
+  if(m_InputValues->RandomizeFeatureIds)
   {
-    randomizeFeatureIds(m_FeatureIdsArray, totalFeatures);
+    randomizeFeatureIds(m_FeatureIdsArray, this->m_FoundFeatures + 1);
   }
 
   return {};
@@ -253,7 +255,7 @@ int64_t ScalarSegmentFeatures::getSeed(int32 gnum, int64 nextSeed) const
   {
     if(featureIds->getValue(randpoint) == 0) // If the GrainId of the voxel is ZERO then we can use this as a seed point
     {
-      if(!m_InputValues->pUseGoodVoxels || m_GoodVoxels->isTrue(randpoint))
+      if(!m_InputValues->UseMask || m_GoodVoxels->isTrue(randpoint))
       {
         seed = randpoint;
       }
@@ -269,11 +271,11 @@ int64_t ScalarSegmentFeatures::getSeed(int32 gnum, int64 nextSeed) const
   }
   if(seed >= 0)
   {
-    auto& activeArray = m_DataStructure.getDataRefAs<UInt8Array>(m_InputValues->pActiveArrayPath);
+    // auto& activeArray = m_DataStructure.getDataRefAs<UInt8Array>(m_InputValues->pActiveArrayPath);
     featureIds->setValue(static_cast<usize>(seed), gnum);
-    std::vector<usize> tDims = {static_cast<usize>(gnum) + 1};
-    auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->pCellFeaturesPath);
-    cellFeaturesAM.resizeTuples(tDims); // This will resize the active array
+    //  std::vector<usize> tDims = {static_cast<usize>(gnum) + 1};
+    //  auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->pCellFeaturesPath);
+    //  cellFeaturesAM.resizeTuples(tDims); // This will resize the active array
   }
   return seed;
 }
@@ -282,7 +284,7 @@ int64_t ScalarSegmentFeatures::getSeed(int32 gnum, int64 nextSeed) const
 bool ScalarSegmentFeatures::determineGrouping(int64 referencepoint, int64 neighborpoint, int32 gnum) const
 {
   auto featureIds = m_FeatureIdsArray->getDataStore();
-  if(featureIds->getValue(neighborpoint) == 0 && (!m_InputValues->pUseGoodVoxels || m_GoodVoxels->isTrue(neighborpoint)))
+  if(featureIds->getValue(neighborpoint) == 0 && (!m_InputValues->UseMask || m_GoodVoxels->isTrue(neighborpoint)))
   {
     CompareFunctor* func = m_CompareFunctor.get();
     return (*func)((usize)(referencepoint), (usize)(neighborpoint), gnum);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
@@ -271,7 +271,6 @@ int64_t ScalarSegmentFeatures::getSeed(int32 gnum, int64 nextSeed) const
   }
   if(seed >= 0)
   {
-    // auto& activeArray = m_DataStructure.getDataRefAs<UInt8Array>(m_InputValues->pActiveArrayPath);
     featureIds->setValue(static_cast<usize>(seed), gnum);
     //  std::vector<usize> tDims = {static_cast<usize>(gnum) + 1};
     //  auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->pCellFeaturesPath);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.hpp
@@ -18,15 +18,15 @@ namespace nx::core
 
 struct SIMPLNXCORE_EXPORT ScalarSegmentFeaturesInputValues
 {
-  DataPath pInputDataPath;
-  int pScalarTolerance = 0;
-  bool pShouldRandomizeFeatureIds = false;
-  DataPath pActiveArrayPath;
-  DataPath pFeatureIdsPath;
-  bool pUseGoodVoxels = false;
-  DataPath pGoodVoxelsPath;
-  DataPath pGridGeomPath;
-  DataPath pCellFeaturesPath;
+  int ScalarTolerance = 0;
+  bool UseMask;
+  bool RandomizeFeatureIds;
+  DataPath ImageGeometryPath;
+  DataPath InputDataPath;
+  DataPath MaskArrayPath;
+  DataPath FeatureIdsArrayPath;
+  DataPath CellFeatureAttributeMatrixPath;
+  DataPath ActiveArrayPath;
 };
 
 /**

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApplyTransformationToGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApplyTransformationToGeometryFilter.cpp
@@ -347,7 +347,7 @@ IFilter::PreflightResult ApplyTransformationToGeometryFilter::preflightImpl(cons
         const AttributeMatrix* selectedCellDataPtr = selectedImageGeom.getCellData();
         if(selectedCellDataPtr == nullptr)
         {
-          return {MakeErrorResult<OutputActions>(-5551, fmt::format("'{}' must have cell data attribute matrix", srcImagePath.toString()))};
+          return {MakeErrorResult<OutputActions>(-5581, fmt::format("'{}' must have cell data attribute matrix", srcImagePath.toString()))};
         }
         const std::string cellDataName = selectedCellDataPtr->getName();
         ignorePaths.push_back(srcImagePath.createChildPath(cellDataName)); // This is needed so that we don't attempt to copy it later on

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropImageGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropImageGeometryFilter.cpp
@@ -276,17 +276,17 @@ IFilter::PreflightResult CropImageGeometryFilter::preflightImpl(const DataStruct
     if(pCropXDim && xMax < xMin)
     {
       const std::string errMsg = fmt::format("X Max ({}) less than X Min ({})", xMax, xMin);
-      return {MakeErrorResult<OutputActions>(-5550, errMsg)};
+      return {MakeErrorResult<OutputActions>(-4011, errMsg)};
     }
     if(pCropYDim && yMax < yMin)
     {
       const std::string errMsg = fmt::format("Y Max ({}) less than Y Min ({})", yMax, yMin);
-      return {MakeErrorResult<OutputActions>(-5551, errMsg)};
+      return {MakeErrorResult<OutputActions>(-4012, errMsg)};
     }
     if(pCropZDim && zMax < zMin)
     {
       const std::string errMsg = fmt::format("Z Max ({}) less than Z Min ({})", zMax, zMin);
-      return {MakeErrorResult<OutputActions>(-5552, errMsg)};
+      return {MakeErrorResult<OutputActions>(-4013, errMsg)};
     }
   }
 
@@ -446,7 +446,7 @@ IFilter::PreflightResult CropImageGeometryFilter::preflightImpl(const DataStruct
     const AttributeMatrix* selectedCellData = srcImageGeomPtr->getCellData();
     if(selectedCellData == nullptr)
     {
-      return {MakeErrorResult<OutputActions>(-5551, fmt::format("'{}' must have cell data attribute matrix", srcImagePath.toString()))};
+      return {MakeErrorResult<OutputActions>(-4014, fmt::format("'{}' must have cell data attribute matrix", srcImagePath.toString()))};
     }
     std::string cellDataName = selectedCellData->getName();
     ignorePaths.push_back(srcImagePath.createChildPath(cellDataName));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeImageGeomCellDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeImageGeomCellDataFilter.cpp
@@ -250,37 +250,37 @@ IFilter::PreflightResult InitializeImageGeomCellDataFilter::preflightImpl(const 
 
   if(cellArrayPaths.empty())
   {
-    return {MakeErrorResult<OutputActions>(-5550, "At least one data array must be selected.")};
+    return {MakeErrorResult<OutputActions>(-3550, "At least one data array must be selected.")};
   }
 
   std::vector<Error> errors;
 
   if(xMax < xMin)
   {
-    errors.push_back(Error{-5551, fmt::format("X Max ({}) less than X Min ({})", xMax, xMin)});
+    errors.push_back(Error{-3551, fmt::format("X Max ({}) less than X Min ({})", xMax, xMin)});
   }
   if(yMax < yMin)
   {
-    errors.push_back(Error{-5552, fmt::format("Y Max ({}) less than Y Min ({})", yMax, yMin)});
+    errors.push_back(Error{-3552, fmt::format("Y Max ({}) less than Y Min ({})", yMax, yMin)});
   }
   if(zMax < zMin)
   {
-    errors.push_back(Error{-5553, fmt::format("Z Max ({}) less than Z Min ({})", zMax, zMin)});
+    errors.push_back(Error{-3553, fmt::format("Z Max ({}) less than Z Min ({})", zMax, zMin)});
   }
 
   const auto& imageGeom = dataStructure.getDataRefAs<ImageGeom>(imageGeomPath);
 
   if(xMax > (static_cast<int64>(imageGeom.getNumXCells()) - 1))
   {
-    errors.push_back(Error{-5557, fmt::format("The X Max you entered of {} is greater than your Max X Point of {}", xMax, static_cast<int64>(imageGeom.getNumXCells()) - 1)});
+    errors.push_back(Error{-3554, fmt::format("The X Max you entered of {} is greater than your Max X Point of {}", xMax, static_cast<int64>(imageGeom.getNumXCells()) - 1)});
   }
   if(yMax > (static_cast<int64>(imageGeom.getNumYCells()) - 1))
   {
-    errors.push_back(Error{-5558, fmt::format("The Y Max you entered of {} is greater than your Max Y Point of {}", yMax, static_cast<int64>(imageGeom.getNumYCells()) - 1)});
+    errors.push_back(Error{-3555, fmt::format("The Y Max you entered of {} is greater than your Max Y Point of {}", yMax, static_cast<int64>(imageGeom.getNumYCells()) - 1)});
   }
   if(zMax > (static_cast<int64>(imageGeom.getNumZCells()) - 1))
   {
-    errors.push_back(Error{-5559, fmt::format("The Z Max you entered of {} is greater than your Max Z Point of {}", zMax, static_cast<int64>(imageGeom.getNumZCells()) - 1)});
+    errors.push_back(Error{-3556, fmt::format("The Z Max you entered of {} is greater than your Max Z Point of {}", zMax, static_cast<int64>(imageGeom.getNumZCells()) - 1)});
   }
 
   SizeVec3 imageDims = imageGeom.getDimensions();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedEdgesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedEdgesFilter.cpp
@@ -146,7 +146,7 @@ IFilter::PreflightResult RemoveFlaggedEdgesFilter::preflightImpl(const DataStruc
     {
       if(!selectedEdgeArrays.empty() && nullptr == srcEdgeAttrMatPtr)
       {
-        return {MakeErrorResult<OutputActions>(-5551, fmt::format("'{}' must have edge data attribute matrix", pInitialGeometryPathValue.toString()))};
+        return {MakeErrorResult<OutputActions>(-5651, fmt::format("'{}' must have edge data attribute matrix", pInitialGeometryPathValue.toString()))};
       }
       TransferGeometryElementData::createDataArrayActions<INodeGeometry1D>(dataStructure, srcEdgeAttrMatPtr, selectedEdgeArrays, reducedEdgeAttributeMatrixPath, resultOutputActions);
     }
@@ -154,7 +154,7 @@ IFilter::PreflightResult RemoveFlaggedEdgesFilter::preflightImpl(const DataStruc
     {
       if(nullptr == srcEdgeAttrMatPtr)
       {
-        return {MakeErrorResult<OutputActions>(-5551, fmt::format("'{}' must have edge data attribute matrix", pInitialGeometryPathValue.toString()))};
+        return {MakeErrorResult<OutputActions>(-5652, fmt::format("'{}' must have edge data attribute matrix", pInitialGeometryPathValue.toString()))};
       }
       std::vector<DataPath> ignorePaths;
 
@@ -176,7 +176,7 @@ IFilter::PreflightResult RemoveFlaggedEdgesFilter::preflightImpl(const DataStruc
     {
       if(!selectedVertexArrays.empty() && nullptr == srcVertexAttrMatPtr)
       {
-        return {MakeErrorResult<OutputActions>(-5551, fmt::format("'{}' must have Vertex data attribute matrix", pInitialGeometryPathValue.toString()))};
+        return {MakeErrorResult<OutputActions>(-5653, fmt::format("'{}' must have Vertex data attribute matrix", pInitialGeometryPathValue.toString()))};
       }
       TransferGeometryElementData::createDataArrayActions<INodeGeometry1D>(dataStructure, srcVertexAttrMatPtr, selectedVertexArrays, reducedVertexAttributeMatrixPath, resultOutputActions);
     }
@@ -184,7 +184,7 @@ IFilter::PreflightResult RemoveFlaggedEdgesFilter::preflightImpl(const DataStruc
     {
       if(nullptr == srcVertexAttrMatPtr)
       {
-        return {MakeErrorResult<OutputActions>(-5551, fmt::format("'{}' must have Vertex data attribute matrix", pInitialGeometryPathValue.toString()))};
+        return {MakeErrorResult<OutputActions>(-5654, fmt::format("'{}' must have Vertex data attribute matrix", pInitialGeometryPathValue.toString()))};
       }
       std::vector<DataPath> ignorePaths;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedTrianglesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedTrianglesFilter.cpp
@@ -148,7 +148,7 @@ IFilter::PreflightResult RemoveFlaggedTrianglesFilter::preflightImpl(const DataS
     {
       if(!selectedTriangleArrays.empty() && nullptr == srcTriangleAttrMatPtr)
       {
-        return {MakeErrorResult<OutputActions>(-5551, fmt::format("'{}' must have face data attribute matrix", pInitialGeometryPathValue.toString()))};
+        return {MakeErrorResult<OutputActions>(-5251, fmt::format("'{}' must have face data attribute matrix", pInitialGeometryPathValue.toString()))};
       }
       TransferGeometryElementData::createDataArrayActions<INodeGeometry1D>(dataStructure, srcTriangleAttrMatPtr, selectedTriangleArrays, reducedFaceAttributeMatrixPath, resultOutputActions);
     }
@@ -156,7 +156,7 @@ IFilter::PreflightResult RemoveFlaggedTrianglesFilter::preflightImpl(const DataS
     {
       if(nullptr == srcTriangleAttrMatPtr)
       {
-        return {MakeErrorResult<OutputActions>(-5551, fmt::format("'{}' must have face data attribute matrix", pInitialGeometryPathValue.toString()))};
+        return {MakeErrorResult<OutputActions>(-5252, fmt::format("'{}' must have face data attribute matrix", pInitialGeometryPathValue.toString()))};
       }
       std::vector<DataPath> ignorePaths;
 
@@ -178,7 +178,7 @@ IFilter::PreflightResult RemoveFlaggedTrianglesFilter::preflightImpl(const DataS
     {
       if(!selectedVertexArrays.empty() && nullptr == srcVertexAttrMatPtr)
       {
-        return {MakeErrorResult<OutputActions>(-5551, fmt::format("'{}' must have Vertex data attribute matrix", pInitialGeometryPathValue.toString()))};
+        return {MakeErrorResult<OutputActions>(-5553, fmt::format("'{}' must have Vertex data attribute matrix", pInitialGeometryPathValue.toString()))};
       }
       TransferGeometryElementData::createDataArrayActions<INodeGeometry1D>(dataStructure, srcVertexAttrMatPtr, selectedVertexArrays, reducedVertexAttributeMatrixPath, resultOutputActions);
     }
@@ -186,7 +186,7 @@ IFilter::PreflightResult RemoveFlaggedTrianglesFilter::preflightImpl(const DataS
     {
       if(nullptr == srcVertexAttrMatPtr)
       {
-        return {MakeErrorResult<OutputActions>(-5551, fmt::format("'{}' must have Vertex data attribute matrix", pInitialGeometryPathValue.toString()))};
+        return {MakeErrorResult<OutputActions>(-5554, fmt::format("'{}' must have Vertex data attribute matrix", pInitialGeometryPathValue.toString()))};
       }
       std::vector<DataPath> ignorePaths;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedVerticesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedVerticesFilter.cpp
@@ -152,7 +152,7 @@ IFilter::PreflightResult RemoveFlaggedVerticesFilter::preflightImpl(const DataSt
     const AttributeMatrix* selectedCellDataPtr = inputVertexGeomPtr->getVertexAttributeMatrix();
     if(selectedCellDataPtr == nullptr)
     {
-      return {MakeErrorResult<OutputActions>(-5551, fmt::format("'{}' must have cell data attribute matrix", vertexGeomPath.toString()))};
+      return {MakeErrorResult<OutputActions>(-5751, fmt::format("'{}' must have cell data attribute matrix", vertexGeomPath.toString()))};
     }
     const std::string cellDataName = selectedCellDataPtr->getName();
     ignorePaths.push_back(vertexGeomPath.createChildPath(cellDataName));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleImageGeomFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleImageGeomFilter.cpp
@@ -235,7 +235,7 @@ IFilter::PreflightResult ResampleImageGeomFilter::preflightImpl(const DataStruct
     const AttributeMatrix* selectedCellData = srcImageGeom->getCellData();
     if(selectedCellData == nullptr)
     {
-      return {MakeErrorResult<OutputActions>(-5551, fmt::format("'{}' must have cell data attribute matrix", srcImagePath.toString()))};
+      return {MakeErrorResult<OutputActions>(-5851, fmt::format("'{}' must have cell data attribute matrix", srcImagePath.toString()))};
     }
     std::string cellDataName = selectedCellData->getName();
     ignorePaths.push_back(srcImagePath.createChildPath(cellDataName));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RotateSampleRefFrameFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RotateSampleRefFrameFilter.cpp
@@ -426,7 +426,7 @@ IFilter::PreflightResult RotateSampleRefFrameFilter::preflightImpl(const DataStr
     const AttributeMatrix* selectedCellData = selectedImageGeom.getCellData();
     if(selectedCellData == nullptr)
     {
-      return {MakeErrorResult<OutputActions>(-5551, fmt::format("'{}' must have cell data attribute matrix", srcImagePath.toString()))};
+      return {MakeErrorResult<OutputActions>(-5951, fmt::format("'{}' must have cell data attribute matrix", srcImagePath.toString()))};
     }
     std::string cellDataName = selectedCellData->getName();
     ignorePaths.push_back(srcImagePath.createChildPath(cellDataName));

--- a/src/Plugins/SimplnxCore/test/CropImageGeometryTest.cpp
+++ b/src/Plugins/SimplnxCore/test/CropImageGeometryTest.cpp
@@ -140,7 +140,7 @@ TEST_CASE("SimplnxCore::CropImageGeometryFilter Invalid Params", "[SimplnxCore][
   preflightResult = filter.preflight(dataStructure, args);
   preflightErrors = preflightResult.outputActions.errors();
   REQUIRE(preflightErrors.size() == 1);
-  REQUIRE(preflightErrors[0].code == -5550);
+  REQUIRE(preflightErrors[0].code == -4011);
 
   k_MinVector = {10, 10, 10};
   k_MaxVector = {20, 1, 20};
@@ -150,7 +150,7 @@ TEST_CASE("SimplnxCore::CropImageGeometryFilter Invalid Params", "[SimplnxCore][
   preflightResult = filter.preflight(dataStructure, args);
   preflightErrors = preflightResult.outputActions.errors();
   REQUIRE(preflightErrors.size() == 1);
-  REQUIRE(preflightErrors[0].code == -5551);
+  REQUIRE(preflightErrors[0].code == -4012);
 
   k_MinVector = {10, 10, 10};
   k_MaxVector = {20, 20, 1};
@@ -160,7 +160,7 @@ TEST_CASE("SimplnxCore::CropImageGeometryFilter Invalid Params", "[SimplnxCore][
   preflightResult = filter.preflight(dataStructure, args);
   preflightErrors = preflightResult.outputActions.errors();
   REQUIRE(preflightErrors.size() == 1);
-  REQUIRE(preflightErrors[0].code == -5552);
+  REQUIRE(preflightErrors[0].code == -4013);
 }
 
 TEST_CASE("SimplnxCore::CropImageGeometryFilter(Execute_Filter)", "[SimplnxCore][CropImageGeometryFilter]")

--- a/src/Plugins/SimplnxCore/test/ScalarSegmentFeaturesFilterTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ScalarSegmentFeaturesFilterTest.cpp
@@ -4,9 +4,6 @@
 #include "simplnx/Parameters/ArrayCreationParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
-#include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
-#include "simplnx/Utilities/Parsing/HDF5/Writers/FileWriter.hpp"
 
 #include <catch2/catch.hpp>
 
@@ -51,7 +48,7 @@ TEST_CASE("SimplnxCore::ScalarSegmentFeatures", "[Reconstruction][ScalarSegmentF
     args.insertOrAssign(ScalarSegmentFeaturesFilter::k_CellFeatureName_Key, std::make_any<std::string>(computedCellDataName));
     args.insertOrAssign(ScalarSegmentFeaturesFilter::k_ActiveArrayName_Key, std::make_any<std::string>(k_ActiveName));
     // Are we going to randomize the featureIds when completed.
-    args.insertOrAssign(ScalarSegmentFeaturesFilter::k_RandomizeFeatures_Key, std::make_any<bool>(false));
+    args.insertOrAssign(ScalarSegmentFeaturesFilter::k_RandomizeFeatures_Key, std::make_any<bool>(true));
 
     // Preflight the filter and check result
     auto preflightResult = filter.preflight(dataStructure, args);
@@ -63,18 +60,10 @@ TEST_CASE("SimplnxCore::ScalarSegmentFeatures", "[Reconstruction][ScalarSegmentF
 
     UInt8Array& actives = dataStructure.getDataRefAs<UInt8Array>(activeArrayDataPath);
     size_t numFeatures = actives.getNumberOfTuples();
-    std::cout << "NumFeatures: " << numFeatures << std::endl;
     REQUIRE(numFeatures == 847);
   }
 
-  {
-    // Write out the DataStructure for later viewing/debugging
-    std::string filePath = fmt::format("{}/ScalarSegmentFeatures.dream3d", unit_test::k_BinaryTestOutputDir);
-    // std::cout << "Writing file to: " << filePath << std::endl;
-    Result<nx::core::HDF5::FileWriter> result = nx::core::HDF5::FileWriter::CreateFile(filePath);
-    nx::core::HDF5::FileWriter fileWriter = std::move(result.value());
-
-    auto resultH5 = HDF5::DataStructureWriter::WriteFile(dataStructure, fileWriter);
-    SIMPLNX_RESULT_REQUIRE_VALID(resultH5);
-  }
+#ifdef SIMPLNX_WRITE_TEST_OUTPUT
+  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/ScalarSegmentFeatures.dream3d", unit_test::k_BinaryTestOutputDir)));
+#endif
 }

--- a/src/Plugins/SimplnxCore/test/ScalarSegmentFeaturesFilterTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ScalarSegmentFeaturesFilterTest.cpp
@@ -60,7 +60,7 @@ TEST_CASE("SimplnxCore::ScalarSegmentFeatures", "[Reconstruction][ScalarSegmentF
 
     UInt8Array& actives = dataStructure.getDataRefAs<UInt8Array>(activeArrayDataPath);
     size_t numFeatures = actives.getNumberOfTuples();
-    REQUIRE(numFeatures == 847);
+    REQUIRE(numFeatures == 848);
   }
 
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT

--- a/src/simplnx/Utilities/DataArrayUtilities.cpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.cpp
@@ -240,7 +240,7 @@ Result<> ValidateNumFeaturesInArray(const DataStructure& dataStructure, const Da
   const auto* featureArrayPtr = dataStructure.getDataAs<IDataArray>(arrayPath);
   if(featureArrayPtr == nullptr)
   {
-    return MakeErrorResult(-5550, fmt::format("Could not find the input array path '{}' for validating number of features", arrayPath.toString()));
+    return MakeErrorResult(-5350, fmt::format("Could not find the input array path '{}' for validating number of features", arrayPath.toString()));
   }
   Result<> results = {};
   const usize numFeatures = featureArrayPtr->getNumberOfTuples();
@@ -250,13 +250,13 @@ Result<> ValidateNumFeaturesInArray(const DataStructure& dataStructure, const Da
     if(featureId < 0)
     {
       results = MakeErrorResult(
-          -5555, fmt::format("Feature Ids array with name '{}' has negative values within the array. The first negative value encountered was '{}'. All values must be positive within the array",
+          -5355, fmt::format("Feature Ids array with name '{}' has negative values within the array. The first negative value encountered was '{}'. All values must be positive within the array",
                              featureIds.getName(), featureId));
       return results;
     }
     if(static_cast<usize>(featureId) >= numFeatures)
     {
-      results = MakeErrorResult(-5551, fmt::format("Feature Ids array with name '{}' has a value '{}' that would exceed the number of tuples {} in the selected feature array '{}'",
+      results = MakeErrorResult(-5351, fmt::format("Feature Ids array with name '{}' has a value '{}' that would exceed the number of tuples {} in the selected feature array '{}'",
                                                    featureIds.getName(), featureId, numFeatures, arrayPath.toString()));
       return results;
     }

--- a/src/simplnx/Utilities/SegmentFeatures.cpp
+++ b/src/simplnx/Utilities/SegmentFeatures.cpp
@@ -135,7 +135,7 @@ Result<> SegmentFeatures::execute(IGridGeometry* gridGeom)
   }
 
   m_MessageHandler({IFilter::Message::Type::Info, fmt::format("Total Features Found: {}", gnum)});
-
+  m_FoundFeatures = gnum;
   return {};
 }
 

--- a/src/simplnx/Utilities/SegmentFeatures.hpp
+++ b/src/simplnx/Utilities/SegmentFeatures.hpp
@@ -92,6 +92,7 @@ protected:
   DataStructure& m_DataStructure;
   const std::atomic_bool& m_ShouldCancel;
   const IFilter::MessageHandler& m_MessageHandler;
+  int32 m_FoundFeatures = 0;
 
 private:
 };


### PR DESCRIPTION

- All will only allocate a single tuple for feature attribute matrix during preflight
- Feature Attribute Matrix is now resized after the segmentation is completed instead of every iteration
- Code is much more consistent in variable naming and code layout between the 3 filters
