### PR TITLE
BUG: Fix format_pr workflow

### DIFF
--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -30,4 +30,4 @@ jobs:
         uses: reviewdog/action-suggester@v1
         with:
           tool_name: clang-format
-          fail_on_error: true
+          fail_level: error

--- a/src/simplnx/Plugin/AbstractPlugin.cpp
+++ b/src/simplnx/Plugin/AbstractPlugin.cpp
@@ -26,8 +26,6 @@ std::string AbstractPlugin::getName() const
   return m_Name;
 }
 
-
-
 std::string AbstractPlugin::getDescription() const
 {
   return m_Description;

--- a/src/simplnx/Plugin/AbstractPlugin.cpp
+++ b/src/simplnx/Plugin/AbstractPlugin.cpp
@@ -26,6 +26,8 @@ std::string AbstractPlugin::getName() const
   return m_Name;
 }
 
+
+
 std::string AbstractPlugin::getDescription() const
 {
   return m_Description;


### PR DESCRIPTION
The `format_pr` workflow was not properly reporting errors due to a deprecated option.