### PR TITLE
ENH: Add LLDB pretty printers for a few SIMPLNX classes.

### DIFF
--- a/scripts/lldb_pretty_printers/data_path_pretty_printer.py
+++ b/scripts/lldb_pretty_printers/data_path_pretty_printer.py
@@ -1,0 +1,36 @@
+import lldb
+
+def data_path_summary(valobj, internal_dict):
+    """
+    Return a string summary for nx::core::DataPath.
+    We'll display the contents of m_Path (std::vector<std::string>)
+    as a list of unquoted string values.
+    """
+    path_valobj = valobj.GetChildMemberWithName('m_Path')
+
+    # Use LLDB's synthetic children for std::vector to retrieve each element.
+    count = path_valobj.GetNumChildren()
+    elements = []
+    for i in range(count):
+        element = path_valobj.GetChildAtIndex(i)
+        # For std::string, GetSummary() often returns the string in quotes, e.g. "\"Hello\""
+        str_val = element.GetSummary()
+        if str_val is None:
+            str_val = "<NULL>"
+        else:
+            # Strip surrounding double quotes if present
+            if len(str_val) >= 2 and str_val.startswith('"') and str_val.endswith('"'):
+                str_val = str_val[1:-1]
+        elements.append(str_val)
+
+    # Join all the strings into a single display
+    return f"\"{'/'.join(elements)}\""
+
+def __lldb_init_module(debugger, internal_dict):
+    """
+    LLDB will call this function automatically when the script is imported.
+    We register our pretty-printer (summary) for the C++ type nx::core::DataPath.
+    """
+    debugger.HandleCommand(
+        'type summary add -F data_path_pretty_printer.data_path_summary "nx::core::DataPath"'
+    )

--- a/scripts/lldb_pretty_printers/image_geom_pretty_printer.py
+++ b/scripts/lldb_pretty_printers/image_geom_pretty_printer.py
@@ -1,0 +1,75 @@
+import lldb
+
+import simplnx_pretty_printer_utils as utils
+
+
+def image_geom_summary(valobj, internal_dict):
+    """
+    Return a string summary for nx::core::ImageGeom.
+    """
+    dims_valobj = valobj.GetChildMemberWithName('m_Dimensions')
+    summary = f'Dims:{utils.array_summary(dims_valobj, internal_dict)}'
+
+    origin_valobj = valobj.GetChildMemberWithName('m_Origin')
+    summary += f' Origin:{utils.array_summary(origin_valobj, internal_dict)}'
+
+    spacing_val_obj= valobj.GetChildMemberWithName('m_Spacing')
+    summary += f' Spacing:{utils.array_summary(spacing_val_obj, internal_dict)}'
+
+    return summary
+
+def vertex_geom_summary(valobj, internal_dict):
+    sbtype = valobj.GetType()
+    obj_type = None
+    if sbtype.IsPointerType():
+        # Dereference the pointer to get an SBValue that represents the actual object
+        obj_type = valobj.Dereference()
+    elif sbtype.IsReferenceType():
+        obj_type = valobj
+    else:
+        # Could be a class/struct/primitive, etc.
+        return "Object (by value)"
+
+    vert_result = obj_type.EvaluateExpression("getNumberOfVertices()")
+
+    if vert_result.IsValid() and vert_result.GetError().Success():
+        return f"Verts: {vert_result.GetValueAsUnsigned()}"
+    else:
+        return "nx::core::VertexGeom* COULD NOT GENERATE SUMMARY"
+
+def edge_geom_summary(valobj, internal_dict):
+
+    sbtype = valobj.GetType()
+    obj_type = None
+    if sbtype.IsPointerType():
+        # Dereference the pointer to get an SBValue that represents the actual object
+        obj_type = valobj.Dereference()
+    elif sbtype.IsReferenceType():
+        obj_type = valobj
+    else:
+        # Could be a class/struct/primitive, etc.
+        return "Object (by value)"
+
+    vert_result = obj_type.EvaluateExpression("getNumberOfVertices()")
+    edge_result = obj_type.EvaluateExpression("getNumberOfCells()")
+
+    if vert_result.IsValid() and vert_result.GetError().Success() and edge_result.IsValid() and edge_result.GetError().Success():
+        return f"Verts: {vert_result.GetValueAsUnsigned()} Edges: {edge_result.GetValueAsUnsigned()}"
+    else:
+        return "nx::core::EdgeGeom* COULD NOT GENERATE SUMMARY"
+
+
+def __lldb_init_module(debugger, internal_dict):
+    """
+    LLDB will call this function automatically when the script is imported.
+    We register our pretty-printer (summary) for the C++ type nx::core::DataPath.
+    """
+    debugger.HandleCommand(
+        'type summary add -F image_geom_pretty_printer.image_geom_summary "nx::core::ImageGeom"'
+    )
+    debugger.HandleCommand(
+        'type summary add -F image_geom_pretty_printer.vertex_geom_summary "nx::core::VertexGeom"'
+    )
+    debugger.HandleCommand(
+        'type summary add -F image_geom_pretty_printer.edge_geom_summary "nx::core::EdgeGeom"'
+    )

