### PR TITLE
DOC: General code clean up to make parameters consistent and docs consistent

### DIFF
--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAbsImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAbsImageFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAcosImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAcosImageFilter.hpp
@@ -78,7 +78,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAdaptiveHistogramEqualizationImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAdaptiveHistogramEqualizationImageFilter.hpp
@@ -77,7 +77,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKApproximateSignedDistanceMapImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKApproximateSignedDistanceMapImageFilter.hpp
@@ -87,7 +87,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAsinImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAsinImageFilter.hpp
@@ -78,7 +78,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAtanImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAtanImageFilter.hpp
@@ -74,7 +74,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryContourImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryContourImageFilter.hpp
@@ -72,7 +72,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryDilateImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryDilateImageFilter.hpp
@@ -83,7 +83,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryErodeImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryErodeImageFilter.hpp
@@ -83,7 +83,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryMorphologicalClosingImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryMorphologicalClosingImageFilter.hpp
@@ -73,7 +73,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryMorphologicalOpeningImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryMorphologicalOpeningImageFilter.hpp
@@ -73,7 +73,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryOpeningByReconstructionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryOpeningByReconstructionImageFilter.hpp
@@ -73,7 +73,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryProjectionImageFilter.hpp
@@ -90,7 +90,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryThinningImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryThinningImageFilter.hpp
@@ -71,7 +71,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryThresholdImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryThresholdImageFilter.hpp
@@ -73,7 +73,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBlackTopHatImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBlackTopHatImageFilter.hpp
@@ -67,7 +67,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBoundedReciprocalImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBoundedReciprocalImageFilter.hpp
@@ -52,7 +52,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKClosingByReconstructionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKClosingByReconstructionImageFilter.hpp
@@ -77,7 +77,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKConnectedComponentImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKConnectedComponentImageFilter.hpp
@@ -63,7 +63,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCosImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCosImageFilter.hpp
@@ -78,7 +78,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCurvatureAnisotropicDiffusionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCurvatureAnisotropicDiffusionImageFilter.hpp
@@ -76,7 +76,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCurvatureFlowImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCurvatureFlowImageFilter.hpp
@@ -90,7 +90,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDanielssonDistanceMapImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDanielssonDistanceMapImageFilter.hpp
@@ -92,7 +92,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDilateObjectMorphologyImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDilateObjectMorphologyImageFilter.hpp
@@ -71,7 +71,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDiscreteGaussianImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDiscreteGaussianImageFilter.hpp
@@ -83,7 +83,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDoubleThresholdImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDoubleThresholdImageFilter.hpp
@@ -71,7 +71,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKErodeObjectMorphologyImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKErodeObjectMorphologyImageFilter.hpp
@@ -72,7 +72,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKExpImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKExpImageFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKExpNegativeImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKExpNegativeImageFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientAnisotropicDiffusionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientAnisotropicDiffusionImageFilter.hpp
@@ -72,7 +72,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientMagnitudeImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientMagnitudeImageFilter.hpp
@@ -69,7 +69,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientMagnitudeRecursiveGaussianImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientMagnitudeRecursiveGaussianImageFilter.hpp
@@ -54,7 +54,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleDilateImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleDilateImageFilter.hpp
@@ -65,7 +65,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleErodeImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleErodeImageFilter.hpp
@@ -65,7 +65,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleFillholeImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleFillholeImageFilter.hpp
@@ -75,7 +75,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleGrindPeakImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleGrindPeakImageFilter.hpp
@@ -77,7 +77,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleMorphologicalClosingImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleMorphologicalClosingImageFilter.hpp
@@ -66,7 +66,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleMorphologicalOpeningImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleMorphologicalOpeningImageFilter.hpp
@@ -66,7 +66,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHConvexImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHConvexImageFilter.hpp
@@ -72,7 +72,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHMaximaImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHMaximaImageFilter.hpp
@@ -77,7 +77,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHMinimaImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHMinimaImageFilter.hpp
@@ -75,7 +75,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImageReaderFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImageReaderFilter.hpp
@@ -67,7 +67,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -106,6 +106,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -115,7 +116,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImageWriterFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImageWriterFilter.hpp
@@ -60,7 +60,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -99,6 +99,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -108,7 +109,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportFijiMontageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportFijiMontageFilter.hpp
@@ -62,7 +62,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -101,6 +101,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -110,7 +111,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportImageStackFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportImageStackFilter.hpp
@@ -64,7 +64,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -103,6 +103,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -112,7 +113,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKIntensityWindowingImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKIntensityWindowingImageFilter.hpp
@@ -70,7 +70,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKInvertIntensityImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKInvertIntensityImageFilter.hpp
@@ -66,7 +66,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKIsoContourDistanceImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKIsoContourDistanceImageFilter.hpp
@@ -60,7 +60,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLabelContourImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLabelContourImageFilter.hpp
@@ -71,7 +71,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLaplacianRecursiveGaussianImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLaplacianRecursiveGaussianImageFilter.hpp
@@ -54,7 +54,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLog10ImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLog10ImageFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLogImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLogImageFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMaskImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMaskImageFilter.hpp
@@ -84,7 +84,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMaximumProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMaximumProjectionImageFilter.hpp
@@ -78,7 +78,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMeanProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMeanProjectionImageFilter.hpp
@@ -78,7 +78,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMedianImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMedianImageFilter.hpp
@@ -75,7 +75,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMedianProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMedianProjectionImageFilter.hpp
@@ -78,7 +78,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMhaFileReaderFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMhaFileReaderFilter.hpp
@@ -45,7 +45,7 @@ public:
   [[nodiscard]] Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   [[nodiscard]] std::string humanName() const override;
