### PR TITLE
ENH: Peregrine HDF5 Reader Layer Thickness Override & Bug Fixes

### DIFF
--- a/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
+++ b/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
@@ -501,7 +501,7 @@ PYBIND11_MODULE(simplnx, mod)
           return DataType::boolean;
         }
 
-        std::string dtypeStr = py::str(dtype);
+        std::string dtypeStr = py::str(static_cast<py::object>(dtype));
         throw std::invalid_argument(fmt::format("Unable to convert dtype to DataType: Unsupported dtype '{}'.", dtypeStr));
       },
       "Convert numpy dtype to simplnx DataType", "dtype"_a);

--- a/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
+++ b/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
@@ -456,51 +456,53 @@ PYBIND11_MODULE(simplnx, mod)
   mod.def(
       "convert_np_dtype_to_datatype",
       [](const py::dtype& dtype) {
-        if(dtype.is(py::dtype::of<int8>()))
+        if((dtype.attr("__eq__")(py::dtype::of<int8>())).cast<bool>())
         {
           return DataType::int8;
         }
-        if(dtype.is(py::dtype::of<uint8>()))
+        if((dtype.attr("__eq__")(py::dtype::of<uint8>())).cast<bool>())
         {
           return DataType::uint8;
         }
-        if(dtype.is(py::dtype::of<int16>()))
+        if((dtype.attr("__eq__")(py::dtype::of<int16>())).cast<bool>())
         {
           return DataType::int16;
         }
-        if(dtype.is(py::dtype::of<uint16>()))
+        if((dtype.attr("__eq__")(py::dtype::of<uint16>())).cast<bool>())
         {
           return DataType::uint16;
         }
-        if(dtype.is(py::dtype::of<int32>()))
+        if((dtype.attr("__eq__")(py::dtype::of<int32>())).cast<bool>())
         {
           return DataType::int32;
         }
-        if(dtype.is(py::dtype::of<uint32>()))
+        if((dtype.attr("__eq__")(py::dtype::of<uint32>())).cast<bool>())
         {
           return DataType::uint32;
         }
-        if(dtype.is(py::dtype::of<int64>()))
+        if((dtype.attr("__eq__")(py::dtype::of<int64>())).cast<bool>())
         {
           return DataType::int64;
         }
-        if(dtype.is(py::dtype::of<uint64>()))
+        if((dtype.attr("__eq__")(py::dtype::of<uint64>())).cast<bool>())
         {
           return DataType::uint64;
         }
-        if(dtype.is(py::dtype::of<float32>()))
+        if((dtype.attr("__eq__")(py::dtype::of<float32>())).cast<bool>())
         {
           return DataType::float32;
         }
-        if(dtype.is(py::dtype::of<float64>()))
+        if((dtype.attr("__eq__")(py::dtype::of<float64>())).cast<bool>())
         {
           return DataType::float64;
         }
-        if(dtype.is(py::dtype::of<bool>()))
+        if((dtype.attr("__eq__")(py::dtype::of<bool>())).cast<bool>())
         {
           return DataType::boolean;
         }
-        throw std::invalid_argument("Unable to convert dtype to DataType: Unsupported dtype.");
+
+        std::string dtypeStr = py::str(dtype);
+        throw std::invalid_argument(fmt::format("Unable to convert dtype to DataType: Unsupported dtype '{}'.", dtypeStr));
       },
       "Convert numpy dtype to simplnx DataType", "dtype"_a);
 
@@ -582,8 +584,7 @@ PYBIND11_MODULE(simplnx, mod)
   parameters.def("insert_linkable_parameter", &PyInsertLinkableParameter<ChoicesParameter>);
   parameters.def("link_parameters", [](Parameters& self, std::string groupKey, std::string childKey, BoolParameter::ValueType value) { self.linkParameters(groupKey, childKey, value); });
   parameters.def("link_parameters", [](Parameters& self, std::string groupKey, std::string childKey, ChoicesParameter::ValueType value) { self.linkParameters(groupKey, childKey, value); });
