### PR TITLE
CI: Updates GitHub CI Clang Formatter to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   clang_format_pr:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -20,11 +20,11 @@ jobs:
         id: check_format
         continue-on-error: true
         run: |
-          python3 scripts/clang_format.py --format-version 10 --commits HEAD^ HEAD
+          python3 scripts/clang_format.py --format-version 13 --commits HEAD^ HEAD
       - name: Apply Formatting
         if: steps.check_format.outcome != 'success'
         run: |
-          python3 scripts/clang_format.py --format-version 10 --modify --commits HEAD^ HEAD
+          python3 scripts/clang_format.py --format-version 13 --modify --commits HEAD^ HEAD
       - name: Add Suggestions
         if: steps.check_format.outcome != 'success'
         uses: reviewdog/action-suggester@v1

--- a/.github/workflows/format_push.yml
+++ b/.github/workflows/format_push.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   clang_format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -16,4 +16,4 @@ jobs:
         uses: ammaraskar/gcc-problem-matcher@a141586609e2a558729b99a8c574c048f7f56204
       - name: Check Formatting
         run: |
-          python3 scripts/clang_format.py --format-version 10
+          python3 scripts/clang_format.py --format-version 13


### PR DESCRIPTION
Ubuntu 20.04 is being deprecated and removed from GitHub CI
