### PR TITLE
BUG: DataArray::getComponent should return a value not a reference

### DIFF
--- a/src/simplnx/DataStructure/DataArray.hpp
+++ b/src/simplnx/DataStructure/DataArray.hpp
@@ -379,7 +379,7 @@ public:
     return m_DataStore->getValue(index);
   }
 
-  const_reference getComponent(usize tupleIndex, usize componentIndex)
+  value_type getComponent(usize tupleIndex, usize componentIndex)
   {
     const usize index = tupleIndex * getNumberOfComponents() + componentIndex;
     return m_DataStore->getValue(index);


### PR DESCRIPTION
* AbstractDataStore::getValue which is used to implement DataArray::getComponent returns a value but before this commit AbstractDataStore::getValue return a reference which lead to a dangling reference to a temporary value