### PR TITLE
BUG: Updated vcpkg baseline to include ITK windows compile fix

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -33,7 +33,7 @@
         "zlib",
         "zstd"
       ],
-      "baseline": "0963043542e4ad7aaacdad243b1eae6b2cf28130"
+      "baseline": "f9df39303b47ad4031afc61c8770c32fae0a69cf"
     }
   ]
 }


### PR DESCRIPTION
https://github.com/InsightSoftwareConsortium/ITK/issues/4820

Until ITK has an official release, we patch ITK in our vcpkg registry.