### PR TITLE
BUG FIX: Data object parent ids are now renumbered correctly when object id clashes are found.

### DIFF
--- a/src/simplnx/DataStructure/BaseGroup.cpp
+++ b/src/simplnx/DataStructure/BaseGroup.cpp
@@ -247,9 +247,9 @@ std::vector<std::string> BaseGroup::GetChildrenNames()
   return m_DataMap.getNames();
 }
 
-void BaseGroup::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+void BaseGroup::checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap)
 {
-  m_DataMap.updateIds(updatedIds);
+  m_DataMap.updateIds(updatedIdsMap);
 }
 
 std::vector<DataObject::IdType> BaseGroup::GetChildrenIds()

--- a/src/simplnx/DataStructure/BaseGroup.hpp
+++ b/src/simplnx/DataStructure/BaseGroup.hpp
@@ -357,9 +357,9 @@ protected:
 
   /**
    * @brief Updates the DataMap IDs. Should only be called by DataObject::checkUpdatedIds.
-   * @param updatedIds
+   * @param updatedIdsMap
    */
-  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+  void checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap) override;
 
   /**
    * @brief Checks if the provided DataObject can be added to the container.

--- a/src/simplnx/DataStructure/DataMap.cpp
+++ b/src/simplnx/DataStructure/DataMap.cpp
@@ -318,7 +318,7 @@ DataMap& DataMap::operator=(DataMap&& rhs) noexcept
   return *this;
 }
 
-void DataMap::updateIds(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+void DataMap::updateIds(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIds)
 {
   using UpdatedValueType = std::pair<IdType, std::shared_ptr<DataObject>>;
   std::list<UpdatedValueType> movedValues;

--- a/src/simplnx/DataStructure/DataMap.hpp
+++ b/src/simplnx/DataStructure/DataMap.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace nx::core

--- a/src/simplnx/DataStructure/DataMap.hpp
+++ b/src/simplnx/DataStructure/DataMap.hpp
@@ -285,10 +285,10 @@ public:
   DataMap& operator=(DataMap&& rhs) noexcept;
 
   /**
-   * @brief Updates the map IDs using a vector of updated IDs and their new values.
-   * @param updatedIds
+   * @brief Updates the map IDs using an unordered map of IDs and their new values.
+   * @param updatedIdsMap
    */
-  void updateIds(const std::vector<std::pair<IdType, IdType>>& updatedIds);
+  void updateIds(const std::unordered_map<IdType, IdType>& updatedIdsMap);
 
 private:
   MapType m_Map;

--- a/src/simplnx/DataStructure/DataObject.cpp
+++ b/src/simplnx/DataStructure/DataObject.cpp
@@ -101,19 +101,22 @@ void DataObject::setId(IdType newId)
   m_Id = newId;
 }
 
-void DataObject::checkUpdatedIds(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+void DataObject::checkUpdatedIds(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap)
 {
-  for(const auto& updatedId : updatedIds)
-  {
-    // Update parent list
-    std::replace(m_ParentList.begin(), m_ParentList.end(), updatedId.first, updatedId.second);
-  }
+  // Use std::transform to map IDs
+  ParentCollectionType newParentList;
+  std::transform(m_ParentList.begin(), m_ParentList.end(), std::back_inserter(newParentList), [&updatedIdsMap](uint64 id) -> uint64 {
+    auto it = updatedIdsMap.find(id);
+    return (it != updatedIdsMap.end()) ? it->second : id;
+  });
+
+  m_ParentList = newParentList;
 
   // For derived classes
-  checkUpdatedIdsImpl(updatedIds);
+  checkUpdatedIdsImpl(updatedIdsMap);
 }
 
-void DataObject::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+void DataObject::checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap)
 {
 }
 

--- a/src/simplnx/DataStructure/DataObject.hpp
+++ b/src/simplnx/DataStructure/DataObject.hpp
@@ -288,15 +288,15 @@ protected:
 
   /**
    * @brief Notifies the DataObject of DataObject IDs that have been changed by the DataStructure.
-   * @param updatedIds std::pair ordered as {old ID, new ID}
+   * @param updatedIdsMap std::unordered_map containing the mappings between the old IDs and the new IDs
    */
