### PR TITLE
BUG: Now catch std::filesystem exceptions in parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,7 @@ set(SIMPLNX_HDRS
   ${SIMPLNX_SOURCE_DIR}/Common/DataTypeUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Common/DataVector.hpp
   ${SIMPLNX_SOURCE_DIR}/Common/EulerAngle.hpp
+  ${SIMPLNX_SOURCE_DIR}/Common/Filesystem.hpp
   ${SIMPLNX_SOURCE_DIR}/Common/IteratorUtility.hpp
   ${SIMPLNX_SOURCE_DIR}/Common/Numbers.hpp
   ${SIMPLNX_SOURCE_DIR}/Common/Range.hpp

--- a/src/simplnx/Common/Filesystem.hpp
+++ b/src/simplnx/Common/Filesystem.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "simplnx/Common/Result.hpp"
+
+#include <nonstd/expected.hpp>
+
+#include <filesystem>
+
+namespace nx::core::filesystem
+{
+inline Result<bool> exists(const std::filesystem::path& path)
+{
+  std::error_code errorCode;
+  bool result = std::filesystem::exists(path, errorCode);
+  if(errorCode)
+  {
+    return MakeErrorResult<bool>(errorCode.value(), errorCode.message());
+  }
+  return {result};
+}
+} // namespace nx::core::filesystem

--- a/src/simplnx/Parameters/Dream3dImportParameter.cpp
+++ b/src/simplnx/Parameters/Dream3dImportParameter.cpp
@@ -156,21 +156,27 @@ Result<> Dream3dImportParameter::validate(const std::any& value) const
 //-----------------------------------------------------------------------------
 Result<> Dream3dImportParameter::validatePath(const ValueType& importData) const
 {
-  std::filesystem::path path = importData.FilePath;
-  if(!fs::exists(path))
+  try
   {
-    return MakeErrorResult(-2, fmt::format("Path '{}' does not exist", path.string()));
-  }
+    std::filesystem::path path = importData.FilePath;
+    if(!fs::exists(path))
+    {
+      return MakeErrorResult(-2, fmt::format("Path '{}' does not exist", path.string()));
+    }
 
-  if(!fs::is_regular_file(path))
-  {
-    return MakeErrorResult(-3, fmt::format("Path '{}' is not a file", path.string()));
-  }
+    if(!fs::is_regular_file(path))
+    {
+      return MakeErrorResult(-3, fmt::format("Path '{}' is not a file", path.string()));
+    }
 
-  nx::core::HDF5::FileReader fileReader(path);
-  if(!fileReader.isValid())
+    nx::core::HDF5::FileReader fileReader(path);
+    if(!fileReader.isValid())
+    {
+      return MakeErrorResult(-4, fmt::format("HDF5 file at path '{}' could not be read", path.string()));
+    }
+  } catch(const fs::filesystem_error& exception)
   {
-    return MakeErrorResult(-4, fmt::format("HDF5 file at path '{}' could not be read", path.string()));
+    return MakeErrorResult(-5, fmt::format("Filesystem excpetion: {}", exception.what()));
   }
   return {};
 }


### PR DESCRIPTION
For the long term use of `std::filesystem` will need to be wrapped in more places to catch all possible errors. The parameters are a good first pass since they should help catch issues during preflight.