--- a/scripts/lldb_pretty_printers/nx_core_array_pretty_printer.py
+++ b/scripts/lldb_pretty_printers/nx_core_array_pretty_printer.py
@@ -1,0 +1,83 @@
+import lldb
+
+def array_summary(valobj, internal_dict):
+    """
+    Custom summary function for nx::core::Array<T, Dimensions>.
+    Shows the elements of the private std::array<T, Dimensions> m_Array.
+    """
+
+    # 1) Retrieve the m_Array child.
+    std_array_elements = valobj.GetChildMemberWithName("m_Array").GetChildMemberWithName("__elems_")
+
+    # 2) For an std::array<T, N>, LLDB usually shows each element as a child.
+    #    We'll iterate through them and collect their values/summaries.
+    count = std_array_elements.GetNumChildren()
+
+    elements = []
+    for i in range(count):
+        elem = std_array_elements.GetChildAtIndex(i)
+        # Prefer GetValue() if it's a scalar; otherwise, fallback to GetSummary().
+        elem_value = elem.GetValue()
+        if elem_value is None:
+            elem_value = elem.GetSummary()
+        if elem_value is None:
+            elem_value = "<unavailable>"
+        elements.append(elem_value)
+
+    # 4) Return a concise summary.
+    return f"{', '.join(elements)}"
+
+def __lldb_init_module(debugger, internal_dict):
+    """
+    LLDB calls this function automatically when this script is imported.
+    
+    We register a summary for the templated type:
+    'nx::core::Array<*, *>' — the wildcard syntax tells LLDB to match
+    any T and Dimensions combination.
+    
+    Alternatively, you can use a regex to match all template instantiations
+    of nx::core::Array if the wildcard approach does not work in your LLDB version:
+        type summary add -x 'nx::core::Array<.*>' -F nx_core_array_pretty_printer.array_summary
+    """
+    debugger.HandleCommand(
+       'type summary add -F nx_core_array_pretty_printer.array_summary "nx::core::Array<*,*>"'
+       # 'type summary add -x nx::core::Array<.*> -F nx_core_array_pretty_printer.array_summary'
+    )
+    debugger.HandleCommand(
+       # 'type summary add -F nx_core_array_pretty_printer.array_summary "nx::core::Array<*,*>"'
+        'type summary add -x nx::core::SizeVec3 -F nx_core_array_pretty_printer.array_summary'
+    )
+    debugger.HandleCommand(
+       # 'type summary add -F nx_core_array_pretty_printer.array_summary "nx::core::Array<*,*>"'
+        'type summary add -x nx::core::FloatVec3 -F nx_core_array_pretty_printer.array_summary'
+    )
+    debugger.HandleCommand(
+       # 'type summary add -F nx_core_array_pretty_printer.array_summary "nx::core::Array<*,*>"'
+        'type summary add -x nx::core::IntVec3 -F nx_core_array_pretty_printer.array_summary'
+    )
+
+    debugger.HandleCommand(
+       # 'type summary add -F nx_core_array_pretty_printer.array_summary "nx::core::Array<*,*>"'
+        'type summary add -x nx::core::SizeVec4 -F nx_core_array_pretty_printer.array_summary'
+    )
+    debugger.HandleCommand(
+       # 'type summary add -F nx_core_array_pretty_printer.array_summary "nx::core::Array<*,*>"'
+        'type summary add -x nx::core::FloatVec4 -F nx_core_array_pretty_printer.array_summary'
+    )
+    debugger.HandleCommand(
+       # 'type summary add -F nx_core_array_pretty_printer.array_summary "nx::core::Array<*,*>"'
+        'type summary add -x nx::core::IntVec4 -F nx_core_array_pretty_printer.array_summary'
+    )
+
+    debugger.HandleCommand(
+       # 'type summary add -F nx_core_array_pretty_printer.array_summary "nx::core::Array<*,*>"'
+        'type summary add -x nx::core::Point3D -F nx_core_array_pretty_printer.array_summary'
+    )
+    debugger.HandleCommand(
+       # 'type summary add -F nx_core_array_pretty_printer.array_summary "nx::core::Array<*,*>"'
+        'type summary add -x nx::core::Point3Df -F nx_core_array_pretty_printer.array_summary'
+    )
+    debugger.HandleCommand(
+       # 'type summary add -F nx_core_array_pretty_printer.array_summary "nx::core::Array<*,*>"'
+        'type summary add -x nx::core::Point3Dd -F nx_core_array_pretty_printer.array_summary'
+    )

