### PR TITLE
BUG: Removes number of triangles guess from QuickMesh and SurfaceNets

### DIFF
--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/QuickSurfaceMeshFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/QuickSurfaceMeshFilter.cpp
@@ -131,7 +131,7 @@ IFilter::PreflightResult QuickSurfaceMeshFilter::preflightImpl(const DataStructu
   {
     return {MakeErrorResult<OutputActions>(-76530, fmt::format("Could not find find selected grid geometry at path '{}'", pGridGeomDataPath.toString()))};
   }
-  auto numElements = gridGeom->getNumberOfCells();
+  constexpr usize numElements = 0;
 
   // Use FeatureIds DataStore format for created DataArrays
   const auto* featureIdsArrayPtr = dataStructure.getDataAs<IDataArray>(pFeatureIdsArrayPathValue);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SurfaceNetsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SurfaceNetsFilter.cpp
@@ -137,7 +137,7 @@ IFilter::PreflightResult SurfaceNetsFilter::preflightImpl(const DataStructure& d
   {
     return {MakeErrorResult<OutputActions>(-76530, fmt::format("Could not find find selected grid geometry at path '{}'", pGridGeomDataPath.toString()))};
   }
-  auto numElements = gridGeom->getNumberOfCells();
+  constexpr usize numElements = 0;
 
   // Use FeatureIds DataStore format for created DataArrays
   const auto* featureIdsArrayPtr = dataStructure.getDataAs<IDataArray>(pFeatureIdsArrayPathValue);


### PR DESCRIPTION
The filters were using a worst case scenario when attempting to create the triangle geometry during preflight. This would lead to cases when the incoming ImageGeom has more voxels than 2^31 which would cause preflight to fail. In reality the produced mesh will most likely NOT have that many triangles.

The Write STL files filter will need to validate the number of triangles does not exceed 2^31 triangles.
