### PR TITLE
ENH: Add support for .ply files and vertex geometries to MeshIO python filters

### DIFF
--- a/wrapping/python/plugins/NXDataAnalysisToolkit/docs/ReadMeshFileFilter.md
+++ b/wrapping/python/plugins/NXDataAnalysisToolkit/docs/ReadMeshFileFilter.md
@@ -11,6 +11,7 @@ The following mesh formats are supported by this filter:
 + Ansys (.msh)
 + Gmsh (.msh)
 + Med (.med)
++ PLY (.ply)
 + TetGen (.node/.ele)
 + VTK (.vtu)
 

--- a/wrapping/python/plugins/NXDataAnalysisToolkit/src/NXDataAnalysisToolkit/WriteAbaqusFile.py
+++ b/wrapping/python/plugins/NXDataAnalysisToolkit/src/NXDataAnalysisToolkit/WriteAbaqusFile.py
@@ -72,7 +72,7 @@ class WriteAbaqusFile:
     params = nx.Parameters()
 
     params.insert(params.Separator("Input Parameters"))
-    params.insert(nx.GeometrySelectionParameter(WriteAbaqusFile.INPUT_GEOMETRY_KEY, 'Input Geometry', 'The input geometry that will be written to the ABAQUS file.', nx.DataPath(), allowed_types={nx.IGeometry.Type.Edge, nx.IGeometry.Type.Triangle, nx.IGeometry.Type.Quad, nx.IGeometry.Type.Tetrahedral, nx.IGeometry.Type.Hexahedral}))
+    params.insert(nx.GeometrySelectionParameter(WriteAbaqusFile.INPUT_GEOMETRY_KEY, 'Input Geometry', 'The input geometry that will be written to the ABAQUS file.', nx.DataPath(), allowed_types={nx.IGeometry.Type.Vertex, nx.IGeometry.Type.Edge, nx.IGeometry.Type.Triangle, nx.IGeometry.Type.Quad, nx.IGeometry.Type.Tetrahedral, nx.IGeometry.Type.Hexahedral}))
 
     params.insert(params.Separator("Output Parameters"))
     params.insert(nx.FileSystemPathParameter(WriteAbaqusFile.OUTPUT_FILE_PATH_KEY, 'Output File (.inp)', 'The output file that contains the specified geometry as a mesh.', '', extensions_type={'.inp'}, path_type=nx.FileSystemPathParameter.PathType.OutputFile))
@@ -108,4 +108,5 @@ class WriteAbaqusFile:
     input_geometry_path: nx.DataPath = args[WriteAbaqusFile.INPUT_GEOMETRY_KEY]
     output_file_path: Path = args[WriteAbaqusFile.OUTPUT_FILE_PATH_KEY]
 
-    return mu.execute_meshio_writer_filter(file_format='abaqus', data_structure=data_structure, input_geometry_path=input_geometry_path, cell_data_array_paths=None, point_data_array_paths=None, output_file_path=output_file_path)
+    message_handler(nx.IFilter.Message(nx.IFilter.Message.Type.Info, f'Writing geometry to Abaqus file "{str(output_file_path)}"'))
+    return mu.execute_meshio_writer_filter(file_format='abaqus', data_structure=data_structure, input_geometry_path=input_geometry_path, cell_data_array_paths=None, point_data_array_paths=None, output_file_path=output_file_path, message_handler=message_handler, should_cancel=should_cancel)

--- a/wrapping/python/plugins/NXDataAnalysisToolkit/src/NXDataAnalysisToolkit/WriteAnsysFile.py
+++ b/wrapping/python/plugins/NXDataAnalysisToolkit/src/NXDataAnalysisToolkit/WriteAnsysFile.py
@@ -73,7 +73,7 @@ class WriteAnsysFile:
     params = nx.Parameters()
 
     params.insert(params.Separator("Input Parameters"))
-    params.insert(nx.GeometrySelectionParameter(WriteAnsysFile.INPUT_GEOMETRY_KEY, 'Input Geometry', 'The input geometry that will be written to the ANSYS file.', nx.DataPath(), allowed_types={nx.IGeometry.Type.Edge, nx.IGeometry.Type.Triangle, nx.IGeometry.Type.Quad, nx.IGeometry.Type.Tetrahedral, nx.IGeometry.Type.Hexahedral}))
+    params.insert(nx.GeometrySelectionParameter(WriteAnsysFile.INPUT_GEOMETRY_KEY, 'Input Geometry', 'The input geometry that will be written to the ANSYS file.', nx.DataPath(), allowed_types={nx.IGeometry.Type.Vertex, nx.IGeometry.Type.Edge, nx.IGeometry.Type.Triangle, nx.IGeometry.Type.Quad, nx.IGeometry.Type.Tetrahedral, nx.IGeometry.Type.Hexahedral}))
 
     params.insert(params.Separator("Output Parameters"))
     params.insert(nx.FileSystemPathParameter(WriteAnsysFile.OUTPUT_FILE_PATH_KEY, 'Output File (.msh)', 'The output file that contains the specified geometry as a mesh.', '', extensions_type={'.msh'}, path_type=nx.FileSystemPathParameter.PathType.OutputFile))
