### PR TITLE
COMP: Use BlueQuartz internal CI cluster

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,7 @@ jobs:
             cc: gcc-11
           - cxx: clang++-14
             cc: clang-14
-    runs-on: ${{matrix.os}}
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,7 @@ jobs:
             preset: ci-macos-x64
           - os: macos-14
             preset: ci-macos-arm64
-    runs-on: ${{matrix.os}}
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,7 @@ jobs:
         toolset:
           - v142
           - v143
-    runs-on: ${{matrix.os}}
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This is a test branch to start configuring the internal BlueQuartz CI Cluster to build repositories from the BlueQuartz GitHub organization