-  void checkUpdatedIds(const std::vector<std::pair<IdType, IdType>>& updatedIds);
+  void checkUpdatedIds(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap);
 
   /**
    * @brief Calls specialized checks for derived classes. Should only be called by checkUpdatedIds.
    * @param updatedIds
    */
-  virtual void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds);
+  virtual void checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap);
 
   /**
    * @brief Attempts to add the specified DataObject to the target DataStructure.

--- a/src/simplnx/DataStructure/DataObject.hpp
+++ b/src/simplnx/DataStructure/DataObject.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace nx::core

--- a/src/simplnx/DataStructure/DataStructure.cpp
+++ b/src/simplnx/DataStructure/DataStructure.cpp
@@ -831,8 +831,7 @@ void DataStructure::resetIds(DataObject::IdType startingId)
 
   // Update DataObject IDs and track changes
   WeakCollectionType newCollection;
-  using UpdatedId = std::pair<DataObject::IdType, DataObject::IdType>;
-  std::vector<UpdatedId> updatedIds;
+  std::unordered_map<DataObject::IdType, DataObject::IdType> updatedIdsMap;
   for(auto& dataObjectIter : m_DataObjects)
   {
     auto dataObjectPtr = dataObjectIter.second.lock();
@@ -845,7 +844,7 @@ void DataStructure::resetIds(DataObject::IdType startingId)
     auto newId = generateId();
 
     dataObjectPtr->setId(newId);
-    updatedIds.push_back({oldId, newId});
+    updatedIdsMap[oldId] = newId;
 
     newCollection.insert({newId, dataObjectPtr});
   }
@@ -859,10 +858,10 @@ void DataStructure::resetIds(DataObject::IdType startingId)
     auto dataObjectPtr = dataObjectIter.second.lock();
     if(dataObjectPtr != nullptr)
     {
-      dataObjectPtr->checkUpdatedIds(updatedIds);
+      dataObjectPtr->checkUpdatedIds(updatedIdsMap);
     }
   }
-  m_RootGroup.updateIds(updatedIds);
+  m_RootGroup.updateIds(updatedIdsMap);
 }
 
 void DataStructure::exportHierarchyAsGraphViz(std::ostream& outputStream) const

--- a/src/simplnx/DataStructure/Geometry/IGeometry.cpp
+++ b/src/simplnx/DataStructure/Geometry/IGeometry.cpp
@@ -193,13 +193,13 @@ std::string IGeometry::LengthUnitToString(LengthUnit unit)
   return "Unknown";
 }
 
-void IGeometry::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+void IGeometry::checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap)
 {
-  BaseGroup::checkUpdatedIdsImpl(updatedIds);
+  BaseGroup::checkUpdatedIdsImpl(updatedIdsMap);
 
   std::vector<bool> visited(1, false);
 
-  for(const auto& updatedId : updatedIds)
+  for(const auto& updatedId : updatedIdsMap)
   {
     m_ElementSizesId = nx::core::VisitDataStructureId(m_ElementSizesId, updatedId, visited, 0);
   }

--- a/src/simplnx/DataStructure/Geometry/IGeometry.hpp
+++ b/src/simplnx/DataStructure/Geometry/IGeometry.hpp
@@ -192,9 +192,9 @@ protected:
 
   /**
    * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
-   * @param updatedIds
+   * @param updatedIdsMap
    */
-  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+  void checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap) override;
 
   std::optional<IdType> m_ElementSizesId;
 

--- a/src/simplnx/DataStructure/Geometry/IGridGeometry.cpp
+++ b/src/simplnx/DataStructure/Geometry/IGridGeometry.cpp
@@ -74,13 +74,13 @@ void IGridGeometry::setCellData(OptionalId id)
   m_CellDataId = id;
 }
 
