### PR TITLE
BUG: Remove ComputeTriangleShapesFilter due to incorrect output.

### DIFF
--- a/src/Plugins/OrientationAnalysis/CMakeLists.txt
+++ b/src/Plugins/OrientationAnalysis/CMakeLists.txt
@@ -52,7 +52,7 @@ set(FilterList
   ComputeSchmidsFilter
   ComputeShapesFilter
   ComputeSlipTransmissionMetricsFilter
-  ComputeTriangleGeomShapesFilter
+  # ComputeTriangleGeomShapesFilter
   ConvertHexGridToSquareGridFilter
   ConvertOrientationsFilter
   ConvertQuaternionFilter
@@ -186,7 +186,7 @@ set(filter_algorithms
   ComputeSchmids
   ComputeShapes
   ComputeSlipTransmissionMetrics
-  ComputeTriangleGeomShapes
+  # ComputeTriangleGeomShapes
   ConvertHexGridToSquareGrid
   ConvertQuaternion
   CreateEnsembleInfo

--- a/src/Plugins/OrientationAnalysis/test/CMakeLists.txt
+++ b/src/Plugins/OrientationAnalysis/test/CMakeLists.txt
@@ -31,7 +31,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   ComputeSchmidsTest.cpp
   ComputeShapesFilterTest.cpp
   ComputeSlipTransmissionMetricsTest.cpp
-  ComputeTriangleGeomShapesTest.cpp
+  # ComputeTriangleGeomShapesTest.cpp
   ConvertHexGridToSquareGridTest.cpp
   ConvertOrientationsTest.cpp
   ConvertQuaternionTest.cpp


### PR DESCRIPTION
This filter is going to be temporarily disabled because it does not compute correct values.


