### PR TITLE
Fixed some compiler warnings in simplnx

### DIFF
--- a/src/simplnx/DataStructure/DataStructure.cpp
+++ b/src/simplnx/DataStructure/DataStructure.cpp
@@ -916,7 +916,6 @@ void DataStructure::recurseHierarchyToGraphViz(std::ostream& outputStream, const
 {
   for(const auto& path : paths)
   {
-    auto* dataObjectPtr = getData(path);
     // Output parent node, child node, and edge connecting them in .dot format
     outputStream << "\"" << parent << "\" -> \"" << path.getTargetName() << "\"\n";
 

--- a/src/simplnx/DataStructure/DataStructure.cpp
+++ b/src/simplnx/DataStructure/DataStructure.cpp
@@ -139,7 +139,7 @@ LinkedPath DataStructure::getLinkedPath(const DataPath& path) const
     }
 
     return LinkedPath(this, pathIds);
-  } catch(std::exception e)
+  } catch(const std::exception& e)
   {
     return LinkedPath();
   }

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry0D.cpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry0D.cpp
@@ -117,7 +117,7 @@ BoundingBox3Df INodeGeometry0D::getBoundingBox() const
       ll[2] = (z < ll[2]) ? z : ll[2];
       ur[2] = (z > ur[2]) ? z : ur[2];
     }
-  } catch(std::bad_cast ex)
+  } catch(const std::bad_cast& ex)
   {
     return {ll, ur}; // will be invalid
   }

--- a/src/simplnx/DataStructure/IO/HDF5/NeighborListIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/NeighborListIO.hpp
@@ -54,7 +54,6 @@ public:
     {
       const auto numNeighbors = numNeighborsStore[i];
       auto sharedVector = std::make_shared<std::vector<T>>(numNeighbors);
-      std::vector<T>& vector = *sharedVector.get();
 
       size_t neighborListStart = offset;
       size_t neighborListEnd = offset + numNeighbors;

--- a/src/simplnx/DataStructure/Messaging/DataRemovedMessage.cpp
+++ b/src/simplnx/DataStructure/Messaging/DataRemovedMessage.cpp
@@ -4,22 +4,22 @@ using namespace nx::core;
 
 DataRemovedMessage::DataRemovedMessage(const DataStructure* dataStructure, DataObject::IdType identifier, const std::string& name)
 : AbstractDataStructureMessage(dataStructure)
-, m_Id(identifier)
 , m_Name(name)
+, m_Id(identifier)
 {
 }
 
 DataRemovedMessage::DataRemovedMessage(const DataRemovedMessage& other)
 : AbstractDataStructureMessage(other)
-, m_Id(other.m_Id)
 , m_Name(other.m_Name)
+, m_Id(other.m_Id)
 {
 }
 
 DataRemovedMessage::DataRemovedMessage(DataRemovedMessage&& other) noexcept
 : AbstractDataStructureMessage(other)
-, m_Id(std::move(other.m_Id))
 , m_Name(std::move(other.m_Name))
+, m_Id(std::move(other.m_Id))
 {
 }
 

--- a/src/simplnx/DataStructure/Montage/AbstractMontage.cpp
+++ b/src/simplnx/DataStructure/Montage/AbstractMontage.cpp
@@ -63,11 +63,6 @@ std::vector<std::string> AbstractMontage::getGeometryNames() const
 
 std::vector<LinkedPath> AbstractMontage::getLinkedPaths() const
 {
-  std::vector<DataPath> paths;
-  for(auto geometry : getGeometries())
-  {
-  }
-
   std::vector<LinkedPath> linkedPaths;
   return linkedPaths;
 }

--- a/src/simplnx/DataStructure/Montage/GridMontage.cpp
+++ b/src/simplnx/DataStructure/Montage/GridMontage.cpp
@@ -252,7 +252,6 @@ usize GridMontage::getOffsetFromTilePos(const SizeVec3& tilePos, const Dimension
 {
   const usize numCols = dims[0];
   const usize numRows = dims[1];
-  const usize numDeep = dims[2];
 
   return tilePos[0] + tilePos[1] * numCols + tilePos[2] * numCols * numRows;
 }

--- a/src/simplnx/Filter/Actions/DeleteDataAction.cpp
+++ b/src/simplnx/Filter/Actions/DeleteDataAction.cpp
@@ -112,7 +112,7 @@ DeleteDataAction::~DeleteDataAction() noexcept = default;
 
 Result<> DeleteDataAction::apply(DataStructure& dataStructure, Mode mode) const
 {
-  auto* targetObject = dataStructure.getDataAs<BaseGroup>(path());
+  // auto* targetObject = dataStructure.getDataAs<BaseGroup>(path());
   switch(type())
   {
   case DeleteType::JustObject:

--- a/src/simplnx/Filter/Actions/RenameDataAction.cpp
+++ b/src/simplnx/Filter/Actions/RenameDataAction.cpp
@@ -31,7 +31,7 @@ Result<> TerminateNodesRecursively(DataStructure& dataStructure, DataObject::IdT
     {
       for(const auto& childId : childIds)
       {
-        result = MergeResults(result, std::move(TerminateNodesRecursively(dataStructure, childId, mode, checkDependence)));
+        result = MergeResults(result, TerminateNodesRecursively(dataStructure, childId, mode, checkDependence));
       }
     }
   }

--- a/src/simplnx/Parameters/ReadCSVFileParameter.cpp
+++ b/src/simplnx/Parameters/ReadCSVFileParameter.cpp
@@ -154,7 +154,7 @@ Result<ReadASCIIWizardDataFilterParameterConverter::ValueType> ReadASCIIWizardDa
   value.headersLine = json[k_HeaderLineKey].get<int32>();
 
   bool headerIsCustom = json[k_HeaderIsCustomKey].get<bool>();
-  bool headerUsesDefaults = json[k_HeaderUsesDefaultsKey].get<bool>();
+  // bool headerUsesDefaults = json[k_HeaderUsesDefaultsKey].get<bool>();
 
   if(headerIsCustom)
   {

--- a/src/simplnx/Pipeline/AbstractPipelineNode.cpp
+++ b/src/simplnx/Pipeline/AbstractPipelineNode.cpp
@@ -234,7 +234,7 @@ std::unique_ptr<Pipeline> AbstractPipelineNode::getPrecedingPipeline() const
     }
     pipeline->push_front(std::move(segment));
   }
-  return std::move(pipeline);
+  return pipeline;
 }
 
 std::unique_ptr<Pipeline> AbstractPipelineNode::getPrecedingPipelineSegment() const
@@ -252,7 +252,7 @@ std::unique_ptr<Pipeline> AbstractPipelineNode::getPrecedingPipelineSegment() co
   }
 
   auto iter = parentPipeline->find(this);
-  return std::move(parentPipeline->copySegment(parentPipeline->begin(), iter));
+  return parentPipeline->copySegment(parentPipeline->begin(), iter);
 }
 
 nx::core::FaultState AbstractPipelineNode::getFaultState() const