-void IGridGeometry::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+void IGridGeometry::checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap)
 {
-  IGeometry::checkUpdatedIdsImpl(updatedIds);
+  IGeometry::checkUpdatedIdsImpl(updatedIdsMap);
 
   std::vector<bool> visited(1, false);
 
-  for(const auto& updatedId : updatedIds)
+  for(const auto& updatedId : updatedIdsMap)
   {
     m_CellDataId = nx::core::VisitDataStructureId(m_CellDataId, updatedId, visited, 0);
     if(visited[0])

--- a/src/simplnx/DataStructure/Geometry/IGridGeometry.hpp
+++ b/src/simplnx/DataStructure/Geometry/IGridGeometry.hpp
@@ -225,9 +225,9 @@ protected:
 
   /**
    * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
-   * @param updatedIds
+   * @param updatedIdsMap
    */
-  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+  void checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap) override;
 
   std::optional<IdType> m_CellDataId;
 };

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry0D.cpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry0D.cpp
@@ -240,13 +240,13 @@ void INodeGeometry0D::setVertexAttributeMatrix(const AttributeMatrix& attributeM
   m_VertexAttributeMatrixId = attributeMatrix.getId();
 }
 
-void INodeGeometry0D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+void INodeGeometry0D::checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap)
 {
-  IGeometry::checkUpdatedIdsImpl(updatedIds);
+  IGeometry::checkUpdatedIdsImpl(updatedIdsMap);
 
   std::vector<bool> visited(2, false);
 
-  for(const auto& updatedId : updatedIds)
+  for(const auto& updatedId : updatedIdsMap)
   {
     m_VertexDataArrayId = nx::core::VisitDataStructureId(m_VertexDataArrayId, updatedId, visited, 0);
     m_VertexAttributeMatrixId = nx::core::VisitDataStructureId(m_VertexAttributeMatrixId, updatedId, visited, 1);

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry0D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry0D.hpp
@@ -186,9 +186,9 @@ protected:
 
   /**
    * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
-   * @param updatedIds
+   * @param updatedIdsMap
    */
-  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+  void checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap) override;
 
   /* ***************************************************************************
    * These variables are the Ids of the arrays from the DataStructure object.

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry1D.cpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry1D.cpp
@@ -258,13 +258,13 @@ void INodeGeometry1D::setElementSizesId(const std::optional<IdType>& sizesId)
   m_ElementSizesId = sizesId;
 }
 
-void INodeGeometry1D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+void INodeGeometry1D::checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap)
 {
-  INodeGeometry0D::checkUpdatedIdsImpl(updatedIds);
+  INodeGeometry0D::checkUpdatedIdsImpl(updatedIdsMap);
 
   std::vector<bool> visited(7, false);
 
-  for(const auto& updatedId : updatedIds)
+  for(const auto& updatedId : updatedIdsMap)
   {
     m_EdgeAttributeMatrixId = nx::core::VisitDataStructureId(m_EdgeAttributeMatrixId, updatedId, visited, 0);
     m_EdgeDataArrayId = nx::core::VisitDataStructureId(m_EdgeDataArrayId, updatedId, visited, 1);

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry1D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry1D.hpp
@@ -223,9 +223,9 @@ protected:
 
   /**
    * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
-   * @param updatedIds
+   * @param updatedIdsMap
    */
-  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+  void checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap) override;
 
   /* ***************************************************************************
    * These variables are the Ids of the arrays from the DataStructure object.

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry2D.cpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry2D.cpp
@@ -212,11 +212,11 @@ INodeGeometry2D::SharedEdgeList* INodeGeometry2D::createSharedEdgeList(usize num
   return edges;
 }
 
-void INodeGeometry2D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+void INodeGeometry2D::checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap)
 {
-  INodeGeometry1D::checkUpdatedIdsImpl(updatedIds);
+  INodeGeometry1D::checkUpdatedIdsImpl(updatedIdsMap);
   std::vector<bool> visited(3, false);
-  for(const auto& updatedId : updatedIds)
+  for(const auto& updatedId : updatedIdsMap)
   {
     m_FaceListId = nx::core::VisitDataStructureId(m_FaceListId, updatedId, visited, 0);
     m_FaceAttributeMatrixId = nx::core::VisitDataStructureId(m_FaceAttributeMatrixId, updatedId, visited, 1);

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry2D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry2D.hpp
@@ -211,9 +211,9 @@ protected:
 
   /**
    * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
-   * @param updatedIds
+   * @param updatedIdsMap
    */
