### PR TITLE
ENH: Excessive Warning Cleanup

### DIFF
--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ArrayCalculatorFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ArrayCalculatorFilter.cpp
@@ -158,15 +158,6 @@ IFilter::PreflightResult ArrayCalculatorFilter::preflightImpl(const DataStructur
     if(const auto* attributeMatrix = dataStructure.getDataAs<AttributeMatrix>(outputGroupPath); attributeMatrix != nullptr)
     {
       calculatedTupleShape = attributeMatrix->getShape();
-      resultOutputActions.warnings().push_back(Warning{static_cast<int>(CalculatorItem::WarningCode::NumericValueWarning),
-                                                       "The result of the chosen expression will be a numeric value. This numeric value will be used to initialize an "
-                                                       "array with the number of tuples equal to the number of tuples in the destination group."});
-    }
-    else
-    {
-      resultOutputActions.warnings().push_back(
-          Warning{static_cast<int>(CalculatorItem::WarningCode::NumericValueWarning),
-                  "The result of the chosen expression will be a numeric value or contain one tuple. This numeric value will be stored in an array with the number of tuples equal to 1"});
     }
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropEdgeGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropEdgeGeometryFilter.cpp
@@ -223,7 +223,7 @@ IFilter::PreflightResult CropEdgeGeometryFilter::preflightImpl(const DataStructu
     {
       // Detected at least one vertex array, throw a warning
       resultOutputActions.warnings().push_back(
-          {-100, "A vertex data array was detected in the selected edge geometry.  This filter currently only interpolates vertex positions, associated vertex data values will not be interpolated."});
+          {-100, "A vertex data array was detected in the selected edge geometry. This filter currently only interpolates vertex positions, associated vertex data values will not be interpolated."});
     }
 
     for(const auto& [identifier, object] : selectedVertexData)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropImageGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropImageGeometryFilter.cpp
@@ -515,11 +515,11 @@ IFilter::PreflightResult CropImageGeometryFilter::preflightImpl(const DataStruct
     }
     if(!warningMsg.empty())
     {
-      resultOutputActions.m_Warnings.push_back(Warning(
-          {-55503,
+      preflightUpdatedValues.push_back(
+          {"Invalidated NeighborLists",
            fmt::format(
-               "This filter will modify the Cell Level Array '{}' which causes all Feature level NeighborLists to become invalid. These NeighborLists will not be copied to the new geometry:{}",
-               featureIdsArrayPath.toString(), warningMsg)}));
+               "This filter will modify the Cell Level Array(s) '{}' which causes all feature level NeighborLists to become invalid. These NeighborLists will not be copied to the new geometry:{}",
+               featureIdsArrayPath.toString(), warningMsg)});
     }
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleImageGeomFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleImageGeomFilter.cpp
@@ -295,11 +295,11 @@ IFilter::PreflightResult ResampleImageGeomFilter::preflightImpl(const DataStruct
     }
     if(!warningMsg.empty())
     {
-      resultOutputActions.m_Warnings.push_back(Warning(
-          {-55503,
+      preflightUpdatedValues.push_back(
+          {"Invalidated NeighborLists",
            fmt::format(
                "This filter will modify the Cell Level Array '{}' which causes all Feature level NeighborLists to become invalid. These NeighborLists will not be copied to the new geometry:{}",
-               featureIdsArrayPath.toString(), warningMsg)}));
+               featureIdsArrayPath.toString(), warningMsg)});
     }
   }
 

--- a/src/Plugins/SimplnxCore/test/ArrayCalculatorTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ArrayCalculatorTest.cpp
@@ -120,9 +120,14 @@ void runTest(const std::string& equation, const DataPath& targetArrayPath, int32
     REQUIRE(executeResult.result.errors()[0].code == expectedErrorCondition);
   }
 
-  if(expectedWarningCondition != CalculatorItem::WarningCode::None)
+  if(executeResult.result.warnings().size() != 0)
   {
+    REQUIRE(expectedWarningCondition != CalculatorItem::WarningCode::None);
     REQUIRE(executeResult.result.warnings()[0].code == static_cast<int32>(expectedWarningCondition));
+  }
+  else
+  {
+    REQUIRE(expectedWarningCondition == CalculatorItem::WarningCode::None);
   }
 
   Float64Array* arrayPtr = dataStructure.getDataAs<Float64Array>(targetArrayPath);