@@ -84,6 +84,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -93,7 +94,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMinMaxCurvatureFlowImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMinMaxCurvatureFlowImageFilter.hpp
@@ -83,7 +83,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMinimumProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMinimumProjectionImageFilter.hpp
@@ -78,7 +78,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalGradientImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalGradientImageFilter.hpp
@@ -63,7 +63,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedFromMarkersImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedFromMarkersImageFilter.hpp
@@ -83,7 +83,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedImageFilter.hpp
@@ -74,7 +74,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeImageFilter.hpp
@@ -65,7 +65,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeToConstantImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeToConstantImageFilter.hpp
@@ -69,7 +69,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNotImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNotImageFilter.hpp
@@ -80,7 +80,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKOpeningByReconstructionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKOpeningByReconstructionImageFilter.hpp
@@ -77,7 +77,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKOtsuMultipleThresholdsImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKOtsuMultipleThresholdsImageFilter.hpp
@@ -78,7 +78,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRegionalMaximaImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRegionalMaximaImageFilter.hpp
@@ -72,7 +72,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRegionalMinimaImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRegionalMinimaImageFilter.hpp
@@ -70,7 +70,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRelabelComponentImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRelabelComponentImageFilter.hpp
@@ -79,7 +79,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRescaleIntensityImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRescaleIntensityImageFilter.hpp
@@ -76,7 +76,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSigmoidImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSigmoidImageFilter.hpp
@@ -67,7 +67,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSignedDanielssonDistanceMapImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSignedDanielssonDistanceMapImageFilter.hpp
@@ -77,7 +77,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSignedMaurerDistanceMapImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSignedMaurerDistanceMapImageFilter.hpp
@@ -79,7 +79,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSinImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSinImageFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSmoothingRecursiveGaussianImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSmoothingRecursiveGaussianImageFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSqrtImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSqrtImageFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSquareImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSquareImageFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKStandardDeviationProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKStandardDeviationProjectionImageFilter.hpp
@@ -79,7 +79,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSumProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSumProjectionImageFilter.hpp
@@ -79,7 +79,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKTanImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKTanImageFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKThresholdImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKThresholdImageFilter.hpp
@@ -74,7 +74,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKThresholdMaximumConnectedComponentsImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKThresholdMaximumConnectedComponentsImageFilter.hpp
@@ -81,7 +81,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKValuedRegionalMaximaImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKValuedRegionalMaximaImageFilter.hpp
@@ -73,7 +73,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKValuedRegionalMinimaImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKValuedRegionalMinimaImageFilter.hpp
@@ -70,7 +70,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKWhiteTopHatImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKWhiteTopHatImageFilter.hpp
@@ -64,7 +64,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKZeroCrossingImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKZeroCrossingImageFilter.hpp
@@ -81,7 +81,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMisorientationFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMisorientationFilter.hpp
@@ -63,7 +63,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -102,6 +102,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -111,7 +112,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMutualInformationFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMutualInformationFilter.hpp
@@ -61,7 +61,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -100,6 +100,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -109,7 +110,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/BadDataNeighborOrientationCheckFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/BadDataNeighborOrientationCheckFilter.hpp
@@ -58,7 +58,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -97,6 +97,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -106,7 +107,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.hpp
@@ -62,7 +62,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -98,9 +98,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -108,9 +109,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgCAxesFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgCAxesFilter.hpp
@@ -57,7 +57,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -93,9 +93,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -103,9 +104,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgOrientationsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgOrientationsFilter.hpp
@@ -58,7 +58,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -97,6 +97,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -106,7 +107,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeBoundaryStrengthsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeBoundaryStrengthsFilter.hpp
@@ -60,7 +60,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -96,9 +96,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -106,9 +107,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeCAxisLocationsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeCAxisLocationsFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,9 +92,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,9 +103,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFZQuaternionsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFZQuaternionsFilter.hpp
@@ -57,7 +57,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -96,6 +96,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -105,7 +106,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFaceIPFColoringFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFaceIPFColoringFilter.hpp
@@ -57,7 +57,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -96,6 +96,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -105,7 +106,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureFaceMisorientationFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureFaceMisorientationFilter.hpp
@@ -57,7 +57,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -96,6 +96,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -105,7 +106,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureNeighborCAxisMisalignmentsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureNeighborCAxisMisalignmentsFilter.hpp
@@ -58,7 +58,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -94,9 +94,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -104,9 +105,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceCAxisMisorientationsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceCAxisMisorientationsFilter.hpp
@@ -60,7 +60,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -96,9 +96,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -106,9 +107,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceMisorientationsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceMisorientationsFilter.hpp
@@ -61,7 +61,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -100,6 +100,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -109,7 +110,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDFilter.hpp
@@ -61,7 +61,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -100,6 +100,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -109,7 +110,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDMetricBasedFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDMetricBasedFilter.hpp
@@ -68,7 +68,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -104,9 +104,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -114,9 +115,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDPoleFigureFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDPoleFigureFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -98,6 +98,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -107,7 +108,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBPDMetricBasedFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBPDMetricBasedFilter.hpp
@@ -67,7 +67,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -103,9 +103,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -113,9 +114,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeIPFColorsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeIPFColorsFilter.hpp
@@ -58,7 +58,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -97,6 +97,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -106,7 +107,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeKernelAvgMisorientationsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeKernelAvgMisorientationsFilter.hpp
@@ -58,7 +58,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -97,6 +97,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -106,7 +107,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeMisorientationsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeMisorientationsFilter.hpp
@@ -58,7 +58,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -97,6 +97,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -106,7 +107,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeQuaternionConjugateFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeQuaternionConjugateFilter.hpp
@@ -54,7 +54,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -93,6 +93,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,7 +103,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSchmidsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSchmidsFilter.hpp
@@ -64,7 +64,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -103,6 +103,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -112,7 +113,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesFilter.hpp
@@ -60,7 +60,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -99,6 +99,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -108,7 +109,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesTriangleGeomFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesTriangleGeomFilter.hpp
@@ -52,7 +52,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -91,6 +91,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -100,7 +101,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSlipTransmissionMetricsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSlipTransmissionMetricsFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -95,9 +95,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -105,9 +106,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeTwinBoundariesFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeTwinBoundariesFilter.hpp
@@ -63,7 +63,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -102,6 +102,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -111,7 +112,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertHexGridToSquareGridFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertHexGridToSquareGridFilter.hpp
@@ -50,7 +50,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -89,6 +89,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -98,7 +99,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertOrientationsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertOrientationsFilter.hpp
@@ -66,7 +66,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -105,6 +105,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -114,7 +115,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertQuaternionFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertQuaternionFilter.hpp
@@ -55,7 +55,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -94,6 +94,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -103,7 +104,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CreateEnsembleInfoFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CreateEnsembleInfoFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -95,6 +95,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -104,7 +105,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EBSDSegmentFeaturesFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EBSDSegmentFeaturesFilter.hpp
@@ -62,7 +62,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -101,6 +101,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -110,7 +111,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EbsdToH5EbsdFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EbsdToH5EbsdFilter.hpp
@@ -49,7 +49,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -88,6 +88,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -97,7 +98,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/MergeTwinsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/MergeTwinsFilter.hpp
@@ -65,7 +65,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -104,6 +104,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -113,7 +114,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.hpp
@@ -60,7 +60,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -99,6 +99,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -108,7 +109,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadAngDataFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadAngDataFilter.hpp
@@ -61,7 +61,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -100,6 +100,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -109,7 +110,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadChannel5DataFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadChannel5DataFilter.hpp
@@ -58,7 +58,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -97,6 +97,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -106,7 +107,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadCtfDataFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadCtfDataFilter.hpp
@@ -58,7 +58,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -97,6 +97,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -106,7 +107,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadEnsembleInfoFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadEnsembleInfoFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,9 +92,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,9 +103,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadGrainMapper3DFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadGrainMapper3DFilter.hpp
@@ -54,7 +54,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -90,9 +90,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -100,9 +101,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EbsdFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EbsdFilter.hpp
@@ -55,7 +55,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -94,6 +94,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -103,7 +104,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EspritDataFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EspritDataFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -95,9 +95,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -105,9 +106,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OimDataFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OimDataFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -95,9 +95,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -105,9 +106,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OinaDataFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OinaDataFilter.hpp
@@ -53,7 +53,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,6 +92,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -99,9 +100,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RodriguesConvertorFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RodriguesConvertorFilter.hpp
@@ -54,7 +54,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -93,6 +93,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,7 +103,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RotateEulerRefFrameFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RotateEulerRefFrameFilter.hpp
@@ -53,7 +53,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,6 +92,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -101,7 +102,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDGMTFileFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDGMTFileFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -95,6 +95,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -104,7 +105,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDTriangleDataFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDTriangleDataFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -95,6 +95,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -104,7 +105,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteINLFileFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteINLFileFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -95,9 +95,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -105,9 +106,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WritePoleFigureFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WritePoleFigureFilter.hpp
@@ -75,7 +75,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -111,9 +111,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -121,9 +122,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteStatsGenOdfAngleFileFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteStatsGenOdfAngleFileFilter.hpp
@@ -66,7 +66,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -102,9 +102,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -112,9 +113,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AddBadDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AddBadDataFilter.hpp
@@ -60,7 +60,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -96,9 +96,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -106,9 +107,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignGeometriesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignGeometriesFilter.hpp
@@ -90,7 +90,7 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignSectionsFeatureCentroidFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignSectionsFeatureCentroidFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -98,6 +98,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -107,7 +108,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignSectionsListFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignSectionsListFilter.hpp
@@ -54,7 +54,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -90,9 +90,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -100,9 +101,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AppendImageGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AppendImageGeometryFilter.hpp
@@ -58,7 +58,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -94,9 +94,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -104,9 +105,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApplyTransformationToGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApplyTransformationToGeometryFilter.hpp
@@ -63,7 +63,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -99,9 +99,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -109,9 +110,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApproximatePointCloudHullFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApproximatePointCloudHullFilter.hpp
@@ -95,19 +95,19 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ArrayCalculatorFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ArrayCalculatorFilter.hpp
@@ -54,7 +54,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -93,6 +93,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,7 +103,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ChangeAngleRepresentationFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ChangeAngleRepresentationFilter.hpp
@@ -53,7 +53,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,6 +92,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -101,7 +102,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineAttributeArraysFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineAttributeArraysFilter.hpp
@@ -55,7 +55,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -94,6 +94,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -103,7 +104,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineNodeBasedGeometriesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineNodeBasedGeometriesFilter.hpp
@@ -96,7 +96,7 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineStlFilesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineStlFilesFilter.hpp
@@ -65,7 +65,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -101,9 +101,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -111,9 +112,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayHistogramFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayHistogramFilter.hpp
@@ -61,7 +61,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -100,6 +100,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -109,7 +110,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayStatisticsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayStatisticsFilter.hpp
@@ -89,7 +89,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -128,6 +128,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -137,7 +138,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBiasedFeaturesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBiasedFeaturesFilter.hpp
@@ -57,7 +57,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -93,9 +93,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -103,9 +104,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundaryCellsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundaryCellsFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,9 +92,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,9 +103,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundaryElementFractionsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundaryElementFractionsFilter.hpp
@@ -55,7 +55,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -91,9 +91,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -101,9 +102,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeDifferencesMapFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeDifferencesMapFilter.hpp
@@ -97,19 +97,19 @@ protected:
    * @param shouldCancel The atomic boolean that holds if the filter should be canceled
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeEuclideanDistMapFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeEuclideanDistMapFilter.hpp
@@ -63,7 +63,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -102,6 +102,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -111,7 +112,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureCentroidsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureCentroidsFilter.hpp
@@ -55,7 +55,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -94,6 +94,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -103,7 +104,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureClusteringFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureClusteringFilter.hpp
@@ -65,7 +65,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -101,9 +101,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -111,9 +112,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureNeighborsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureNeighborsFilter.hpp
@@ -91,25 +91,28 @@ public:
 
 protected:
   /**
-   * @brief
-   * @param data
-   * @param args
-   * @param messageHandler
-   * @return PreflightResult
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesBinaryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesBinaryFilter.hpp
@@ -55,7 +55,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -91,9 +91,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -101,9 +102,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -98,6 +98,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -107,7 +108,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureRectFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureRectFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,9 +92,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,9 +103,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.hpp
@@ -93,25 +93,28 @@ public:
 
 protected:
   /**
-   * @brief
-   * @param data
-   * @param args
-   * @param messageHandler
-   * @return PreflightResult
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMeansFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMeansFilter.hpp
@@ -62,7 +62,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -98,9 +98,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -108,9 +109,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMedoidsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMedoidsFilter.hpp
@@ -62,7 +62,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -98,9 +98,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -108,9 +109,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeLargestCrossSectionsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeLargestCrossSectionsFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,9 +92,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,9 +103,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeMomentInvariants2DFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeMomentInvariants2DFilter.hpp
@@ -61,7 +61,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -97,9 +97,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -107,9 +108,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborListStatisticsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborListStatisticsFilter.hpp
@@ -100,25 +100,28 @@ public:
 
 protected:
   /**
-   * @brief
-   * @param data
-   * @param args
-   * @param messageHandler
-   * @return PreflightResult
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborhoodsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborhoodsFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -98,6 +98,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -107,7 +108,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNumFeaturesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNumFeaturesFilter.hpp
@@ -54,7 +54,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -93,6 +93,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,7 +103,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceAreaToVolumeFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceAreaToVolumeFilter.hpp
@@ -58,7 +58,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -97,6 +97,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -106,7 +107,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceFeaturesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceFeaturesFilter.hpp
@@ -71,7 +71,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -110,6 +110,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -119,7 +120,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleAreasFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleAreasFilter.hpp
@@ -53,7 +53,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,6 +92,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -101,7 +102,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleGeomCentroidsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleGeomCentroidsFilter.hpp
@@ -48,7 +48,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -87,6 +87,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -96,7 +97,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleGeomVolumesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleGeomVolumesFilter.hpp
@@ -48,7 +48,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -87,6 +87,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -96,7 +97,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVectorColorsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVectorColorsFilter.hpp
@@ -55,7 +55,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -91,9 +91,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -101,9 +102,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVertexToTriangleDistancesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVertexToTriangleDistancesFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,9 +92,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,9 +103,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVolumeFractionsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVolumeFractionsFilter.hpp
@@ -54,7 +54,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -93,6 +93,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,7 +103,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConditionalSetValueFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConditionalSetValueFilter.hpp
@@ -57,7 +57,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -96,6 +96,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertColorToGrayScaleFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertColorToGrayScaleFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -95,6 +95,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -104,7 +105,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertDataFilter.hpp
@@ -55,7 +55,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -94,6 +94,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -103,7 +104,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CopyDataObjectFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CopyDataObjectFilter.hpp
@@ -85,25 +85,28 @@ public:
 
 protected:
   /**
-   * @brief
-   * @param data
-   * @param args
-   * @param messageHandler
-   * @return PreflightResult
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CopyFeatureArrayToElementArrayFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CopyFeatureArrayToElementArrayFilter.hpp
@@ -57,7 +57,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -96,6 +96,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -105,7 +106,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateAMScanPathsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateAMScanPathsFilter.hpp
@@ -61,7 +61,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -97,22 +97,26 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& ds, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                       const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateAttributeMatrixFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateAttributeMatrixFilter.hpp
@@ -52,7 +52,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,7 +92,7 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateColorMapFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateColorMapFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -98,6 +98,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -105,9 +106,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataGroupFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataGroupFilter.hpp
@@ -51,7 +51,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -91,7 +91,7 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateFeatureArrayFromElementArrayFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateFeatureArrayFromElementArrayFilter.hpp
@@ -55,7 +55,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -94,6 +94,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -103,7 +104,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateGeometryFilter.hpp
@@ -89,7 +89,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -128,6 +128,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -137,7 +138,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateImageGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateImageGeometryFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -95,6 +95,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -104,7 +105,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreatePythonSkeletonFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreatePythonSkeletonFilter.hpp
@@ -57,7 +57,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -93,9 +93,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -103,9 +104,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropVertexGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropVertexGeometryFilter.hpp
@@ -87,25 +87,28 @@ public:
 
 protected:
   /**
-   * @brief
-   * @param data
-   * @param args
-   * @param messageHandler
-   * @return PreflightResult
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/DBSCANFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/DBSCANFilter.hpp
@@ -70,7 +70,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -106,9 +106,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -116,9 +117,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/DeleteDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/DeleteDataFilter.hpp
@@ -92,25 +92,28 @@ public:
 
 protected:
   /**
-   * @brief
-   * @param data
-   * @param args
-   * @param messageHandler
-   * @return PreflightResult
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateBadDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateBadDataFilter.hpp
@@ -61,7 +61,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -100,6 +100,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -109,7 +110,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateCoordinationNumberFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateCoordinationNumberFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,9 +92,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,9 +103,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateMaskFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateMaskFilter.hpp
@@ -60,7 +60,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -96,9 +96,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -106,9 +107,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExecuteProcessFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExecuteProcessFilter.hpp
@@ -55,7 +55,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -91,9 +91,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -101,9 +102,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractComponentAsArrayFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractComponentAsArrayFilter.hpp
@@ -57,7 +57,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -96,6 +96,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -105,7 +106,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.hpp
@@ -96,7 +96,7 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractVertexGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractVertexGeometryFilter.hpp
@@ -54,7 +54,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -93,6 +93,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,7 +103,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FeatureFaceCurvatureFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FeatureFaceCurvatureFilter.hpp
@@ -64,7 +64,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -103,6 +103,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -112,7 +113,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FillBadDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FillBadDataFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -98,6 +98,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -107,7 +108,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FlyingEdges3DFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FlyingEdges3DFilter.hpp
@@ -48,7 +48,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -87,6 +87,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -96,7 +97,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IdentifySampleFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IdentifySampleFilter.hpp
@@ -86,25 +86,28 @@ public:
 
 protected:
   /**
-   * @brief
-   * @param data
-   * @param args
-   * @param messageHandler
-   * @return PreflightResult
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeDataFilter.hpp
@@ -93,7 +93,7 @@ protected:
    * @param shouldCancel
    * @return PreflightResult
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeImageGeomCellDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeImageGeomCellDataFilter.hpp
@@ -105,7 +105,7 @@ protected:
    * @param shouldCancel
    * @return PreflightResult
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp
@@ -106,19 +106,19 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IterativeClosestPointFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IterativeClosestPointFilter.hpp
@@ -92,19 +92,19 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LabelTriangleGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LabelTriangleGeometryFilter.hpp
@@ -55,7 +55,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -91,9 +91,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -101,9 +102,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LaplacianSmoothingFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LaplacianSmoothingFilter.hpp
@@ -63,7 +63,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MapPointCloudToRegularGridFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MapPointCloudToRegularGridFilter.hpp
@@ -102,19 +102,19 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MoveDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MoveDataFilter.hpp
@@ -83,25 +83,28 @@ public:
 
 protected:
   /**
-   * @brief
-   * @param data
-   * @param args
-   * @param messageHandler
-   * @return PreflightResult
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MultiThresholdObjectsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MultiThresholdObjectsFilter.hpp
@@ -98,25 +98,28 @@ public:
 
 protected:
   /**
-   * @brief
-   * @param data
-   * @param args
-   * @param messageHandler
-   * @return PreflightResult
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/NearestPointFuseRegularGridsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/NearestPointFuseRegularGridsFilter.hpp
@@ -57,7 +57,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -93,9 +93,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -103,9 +104,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PartitionGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PartitionGeometryFilter.hpp
@@ -90,7 +90,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -129,6 +129,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -138,7 +139,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PointSampleTriangleGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PointSampleTriangleGeometryFilter.hpp
@@ -65,7 +65,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -104,6 +104,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -113,7 +114,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/QuickSurfaceMeshFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/QuickSurfaceMeshFilter.hpp
@@ -66,7 +66,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -105,6 +105,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -114,7 +115,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadBinaryCTNorthstarFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadBinaryCTNorthstarFilter.hpp
@@ -75,7 +75,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -111,9 +111,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -121,9 +122,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadCSVFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadCSVFileFilter.hpp
@@ -65,7 +65,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -104,6 +104,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -113,7 +114,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadDREAM3DFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadDREAM3DFilter.hpp
@@ -102,7 +102,7 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadDeformKeyFileV12Filter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadDeformKeyFileV12Filter.hpp
@@ -60,7 +60,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -99,6 +99,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -108,7 +109,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadHDF5DatasetFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadHDF5DatasetFilter.hpp
@@ -54,7 +54,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -93,6 +93,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,7 +103,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadRawBinaryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadRawBinaryFilter.hpp
@@ -63,7 +63,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -102,6 +102,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -111,7 +112,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStlFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStlFileFilter.hpp
@@ -64,7 +64,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -103,6 +103,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -112,7 +113,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStringDataArrayFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStringDataArrayFilter.hpp
@@ -92,19 +92,19 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadTextDataArrayFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadTextDataArrayFilter.hpp
@@ -94,19 +94,19 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadVolumeGraphicsFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadVolumeGraphicsFileFilter.hpp
@@ -68,7 +68,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadVtkStructuredPointsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadVtkStructuredPointsFilter.hpp
@@ -58,7 +58,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -94,9 +94,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -104,9 +105,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RegularGridSampleSurfaceMeshFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RegularGridSampleSurfaceMeshFilter.hpp
@@ -60,7 +60,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -96,9 +96,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -106,9 +107,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedEdgesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedEdgesFilter.hpp
@@ -62,7 +62,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -98,9 +98,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -108,9 +109,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedFeaturesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedFeaturesFilter.hpp
@@ -58,7 +58,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -97,6 +97,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -106,7 +107,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedTrianglesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedTrianglesFilter.hpp
@@ -62,7 +62,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -98,9 +98,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -108,9 +109,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedVerticesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedVerticesFilter.hpp
@@ -93,6 +93,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,7 +103,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.hpp
@@ -57,7 +57,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -93,9 +93,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -103,9 +104,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinNumNeighborsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinNumNeighborsFilter.hpp
@@ -98,19 +98,19 @@ protected:
    * @param shouldCancel The atomic boolean that holds if the filter should be canceled
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.hpp
@@ -100,19 +100,19 @@ protected:
    * @param shouldCancel The atomic boolean that holds if the filter should be canceled
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleImageGeomFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleImageGeomFilter.hpp
@@ -61,7 +61,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleRectGridToImageGeomFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleRectGridToImageGeomFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,9 +92,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,9 +103,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReverseTriangleWindingFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReverseTriangleWindingFilter.hpp
@@ -53,7 +53,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -89,9 +89,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -99,9 +100,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RobustAutomaticThresholdFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RobustAutomaticThresholdFilter.hpp
@@ -88,19 +88,19 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ScalarSegmentFeaturesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ScalarSegmentFeaturesFilter.hpp
@@ -106,19 +106,19 @@ protected:
    * @param shouldCancel The atomic boolean that holds if the filter should be canceled
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SharedFeatureFaceFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SharedFeatureFaceFilter.hpp
@@ -51,7 +51,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -90,6 +90,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -99,7 +100,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SilhouetteFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SilhouetteFilter.hpp
@@ -57,7 +57,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -93,9 +93,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -103,9 +104,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SliceTriangleGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SliceTriangleGeometryFilter.hpp
@@ -66,7 +66,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -102,22 +102,26 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& ds, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                       const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitAttributeArrayFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitAttributeArrayFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -95,6 +95,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -104,7 +105,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SurfaceNetsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SurfaceNetsFilter.hpp
@@ -61,7 +61,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -100,6 +100,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -109,7 +110,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleCentroidFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleCentroidFilter.hpp
@@ -53,7 +53,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,6 +92,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -101,7 +102,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleDihedralAngleFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleDihedralAngleFilter.hpp
@@ -53,7 +53,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,6 +92,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -101,7 +102,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleNormalFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleNormalFilter.hpp
@@ -53,7 +53,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,6 +92,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -101,7 +102,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/UncertainRegularGridSampleSurfaceMeshFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/UncertainRegularGridSampleSurfaceMeshFilter.hpp
@@ -63,7 +63,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -99,9 +99,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -109,9 +110,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteASCIIDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteASCIIDataFilter.hpp
@@ -73,7 +73,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -112,6 +112,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -121,7 +122,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAbaqusHexahedronFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAbaqusHexahedronFilter.hpp
@@ -57,7 +57,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -93,9 +93,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -103,9 +104,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoRectilinearCoordinateFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoRectilinearCoordinateFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,9 +92,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,9 +103,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoUniformCoordinateFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoUniformCoordinateFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,9 +92,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,9 +103,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteBinaryDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteBinaryDataFilter.hpp
@@ -55,7 +55,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -94,6 +94,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -103,7 +104,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteDREAM3DFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteDREAM3DFilter.hpp
@@ -96,7 +96,7 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteFeatureDataCSVFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteFeatureDataCSVFilter.hpp
@@ -65,7 +65,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -104,6 +104,7 @@ protected:
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -113,7 +114,9 @@ protected:
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteLosAlamosFFTFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteLosAlamosFFTFilter.hpp
@@ -56,7 +56,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -92,9 +92,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -102,9 +103,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteNodesAndElementsFilesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteNodesAndElementsFilesFilter.hpp
@@ -103,7 +103,7 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteStlFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteStlFileFilter.hpp
@@ -59,7 +59,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -95,9 +95,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -105,9 +106,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteVtkRectilinearGridFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteVtkRectilinearGridFilter.hpp
@@ -55,7 +55,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -91,9 +91,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -101,9 +102,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteVtkStructuredPointsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteVtkStructuredPointsFilter.hpp
@@ -55,7 +55,7 @@ public:
   Uuid uuid() const override;
 
   /**
-   * @brief Returns the human readable name of the filter.
+   * @brief Returns the human-readable name of the filter.
    * @return
    */
   std::string humanName() const override;