-  parameters.def(
-      "__getitem__", [](Parameters& self, std::string_view key) { return self.at(key).get(); }, py::return_value_policy::reference_internal);
+  parameters.def("__getitem__", [](Parameters& self, std::string_view key) { return self.at(key).get(); }, py::return_value_policy::reference_internal);
 
   py::class_<IArrayThreshold, std::shared_ptr<IArrayThreshold>> iArrayThreshold(mod, "IArrayThreshold");
 
@@ -1420,12 +1421,10 @@ PYBIND11_MODULE(simplnx, mod)
       "path"_a);
   pipeline.def_property("name", &Pipeline::getName, &Pipeline::setName);
   pipeline.def("execute", &ExecutePipeline);
-  pipeline.def(
-      "__getitem__", [](Pipeline& self, Pipeline::index_type index) { return self.at(index); }, py::return_value_policy::reference_internal);
+  pipeline.def("__getitem__", [](Pipeline& self, Pipeline::index_type index) { return self.at(index); }, py::return_value_policy::reference_internal);
   pipeline.def("__len__", &Pipeline::size);
   pipeline.def("size", &Pipeline::size);
-  pipeline.def(
-      "__iter__", [](Pipeline& self) { return py::make_iterator(self.begin(), self.end()); }, py::keep_alive<0, 1>());
+  pipeline.def("__iter__", [](Pipeline& self) { return py::make_iterator(self.begin(), self.end()); }, py::keep_alive<0, 1>());
   pipeline.def(
       "insert",
       [internals](Pipeline& self, Pipeline::index_type index, const IFilter& filter, const py::dict& args) {
@@ -1439,10 +1438,8 @@ PYBIND11_MODULE(simplnx, mod)
   pipeline.def("remove", &Pipeline::removeAt, "index"_a);
 
   pipelineFilter.def("get_args", [internals](PipelineFilter& self) { return ConvertArgsToDict(*internals, self.getParameters(), self.getArguments()); });
-  pipelineFilter.def(
-      "set_args", [internals](PipelineFilter& self, py::dict& args) { self.setArguments(ConvertDictToArgs(*internals, self.getParameters(), args)); }, "args"_a);
-  pipelineFilter.def(
-      "get_filter", [](PipelineFilter& self) { return self.getFilter(); }, py::return_value_policy::reference_internal);
+  pipelineFilter.def("set_args", [internals](PipelineFilter& self, py::dict& args) { self.setArguments(ConvertDictToArgs(*internals, self.getParameters(), args)); }, "args"_a);
+  pipelineFilter.def("get_filter", [](PipelineFilter& self) { return self.getFilter(); }, py::return_value_policy::reference_internal);
   pipelineFilter.def(
       "name",
       [](const PipelineFilter& self) {

--- a/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
+++ b/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
@@ -584,7 +584,8 @@ PYBIND11_MODULE(simplnx, mod)
   parameters.def("insert_linkable_parameter", &PyInsertLinkableParameter<ChoicesParameter>);
   parameters.def("link_parameters", [](Parameters& self, std::string groupKey, std::string childKey, BoolParameter::ValueType value) { self.linkParameters(groupKey, childKey, value); });
   parameters.def("link_parameters", [](Parameters& self, std::string groupKey, std::string childKey, ChoicesParameter::ValueType value) { self.linkParameters(groupKey, childKey, value); });
-  parameters.def("__getitem__", [](Parameters& self, std::string_view key) { return self.at(key).get(); }, py::return_value_policy::reference_internal);
+  parameters.def(
+      "__getitem__", [](Parameters& self, std::string_view key) { return self.at(key).get(); }, py::return_value_policy::reference_internal);
 
   py::class_<IArrayThreshold, std::shared_ptr<IArrayThreshold>> iArrayThreshold(mod, "IArrayThreshold");
 
@@ -1421,10 +1422,12 @@ PYBIND11_MODULE(simplnx, mod)
       "path"_a);
   pipeline.def_property("name", &Pipeline::getName, &Pipeline::setName);
   pipeline.def("execute", &ExecutePipeline);
-  pipeline.def("__getitem__", [](Pipeline& self, Pipeline::index_type index) { return self.at(index); }, py::return_value_policy::reference_internal);
+  pipeline.def(
+      "__getitem__", [](Pipeline& self, Pipeline::index_type index) { return self.at(index); }, py::return_value_policy::reference_internal);
   pipeline.def("__len__", &Pipeline::size);
   pipeline.def("size", &Pipeline::size);
-  pipeline.def("__iter__", [](Pipeline& self) { return py::make_iterator(self.begin(), self.end()); }, py::keep_alive<0, 1>());
+  pipeline.def(
+      "__iter__", [](Pipeline& self) { return py::make_iterator(self.begin(), self.end()); }, py::keep_alive<0, 1>());
   pipeline.def(
       "insert",
       [internals](Pipeline& self, Pipeline::index_type index, const IFilter& filter, const py::dict& args) {
@@ -1438,8 +1441,10 @@ PYBIND11_MODULE(simplnx, mod)
   pipeline.def("remove", &Pipeline::removeAt, "index"_a);
 
   pipelineFilter.def("get_args", [internals](PipelineFilter& self) { return ConvertArgsToDict(*internals, self.getParameters(), self.getArguments()); });
-  pipelineFilter.def("set_args", [internals](PipelineFilter& self, py::dict& args) { self.setArguments(ConvertDictToArgs(*internals, self.getParameters(), args)); }, "args"_a);
-  pipelineFilter.def("get_filter", [](PipelineFilter& self) { return self.getFilter(); }, py::return_value_policy::reference_internal);
+  pipelineFilter.def(
+      "set_args", [internals](PipelineFilter& self, py::dict& args) { self.setArguments(ConvertDictToArgs(*internals, self.getParameters(), args)); }, "args"_a);
+  pipelineFilter.def(
+      "get_filter", [](PipelineFilter& self) { return self.getFilter(); }, py::return_value_policy::reference_internal);
   pipelineFilter.def(
       "name",
       [](const PipelineFilter& self) {

--- a/wrapping/python/plugins/NXDataAnalysisToolkit/src/NXDataAnalysisToolkit/CliReaderFilter.py
+++ b/wrapping/python/plugins/NXDataAnalysisToolkit/src/NXDataAnalysisToolkit/CliReaderFilter.py
@@ -9,7 +9,7 @@ import copy
 import re
 from typing import List, Tuple
 from pathlib import Path
-from NXDataAnalysisToolkit.common.Result import Result, make_error_result
+from .common.Result import Result, make_error_result
 
 class Polyline(object):
     def __init__(self, layer_id, z_height, data: dict, poly_id, dir, n, xvals, yvals) -> Result:

--- a/wrapping/python/plugins/NXDataAnalysisToolkit/src/NXDataAnalysisToolkit/ReadPeregrineHDF5File.py
+++ b/wrapping/python/plugins/NXDataAnalysisToolkit/src/NXDataAnalysisToolkit/ReadPeregrineHDF5File.py
@@ -729,7 +729,9 @@ class ReadPeregrineHDF5File:
       if should_cancel:
         return Result()
 
-      for camera_data_dataset in camera_data_datasets_str:
+      camera_data_datasets_str = camera_data_datasets_str.strip()
+      camera_data_datasets = camera_data_datasets_str.split(',')
+      for camera_data_dataset in camera_data_datasets:
         if should_cancel:
           return Result()
     


### PR DESCRIPTION
Enhancements:
* Added an option to override layer thickness from the input HDF5 file.

Bug Fixes:
* Numpy dtypes are now properly converted to NX DataTypes.
* Filter iterates properly through camera data during execute.