@@ -288,22 +293,22 @@ void SingleComponentArrayCalculatorTest1()
   {
     int numTuple = 1;
     double value = -3;
-    runTest("-3", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("-3", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     numTuple = 1;
     value = 14;
-    runTest("14", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("14", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     numTuple = 1;
     value = 0.345;
-    runTest(".345", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest(".345", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Mismatched Parentheses Tests")
   {
     int numTuple = 1;
     double value = 12;
-    runTest("(3*4)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("(3*4)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
     runTest("(3*4", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::MismatchedParentheses), CalculatorItem::WarningCode::None);
     runTest("3*4)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::MismatchedParentheses), CalculatorItem::WarningCode::None);
   }
@@ -312,7 +317,7 @@ void SingleComponentArrayCalculatorTest1()
   {
     int numTuple = 1;
     double value = sin(pow(fabs(cos(fabs(static_cast<double>(3)) / 4) + 7), 2));
-    runTest("sin( abs( cos( abs(3)/4) + 7)^2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("sin( abs( cos( abs(3)/4) + 7)^2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Single Array Tests (Force Incorrect Tuple Counts)")
@@ -322,7 +327,7 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 10;
     double value = 18;
-    runTest("12 + 6", k_AttributeArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("12 + 6", k_AttributeArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Unrecognized Item Tests")
@@ -342,11 +347,11 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 18;
-    runTest("12 + 6", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("12 + 6", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = -6;
-    runTest("-12 + 6", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
-    runTest("6 + -12", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("-12 + 6", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
+    runTest("6 + -12", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Subtraction Operator")
@@ -355,13 +360,13 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 43;
-    runTest("97 - 54", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("97 - 54", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = -34;
-    runTest("-32 - 2", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("-32 - 2", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = 19;
-    runTest("7 - -12", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("7 - -12", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Multiplication Operator")
@@ -387,13 +392,13 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 2;
-    runTest("12 / 6", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("12 / 6", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = -2;
-    runTest("-12 / 6", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("-12 / 6", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = -0.5;
-    runTest("6 / -12", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("6 / -12", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Pow Operator")
@@ -404,13 +409,13 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 125;
-    runTest("5 ^ 3", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("5 ^ 3", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = -8;
-    runTest("-2 ^ 3", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("-2 ^ 3", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = 0.25;
-    runTest("2 ^ -2", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("2 ^ -2", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Abs Operator")
@@ -422,13 +427,13 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 2;
-    runTest("abs(2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("abs(2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = 4.3;
-    runTest("abs(-4.3)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("abs(-4.3)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = 6.7;
-    runTest("abs(abs(6.7))", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("abs(abs(6.7))", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Sin Operator")
@@ -440,18 +445,16 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 1;
-    runTest("sin(90)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value, CalculatorParameter::Degrees);
+    runTest("sin(90)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Degrees);
 
     value = 0;
-    runTest("sin(-180)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value, CalculatorParameter::Degrees);
+    runTest("sin(-180)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Degrees);
 
     value = 0.5;
-    runTest("sin(" + k_Pi_Str + "/6)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value,
-            CalculatorParameter::Radians);
+    runTest("sin(" + k_Pi_Str + "/6)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Radians);
 
     value = 1;
-    runTest("sin(" + k_Pi_Str + "/2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value,
-            CalculatorParameter::Radians);
+    runTest("sin(" + k_Pi_Str + "/2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Radians);
   }
 
   SECTION("Cos Operator")
@@ -463,17 +466,16 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 0;
-    runTest("cos(90)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value, CalculatorParameter::Degrees);
+    runTest("cos(90)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Degrees);
 
     value = -1;
-    runTest("cos(-180)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value, CalculatorParameter::Degrees);
+    runTest("cos(-180)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Degrees);
 
     value = 0.5;
-    runTest("cos(" + k_Pi_Str + "/3)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value,
-            CalculatorParameter::Radians);
+    runTest("cos(" + k_Pi_Str + "/3)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Radians);
 
     value = -0.5;
-    runTest("cos(2*" + k_Pi_Str + "/3)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value,
+    runTest("cos(2*" + k_Pi_Str + "/3)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value,
             CalculatorParameter::Radians);
   }
 
@@ -486,17 +488,16 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 1;
-    runTest("tan(45)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value, CalculatorParameter::Degrees);
+    runTest("tan(45)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Degrees);
 
     value = sqrt(3);
-    runTest("tan(60)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value, CalculatorParameter::Degrees);
+    runTest("tan(60)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Degrees);
 
     value = 1;
-    runTest("tan(" + k_Pi_Str + "/4)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value,
-            CalculatorParameter::Radians);
+    runTest("tan(" + k_Pi_Str + "/4)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Radians);
 
     value = -sqrt(static_cast<double>(1) / static_cast<double>(3));
-    runTest("tan(5*" + k_Pi_Str + "/6)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value,
+    runTest("tan(5*" + k_Pi_Str + "/6)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value,
             CalculatorParameter::Radians);
   }
 
@@ -509,18 +510,16 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 30;
-    runTest("asin(0.5)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value, CalculatorParameter::Degrees);
+    runTest("asin(0.5)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Degrees);
 
     value = 45;
-    runTest("asin(sqrt(2)/2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value,
-            CalculatorParameter::Degrees);
+    runTest("asin(sqrt(2)/2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Degrees);
 
     value = numbers::pi / 3;
-    runTest("asin(sqrt(3)/2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value,
-            CalculatorParameter::Radians);
+    runTest("asin(sqrt(3)/2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Radians);
 
     value = numbers::pi / 2;
-    runTest("asin(1)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value, CalculatorParameter::Radians);
+    runTest("asin(1)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Radians);
   }
 
   SECTION("ACos Operator")
@@ -532,18 +531,16 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 60;
-    runTest("acos(0.5)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value, CalculatorParameter::Degrees);
+    runTest("acos(0.5)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Degrees);
 
     value = 45;
-    runTest("acos(sqrt(2)/2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value,
-            CalculatorParameter::Degrees);
+    runTest("acos(sqrt(2)/2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Degrees);
 
     value = numbers::pi / 6;
-    runTest("acos(sqrt(3)/2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value,
-            CalculatorParameter::Radians);
+    runTest("acos(sqrt(3)/2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Radians);
 
     value = 0;
-    runTest("acos(1)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value, CalculatorParameter::Radians);
+    runTest("acos(1)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Radians);
   }
 
   SECTION("ATan Operator")
@@ -555,19 +552,16 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = -45;
-    runTest("atan(-1)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value, CalculatorParameter::Degrees);
+    runTest("atan(-1)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Degrees);
 
     value = -60;
-    runTest("atan(-sqrt(3))", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value,
-            CalculatorParameter::Degrees);
+    runTest("atan(-sqrt(3))", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Degrees);
 
     value = numbers::pi / 6;
-    runTest("atan(1/sqrt(3))", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value,
-            CalculatorParameter::Radians);
+    runTest("atan(1/sqrt(3))", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Radians);
 
     value = numbers::pi / 3;
-    runTest("atan(sqrt(3))", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value,
-            CalculatorParameter::Radians);
+    runTest("atan(sqrt(3))", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value, CalculatorParameter::Radians);
   }
 
   SECTION("Sqrt Operator")
@@ -580,13 +574,13 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 3;
-    runTest("sqrt(9)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("sqrt(9)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = 4;
-    runTest("sqrt(4*4)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("sqrt(4*4)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = 3;
-    runTest("sqrt(3^2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("sqrt(3^2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Root Operator")
@@ -600,16 +594,16 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 3;
-    runTest("root(9, 2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("root(9, 2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = 4;
-    runTest("root(4*4, 2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("root(4*4, 2)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = 4;
-    runTest("root(4*4+0, 1*2+0)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("root(4*4+0, 1*2+0)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = 4;
-    runTest("root(64, 3)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("root(64, 3)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Log10 Operator")
@@ -623,10 +617,10 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = log10(10);
-    runTest("log10(10)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("log10(10)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = log10(40);
-    runTest("log10(40)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("log10(40)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Log Operator")
@@ -640,10 +634,10 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = log(5) / log(2);
-    runTest("log(2, 5)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("log(2, 5)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = 2;
-    runTest("log(10, 100)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("log(10, 100)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Exp Operator")
@@ -657,10 +651,10 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 2.7182818284590452354; // M_E
-    runTest("exp(1)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("exp(1)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = 1;
-    runTest("exp(0)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("exp(0)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Ln Operator")
@@ -674,10 +668,10 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = log(1);
-    runTest("ln(1)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("ln(1)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = log(7);
-    runTest("ln(7)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("ln(7)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Floor Operator")
@@ -691,10 +685,10 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 12;
-    runTest("floor(12.4564)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("floor(12.4564)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = -83;
-    runTest("floor(-82.789367)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("floor(-82.789367)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Ceil Operator")
@@ -708,10 +702,10 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = 1;
-    runTest("ceil(.4564)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("ceil(.4564)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = -82;
-    runTest("ceil(-82.789367)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("ceil(-82.789367)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 
   SECTION("Negative Operator")
@@ -726,13 +720,13 @@ void SingleComponentArrayCalculatorTest1()
 
     int numTuple = 1;
     double value = -9;
-    runTest("- 9", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("- 9", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = -0.4564;
-    runTest("-(.4564)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("-(.4564)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
 
     value = 1;
-    runTest("-(3-4)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::NumericValueWarning, &numTuple, &value);
+    runTest("-(3-4)", k_NumericArrayPath, static_cast<int32>(CalculatorItem::ErrorCode::Success), CalculatorItem::WarningCode::None, &numTuple, &value);
   }
 }
 

--- a/src/simplnx/Parameters/FileSystemPathParameter.cpp
+++ b/src/simplnx/Parameters/FileSystemPathParameter.cpp
@@ -80,9 +80,9 @@ Result<> ValidateOutputFile(const FileSystemPathParameter::ValueType& path)
     {
       return result;
     }
-    if(!fs::exists(path))
+    if(fs::exists(path))
     {
-      return MakeWarningVoidResult(-6, fmt::format("File System Path '{}' does not exist. It will be created during execution.", path.string()));
+      return MakeWarningVoidResult(-6, fmt::format("File System Path '{}' already exists. It will be OVERWRITTEN during execution.", path.string()));
     }
   } catch(const fs::filesystem_error& exception)
   {
@@ -104,7 +104,7 @@ Result<> ValidateOutputDir(const FileSystemPathParameter::ValueType& path)
     }
     if(!fs::exists(path))
     {
-      return MakeWarningVoidResult(-7, fmt::format("File System Path '{}' does not exist. It will be created during execution.", path.string()));
+      return MakeWarningVoidResult(-17, fmt::format("File System Directory Path '{}' does not exist. It will be created during execution.", path.string()));
     }
   } catch(const fs::filesystem_error& exception)
   {

--- a/src/simplnx/Utilities/FilterUtilities.cpp
+++ b/src/simplnx/Utilities/FilterUtilities.cpp
@@ -53,7 +53,7 @@ IFilter::PreflightResult NeighborListRemovalPreflightCode(const DataStructure& d
 
   // Throw a warning to inform the user that the neighbor list arrays could be deleted by this filter
   std::string ss =
-      fmt::format("This filter WILL remove all arrays of type NeighborList from the feature Attribute Matrix '{}'.  These arrays are:\n", featureIdsPath.toString(), featureGroupDataPath.toString());
+      fmt::format("This filter will REMOVE all arrays of type NeighborList from the feature Attribute Matrix '{}'.  These arrays are:\n", featureIdsPath.toString(), featureGroupDataPath.toString());
 
   auto result = nx::core::GetAllChildDataPaths(dataStructure, featureGroupDataPath, DataObject::Type::NeighborList);
   if(!result.has_value())


### PR DESCRIPTION
The UI side of warning cleanup does not have an active PR yet, but it will be addressing the warning when there is no dream3d file in the pipeline.

## Fixes
- Extracted the top 4 most frequent warnings
- Changed the output file warnings to report when overwriting rather than if file doesn't exist yet

### Previous 
The warning frequency before this PR:

These don't account for the ones in the UI and ignore intentional warnings from example filters. This is from the test cases alone and doesn't account for pipelines.

| Frequency | Code | Description |
|-----------|------|-------------|
| 188 | -6 | File System Path does not exist. created during execution (Parameter) |
| 71 | -5010 | The result of the chosen expression will be a numeric value. |
| 28 | -55503 | This filter will modify the Cell Level Array. |
| 20 | -100 | A vertex data array was detected in the selected edge geometry. |
| 14 | -7 | File System Path does not exist. created during execution (Filter) |
| 12 | -8412 | You are appending cell data together which may change the number of features |
| 10 | -5555 | The selected geometry is not an 'Image Geometry'. NO interpolation. |
| 8 | -5558 | This filter WILL remove all arrays of type NeighborList in AM |
| 6 | -14600 | By modifying the cell level data, any feature data invalid. |
| 4 | -1 | The list of arguments for Filter 'Color to GrayScale' contained the argument key 'conversion_algorithm' which is not an accepted argument key. |
| 4 | -8361 | Segmenting features via c-axis mis-orientation requires Hexagonal-Low |
| 4 | -6401 | Finding the average c-axes requires Hexagonal-Low 6/m or Hexagonal |
| 4 | -3521 | Finding the c-axis locations requires Hexagonal-Low 6/m |
| 4 | -1561 | Finding the feature neighbor c-axis mis orientation requires |
| 4 | -9801 | Finding the feature reference c-axis mis orientation requires |
| 3 | -200 | The Array Tuple Dimensions () will be ignored |
| 3 | -5011 | Item '*' in the infix expression is the name of an array in the AM. |
| 2 | -1000 | Elements from Feature 399 do not all have the same value. |
| 2 | -2581 | Output file incorrect extension |
| 2 | -69250 | The tuple dimensions of Array1 do not match AM |
| 1 | -27361 | The tuple dimensions of Phases [] do not match. |
