### PR TITLE
BUG: Fixed ASAN CI test discovery and leak detection

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     env:
       VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
+      CC: clang-14
+      CXX: clang++-14
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -44,17 +46,15 @@ jobs:
           setapikey "${{secrets.GITHUB_TOKEN}}" \
           -source "https://nuget.pkg.github.com/BlueQuartzSoftware/index.json"
       - name: Configure
-        env:
-          CC: clang-14
-          CXX: clang++-14
         run: |
           cmake --preset ci-asan ${{github.workspace}}
       - name: Build
         run: |
+          export LD_LIBRARY_PATH=$($CXX -print-file-name=libclang_rt.asan-x86_64.so)
           cmake --build --preset ci-asan
       - name: Test
         run: |
-          export LD_PRELOAD=$(clang++-14 -print-file-name=libclang_rt.asan-x86_64.so)
+          export LD_PRELOAD=$($CXX -print-file-name=libclang_rt.asan-x86_64.so)
           ctest --preset ci-asan -E "PY"
           export ASAN_OPTIONS=detect_leaks=0
           ctest --preset ci-asan -R "PY"

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -55,6 +55,5 @@ jobs:
       - name: Test
         run: |
           export LD_PRELOAD=$($CXX -print-file-name=libclang_rt.asan-x86_64.so)
-          ctest --preset ci-asan -E "PY"
-          export ASAN_OPTIONS=detect_leaks=0
-          ctest --preset ci-asan -R "PY"
+          export LSAN_OPTIONS=suppressions=${{github.workspace}}/utilites/leak_suppressions.txt
+          ctest --preset ci-asan

--- a/utilities/leak_suppressions.txt
+++ b/utilities/leak_suppressions.txt
@@ -1,0 +1,3 @@
+leak:pybind11.h
+leak:/usr/bin
+leak:site-packages/


### PR DESCRIPTION
* Catch2 runs the test executable in order to discover the tests
but the executable couldn't find the clang asan library in the build
step
* Ignore leaks detected in:
  * "/usr/bin" e.g. bash and python
  * "site-packages/" e.g. numpy
  * "pybind11.h"
    * Currently having an issue with leaking enum bindings
    * https://github.com/pybind/pybind11/issues/3865