@@ -109,4 +109,5 @@ class WriteAnsysFile:
     input_geometry_path: nx.DataPath = args[WriteAnsysFile.INPUT_GEOMETRY_KEY]
     output_file_path: Path = args[WriteAnsysFile.OUTPUT_FILE_PATH_KEY]
 
-    return mu.execute_meshio_writer_filter(file_format='ansys', data_structure=data_structure, input_geometry_path=input_geometry_path, cell_data_array_paths=None, point_data_array_paths=None, output_file_path=output_file_path, binary=True)
+    message_handler(nx.IFilter.Message(nx.IFilter.Message.Type.Info, f'Writing geometry to Ansys file "{str(output_file_path)}"'))
+    return mu.execute_meshio_writer_filter(file_format='ansys', data_structure=data_structure, input_geometry_path=input_geometry_path, cell_data_array_paths=None, point_data_array_paths=None, output_file_path=output_file_path, message_handler=message_handler, should_cancel=should_cancel, binary=True)

--- a/wrapping/python/plugins/NXDataAnalysisToolkit/src/NXDataAnalysisToolkit/WriteMedFile.py
+++ b/wrapping/python/plugins/NXDataAnalysisToolkit/src/NXDataAnalysisToolkit/WriteMedFile.py
@@ -75,7 +75,7 @@ class WriteMedFile:
     params = nx.Parameters()
 
     params.insert(params.Separator("Input Parameters"))
-    params.insert(nx.GeometrySelectionParameter(WriteMedFile.INPUT_GEOMETRY_KEY, 'Input Geometry', 'The input geometry that will be written to the MED file.', nx.DataPath(), allowed_types={nx.IGeometry.Type.Edge, nx.IGeometry.Type.Triangle, nx.IGeometry.Type.Quad, nx.IGeometry.Type.Tetrahedral, nx.IGeometry.Type.Hexahedral}))
+    params.insert(nx.GeometrySelectionParameter(WriteMedFile.INPUT_GEOMETRY_KEY, 'Input Geometry', 'The input geometry that will be written to the MED file.', nx.DataPath(), allowed_types={nx.IGeometry.Type.Vertex, nx.IGeometry.Type.Edge, nx.IGeometry.Type.Triangle, nx.IGeometry.Type.Quad, nx.IGeometry.Type.Tetrahedral, nx.IGeometry.Type.Hexahedral}))
     params.insert(nx.MultiArraySelectionParameter(WriteMedFile.CELL_DATA_ARRAY_PATHS_KEY, 'Cell Data Arrays To Write', 'The cell data arrays to write to the MED file.', [], allowed_types={nx.IArray.ArrayType.DataArray}, allowed_data_types=nx.get_all_data_types()))
     params.insert(nx.MultiArraySelectionParameter(WriteMedFile.POINT_DATA_ARRAY_PATHS_KEY, 'Point Data Arrays To Write', 'The point data arrays to write to the MED file.', [], allowed_types={nx.IArray.ArrayType.DataArray}, allowed_data_types=nx.get_all_data_types()))
 
@@ -117,4 +117,5 @@ class WriteMedFile:
     cell_data_array_paths = args[WriteMedFile.CELL_DATA_ARRAY_PATHS_KEY]
     point_data_array_paths = args[WriteMedFile.POINT_DATA_ARRAY_PATHS_KEY]
 
-    return mu.execute_meshio_writer_filter(file_format='med', data_structure=data_structure, input_geometry_path=input_geometry_path, cell_data_array_paths=cell_data_array_paths, point_data_array_paths=point_data_array_paths, output_file_path=output_file_path)
+    message_handler(nx.IFilter.Message(nx.IFilter.Message.Type.Info, f'Writing geometry to Med file "{str(output_file_path)}"'))
+    return mu.execute_meshio_writer_filter(file_format='med', data_structure=data_structure, input_geometry_path=input_geometry_path, cell_data_array_paths=cell_data_array_paths, point_data_array_paths=point_data_array_paths, output_file_path=output_file_path, message_handler=message_handler, should_cancel=should_cancel)

