### PR TITLE
Updated to clang 17 for asan workflow

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -8,9 +8,9 @@ jobs:
   build:
     env:
       VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
-      CC: clang-14
-      CXX: clang++-14
-    runs-on: ubuntu-22.04
+      CC: clang-17
+      CXX: clang++-17
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Asan nightly build had this issue for python tests:
https://github.com/BlueQuartzSoftware/simplnx/actions/runs/13714318242/job/38356395125
```
Tracer caught signal 11: addr=0x550 pc=0x7f8ae3c4272a sp=0x7f8abda00d40
==9389==LeakSanitizer has encountered a fatal error.
==9389==HINT: For debugging, try setting environment variable LSAN_OPTIONS=verbosity=1:log_threads=1
==9389==HINT: LeakSanitizer does not work under ptrace (strace, gdb, etc)
```
https://github.com/google/sanitizers/issues/1267
https://reviews.llvm.org/D147459
Later clang versions may have this issue fixed otherwise will try
ASAN_OPTIONS=intercept_tls_get_addr=0