@@ -91,9 +91,10 @@ protected:
    * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
    * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
    * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
@@ -101,9 +102,11 @@ protected:
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
-   * @param ds The input DataStructure instance
+   * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/TestOne/src/TestOne/Filters/CreateOutOfCoreArrayFilter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/CreateOutOfCoreArrayFilter.hpp
@@ -70,19 +70,19 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExampleFilter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExampleFilter.hpp
@@ -77,19 +77,19 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1Filter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1Filter.hpp
@@ -83,19 +83,19 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2Filter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2Filter.hpp
@@ -77,19 +77,19 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
    * On failure, there is no guarantee that the DataStructure is in a correct state.
    * @param dataStructure The input DataStructure instance
    * @param filterArgs These are the input values for each parameter that is required for the filter
-   * @param pipelineNode The PipelineNode object that called this filter
+   * @param pipelineNode The node in the pipeline that is being executed
    * @param messageHandler The MessageHandler object
-   * @param shouldCancel The atomic boolean that holds if the filter should be canceled
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                        const std::atomic_bool& shouldCancel) const override;
 };
 } // namespace nx::core


### PR DESCRIPTION
Just small cleanups to method docs, hyphenated words and another small bits. No actual code is being changed.

* Modified `humanName()` doc comment
* Modified `preflightImpl()` and `executeImpl()` doc comment and argument names