### PR TITLE
CI: Fixed python tests on asan CI

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -54,4 +54,7 @@ jobs:
           cmake --build --preset ci-asan
       - name: Test
         run: |
-          ctest --preset ci-asan
+          export LD_PRELOAD=$(clang++-14 -print-file-name=libclang_rt.asan-x86_64.so)
+          ctest --preset ci-asan -E "PY"
+          export ASAN_OPTIONS=detect_leaks=0
+          ctest --preset ci-asan -R "PY"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -69,7 +69,7 @@
         },
         "CMAKE_CXX_FLAGS": {
           "type": "STRING",
-          "value": "-O1 -fsanitize=address -fno-omit-frame-pointer"
+          "value": "-O1 -fsanitize=address -fno-omit-frame-pointer -shared-libasan"
         },
         "VCPKG_TARGET_TRIPLET": {
           "type": "STRING",


### PR DESCRIPTION
* Since python is not built with asan we must use the shared library version of asan
* Disabled leak detection for python tests as it reports leaks from pybind11