### PR TITLE
CI: Added option to download data before compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -829,6 +829,11 @@ target_include_directories(simplnx
     $<INSTALL_INTERFACE:include>
 )
 
+cmake_dependent_option(SIMPLNX_DOWNLOAD_TEST_FILES_FIRST "Forces test files to download before simplnx builds" OFF "SIMPLNX_DOWNLOAD_TEST_FILES" OFF)
+if(SIMPLNX_DOWNLOAD_TEST_FILES_FIRST)
+  add_dependencies(simplnx Fetch_Remote_Data_Files)
+endif()
+
 # ------------------------------------------------------------------------------
 # CLI Executable
 # ------------------------------------------------------------------------------

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -56,6 +56,10 @@
         "VCPKG_OVERLAY_TRIPLETS": {
           "type": "PATH",
           "value": "${sourceDir}/cmake/triplets"
+        },
+        "SIMPLNX_DOWNLOAD_TEST_FILES_FIRST": {
+          "type": "BOOL",
+          "value": "ON"
         }
       }
     },


### PR DESCRIPTION
Sometimes the CI builds fail when downloading the test data while compiling. The download might not be able to complete due to the compile so this change forces the download to occur before the compile can start. It does this by making the data download target a dependency of simplnx.