--- a/wrapping/python/plugins/NXDataAnalysisToolkit/src/NXDataAnalysisToolkit/WriteTetGenFile.py
+++ b/wrapping/python/plugins/NXDataAnalysisToolkit/src/NXDataAnalysisToolkit/WriteTetGenFile.py
@@ -117,4 +117,6 @@ class WriteTetGenFile:
     cell_data_array_paths = args[WriteTetGenFile.CELL_DATA_ARRAY_PATHS_KEY]
     point_data_array_paths = args[WriteTetGenFile.POINT_DATA_ARRAY_PATHS_KEY]
 
-    return mu.execute_meshio_writer_filter(file_format='tetgen', data_structure=data_structure, input_geometry_path=input_geometry_path, cell_data_array_paths=cell_data_array_paths, point_data_array_paths=point_data_array_paths, output_file_path=output_file_path)
+    no_suffix_path = output_file_path.with_suffix("")
+    message_handler(nx.IFilter.Message(nx.IFilter.Message.Type.Info, f'Writing geometry to TetGen files "{str(no_suffix_path.with_suffix(".node"))}" and "{str(no_suffix_path.with_suffix(".ele"))}"'))
+    return mu.execute_meshio_writer_filter(file_format='tetgen', data_structure=data_structure, input_geometry_path=input_geometry_path, cell_data_array_paths=cell_data_array_paths, point_data_array_paths=point_data_array_paths, output_file_path=output_file_path, message_handler=message_handler, should_cancel=should_cancel)

--- a/wrapping/python/plugins/NXDataAnalysisToolkit/src/NXDataAnalysisToolkit/WriteVtuFile.py
+++ b/wrapping/python/plugins/NXDataAnalysisToolkit/src/NXDataAnalysisToolkit/WriteVtuFile.py
@@ -91,7 +91,7 @@ class WriteVtuFile:
     params = nx.Parameters()
 
     params.insert(params.Separator("Input Parameters"))
-    params.insert(nx.GeometrySelectionParameter(WriteVtuFile.INPUT_GEOMETRY_KEY, 'Input Geometry', 'The input geometry that will be written to the VTK file.', nx.DataPath(), allowed_types={nx.IGeometry.Type.Edge, nx.IGeometry.Type.Triangle, nx.IGeometry.Type.Quad, nx.IGeometry.Type.Tetrahedral, nx.IGeometry.Type.Hexahedral}))
+    params.insert(nx.GeometrySelectionParameter(WriteVtuFile.INPUT_GEOMETRY_KEY, 'Input Geometry', 'The input geometry that will be written to the VTK file.', nx.DataPath(), allowed_types={nx.IGeometry.Type.Vertex, nx.IGeometry.Type.Edge, nx.IGeometry.Type.Triangle, nx.IGeometry.Type.Quad, nx.IGeometry.Type.Tetrahedral, nx.IGeometry.Type.Hexahedral}))
     params.insert(nx.MultiArraySelectionParameter(WriteVtuFile.CELL_DATA_ARRAY_PATHS_KEY, 'Cell Data Arrays To Write', 'The cell data arrays to write to the VTK file.', [], allowed_types={nx.IArray.ArrayType.DataArray}, allowed_data_types=nx.get_all_data_types()))
     params.insert(nx.MultiArraySelectionParameter(WriteVtuFile.POINT_DATA_ARRAY_PATHS_KEY, 'Point Data Arrays To Write', 'The point data arrays to write to the VTK file.', [], allowed_types={nx.IArray.ArrayType.DataArray}, allowed_data_types=nx.get_all_data_types()))
 
@@ -135,4 +135,5 @@ class WriteVtuFile:
     cell_data_array_paths = args[WriteVtuFile.CELL_DATA_ARRAY_PATHS_KEY]
     point_data_array_paths = args[WriteVtuFile.POINT_DATA_ARRAY_PATHS_KEY]
 
-    return mu.execute_meshio_writer_filter(file_format='vtu', data_structure=data_structure, input_geometry_path=input_geometry_path, cell_data_array_paths=cell_data_array_paths, point_data_array_paths=point_data_array_paths, output_file_path=output_file_path, remove_array_name_spaces=True, binary=True, compression=self.compression_type_values[compression_type])
+    message_handler(nx.IFilter.Message(nx.IFilter.Message.Type.Info, f'Writing geometry to Vtu file "{str(output_file_path)}"'))
+    return mu.execute_meshio_writer_filter(file_format='vtu', data_structure=data_structure, input_geometry_path=input_geometry_path, cell_data_array_paths=cell_data_array_paths, point_data_array_paths=point_data_array_paths, output_file_path=output_file_path, message_handler=message_handler, should_cancel=should_cancel, remove_array_name_spaces=True, binary=True, compression=self.compression_type_values[compression_type])


### PR DESCRIPTION
+ ReadMeshFile filter can now read .ply files, and can read mesh files that contain only points and make a vertex geometry out of it.
+ All writer filters can write vertex geometries out to a file.