--- a/scripts/lldb_pretty_printers/nx_core_array_pretty_printer.py
+++ b/scripts/lldb_pretty_printers/nx_core_array_pretty_printer.py
@@ -1,31 +1,10 @@
 import lldb
 
+import simplnx_pretty_printer_utils as utils
+
 def array_summary(valobj, internal_dict):
-    """
-    Custom summary function for nx::core::Array<T, Dimensions>.
-    Shows the elements of the private std::array<T, Dimensions> m_Array.
-    """
+    return utils.array_summary(valobj, internal_dict)
 
-    # 1) Retrieve the m_Array child.
-    std_array_elements = valobj.GetChildMemberWithName("m_Array").GetChildMemberWithName("__elems_")
-
-    # 2) For an std::array<T, N>, LLDB usually shows each element as a child.
-    #    We'll iterate through them and collect their values/summaries.
-    count = std_array_elements.GetNumChildren()
-
-    elements = []
-    for i in range(count):
-        elem = std_array_elements.GetChildAtIndex(i)
-        # Prefer GetValue() if it's a scalar; otherwise, fallback to GetSummary().
-        elem_value = elem.GetValue()
-        if elem_value is None:
-            elem_value = elem.GetSummary()
-        if elem_value is None:
-            elem_value = "<unavailable>"
-        elements.append(elem_value)
-
-    # 4) Return a concise summary.
-    return f"{', '.join(elements)}"
 
 def __lldb_init_module(debugger, internal_dict):
     """
@@ -40,7 +19,7 @@ def __lldb_init_module(debugger, internal_dict):
         type summary add -x 'nx::core::Array<.*>' -F nx_core_array_pretty_printer.array_summary
     """
     debugger.HandleCommand(
-       'type summary add -F nx_core_array_pretty_printer.array_summary "nx::core::Array<*,*>"'
+       'type summary add -F nx_core_array_pretty_printer.array_summary -x "nx::core::Array<.*,.*>"'
        # 'type summary add -x nx::core::Array<.*> -F nx_core_array_pretty_printer.array_summary'
     )
     debugger.HandleCommand(

--- a/scripts/lldb_pretty_printers/simplnx_pretty_printer_utils.py
+++ b/scripts/lldb_pretty_printers/simplnx_pretty_printer_utils.py
@@ -1,0 +1,28 @@
+import lldb
+
+def array_summary(valobj, internal_dict):
+    """
+    Custom summary function for nx::core::Array<T, Dimensions>.
+    Shows the elements of the private std::array<T, Dimensions> m_Array.
+    """
+
+    # 1) Retrieve the m_Array child.
+    std_array_elements = valobj.GetChildMemberWithName("m_Array").GetChildMemberWithName("__elems_")
+
+    # 2) For an std::array<T, N>, LLDB usually shows each element as a child.
+    #    We'll iterate through them and collect their values/summaries.
+    count = std_array_elements.GetNumChildren()
+
+    elements = []
+    for i in range(count):
+        elem = std_array_elements.GetChildAtIndex(i)
+        # Prefer GetValue() if it's a scalar; otherwise, fallback to GetSummary().
+        elem_value = elem.GetValue()
+        if elem_value is None:
+            elem_value = elem.GetSummary()
+        if elem_value is None:
+            elem_value = "<unavailable>"
+        elements.append(elem_value)
+
+    # 4) Return a concise summary.
+    return f"{', '.join(elements)}"

--- a/test/GeometryTest.cpp
+++ b/test/GeometryTest.cpp
@@ -250,6 +250,8 @@ TEST_CASE("VertexGeomTest")
   DataStructure dataStructure;
   auto geom = createGeom<VertexGeom>(dataStructure);
 
+  VertexGeom& geomRef = *geom;
+
   testAbstractGeometry(geom);
 
   SECTION("type as string")


### PR DESCRIPTION
* More to come later

There is a bit of setup that one must do in order to get LLDB to use these pretty
   printers. Namely create a file called `.lldbinit` at the top level of your home
   directory and put the following code in it:

```
command script import /Users/${USER}/Workspace1/simplnx/scripts/lldb_pretty_printers/data_path_pretty_printer.py

command script import /Users/${USER}/Workspace1/simplnx/scripts/lldb_pretty_printers/nx_core_array_pretty_printer.py
```

Where you will need to adjust the path to the actual python files based on how you have your environment setup.