--- a/src/simplnx/Pipeline/Pipeline.cpp
+++ b/src/simplnx/Pipeline/Pipeline.cpp
@@ -725,7 +725,7 @@ std::unique_ptr<Pipeline> Pipeline::copySegment(const iterator& startIter, const
   {
     pipelineCopy->push_back(iter->get()->deepCopy());
   }
-  return std::move(pipelineCopy);
+  return pipelineCopy;
 }
 
 std::unique_ptr<Pipeline> Pipeline::copySegment(const const_iterator& startIter, const const_iterator& endIter) const
@@ -740,7 +740,7 @@ std::unique_ptr<Pipeline> Pipeline::copySegment(const const_iterator& startIter,
   {
     pipelineCopy->push_back(endIter->get()->deepCopy());
   }
-  return std::move(pipelineCopy);
+  return pipelineCopy;
 }
 
 Pipeline::iterator Pipeline::begin()

--- a/src/simplnx/Pipeline/PipelineFilter.cpp
+++ b/src/simplnx/Pipeline/PipelineFilter.cpp
@@ -632,7 +632,7 @@ nx::core::WarningCollection convertErrors(const nx::core::ErrorCollection& error
   {
     warnings.emplace_back(Warning{error.code, prefix + error.message});
   }
-  return std::move(warnings);
+  return warnings;
 }
 
 std::string PipelineFilter::CreateErrorComments(const nx::core::ErrorCollection& errors, const std::string& prefix)