-  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+  void checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap) override;
 
   /* ***************************************************************************
    * These variables are the Ids of the arrays from the DataStructure object.

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry3D.cpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry3D.cpp
@@ -222,12 +222,12 @@ INodeGeometry3D::SharedTriList* INodeGeometry3D::createSharedTriList(usize numTr
   return triangles;
 }
 
-void INodeGeometry3D::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+void INodeGeometry3D::checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap)
 {
-  INodeGeometry2D::checkUpdatedIdsImpl(updatedIds);
+  INodeGeometry2D::checkUpdatedIdsImpl(updatedIdsMap);
   std::vector<bool> visited(3, false);
 
-  for(const auto& updatedId : updatedIds)
+  for(const auto& updatedId : updatedIdsMap)
   {
     m_PolyhedronListId = nx::core::VisitDataStructureId(m_PolyhedronListId, updatedId, visited, 0);
     m_PolyhedronAttributeMatrixId = nx::core::VisitDataStructureId(m_PolyhedronAttributeMatrixId, updatedId, visited, 1);

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry3D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry3D.hpp
@@ -205,9 +205,9 @@ protected:
 
   /**
    * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
-   * @param updatedIds
+   * @param updatedIdsMap
    */
-  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+  void checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap) override;
 
   /* ***************************************************************************
    * These variables are the Ids of the arrays from the DataStructure object.

--- a/src/simplnx/DataStructure/Geometry/RectGridGeom.cpp
+++ b/src/simplnx/DataStructure/Geometry/RectGridGeom.cpp
@@ -700,12 +700,12 @@ std::optional<usize> RectGridGeom::getIndex(float64 xCoord, float64 yCoord, floa
   return (ySize * xSize * z) + (xSize * y) + x;
 }
 
-void RectGridGeom::checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds)
+void RectGridGeom::checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap)
 {
-  IGridGeometry::checkUpdatedIdsImpl(updatedIds);
+  IGridGeometry::checkUpdatedIdsImpl(updatedIdsMap);
   std::vector<bool> visited(3, false);
 
-  for(const auto& updatedId : updatedIds)
+  for(const auto& updatedId : updatedIdsMap)
   {
     m_xBoundsId = nx::core::VisitDataStructureId(m_xBoundsId, updatedId, visited, 0);
     m_yBoundsId = nx::core::VisitDataStructureId(m_yBoundsId, updatedId, visited, 1);

--- a/src/simplnx/DataStructure/Geometry/RectGridGeom.hpp
+++ b/src/simplnx/DataStructure/Geometry/RectGridGeom.hpp
@@ -385,9 +385,9 @@ protected:
 
   /**
    * @brief Updates the array IDs. Should only be called by DataObject::checkUpdatedIds.
-   * @param updatedIds
+   * @param updatedIdsMap
    */
-  void checkUpdatedIdsImpl(const std::vector<std::pair<IdType, IdType>>& updatedIds) override;
+  void checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap) override;
 
 private:
   std::optional<IdType> m_xBoundsId;


### PR DESCRIPTION
+ Fixes a bug where if a DREAM3D file is read into a data structure that already has existing data objects in it and the file is read in without specifying data paths, then an infinite loop occurs when getting the data paths of each object.  This ONLY happens when using Python or executing non-GUI C++ code because the GUI never leaves the data paths variable empty.  This is because the data object parent ids were getting renumbered incorrectly.
+ Added an additional unit test case to DREAM3DFileTest to test that this is working correctly.