### PR TITLE
Added fallback data store format

### DIFF
--- a/src/simplnx/DataStructure/IO/Generic/DataIOCollection.cpp
+++ b/src/simplnx/DataStructure/IO/Generic/DataIOCollection.cpp
@@ -56,7 +56,8 @@ std::unique_ptr<IDataStore> DataIOCollection::createDataStore(const std::string&
     }
   }
 
-  return nullptr;
+  nx::core::Generic::CoreDataIOManager coreManager;
+  return coreManager.dataStoreCreationFnc(coreManager.formatName())(dataType, tupleShape, componentShape, {});
 }
 
 void DataIOCollection::checkStoreDataFormat(uint64 dataSize, std::string& dataFormat) const


### PR DESCRIPTION
Now `DataIOCollection::createDataStore` will fallback to a standard in memory `DataStore` if the request data format is not available.