--- a/src/simplnx/Utilities/FileUtilities.cpp
+++ b/src/simplnx/Utilities/FileUtilities.cpp
@@ -43,7 +43,11 @@ int64 LinesInFile(const std::string& filepath)
   // Check if the very last character is NOT a newline character
   fseek(fd, -1, SEEK_END);
   char last[1];
-  fread(last, 1, 1, fd);
+  usize bytesRead = fread(last, 1, 1, fd);
+  if(bytesRead != 1)
+  {
+    return -1;
+  }
   if(last[0] != '\n')
   {
     lines++;

--- a/src/simplnx/Utilities/FileUtilities.cpp
+++ b/src/simplnx/Utilities/FileUtilities.cpp
@@ -43,7 +43,7 @@ int64 LinesInFile(const std::string& filepath)
   // Check if the very last character is NOT a newline character
   fseek(fd, -1, SEEK_END);
   char last[1];
-  auto bytsRead = fread(last, 1, 1, fd);
+  fread(last, 1, 1, fd);
   if(last[0] != '\n')
   {
     lines++;

--- a/src/simplnx/Utilities/GeometryHelpers.hpp
+++ b/src/simplnx/Utilities/GeometryHelpers.hpp
@@ -185,9 +185,6 @@ usize FindNumEdges(const AbstractDataStore<T>& faceStore, usize numVertices = (d
 template <typename T, typename K>
 void FindElementsContainingVert(const DataArray<K>* elemList, DynamicListArray<T, K>* dynamicList, usize numVerts)
 {
-  DataStructure* dataStructure = dynamicList->getDataStructure();
-  auto parentId = dynamicList->getParentIds().front();
-
   auto& elems = *elemList;
   const usize numElems = elemList->getNumberOfTuples();
   const usize numVertsPerElem = elemList->getNumberOfComponents();
@@ -197,7 +194,6 @@ void FindElementsContainingVert(const DataArray<K>* elemList, DynamicListArray<T
 
   // Fill out lists with number of references to cells
   std::vector<K> linkLoc(numVerts, static_cast<K>(0));
-  K* verts = nullptr;
 
   // vtkPolyData *pdata = static_cast<vtkPolyData *>(data);
   // Traverse data to determine number of uses of each point
@@ -236,8 +232,6 @@ void FindElementsContainingVert(const DataArray<K>* elemList, DynamicListArray<T
 template <typename T, typename K>
 ErrorCode FindElementNeighbors(const DataArray<K>* elemList, const DynamicListArray<T, K>* elemsContainingVert, DynamicListArray<T, K>* dynamicList, IGeometry::Type geometryType)
 {
-  DataStructure* dataStructure = dynamicList->getDataStructure();
-  auto parentId = dynamicList->getParentIds().front();
   auto& elems = *elemList;
   const usize numElems = elemList->getNumberOfTuples();
   const usize numVertsPerElem = elemList->getNumberOfComponents();

--- a/src/simplnx/Utilities/GeometryUtilities.cpp
+++ b/src/simplnx/Utilities/GeometryUtilities.cpp
@@ -165,7 +165,6 @@ public:
 
   void convert(size_t start, size_t end) const
   {
-    std::array<float, 3> cross = {0.0f, 0.0f, 0.0f};
     for(size_t triangleIndex = start; triangleIndex < end; triangleIndex++)
     {
       if(m_ShouldCancel)

--- a/src/simplnx/Utilities/GeometryUtilities.cpp
+++ b/src/simplnx/Utilities/GeometryUtilities.cpp
@@ -378,7 +378,7 @@ Edge IntersectTriangleWithPlane(const Point3Df& v0, const Point3Df& v1, const Po
     e.positiveCount = positiveCount;
     e.negativeCount = negativeCount;
     e.zeroCount = zeroCount;
-    return std::move(e); // Invalid edge because triangle is completely above or below the plane
+    return e; // Invalid edge because triangle is completely above or below the plane
   }
 
   // Edge to store the intersection line segment
@@ -402,7 +402,7 @@ Edge IntersectTriangleWithPlane(const Point3Df& v0, const Point3Df& v1, const Po
     e.positiveCount = positiveCount;
     e.negativeCount = negativeCount;
     e.zeroCount = zeroCount;
-    return std::move(e);
+    return e;
   }
 
   if(positiveCount == 1 && negativeCount == 1 && zeroCount == 1)
@@ -427,7 +427,7 @@ Edge IntersectTriangleWithPlane(const Point3Df& v0, const Point3Df& v1, const Po
     e.negativeCount = negativeCount;
     e.zeroCount = zeroCount;
     e.valid = true;
-    return std::move(e);
+    return e;
   }
 
   // Check edges for coincidence with plane
@@ -437,7 +437,7 @@ Edge IntersectTriangleWithPlane(const Point3Df& v0, const Point3Df& v1, const Po
     e.positiveCount = positiveCount;
     e.negativeCount = negativeCount;
     e.zeroCount = zeroCount;
-    return std::move(e);
+    return e;
   }
   if(p1.onPlane() && p2.onPlane() && zeroCount == 2)
   {
@@ -445,7 +445,7 @@ Edge IntersectTriangleWithPlane(const Point3Df& v0, const Point3Df& v1, const Po
     e.positiveCount = positiveCount;
     e.negativeCount = negativeCount;
     e.zeroCount = zeroCount;
-    return std::move(e);
+    return e;
   }
   if(p0.onPlane() && p2.onPlane() && zeroCount == 2)
   {
@@ -453,7 +453,7 @@ Edge IntersectTriangleWithPlane(const Point3Df& v0, const Point3Df& v1, const Po
     e.positiveCount = positiveCount;
     e.negativeCount = negativeCount;
     e.zeroCount = zeroCount;
-    return std::move(e);
+    return e;
   }
 
   if(p0.planeSplitsEdge(p1) && p0.planeSplitsEdge(p2))
@@ -465,7 +465,7 @@ Edge IntersectTriangleWithPlane(const Point3Df& v0, const Point3Df& v1, const Po
     e.positiveCount = positiveCount;
     e.negativeCount = negativeCount;
     e.zeroCount = zeroCount;
-    return std::move(e);
+    return e;
   }
 
   if(p0.planeSplitsEdge(p1) && p1.planeSplitsEdge(p2))
@@ -476,7 +476,7 @@ Edge IntersectTriangleWithPlane(const Point3Df& v0, const Point3Df& v1, const Po
     e.positiveCount = positiveCount;
     e.negativeCount = negativeCount;
     e.zeroCount = zeroCount;
-    return std::move(e);
+    return e;
   }
 
   if(p1.planeSplitsEdge(p2) && p2.planeSplitsEdge(p0))
@@ -487,7 +487,7 @@ Edge IntersectTriangleWithPlane(const Point3Df& v0, const Point3Df& v1, const Po
     e.positiveCount = positiveCount;
     e.negativeCount = negativeCount;
     e.zeroCount = zeroCount;
-    return std::move(e);
+    return e;
   }
 
   // No valid intersection found
@@ -495,7 +495,7 @@ Edge IntersectTriangleWithPlane(const Point3Df& v0, const Point3Df& v1, const Po
   e.positiveCount = positiveCount;
   e.negativeCount = negativeCount;
   e.zeroCount = zeroCount;
-  return std::move(e); // Invalid edge
+  return e; // Invalid edge
 }
 } // namespace slice_helper
 

--- a/src/simplnx/Utilities/ImageRotationUtilities.hpp
+++ b/src/simplnx/Utilities/ImageRotationUtilities.hpp
@@ -595,8 +595,8 @@ class ApplyTransformationToNodeGeometry
 
 public:
   ApplyTransformationToNodeGeometry(IGeometry::SharedVertexList& verticesPtr, const Matrix4fR& transformationMatrix, FilterProgressCallback* filterCallback)
-  : m_Vertices(verticesPtr)
-  , m_TransformationMatrix(transformationMatrix)
+  : m_TransformationMatrix(transformationMatrix)
+  , m_Vertices(verticesPtr)
   , m_FilterCallback(filterCallback)
   {
   }

--- a/src/simplnx/Utilities/OStreamUtilities.cpp
+++ b/src/simplnx/Utilities/OStreamUtilities.cpp
@@ -284,8 +284,8 @@ class TupleWriter : public ITupleWriter
 
 public:
   TupleWriter(const IDataArray& iDataArray, const std::string& delimiter)
-  : m_DataStore(iDataArray.template getIDataStoreRefAs<AbstractDataStore<ScalarType>>())
-  , m_Name(iDataArray.getName())
+  : m_Name(iDataArray.getName())
+  , m_DataStore(iDataArray.template getIDataStoreRefAs<AbstractDataStore<ScalarType>>())
   , m_Delimiter(delimiter)
   {
     m_NumComps = m_DataStore.getNumberOfComponents();

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -1578,7 +1578,7 @@ Result<DREAM3D::FileData> DREAM3D::ReadFile(const std::filesystem::path& path)
   {
     return MakeErrorResult<FileData>(-1, fmt::format("DREAM3D::ReadFile: Unable to read '{}'", path.string()));
   }
-  return {std::move(fileData)};
+  return fileData;
 }
 
 Result<> WritePipeline(nx::core::HDF5::FileWriter& fileWriter, const Pipeline& pipeline)

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -904,8 +904,6 @@ Result<> readLegacyStringArray(DataStructure& dataStructure, const nx::core::HDF
 Result<IDataArray*> readLegacyDataArray(DataStructure& dataStructure, const nx::core::HDF5::DatasetReader& dataArrayReader, DataObject::IdType parentId, std::vector<uint64>& amTDims,
                                         bool preflight = false)
 {
-  auto size = H5Dget_storage_size(dataArrayReader.getId());
-
   std::vector<usize> tDims;
   std::vector<usize> cDims;
   Result<> dimsResult = readLegacyDataArrayDims(dataArrayReader, tDims, cDims);
@@ -1014,8 +1012,6 @@ Result<UInt64Array*> readLegacyNodeConnectivityList(DataStructure& dataStructure
 {
   HDF5::DatasetReader dataArrayReader = geomGroup.openDataset(arrayName);
   DataObject::IdType parentId = geometry->getId();
-
-  auto size = H5Dget_storage_size(dataArrayReader.getId());
 
   std::vector<usize> tDims;
   std::vector<usize> cDims;
@@ -1333,7 +1329,6 @@ DataObject* readLegacyHexGeom(DataStructure& dataStructure, const nx::core::HDF5
 DataObject* readLegacyEdgeGeom(DataStructure& dataStructure, const nx::core::HDF5::GroupReader& geomGroup, const std::string& name, bool preflight)
 {
   auto geom = EdgeGeom::Create(dataStructure, name);
-  auto edge = dynamic_cast<EdgeGeom*>(geom);
   readGenericGeomDims(geom, geomGroup);
   auto sharedVertexList = readLegacyGeomArrayAs<Float32Array>(dataStructure, geom, geomGroup, Legacy::VertexListName, preflight);
   auto sharedEdgeList = readLegacyNodeConnectivityList(dataStructure, geom, geomGroup, Legacy::EdgeListName, preflight);

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/GroupIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/GroupIO.cpp
@@ -256,7 +256,7 @@ DatasetIO GroupIO::createDataset(const std::string& childName)
   }
 
   DatasetIO dataset(getId(), childName);
-  return std::move(dataset);
+  return dataset;
 }
 
 std::shared_ptr<DatasetIO> GroupIO::createDatasetPtr(const std::string& childName)

--- a/src/simplnx/Utilities/Parsing/HDF5/Writers/DatasetWriter.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/Writers/DatasetWriter.hpp
@@ -175,7 +175,7 @@ public:
           }
           /* Write the attribute data. */
           const void* data = static_cast<const void*>(values.data());
-          auto properties = CreateTransferChunkProperties(chunkShape);
+          // auto properties = CreateTransferChunkProperties(chunkShape);
           // error = H5Dwrite_chunk(getId(), properties, H5P_DEFAULT, offset.data(), values.size(), data);
           error = H5Dwrite_chunk(getId(), H5P_DEFAULT, H5P_DEFAULT, offset.data(), values.size() * sizeof(T), data);
           if(error < 0)

--- a/src/simplnx/Utilities/SampleSurfaceMesh.cpp
+++ b/src/simplnx/Utilities/SampleSurfaceMesh.cpp
@@ -92,8 +92,8 @@ public:
   , m_FaceIds(faceIds)
   , m_FaceBBs(faceBBs)
   , m_Points(points)
-  , m_FeatureId(featureId)
   , m_PolyIds(polyIds)
+  , m_FeatureId(featureId)
   , m_ShouldCancel(shouldCancel)
   {
   }


### PR DESCRIPTION
Fixed the following gcc compiler warnings for the base simplnx library:
- `Wreorder`
- `Wunused-variable`
- `Wpessimizing-move`
- `Wcatch-value`