### PR TITLE
ENH: Added pipeline relative path support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,6 +466,7 @@ set(SIMPLNX_HDRS
   ${SIMPLNX_SOURCE_DIR}/Filter/Arguments.hpp
   ${SIMPLNX_SOURCE_DIR}/Filter/ConstDataParameter.hpp
   ${SIMPLNX_SOURCE_DIR}/Filter/DataParameter.hpp
+  ${SIMPLNX_SOURCE_DIR}/Filter/ExecutionContext.hpp
   ${SIMPLNX_SOURCE_DIR}/Filter/FilterTraits.hpp
   ${SIMPLNX_SOURCE_DIR}/Filter/IFilter.hpp
   ${SIMPLNX_SOURCE_DIR}/Filter/IParameter.hpp

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAbsImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAbsImageFilter.cpp
@@ -95,8 +95,8 @@ IFilter::UniquePointer ITKAbsImageFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ITKAbsImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ITKAbsImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -110,7 +110,7 @@ IFilter::PreflightResult ITKAbsImageFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> ITKAbsImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAbsImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAbsImageFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAcosImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAcosImageFilter.cpp
@@ -95,8 +95,8 @@ IFilter::UniquePointer ITKAcosImageFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ITKAcosImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ITKAcosImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                           const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -110,7 +110,7 @@ IFilter::PreflightResult ITKAcosImageFilter::preflightImpl(const DataStructure& 
 
 //------------------------------------------------------------------------------
 Result<> ITKAcosImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                         const std::atomic_bool& shouldCancel) const
+                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAcosImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAcosImageFilter.hpp
@@ -120,7 +120,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -131,8 +132,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAdaptiveHistogramEqualizationImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAdaptiveHistogramEqualizationImageFilter.cpp
@@ -119,7 +119,7 @@ IFilter::UniquePointer ITKAdaptiveHistogramEqualizationImageFilter::clone() cons
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKAdaptiveHistogramEqualizationImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                    const std::atomic_bool& shouldCancel) const
+                                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -137,7 +137,7 @@ IFilter::PreflightResult ITKAdaptiveHistogramEqualizationImageFilter::preflightI
 
 //------------------------------------------------------------------------------
 Result<> ITKAdaptiveHistogramEqualizationImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAdaptiveHistogramEqualizationImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAdaptiveHistogramEqualizationImageFilter.hpp
@@ -119,7 +119,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -130,8 +131,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKApproximateSignedDistanceMapImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKApproximateSignedDistanceMapImageFilter.cpp
@@ -102,7 +102,7 @@ IFilter::UniquePointer ITKApproximateSignedDistanceMapImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKApproximateSignedDistanceMapImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                   const std::atomic_bool& shouldCancel) const
+                                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -119,7 +119,7 @@ IFilter::PreflightResult ITKApproximateSignedDistanceMapImageFilter::preflightIm
 
 //------------------------------------------------------------------------------
 Result<> ITKApproximateSignedDistanceMapImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                                 const std::atomic_bool& shouldCancel) const
+                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKApproximateSignedDistanceMapImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKApproximateSignedDistanceMapImageFilter.hpp
@@ -129,7 +129,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -140,8 +141,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAsinImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAsinImageFilter.cpp
@@ -95,8 +95,8 @@ IFilter::UniquePointer ITKAsinImageFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ITKAsinImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ITKAsinImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                           const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -110,7 +110,7 @@ IFilter::PreflightResult ITKAsinImageFilter::preflightImpl(const DataStructure& 
 
 //------------------------------------------------------------------------------
 Result<> ITKAsinImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                         const std::atomic_bool& shouldCancel) const
+                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAsinImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAsinImageFilter.hpp
@@ -120,7 +120,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -131,8 +132,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAtanImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAtanImageFilter.cpp
@@ -95,8 +95,8 @@ IFilter::UniquePointer ITKAtanImageFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ITKAtanImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ITKAtanImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                           const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -110,7 +110,7 @@ IFilter::PreflightResult ITKAtanImageFilter::preflightImpl(const DataStructure& 
 
 //------------------------------------------------------------------------------
 Result<> ITKAtanImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                         const std::atomic_bool& shouldCancel) const
+                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAtanImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKAtanImageFilter.hpp
@@ -116,7 +116,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -127,8 +128,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryContourImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryContourImageFilter.cpp
@@ -111,7 +111,7 @@ IFilter::UniquePointer ITKBinaryContourImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKBinaryContourImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -128,7 +128,7 @@ IFilter::PreflightResult ITKBinaryContourImageFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> ITKBinaryContourImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryContourImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryContourImageFilter.hpp
@@ -114,7 +114,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -125,8 +126,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryDilateImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryDilateImageFilter.cpp
@@ -118,7 +118,7 @@ IFilter::UniquePointer ITKBinaryDilateImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKBinaryDilateImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                   const std::atomic_bool& shouldCancel) const
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -137,7 +137,7 @@ IFilter::PreflightResult ITKBinaryDilateImageFilter::preflightImpl(const DataStr
 
 //------------------------------------------------------------------------------
 Result<> ITKBinaryDilateImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                 const std::atomic_bool& shouldCancel) const
+                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryDilateImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryDilateImageFilter.hpp
@@ -125,7 +125,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -136,8 +137,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryErodeImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryErodeImageFilter.cpp
@@ -118,7 +118,7 @@ IFilter::UniquePointer ITKBinaryErodeImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKBinaryErodeImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -137,7 +137,7 @@ IFilter::PreflightResult ITKBinaryErodeImageFilter::preflightImpl(const DataStru
 
 //------------------------------------------------------------------------------
 Result<> ITKBinaryErodeImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryErodeImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryErodeImageFilter.hpp
@@ -125,7 +125,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -136,8 +137,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryMorphologicalClosingImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryMorphologicalClosingImageFilter.cpp
@@ -114,7 +114,7 @@ IFilter::UniquePointer ITKBinaryMorphologicalClosingImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKBinaryMorphologicalClosingImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                 const std::atomic_bool& shouldCancel) const
+                                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -132,7 +132,7 @@ IFilter::PreflightResult ITKBinaryMorphologicalClosingImageFilter::preflightImpl
 
 //------------------------------------------------------------------------------
 Result<> ITKBinaryMorphologicalClosingImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryMorphologicalClosingImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryMorphologicalClosingImageFilter.hpp
@@ -115,7 +115,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -126,8 +127,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryMorphologicalOpeningImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryMorphologicalOpeningImageFilter.cpp
@@ -114,7 +114,7 @@ IFilter::UniquePointer ITKBinaryMorphologicalOpeningImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKBinaryMorphologicalOpeningImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                 const std::atomic_bool& shouldCancel) const
+                                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -132,7 +132,7 @@ IFilter::PreflightResult ITKBinaryMorphologicalOpeningImageFilter::preflightImpl
 
 //------------------------------------------------------------------------------
 Result<> ITKBinaryMorphologicalOpeningImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryMorphologicalOpeningImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryMorphologicalOpeningImageFilter.hpp
@@ -115,7 +115,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -126,8 +127,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryOpeningByReconstructionImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryOpeningByReconstructionImageFilter.cpp
@@ -121,7 +121,7 @@ IFilter::UniquePointer ITKBinaryOpeningByReconstructionImageFilter::clone() cons
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKBinaryOpeningByReconstructionImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                    const std::atomic_bool& shouldCancel) const
+                                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -140,7 +140,7 @@ IFilter::PreflightResult ITKBinaryOpeningByReconstructionImageFilter::preflightI
 
 //------------------------------------------------------------------------------
 Result<> ITKBinaryOpeningByReconstructionImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryOpeningByReconstructionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryOpeningByReconstructionImageFilter.hpp
@@ -115,7 +115,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -126,8 +127,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryProjectionImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryProjectionImageFilter.cpp
@@ -118,7 +118,7 @@ IFilter::UniquePointer ITKBinaryProjectionImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKBinaryProjectionImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                       const std::atomic_bool& shouldCancel) const
+                                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -156,7 +156,7 @@ IFilter::PreflightResult ITKBinaryProjectionImageFilter::preflightImpl(const Dat
 
 //------------------------------------------------------------------------------
 Result<> ITKBinaryProjectionImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                     const std::atomic_bool& shouldCancel) const
+                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryProjectionImageFilter.hpp
@@ -132,7 +132,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -143,8 +144,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryThinningImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryThinningImageFilter.cpp
@@ -95,7 +95,7 @@ IFilter::UniquePointer ITKBinaryThinningImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKBinaryThinningImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -109,7 +109,7 @@ IFilter::PreflightResult ITKBinaryThinningImageFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> ITKBinaryThinningImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryThinningImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryThinningImageFilter.hpp
@@ -113,7 +113,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -124,8 +125,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryThresholdImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryThresholdImageFilter.cpp
@@ -115,7 +115,7 @@ IFilter::UniquePointer ITKBinaryThresholdImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKBinaryThresholdImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                      const std::atomic_bool& shouldCancel) const
+                                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -134,7 +134,7 @@ IFilter::PreflightResult ITKBinaryThresholdImageFilter::preflightImpl(const Data
 
 //------------------------------------------------------------------------------
 Result<> ITKBinaryThresholdImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                    const std::atomic_bool& shouldCancel) const
+                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryThresholdImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBinaryThresholdImageFilter.hpp
@@ -115,7 +115,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -126,8 +127,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBlackTopHatImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBlackTopHatImageFilter.cpp
@@ -111,7 +111,7 @@ IFilter::UniquePointer ITKBlackTopHatImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKBlackTopHatImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -128,7 +128,7 @@ IFilter::PreflightResult ITKBlackTopHatImageFilter::preflightImpl(const DataStru
 
 //------------------------------------------------------------------------------
 Result<> ITKBlackTopHatImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBlackTopHatImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBlackTopHatImageFilter.hpp
@@ -109,7 +109,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -120,8 +121,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBoundedReciprocalImageFIlter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBoundedReciprocalImageFIlter.cpp
@@ -94,7 +94,7 @@ IFilter::UniquePointer ITKBoundedReciprocalImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKBoundedReciprocalImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -109,7 +109,7 @@ IFilter::PreflightResult ITKBoundedReciprocalImageFilter::preflightImpl(const Da
 
 //------------------------------------------------------------------------------
 Result<> ITKBoundedReciprocalImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBoundedReciprocalImageFIlter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBoundedReciprocalImageFIlter.cpp
@@ -94,7 +94,7 @@ IFilter::UniquePointer ITKBoundedReciprocalImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKBoundedReciprocalImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                        const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -109,7 +109,7 @@ IFilter::PreflightResult ITKBoundedReciprocalImageFilter::preflightImpl(const Da
 
 //------------------------------------------------------------------------------
 Result<> ITKBoundedReciprocalImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                      const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBoundedReciprocalImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBoundedReciprocalImageFilter.hpp
@@ -94,7 +94,7 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -106,7 +106,7 @@ protected:
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBoundedReciprocalImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKBoundedReciprocalImageFilter.hpp
@@ -94,7 +94,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -105,8 +106,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKClosingByReconstructionImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKClosingByReconstructionImageFilter.cpp
@@ -119,7 +119,7 @@ IFilter::UniquePointer ITKClosingByReconstructionImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKClosingByReconstructionImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                              const std::atomic_bool& shouldCancel) const
+                                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -137,7 +137,7 @@ IFilter::PreflightResult ITKClosingByReconstructionImageFilter::preflightImpl(co
 
 //------------------------------------------------------------------------------
 Result<> ITKClosingByReconstructionImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                            const std::atomic_bool& shouldCancel) const
+                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKClosingByReconstructionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKClosingByReconstructionImageFilter.hpp
@@ -119,7 +119,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -130,8 +131,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKConnectedComponentImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKConnectedComponentImageFilter.cpp
@@ -102,7 +102,7 @@ IFilter::UniquePointer ITKConnectedComponentImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKConnectedComponentImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                         const std::atomic_bool& shouldCancel) const
+                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -118,7 +118,7 @@ IFilter::PreflightResult ITKConnectedComponentImageFilter::preflightImpl(const D
 
 //------------------------------------------------------------------------------
 Result<> ITKConnectedComponentImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                       const std::atomic_bool& shouldCancel) const
+                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKConnectedComponentImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKConnectedComponentImageFilter.hpp
@@ -105,7 +105,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -116,8 +117,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCosImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCosImageFilter.cpp
@@ -95,8 +95,8 @@ IFilter::UniquePointer ITKCosImageFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ITKCosImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ITKCosImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -110,7 +110,7 @@ IFilter::PreflightResult ITKCosImageFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> ITKCosImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCosImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCosImageFilter.hpp
@@ -120,7 +120,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -131,8 +132,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCurvatureAnisotropicDiffusionImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCurvatureAnisotropicDiffusionImageFilter.cpp
@@ -108,7 +108,7 @@ IFilter::UniquePointer ITKCurvatureAnisotropicDiffusionImageFilter::clone() cons
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKCurvatureAnisotropicDiffusionImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                    const std::atomic_bool& shouldCancel) const
+                                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -126,7 +126,7 @@ IFilter::PreflightResult ITKCurvatureAnisotropicDiffusionImageFilter::preflightI
 
 //------------------------------------------------------------------------------
 Result<> ITKCurvatureAnisotropicDiffusionImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCurvatureAnisotropicDiffusionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCurvatureAnisotropicDiffusionImageFilter.hpp
@@ -118,7 +118,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -129,8 +130,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCurvatureFlowImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCurvatureFlowImageFilter.cpp
@@ -102,7 +102,7 @@ IFilter::UniquePointer ITKCurvatureFlowImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKCurvatureFlowImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -118,7 +118,7 @@ IFilter::PreflightResult ITKCurvatureFlowImageFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> ITKCurvatureFlowImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCurvatureFlowImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKCurvatureFlowImageFilter.hpp
@@ -132,7 +132,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -143,8 +144,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDanielssonDistanceMapImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDanielssonDistanceMapImageFilter.cpp
@@ -109,7 +109,7 @@ IFilter::UniquePointer ITKDanielssonDistanceMapImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKDanielssonDistanceMapImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                            const std::atomic_bool& shouldCancel) const
+                                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -127,7 +127,7 @@ IFilter::PreflightResult ITKDanielssonDistanceMapImageFilter::preflightImpl(cons
 
 //------------------------------------------------------------------------------
 Result<> ITKDanielssonDistanceMapImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDanielssonDistanceMapImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDanielssonDistanceMapImageFilter.hpp
@@ -134,7 +134,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -145,8 +146,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDilateObjectMorphologyImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDilateObjectMorphologyImageFilter.cpp
@@ -111,7 +111,7 @@ IFilter::UniquePointer ITKDilateObjectMorphologyImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKDilateObjectMorphologyImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                             const std::atomic_bool& shouldCancel) const
+                                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -128,7 +128,7 @@ IFilter::PreflightResult ITKDilateObjectMorphologyImageFilter::preflightImpl(con
 
 //------------------------------------------------------------------------------
 Result<> ITKDilateObjectMorphologyImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+                                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDilateObjectMorphologyImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDilateObjectMorphologyImageFilter.hpp
@@ -113,7 +113,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -124,8 +125,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDiscreteGaussianImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDiscreteGaussianImageFilter.cpp
@@ -128,7 +128,7 @@ IFilter::UniquePointer ITKDiscreteGaussianImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKDiscreteGaussianImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                       const std::atomic_bool& shouldCancel) const
+                                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -148,7 +148,7 @@ IFilter::PreflightResult ITKDiscreteGaussianImageFilter::preflightImpl(const Dat
 
 //------------------------------------------------------------------------------
 Result<> ITKDiscreteGaussianImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                     const std::atomic_bool& shouldCancel) const
+                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDiscreteGaussianImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDiscreteGaussianImageFilter.hpp
@@ -125,7 +125,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -136,8 +137,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDoubleThresholdImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDoubleThresholdImageFilter.cpp
@@ -133,7 +133,7 @@ IFilter::UniquePointer ITKDoubleThresholdImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKDoubleThresholdImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                      const std::atomic_bool& shouldCancel) const
+                                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -155,7 +155,7 @@ IFilter::PreflightResult ITKDoubleThresholdImageFilter::preflightImpl(const Data
 
 //------------------------------------------------------------------------------
 Result<> ITKDoubleThresholdImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                    const std::atomic_bool& shouldCancel) const
+                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDoubleThresholdImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKDoubleThresholdImageFilter.hpp
@@ -113,7 +113,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -124,8 +125,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKErodeObjectMorphologyImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKErodeObjectMorphologyImageFilter.cpp
@@ -114,7 +114,7 @@ IFilter::UniquePointer ITKErodeObjectMorphologyImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKErodeObjectMorphologyImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                            const std::atomic_bool& shouldCancel) const
+                                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -132,7 +132,7 @@ IFilter::PreflightResult ITKErodeObjectMorphologyImageFilter::preflightImpl(cons
 
 //------------------------------------------------------------------------------
 Result<> ITKErodeObjectMorphologyImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKErodeObjectMorphologyImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKErodeObjectMorphologyImageFilter.hpp
@@ -114,7 +114,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -125,8 +126,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKExpImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKExpImageFilter.cpp
@@ -95,8 +95,8 @@ IFilter::UniquePointer ITKExpImageFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ITKExpImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ITKExpImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -110,7 +110,7 @@ IFilter::PreflightResult ITKExpImageFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> ITKExpImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKExpImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKExpImageFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKExpNegativeImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKExpNegativeImageFilter.cpp
@@ -96,7 +96,7 @@ IFilter::UniquePointer ITKExpNegativeImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKExpNegativeImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -110,7 +110,7 @@ IFilter::PreflightResult ITKExpNegativeImageFilter::preflightImpl(const DataStru
 
 //------------------------------------------------------------------------------
 Result<> ITKExpNegativeImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKExpNegativeImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKExpNegativeImageFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientAnisotropicDiffusionImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientAnisotropicDiffusionImageFilter.cpp
@@ -110,7 +110,7 @@ IFilter::UniquePointer ITKGradientAnisotropicDiffusionImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKGradientAnisotropicDiffusionImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                   const std::atomic_bool& shouldCancel) const
+                                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -128,7 +128,7 @@ IFilter::PreflightResult ITKGradientAnisotropicDiffusionImageFilter::preflightIm
 
 //------------------------------------------------------------------------------
 Result<> ITKGradientAnisotropicDiffusionImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                                 const std::atomic_bool& shouldCancel) const
+                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientAnisotropicDiffusionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientAnisotropicDiffusionImageFilter.hpp
@@ -114,7 +114,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -125,8 +126,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientMagnitudeImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientMagnitudeImageFilter.cpp
@@ -106,7 +106,7 @@ IFilter::UniquePointer ITKGradientMagnitudeImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKGradientMagnitudeImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                        const std::atomic_bool& shouldCancel) const
+                                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -122,7 +122,7 @@ IFilter::PreflightResult ITKGradientMagnitudeImageFilter::preflightImpl(const Da
 
 //------------------------------------------------------------------------------
 Result<> ITKGradientMagnitudeImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                      const std::atomic_bool& shouldCancel) const
+                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientMagnitudeImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientMagnitudeImageFilter.hpp
@@ -111,7 +111,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -122,8 +123,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientMagnitudeRecursiveGaussianImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientMagnitudeRecursiveGaussianImageFilter.cpp
@@ -104,7 +104,7 @@ IFilter::UniquePointer ITKGradientMagnitudeRecursiveGaussianImageFilter::clone()
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKGradientMagnitudeRecursiveGaussianImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                         const std::atomic_bool& shouldCancel) const
+                                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -122,7 +122,7 @@ IFilter::PreflightResult ITKGradientMagnitudeRecursiveGaussianImageFilter::prefl
 
 //------------------------------------------------------------------------------
 Result<> ITKGradientMagnitudeRecursiveGaussianImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode,
-                                                                       const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+                                                                       const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientMagnitudeRecursiveGaussianImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGradientMagnitudeRecursiveGaussianImageFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -107,8 +108,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleDilateImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleDilateImageFilter.cpp
@@ -107,7 +107,7 @@ IFilter::UniquePointer ITKGrayscaleDilateImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKGrayscaleDilateImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                      const std::atomic_bool& shouldCancel) const
+                                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -123,7 +123,7 @@ IFilter::PreflightResult ITKGrayscaleDilateImageFilter::preflightImpl(const Data
 
 //------------------------------------------------------------------------------
 Result<> ITKGrayscaleDilateImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                    const std::atomic_bool& shouldCancel) const
+                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleDilateImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleDilateImageFilter.hpp
@@ -107,7 +107,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -118,8 +119,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleErodeImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleErodeImageFilter.cpp
@@ -107,7 +107,7 @@ IFilter::UniquePointer ITKGrayscaleErodeImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKGrayscaleErodeImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -123,7 +123,7 @@ IFilter::PreflightResult ITKGrayscaleErodeImageFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> ITKGrayscaleErodeImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleErodeImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleErodeImageFilter.hpp
@@ -107,7 +107,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -118,8 +119,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleFillholeImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleFillholeImageFilter.cpp
@@ -104,7 +104,7 @@ IFilter::UniquePointer ITKGrayscaleFillholeImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKGrayscaleFillholeImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                        const std::atomic_bool& shouldCancel) const
+                                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -119,7 +119,7 @@ IFilter::PreflightResult ITKGrayscaleFillholeImageFilter::preflightImpl(const Da
 
 //------------------------------------------------------------------------------
 Result<> ITKGrayscaleFillholeImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                      const std::atomic_bool& shouldCancel) const
+                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleFillholeImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleFillholeImageFilter.hpp
@@ -117,7 +117,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -128,8 +129,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleGrindPeakImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleGrindPeakImageFilter.cpp
@@ -104,7 +104,7 @@ IFilter::UniquePointer ITKGrayscaleGrindPeakImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKGrayscaleGrindPeakImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                         const std::atomic_bool& shouldCancel) const
+                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -119,7 +119,7 @@ IFilter::PreflightResult ITKGrayscaleGrindPeakImageFilter::preflightImpl(const D
 
 //------------------------------------------------------------------------------
 Result<> ITKGrayscaleGrindPeakImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                       const std::atomic_bool& shouldCancel) const
+                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleGrindPeakImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleGrindPeakImageFilter.hpp
@@ -119,7 +119,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -130,8 +131,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleMorphologicalClosingImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleMorphologicalClosingImageFilter.cpp
@@ -111,7 +111,7 @@ IFilter::UniquePointer ITKGrayscaleMorphologicalClosingImageFilter::clone() cons
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKGrayscaleMorphologicalClosingImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                    const std::atomic_bool& shouldCancel) const
+                                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -128,7 +128,7 @@ IFilter::PreflightResult ITKGrayscaleMorphologicalClosingImageFilter::preflightI
 
 //------------------------------------------------------------------------------
 Result<> ITKGrayscaleMorphologicalClosingImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleMorphologicalClosingImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleMorphologicalClosingImageFilter.hpp
@@ -108,7 +108,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -119,8 +120,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleMorphologicalOpeningImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleMorphologicalOpeningImageFilter.cpp
@@ -111,7 +111,7 @@ IFilter::UniquePointer ITKGrayscaleMorphologicalOpeningImageFilter::clone() cons
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKGrayscaleMorphologicalOpeningImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                    const std::atomic_bool& shouldCancel) const
+                                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -128,7 +128,7 @@ IFilter::PreflightResult ITKGrayscaleMorphologicalOpeningImageFilter::preflightI
 
 //------------------------------------------------------------------------------
 Result<> ITKGrayscaleMorphologicalOpeningImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleMorphologicalOpeningImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKGrayscaleMorphologicalOpeningImageFilter.hpp
@@ -108,7 +108,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -119,8 +120,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHConvexImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHConvexImageFilter.cpp
@@ -111,7 +111,7 @@ IFilter::UniquePointer ITKHConvexImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKHConvexImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -127,7 +127,7 @@ IFilter::PreflightResult ITKHConvexImageFilter::preflightImpl(const DataStructur
 
 //------------------------------------------------------------------------------
 Result<> ITKHConvexImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHConvexImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHConvexImageFilter.hpp
@@ -114,7 +114,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -125,8 +126,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHMaximaImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHMaximaImageFilter.cpp
@@ -104,7 +104,7 @@ IFilter::UniquePointer ITKHMaximaImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKHMaximaImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -119,7 +119,7 @@ IFilter::PreflightResult ITKHMaximaImageFilter::preflightImpl(const DataStructur
 
 //------------------------------------------------------------------------------
 Result<> ITKHMaximaImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHMaximaImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHMaximaImageFilter.hpp
@@ -119,7 +119,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -130,8 +131,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHMinimaImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHMinimaImageFilter.cpp
@@ -111,7 +111,7 @@ IFilter::UniquePointer ITKHMinimaImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKHMinimaImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -127,7 +127,7 @@ IFilter::PreflightResult ITKHMinimaImageFilter::preflightImpl(const DataStructur
 
 //------------------------------------------------------------------------------
 Result<> ITKHMinimaImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHMinimaImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKHMinimaImageFilter.hpp
@@ -117,7 +117,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -128,8 +129,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImageReaderFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImageReaderFilter.cpp
@@ -112,7 +112,7 @@ IFilter::UniquePointer ITKImageReaderFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKImageReaderFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto fileName = filterArgs.value<fs::path>(k_FileName_Key);
   auto imageGeomPath = filterArgs.value<DataPath>(k_ImageGeometryPath_Key);
@@ -145,7 +145,7 @@ IFilter::PreflightResult ITKImageReaderFilter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> ITKImageReaderFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto fileName = filterArgs.value<FileSystemPathParameter::ValueType>(k_FileName_Key);
   auto imageGeometryPath = filterArgs.value<DataPath>(k_ImageGeometryPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImageReaderFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImageReaderFilter.hpp
@@ -109,7 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -121,8 +122,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImageWriterFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImageWriterFilter.cpp
@@ -322,7 +322,7 @@ IFilter::UniquePointer ITKImageWriterFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKImageWriterFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto plane = filterArgs.value<ChoicesParameter::ValueType>(k_Plane_Key);
   auto filePath = filterArgs.value<fs::path>(k_FileName_Key);
@@ -347,7 +347,7 @@ IFilter::PreflightResult ITKImageWriterFilter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> ITKImageWriterFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto plane = filterArgs.value<ChoicesParameter::ValueType>(k_Plane_Key);
   auto filePath = filterArgs.value<fs::path>(k_FileName_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImageWriterFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImageWriterFilter.hpp
@@ -102,7 +102,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -114,8 +115,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportFijiMontageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportFijiMontageFilter.cpp
@@ -119,7 +119,7 @@ IFilter::UniquePointer ITKImportFijiMontageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKImportFijiMontageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                   const std::atomic_bool& shouldCancel) const
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pInputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFile_Key);
   auto pDataGroupNameValue = filterArgs.value<StringParameter::ValueType>(k_DataGroupName_Key);
@@ -231,7 +231,7 @@ IFilter::PreflightResult ITKImportFijiMontageFilter::preflightImpl(const DataStr
 
 //------------------------------------------------------------------------------
 Result<> ITKImportFijiMontageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                 const std::atomic_bool& shouldCancel) const
+                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ITKImportFijiMontageInputValues inputValues;
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportFijiMontageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportFijiMontageFilter.hpp
@@ -104,7 +104,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -116,8 +117,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 
 private:
   int32 m_InstanceId;

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportImageStackFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportImageStackFilter.cpp
@@ -431,7 +431,7 @@ IFilter::UniquePointer ITKImportImageStackFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKImportImageStackFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto inputFileListInfo = filterArgs.value<GeneratedFileListParameter::ValueType>(k_InputFileListInfo_Key);
   auto origin = filterArgs.value<VectorFloat32Parameter::ValueType>(k_Origin_Key);
@@ -582,7 +582,7 @@ IFilter::PreflightResult ITKImportImageStackFilter::preflightImpl(const DataStru
 
 //------------------------------------------------------------------------------
 Result<> ITKImportImageStackFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto inputFileListInfo = filterArgs.value<GeneratedFileListParameter::ValueType>(k_InputFileListInfo_Key);
   auto origin = filterArgs.value<VectorFloat32Parameter::ValueType>(k_Origin_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportImageStackFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImportImageStackFilter.hpp
@@ -106,7 +106,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -118,8 +119,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKIntensityWindowingImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKIntensityWindowingImageFilter.cpp
@@ -110,7 +110,7 @@ IFilter::UniquePointer ITKIntensityWindowingImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKIntensityWindowingImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                         const std::atomic_bool& shouldCancel) const
+                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -128,7 +128,7 @@ IFilter::PreflightResult ITKIntensityWindowingImageFilter::preflightImpl(const D
 
 //------------------------------------------------------------------------------
 Result<> ITKIntensityWindowingImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                       const std::atomic_bool& shouldCancel) const
+                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKIntensityWindowingImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKIntensityWindowingImageFilter.hpp
@@ -112,7 +112,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -123,8 +124,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKInvertIntensityImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKInvertIntensityImageFilter.cpp
@@ -102,7 +102,7 @@ IFilter::UniquePointer ITKInvertIntensityImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKInvertIntensityImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                      const std::atomic_bool& shouldCancel) const
+                                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -117,7 +117,7 @@ IFilter::PreflightResult ITKInvertIntensityImageFilter::preflightImpl(const Data
 
 //------------------------------------------------------------------------------
 Result<> ITKInvertIntensityImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                    const std::atomic_bool& shouldCancel) const
+                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKInvertIntensityImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKInvertIntensityImageFilter.hpp
@@ -108,7 +108,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -119,8 +120,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKIsoContourDistanceImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKIsoContourDistanceImageFilter.cpp
@@ -102,7 +102,7 @@ IFilter::UniquePointer ITKIsoContourDistanceImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKIsoContourDistanceImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                         const std::atomic_bool& shouldCancel) const
+                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -119,7 +119,7 @@ IFilter::PreflightResult ITKIsoContourDistanceImageFilter::preflightImpl(const D
 
 //------------------------------------------------------------------------------
 Result<> ITKIsoContourDistanceImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                       const std::atomic_bool& shouldCancel) const
+                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKIsoContourDistanceImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKIsoContourDistanceImageFilter.hpp
@@ -102,7 +102,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -113,8 +114,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLabelContourImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLabelContourImageFilter.cpp
@@ -109,7 +109,7 @@ IFilter::UniquePointer ITKLabelContourImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKLabelContourImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                   const std::atomic_bool& shouldCancel) const
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -125,7 +125,7 @@ IFilter::PreflightResult ITKLabelContourImageFilter::preflightImpl(const DataStr
 
 //------------------------------------------------------------------------------
 Result<> ITKLabelContourImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                 const std::atomic_bool& shouldCancel) const
+                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLabelContourImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLabelContourImageFilter.hpp
@@ -113,7 +113,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -124,8 +125,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLaplacianRecursiveGaussianImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLaplacianRecursiveGaussianImageFilter.cpp
@@ -104,7 +104,7 @@ IFilter::UniquePointer ITKLaplacianRecursiveGaussianImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKLaplacianRecursiveGaussianImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                 const std::atomic_bool& shouldCancel) const
+                                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -121,7 +121,7 @@ IFilter::PreflightResult ITKLaplacianRecursiveGaussianImageFilter::preflightImpl
 
 //------------------------------------------------------------------------------
 Result<> ITKLaplacianRecursiveGaussianImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLaplacianRecursiveGaussianImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLaplacianRecursiveGaussianImageFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -107,8 +108,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLog10ImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLog10ImageFilter.cpp
@@ -95,8 +95,8 @@ IFilter::UniquePointer ITKLog10ImageFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ITKLog10ImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                            const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ITKLog10ImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                            const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -110,7 +110,7 @@ IFilter::PreflightResult ITKLog10ImageFilter::preflightImpl(const DataStructure&
 
 //------------------------------------------------------------------------------
 Result<> ITKLog10ImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                          const std::atomic_bool& shouldCancel) const
+                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLog10ImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLog10ImageFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLogImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLogImageFilter.cpp
@@ -95,8 +95,8 @@ IFilter::UniquePointer ITKLogImageFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ITKLogImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ITKLogImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -110,7 +110,7 @@ IFilter::PreflightResult ITKLogImageFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> ITKLogImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLogImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKLogImageFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMaskImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMaskImageFilter.cpp
@@ -177,8 +177,8 @@ IFilter::UniquePointer ITKMaskImageFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ITKMaskImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ITKMaskImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                           const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -201,7 +201,7 @@ IFilter::PreflightResult ITKMaskImageFilter::preflightImpl(const DataStructure& 
 
 //------------------------------------------------------------------------------
 Result<> ITKMaskImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                         const std::atomic_bool& shouldCancel) const
+                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMaskImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMaskImageFilter.hpp
@@ -126,7 +126,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -137,7 +138,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& data, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMaximumProjectionImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMaximumProjectionImageFilter.cpp
@@ -105,7 +105,7 @@ IFilter::UniquePointer ITKMaximumProjectionImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKMaximumProjectionImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                        const std::atomic_bool& shouldCancel) const
+                                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -120,7 +120,7 @@ IFilter::PreflightResult ITKMaximumProjectionImageFilter::preflightImpl(const Da
 
 //------------------------------------------------------------------------------
 Result<> ITKMaximumProjectionImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                      const std::atomic_bool& shouldCancel) const
+                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMaximumProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMaximumProjectionImageFilter.hpp
@@ -120,7 +120,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -131,8 +132,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMeanProjectionImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMeanProjectionImageFilter.cpp
@@ -106,7 +106,7 @@ IFilter::UniquePointer ITKMeanProjectionImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKMeanProjectionImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -143,7 +143,7 @@ IFilter::PreflightResult ITKMeanProjectionImageFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> ITKMeanProjectionImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMeanProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMeanProjectionImageFilter.hpp
@@ -120,7 +120,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -131,8 +132,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMedianImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMedianImageFilter.cpp
@@ -109,7 +109,7 @@ IFilter::UniquePointer ITKMedianImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKMedianImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -125,7 +125,7 @@ IFilter::PreflightResult ITKMedianImageFilter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> ITKMedianImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMedianImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMedianImageFilter.hpp
@@ -117,7 +117,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -128,8 +129,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMedianProjectionImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMedianProjectionImageFilter.cpp
@@ -108,7 +108,7 @@ IFilter::UniquePointer ITKMedianProjectionImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKMedianProjectionImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                       const std::atomic_bool& shouldCancel) const
+                                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -123,7 +123,7 @@ IFilter::PreflightResult ITKMedianProjectionImageFilter::preflightImpl(const Dat
 
 //------------------------------------------------------------------------------
 Result<> ITKMedianProjectionImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                     const std::atomic_bool& shouldCancel) const
+                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMedianProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMedianProjectionImageFilter.hpp
@@ -120,7 +120,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -131,8 +132,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMhaFileReaderFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMhaFileReaderFilter.cpp
@@ -314,7 +314,7 @@ IFilter::UniquePointer ITKMhaFileReaderFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKMhaFileReaderFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto fileNamePath = filterArgs.value<FileSystemPathParameter::ValueType>(ITKImageReaderFilter::k_FileName_Key);
   auto imageGeomPath = filterArgs.value<DataGroupCreationParameter::ValueType>(ITKImageReaderFilter::k_ImageGeometryPath_Key);
@@ -407,7 +407,7 @@ IFilter::PreflightResult ITKMhaFileReaderFilter::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> ITKMhaFileReaderFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                             const std::atomic_bool& shouldCancel) const
+                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto fileNamePath = filterArgs.value<FileSystemPathParameter::ValueType>(ITKImageReaderFilter::k_FileName_Key);
   auto imageGeomPath = filterArgs.value<DataGroupCreationParameter::ValueType>(ITKImageReaderFilter::k_ImageGeometryPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMhaFileReaderFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMhaFileReaderFilter.hpp
@@ -87,7 +87,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -99,8 +100,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMinMaxCurvatureFlowImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMinMaxCurvatureFlowImageFilter.cpp
@@ -106,7 +106,7 @@ IFilter::UniquePointer ITKMinMaxCurvatureFlowImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKMinMaxCurvatureFlowImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                          const std::atomic_bool& shouldCancel) const
+                                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -123,7 +123,7 @@ IFilter::PreflightResult ITKMinMaxCurvatureFlowImageFilter::preflightImpl(const 
 
 //------------------------------------------------------------------------------
 Result<> ITKMinMaxCurvatureFlowImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                        const std::atomic_bool& shouldCancel) const
+                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMinMaxCurvatureFlowImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMinMaxCurvatureFlowImageFilter.hpp
@@ -125,7 +125,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -136,8 +137,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMinimumProjectionImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMinimumProjectionImageFilter.cpp
@@ -105,7 +105,7 @@ IFilter::UniquePointer ITKMinimumProjectionImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKMinimumProjectionImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                        const std::atomic_bool& shouldCancel) const
+                                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -120,7 +120,7 @@ IFilter::PreflightResult ITKMinimumProjectionImageFilter::preflightImpl(const Da
 
 //------------------------------------------------------------------------------
 Result<> ITKMinimumProjectionImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                      const std::atomic_bool& shouldCancel) const
+                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMinimumProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMinimumProjectionImageFilter.hpp
@@ -120,7 +120,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -131,8 +132,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalGradientImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalGradientImageFilter.cpp
@@ -107,7 +107,7 @@ IFilter::UniquePointer ITKMorphologicalGradientImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKMorphologicalGradientImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                            const std::atomic_bool& shouldCancel) const
+                                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -123,7 +123,7 @@ IFilter::PreflightResult ITKMorphologicalGradientImageFilter::preflightImpl(cons
 
 //------------------------------------------------------------------------------
 Result<> ITKMorphologicalGradientImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalGradientImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalGradientImageFilter.hpp
@@ -105,7 +105,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -116,8 +117,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedFromMarkersImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedFromMarkersImageFilter.cpp
@@ -105,7 +105,7 @@ IFilter::UniquePointer ITKMorphologicalWatershedFromMarkersImageFilter::clone() 
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKMorphologicalWatershedFromMarkersImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                        const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -120,8 +120,8 @@ IFilter::PreflightResult ITKMorphologicalWatershedFromMarkersImageFilter::prefli
 }
 
 //------------------------------------------------------------------------------
-Result<> ITKMorphologicalWatershedFromMarkersImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode,
-                                                                      const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+Result<> ITKMorphologicalWatershedFromMarkersImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedFromMarkersImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedFromMarkersImageFilter.cpp
@@ -105,7 +105,7 @@ IFilter::UniquePointer ITKMorphologicalWatershedFromMarkersImageFilter::clone() 
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKMorphologicalWatershedFromMarkersImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -120,8 +120,8 @@ IFilter::PreflightResult ITKMorphologicalWatershedFromMarkersImageFilter::prefli
 }
 
 //------------------------------------------------------------------------------
-Result<> ITKMorphologicalWatershedFromMarkersImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+Result<> ITKMorphologicalWatershedFromMarkersImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode,
+                                                                      const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedFromMarkersImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedFromMarkersImageFilter.hpp
@@ -125,7 +125,7 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -137,7 +137,7 @@ protected:
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedFromMarkersImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedFromMarkersImageFilter.hpp
@@ -125,7 +125,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -136,8 +137,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedImageFilter.cpp
@@ -115,7 +115,7 @@ IFilter::UniquePointer ITKMorphologicalWatershedImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKMorphologicalWatershedImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                             const std::atomic_bool& shouldCancel) const
+                                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -133,7 +133,7 @@ IFilter::PreflightResult ITKMorphologicalWatershedImageFilter::preflightImpl(con
 
 //------------------------------------------------------------------------------
 Result<> ITKMorphologicalWatershedImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+                                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMorphologicalWatershedImageFilter.hpp
@@ -116,7 +116,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -127,8 +128,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeImageFilter.cpp
@@ -97,7 +97,7 @@ IFilter::UniquePointer ITKNormalizeImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKNormalizeImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -112,7 +112,7 @@ IFilter::PreflightResult ITKNormalizeImageFilter::preflightImpl(const DataStruct
 
 //------------------------------------------------------------------------------
 Result<> ITKNormalizeImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                              const std::atomic_bool& shouldCancel) const
+                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeImageFilter.hpp
@@ -107,7 +107,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -118,8 +119,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeToConstantImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeToConstantImageFilter.cpp
@@ -100,7 +100,7 @@ IFilter::UniquePointer ITKNormalizeToConstantImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKNormalizeToConstantImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                          const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -116,7 +116,7 @@ IFilter::PreflightResult ITKNormalizeToConstantImageFilter::preflightImpl(const 
 
 //------------------------------------------------------------------------------
 Result<> ITKNormalizeToConstantImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                        const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -135,7 +135,7 @@ Result<> ITKNormalizeToConstantImageFilter::executeImpl(DataStructure& dataStruc
 
 //------------------------------------------------------------------------------
 Result<> ITKNormalizeToConstantImage::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_SelectedImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_SelectedImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeToConstantImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeToConstantImageFilter.cpp
@@ -100,7 +100,7 @@ IFilter::UniquePointer ITKNormalizeToConstantImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKNormalizeToConstantImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -116,7 +116,7 @@ IFilter::PreflightResult ITKNormalizeToConstantImageFilter::preflightImpl(const 
 
 //------------------------------------------------------------------------------
 Result<> ITKNormalizeToConstantImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -135,7 +135,7 @@ Result<> ITKNormalizeToConstantImageFilter::executeImpl(DataStructure& dataStruc
 
 //------------------------------------------------------------------------------
 Result<> ITKNormalizeToConstantImage::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_SelectedImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_SelectedImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeToConstantImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeToConstantImageFilter.hpp
@@ -111,7 +111,7 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -123,7 +123,7 @@ protected:
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeToConstantImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNormalizeToConstantImageFilter.hpp
@@ -111,7 +111,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -122,8 +123,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNotImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNotImageFilter.cpp
@@ -94,8 +94,8 @@ IFilter::UniquePointer ITKNotImageFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ITKNotImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ITKNotImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -109,7 +109,7 @@ IFilter::PreflightResult ITKNotImageFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> ITKNotImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNotImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKNotImageFilter.hpp
@@ -122,7 +122,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -133,8 +134,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKOpeningByReconstructionImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKOpeningByReconstructionImageFilter.cpp
@@ -119,7 +119,7 @@ IFilter::UniquePointer ITKOpeningByReconstructionImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKOpeningByReconstructionImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                              const std::atomic_bool& shouldCancel) const
+                                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -137,7 +137,7 @@ IFilter::PreflightResult ITKOpeningByReconstructionImageFilter::preflightImpl(co
 
 //------------------------------------------------------------------------------
 Result<> ITKOpeningByReconstructionImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                            const std::atomic_bool& shouldCancel) const
+                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKOpeningByReconstructionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKOpeningByReconstructionImageFilter.hpp
@@ -119,7 +119,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -130,8 +131,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKOtsuMultipleThresholdsImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKOtsuMultipleThresholdsImageFilter.cpp
@@ -117,7 +117,7 @@ IFilter::UniquePointer ITKOtsuMultipleThresholdsImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKOtsuMultipleThresholdsImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                             const std::atomic_bool& shouldCancel) const
+                                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -137,7 +137,7 @@ IFilter::PreflightResult ITKOtsuMultipleThresholdsImageFilter::preflightImpl(con
 
 //------------------------------------------------------------------------------
 Result<> ITKOtsuMultipleThresholdsImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+                                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKOtsuMultipleThresholdsImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKOtsuMultipleThresholdsImageFilter.hpp
@@ -120,7 +120,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -131,8 +132,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRegionalMaximaImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRegionalMaximaImageFilter.cpp
@@ -114,7 +114,7 @@ IFilter::UniquePointer ITKRegionalMaximaImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKRegionalMaximaImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -133,7 +133,7 @@ IFilter::PreflightResult ITKRegionalMaximaImageFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> ITKRegionalMaximaImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRegionalMaximaImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRegionalMaximaImageFilter.hpp
@@ -114,7 +114,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -125,8 +126,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRegionalMinimaImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRegionalMinimaImageFilter.cpp
@@ -114,7 +114,7 @@ IFilter::UniquePointer ITKRegionalMinimaImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKRegionalMinimaImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -133,7 +133,7 @@ IFilter::PreflightResult ITKRegionalMinimaImageFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> ITKRegionalMinimaImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRegionalMinimaImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRegionalMinimaImageFilter.hpp
@@ -112,7 +112,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -123,8 +124,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRelabelComponentImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRelabelComponentImageFilter.cpp
@@ -109,7 +109,7 @@ IFilter::UniquePointer ITKRelabelComponentImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKRelabelComponentImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                       const std::atomic_bool& shouldCancel) const
+                                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -125,7 +125,7 @@ IFilter::PreflightResult ITKRelabelComponentImageFilter::preflightImpl(const Dat
 
 //------------------------------------------------------------------------------
 Result<> ITKRelabelComponentImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                     const std::atomic_bool& shouldCancel) const
+                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRelabelComponentImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRelabelComponentImageFilter.hpp
@@ -121,7 +121,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -132,8 +133,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRescaleIntensityImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRescaleIntensityImageFilter.cpp
@@ -105,7 +105,7 @@ IFilter::UniquePointer ITKRescaleIntensityImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKRescaleIntensityImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                       const std::atomic_bool& shouldCancel) const
+                                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -121,7 +121,7 @@ IFilter::PreflightResult ITKRescaleIntensityImageFilter::preflightImpl(const Dat
 
 //------------------------------------------------------------------------------
 Result<> ITKRescaleIntensityImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                     const std::atomic_bool& shouldCancel) const
+                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRescaleIntensityImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKRescaleIntensityImageFilter.hpp
@@ -118,7 +118,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -129,8 +130,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSigmoidImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSigmoidImageFilter.cpp
@@ -110,7 +110,7 @@ IFilter::UniquePointer ITKSigmoidImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKSigmoidImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -128,7 +128,7 @@ IFilter::PreflightResult ITKSigmoidImageFilter::preflightImpl(const DataStructur
 
 //------------------------------------------------------------------------------
 Result<> ITKSigmoidImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSigmoidImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSigmoidImageFilter.hpp
@@ -109,7 +109,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -120,8 +121,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSignedDanielssonDistanceMapImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSignedDanielssonDistanceMapImageFilter.cpp
@@ -106,7 +106,7 @@ IFilter::UniquePointer ITKSignedDanielssonDistanceMapImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKSignedDanielssonDistanceMapImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                  const std::atomic_bool& shouldCancel) const
+                                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -124,7 +124,7 @@ IFilter::PreflightResult ITKSignedDanielssonDistanceMapImageFilter::preflightImp
 
 //------------------------------------------------------------------------------
 Result<> ITKSignedDanielssonDistanceMapImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSignedDanielssonDistanceMapImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSignedDanielssonDistanceMapImageFilter.hpp
@@ -119,7 +119,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -130,8 +131,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSignedMaurerDistanceMapImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSignedMaurerDistanceMapImageFilter.cpp
@@ -114,7 +114,7 @@ IFilter::UniquePointer ITKSignedMaurerDistanceMapImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKSignedMaurerDistanceMapImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                              const std::atomic_bool& shouldCancel) const
+                                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -133,7 +133,7 @@ IFilter::PreflightResult ITKSignedMaurerDistanceMapImageFilter::preflightImpl(co
 
 //------------------------------------------------------------------------------
 Result<> ITKSignedMaurerDistanceMapImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                            const std::atomic_bool& shouldCancel) const
+                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSignedMaurerDistanceMapImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSignedMaurerDistanceMapImageFilter.hpp
@@ -121,7 +121,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -132,8 +133,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSinImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSinImageFilter.cpp
@@ -95,8 +95,8 @@ IFilter::UniquePointer ITKSinImageFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ITKSinImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ITKSinImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -110,7 +110,7 @@ IFilter::PreflightResult ITKSinImageFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> ITKSinImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSinImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSinImageFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSmoothingRecursiveGaussianImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSmoothingRecursiveGaussianImageFilter.cpp
@@ -109,7 +109,7 @@ IFilter::UniquePointer ITKSmoothingRecursiveGaussianImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKSmoothingRecursiveGaussianImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                 const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -126,7 +126,7 @@ IFilter::PreflightResult ITKSmoothingRecursiveGaussianImageFilter::preflightImpl
 
 //------------------------------------------------------------------------------
 Result<> ITKSmoothingRecursiveGaussianImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSmoothingRecursiveGaussianImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSmoothingRecursiveGaussianImageFilter.cpp
@@ -109,7 +109,7 @@ IFilter::UniquePointer ITKSmoothingRecursiveGaussianImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKSmoothingRecursiveGaussianImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -126,7 +126,7 @@ IFilter::PreflightResult ITKSmoothingRecursiveGaussianImageFilter::preflightImpl
 
 //------------------------------------------------------------------------------
 Result<> ITKSmoothingRecursiveGaussianImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSmoothingRecursiveGaussianImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSmoothingRecursiveGaussianImageFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSmoothingRecursiveGaussianImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSmoothingRecursiveGaussianImageFilter.hpp
@@ -98,7 +98,7 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,7 +110,7 @@ protected:
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSqrtImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSqrtImageFilter.cpp
@@ -94,8 +94,8 @@ IFilter::UniquePointer ITKSqrtImageFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ITKSqrtImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ITKSqrtImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                           const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -109,7 +109,7 @@ IFilter::PreflightResult ITKSqrtImageFilter::preflightImpl(const DataStructure& 
 
 //------------------------------------------------------------------------------
 Result<> ITKSqrtImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                         const std::atomic_bool& shouldCancel) const
+                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSqrtImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSqrtImageFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSquareImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSquareImageFilter.cpp
@@ -95,7 +95,7 @@ IFilter::UniquePointer ITKSquareImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKSquareImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -109,7 +109,7 @@ IFilter::PreflightResult ITKSquareImageFilter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> ITKSquareImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSquareImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSquareImageFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKStandardDeviationProjectionImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKStandardDeviationProjectionImageFilter.cpp
@@ -99,7 +99,7 @@ IFilter::UniquePointer ITKStandardDeviationProjectionImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKStandardDeviationProjectionImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                  const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -115,7 +115,7 @@ IFilter::PreflightResult ITKStandardDeviationProjectionImageFilter::preflightImp
 
 //------------------------------------------------------------------------------
 Result<> ITKStandardDeviationProjectionImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKStandardDeviationProjectionImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKStandardDeviationProjectionImageFilter.cpp
@@ -99,7 +99,7 @@ IFilter::UniquePointer ITKStandardDeviationProjectionImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKStandardDeviationProjectionImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -115,7 +115,7 @@ IFilter::PreflightResult ITKStandardDeviationProjectionImageFilter::preflightImp
 
 //------------------------------------------------------------------------------
 Result<> ITKStandardDeviationProjectionImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKStandardDeviationProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKStandardDeviationProjectionImageFilter.hpp
@@ -121,7 +121,7 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -133,7 +133,7 @@ protected:
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKStandardDeviationProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKStandardDeviationProjectionImageFilter.hpp
@@ -121,7 +121,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -132,8 +133,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSumProjectionImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSumProjectionImageFilter.cpp
@@ -100,7 +100,7 @@ IFilter::UniquePointer ITKSumProjectionImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKSumProjectionImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -116,7 +116,7 @@ IFilter::PreflightResult ITKSumProjectionImageFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> ITKSumProjectionImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSumProjectionImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSumProjectionImageFilter.cpp
@@ -100,7 +100,7 @@ IFilter::UniquePointer ITKSumProjectionImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKSumProjectionImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -116,7 +116,7 @@ IFilter::PreflightResult ITKSumProjectionImageFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> ITKSumProjectionImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSumProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSumProjectionImageFilter.hpp
@@ -121,7 +121,7 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -133,7 +133,7 @@ protected:
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSumProjectionImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKSumProjectionImageFilter.hpp
@@ -121,7 +121,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -132,8 +133,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKTanImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKTanImageFilter.cpp
@@ -94,8 +94,8 @@ IFilter::UniquePointer ITKTanImageFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ITKTanImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ITKTanImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -109,7 +109,7 @@ IFilter::PreflightResult ITKTanImageFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> ITKTanImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKTanImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKTanImageFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKThresholdImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKThresholdImageFilter.cpp
@@ -108,7 +108,7 @@ IFilter::UniquePointer ITKThresholdImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKThresholdImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -125,7 +125,7 @@ IFilter::PreflightResult ITKThresholdImageFilter::preflightImpl(const DataStruct
 
 //------------------------------------------------------------------------------
 Result<> ITKThresholdImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                              const std::atomic_bool& shouldCancel) const
+                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKThresholdImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKThresholdImageFilter.hpp
@@ -116,7 +116,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -127,8 +128,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKThresholdMaximumConnectedComponentsImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKThresholdMaximumConnectedComponentsImageFilter.cpp
@@ -132,7 +132,7 @@ IFilter::UniquePointer ITKThresholdMaximumConnectedComponentsImageFilter::clone(
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKThresholdMaximumConnectedComponentsImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                          const std::atomic_bool& shouldCancel) const
+                                                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -152,7 +152,7 @@ IFilter::PreflightResult ITKThresholdMaximumConnectedComponentsImageFilter::pref
 
 //------------------------------------------------------------------------------
 Result<> ITKThresholdMaximumConnectedComponentsImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode,
-                                                                        const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+                                                                        const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKThresholdMaximumConnectedComponentsImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKThresholdMaximumConnectedComponentsImageFilter.hpp
@@ -123,7 +123,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -134,8 +135,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKValuedRegionalMaximaImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKValuedRegionalMaximaImageFilter.cpp
@@ -103,7 +103,7 @@ IFilter::UniquePointer ITKValuedRegionalMaximaImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKValuedRegionalMaximaImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                           const std::atomic_bool& shouldCancel) const
+                                                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -118,7 +118,7 @@ IFilter::PreflightResult ITKValuedRegionalMaximaImageFilter::preflightImpl(const
 
 //------------------------------------------------------------------------------
 Result<> ITKValuedRegionalMaximaImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                         const std::atomic_bool& shouldCancel) const
+                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKValuedRegionalMaximaImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKValuedRegionalMaximaImageFilter.hpp
@@ -115,7 +115,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -126,8 +127,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKValuedRegionalMinimaImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKValuedRegionalMinimaImageFilter.cpp
@@ -103,7 +103,7 @@ IFilter::UniquePointer ITKValuedRegionalMinimaImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKValuedRegionalMinimaImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                           const std::atomic_bool& shouldCancel) const
+                                                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -118,7 +118,7 @@ IFilter::PreflightResult ITKValuedRegionalMinimaImageFilter::preflightImpl(const
 
 //------------------------------------------------------------------------------
 Result<> ITKValuedRegionalMinimaImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                         const std::atomic_bool& shouldCancel) const
+                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKValuedRegionalMinimaImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKValuedRegionalMinimaImageFilter.hpp
@@ -112,7 +112,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -123,8 +124,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKWhiteTopHatImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKWhiteTopHatImageFilter.cpp
@@ -111,7 +111,7 @@ IFilter::UniquePointer ITKWhiteTopHatImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKWhiteTopHatImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -128,7 +128,7 @@ IFilter::PreflightResult ITKWhiteTopHatImageFilter::preflightImpl(const DataStru
 
 //------------------------------------------------------------------------------
 Result<> ITKWhiteTopHatImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKWhiteTopHatImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKWhiteTopHatImageFilter.hpp
@@ -106,7 +106,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -117,8 +118,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKZeroCrossingImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKZeroCrossingImageFilter.cpp
@@ -102,7 +102,7 @@ IFilter::UniquePointer ITKZeroCrossingImageFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKZeroCrossingImageFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                   const std::atomic_bool& shouldCancel) const
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -119,7 +119,7 @@ IFilter::PreflightResult ITKZeroCrossingImageFilter::preflightImpl(const DataStr
 
 //------------------------------------------------------------------------------
 Result<> ITKZeroCrossingImageFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                 const std::atomic_bool& shouldCancel) const
+                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKZeroCrossingImageFilter.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKZeroCrossingImageFilter.hpp
@@ -123,7 +123,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -134,8 +135,8 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ITKImportFijiMontage.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ITKImportFijiMontage.cpp
@@ -80,7 +80,7 @@ IFilter::UniquePointer ITKImportFijiMontage::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKImportFijiMontage::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Write any preflight sanity checking codes in this function
@@ -146,7 +146,7 @@ IFilter::PreflightResult ITKImportFijiMontage::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> ITKImportFijiMontage::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Extract the actual input values from the 'filterArgs' object

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ITKImportFijiMontage.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ITKImportFijiMontage.cpp
@@ -80,7 +80,7 @@ IFilter::UniquePointer ITKImportFijiMontage::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKImportFijiMontage::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Write any preflight sanity checking codes in this function
@@ -146,7 +146,7 @@ IFilter::PreflightResult ITKImportFijiMontage::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> ITKImportFijiMontage::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Extract the actual input values from the 'filterArgs' object

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ITKImportRoboMetMontage.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ITKImportRoboMetMontage.cpp
@@ -86,7 +86,7 @@ IFilter::UniquePointer ITKImportRoboMetMontage::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKImportRoboMetMontage::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Write any preflight sanity checking codes in this function
@@ -157,7 +157,7 @@ IFilter::PreflightResult ITKImportRoboMetMontage::preflightImpl(const DataStruct
 
 //------------------------------------------------------------------------------
 Result<> ITKImportRoboMetMontage::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                              const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Extract the actual input values from the 'filterArgs' object

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ITKImportRoboMetMontage.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ITKImportRoboMetMontage.cpp
@@ -86,7 +86,7 @@ IFilter::UniquePointer ITKImportRoboMetMontage::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ITKImportRoboMetMontage::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Write any preflight sanity checking codes in this function
@@ -157,7 +157,7 @@ IFilter::PreflightResult ITKImportRoboMetMontage::preflightImpl(const DataStruct
 
 //------------------------------------------------------------------------------
 Result<> ITKImportRoboMetMontage::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Extract the actual input values from the 'filterArgs' object

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/IlluminationCorrection.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/IlluminationCorrection.cpp
@@ -105,7 +105,7 @@ IFilter::UniquePointer IlluminationCorrection::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult IlluminationCorrection::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Write any preflight sanity checking codes in this function
@@ -177,7 +177,7 @@ IFilter::PreflightResult IlluminationCorrection::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> IlluminationCorrection::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                             const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Extract the actual input values from the 'filterArgs' object

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/IlluminationCorrection.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/IlluminationCorrection.cpp
@@ -105,7 +105,7 @@ IFilter::UniquePointer IlluminationCorrection::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult IlluminationCorrection::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Write any preflight sanity checking codes in this function
@@ -177,7 +177,7 @@ IFilter::PreflightResult IlluminationCorrection::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> IlluminationCorrection::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Extract the actual input values from the 'filterArgs' object

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ImportAxioVisionV4Montage.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ImportAxioVisionV4Montage.cpp
@@ -82,7 +82,7 @@ IFilter::UniquePointer ImportAxioVisionV4Montage::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ImportAxioVisionV4Montage::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Write any preflight sanity checking codes in this function
@@ -151,7 +151,7 @@ IFilter::PreflightResult ImportAxioVisionV4Montage::preflightImpl(const DataStru
 
 //------------------------------------------------------------------------------
 Result<> ImportAxioVisionV4Montage::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Extract the actual input values from the 'filterArgs' object

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ImportAxioVisionV4Montage.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ImportAxioVisionV4Montage.cpp
@@ -82,7 +82,7 @@ IFilter::UniquePointer ImportAxioVisionV4Montage::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ImportAxioVisionV4Montage::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Write any preflight sanity checking codes in this function

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ImportVectorImageStack.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ImportVectorImageStack.cpp
@@ -67,7 +67,7 @@ IFilter::UniquePointer ImportVectorImageStack::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ImportVectorImageStack::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Write any preflight sanity checking codes in this function
@@ -124,7 +124,7 @@ IFilter::PreflightResult ImportVectorImageStack::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> ImportVectorImageStack::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Extract the actual input values from the 'filterArgs' object

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ImportVectorImageStack.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ImportVectorImageStack.cpp
@@ -67,7 +67,7 @@ IFilter::UniquePointer ImportVectorImageStack::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ImportVectorImageStack::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Write any preflight sanity checking codes in this function
@@ -124,7 +124,7 @@ IFilter::PreflightResult ImportVectorImageStack::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> ImportVectorImageStack::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                             const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Extract the actual input values from the 'filterArgs' object

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ImportZenInfoMontage.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ImportZenInfoMontage.cpp
@@ -80,7 +80,7 @@ IFilter::UniquePointer ImportZenInfoMontage::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ImportZenInfoMontage::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Write any preflight sanity checking codes in this function
@@ -146,7 +146,7 @@ IFilter::PreflightResult ImportZenInfoMontage::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> ImportZenInfoMontage::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Extract the actual input values from the 'filterArgs' object

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ImportZenInfoMontage.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters_Private/ImportZenInfoMontage.cpp
@@ -80,7 +80,7 @@ IFilter::UniquePointer ImportZenInfoMontage::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ImportZenInfoMontage::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Write any preflight sanity checking codes in this function
@@ -146,7 +146,7 @@ IFilter::PreflightResult ImportZenInfoMontage::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> ImportZenInfoMontage::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Extract the actual input values from the 'filterArgs' object

--- a/src/Plugins/ITKImageProcessing/tools/filter.cpp.in
+++ b/src/Plugins/ITKImageProcessing/tools/filter.cpp.in
@@ -72,7 +72,7 @@ IFilter::UniquePointer ${FILTER_NAME}Filter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ${FILTER_NAME}Filter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);
@@ -86,7 +86,7 @@ IFilter::PreflightResult ${FILTER_NAME}Filter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> ${FILTER_NAME}Filter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_InputImageGeomPath_Key);
   auto selectedInputArray = filterArgs.value<DataPath>(k_InputImageDataPath_Key);

--- a/src/Plugins/ITKImageProcessing/tools/filter.hpp.in
+++ b/src/Plugins/ITKImageProcessing/tools/filter.hpp.in
@@ -100,7 +100,7 @@ protected:
    * @param shouldCancel Boolean that gets set if the filter should stop executing and return
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,7 +112,7 @@ protected:
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMisorientationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMisorientationFilter.cpp
@@ -148,7 +148,7 @@ IFilter::UniquePointer AlignSectionsMisorientationFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult AlignSectionsMisorientationFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                          const std::atomic_bool& shouldCancel) const
+                                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pMisorientationTolerance = filterArgs.value<float32>(k_MisorientationTolerance_Key);
   auto pUseGoodVoxels = filterArgs.value<bool>(k_UseMask_Key);
@@ -228,7 +228,7 @@ IFilter::PreflightResult AlignSectionsMisorientationFilter::preflightImpl(const 
 
 //------------------------------------------------------------------------------
 Result<> AlignSectionsMisorientationFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                        const std::atomic_bool& shouldCancel) const
+                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   AlignSectionsMisorientationInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMisorientationFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMisorientationFilter.hpp
@@ -108,7 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -120,8 +121,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMutualInformationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMutualInformationFilter.cpp
@@ -134,7 +134,7 @@ IFilter::UniquePointer AlignSectionsMutualInformationFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult AlignSectionsMutualInformationFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                             const std::atomic_bool& shouldCancel) const
+                                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeometryPath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
   auto pQuatsArrayPathValue = filterArgs.value<DataPath>(k_QuatsArrayPath_Key);
@@ -197,7 +197,7 @@ IFilter::PreflightResult AlignSectionsMutualInformationFilter::preflightImpl(con
 
 //------------------------------------------------------------------------------
 Result<> AlignSectionsMutualInformationFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+                                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   AlignSectionsMutualInformationInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMutualInformationFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMutualInformationFilter.hpp
@@ -107,7 +107,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -119,8 +120,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/BadDataNeighborOrientationCheckFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/BadDataNeighborOrientationCheckFilter.cpp
@@ -98,7 +98,7 @@ IFilter::UniquePointer BadDataNeighborOrientationCheckFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult BadDataNeighborOrientationCheckFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                              const std::atomic_bool& shouldCancel) const
+                                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pMisorientationToleranceValue = filterArgs.value<float32>(k_MisorientationTolerance_Key);
   auto pNumberOfNeighborsValue = filterArgs.value<int32>(k_NumberOfNeighbors_Key);
@@ -204,7 +204,7 @@ IFilter::PreflightResult BadDataNeighborOrientationCheckFilter::preflightImpl(co
 
 //------------------------------------------------------------------------------
 Result<> BadDataNeighborOrientationCheckFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                            const std::atomic_bool& shouldCancel) const
+                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   BadDataNeighborOrientationCheckInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/BadDataNeighborOrientationCheckFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/BadDataNeighborOrientationCheckFilter.hpp
@@ -100,7 +100,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.cpp
@@ -117,7 +117,7 @@ IFilter::UniquePointer CAxisSegmentFeaturesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CAxisSegmentFeaturesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                   const std::atomic_bool& shouldCancel) const
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pQuatsArrayPathValue = args.value<DataPath>(k_QuatsArrayPath_Key);
   auto pCellPhasesArrayPathValue = args.value<DataPath>(k_CellPhasesArrayPath_Key);
@@ -192,7 +192,7 @@ IFilter::PreflightResult CAxisSegmentFeaturesFilter::preflightImpl(const DataStr
 
 //------------------------------------------------------------------------------
 Result<> CAxisSegmentFeaturesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                 const std::atomic_bool& shouldCancel) const
+                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   CAxisSegmentFeaturesInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.hpp
@@ -104,7 +104,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -116,8 +117,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgCAxesFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgCAxesFilter.cpp
@@ -81,7 +81,7 @@ IFilter::UniquePointer ComputeAvgCAxesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeAvgCAxesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pQuatsArrayPathValue = filterArgs.value<DataPath>(k_QuatsArrayPath_Key);
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_FeatureIdsArrayPath_Key);
@@ -116,7 +116,7 @@ IFilter::PreflightResult ComputeAvgCAxesFilter::preflightImpl(const DataStructur
 
 //------------------------------------------------------------------------------
 Result<> ComputeAvgCAxesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeAvgCAxesInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgCAxesFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgCAxesFilter.hpp
@@ -99,7 +99,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -111,8 +112,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgOrientationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgOrientationsFilter.cpp
@@ -100,7 +100,7 @@ IFilter::UniquePointer ComputeAvgOrientationsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeAvgOrientationsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pCellFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
   auto pCellPhasesArrayPathValue = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
@@ -172,7 +172,7 @@ IFilter::PreflightResult ComputeAvgOrientationsFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> ComputeAvgOrientationsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeAvgOrientationsInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgOrientationsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgOrientationsFilter.hpp
@@ -100,7 +100,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeBoundaryStrengthsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeBoundaryStrengthsFilter.cpp
@@ -94,7 +94,7 @@ IFilter::UniquePointer ComputeBoundaryStrengthsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeBoundaryStrengthsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                       const std::atomic_bool& shouldCancel) const
+                                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pSurfaceMeshFaceLabelsArrayPathValue = filterArgs.value<DataPath>(k_SurfaceMeshFaceLabelsArrayPath_Key);
   auto pSurfaceMeshF1sArrayNameValue = filterArgs.value<std::string>(k_SurfaceMeshF1sArrayName_Key);
@@ -134,7 +134,7 @@ IFilter::PreflightResult ComputeBoundaryStrengthsFilter::preflightImpl(const Dat
 
 //------------------------------------------------------------------------------
 Result<> ComputeBoundaryStrengthsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                     const std::atomic_bool& shouldCancel) const
+                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeBoundaryStrengthsInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeBoundaryStrengthsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeBoundaryStrengthsFilter.hpp
@@ -102,7 +102,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -114,8 +115,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeCAxisLocationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeCAxisLocationsFilter.cpp
@@ -79,7 +79,7 @@ IFilter::UniquePointer ComputeCAxisLocationsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeCAxisLocationsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pQuatsArrayPathValue = filterArgs.value<DataPath>(k_QuatsArrayPath_Key);
   auto pCellPhasesArrayPathValue = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
@@ -110,7 +110,7 @@ IFilter::PreflightResult ComputeCAxisLocationsFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> ComputeCAxisLocationsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeCAxisLocationsInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeCAxisLocationsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeCAxisLocationsFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFZQuaternionsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFZQuaternionsFilter.cpp
@@ -188,7 +188,7 @@ IFilter::UniquePointer ComputeFZQuaternionsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeFZQuaternionsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                   const std::atomic_bool& shouldCancel) const
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
 
   auto pUseGoodVoxelsValue = filterArgs.value<bool>(k_UseMask_Key);
@@ -256,7 +256,7 @@ IFilter::PreflightResult ComputeFZQuaternionsFilter::preflightImpl(const DataStr
 
 //------------------------------------------------------------------------------
 Result<> ComputeFZQuaternionsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                 const std::atomic_bool& shouldCancel) const
+                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pUseGoodVoxelsValue = filterArgs.value<bool>(k_UseMask_Key);
   auto pQuatsArrayPathValue = filterArgs.value<DataPath>(k_QuatsArrayPath_Key);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFZQuaternionsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFZQuaternionsFilter.hpp
@@ -99,7 +99,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -111,8 +112,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFaceIPFColoringFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFaceIPFColoringFilter.cpp
@@ -85,7 +85,7 @@ IFilter::UniquePointer ComputeFaceIPFColoringFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeFaceIPFColoringFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pSurfaceMeshFaceLabelsArrayPathValue = filterArgs.value<DataPath>(k_SurfaceMeshFaceLabelsArrayPath_Key);
   auto pSurfaceMeshFaceNormalsArrayPathValue = filterArgs.value<DataPath>(k_SurfaceMeshFaceNormalsArrayPath_Key);
@@ -129,7 +129,7 @@ IFilter::PreflightResult ComputeFaceIPFColoringFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> ComputeFaceIPFColoringFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeFaceIPFColoringInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFaceIPFColoringFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFaceIPFColoringFilter.hpp
@@ -99,7 +99,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -111,8 +112,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureFaceMisorientationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureFaceMisorientationFilter.cpp
@@ -83,7 +83,7 @@ IFilter::UniquePointer ComputeFeatureFaceMisorientationFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeFeatureFaceMisorientationFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                               const std::atomic_bool& shouldCancel) const
+                                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pSurfaceMeshFaceLabelsArrayPathValue = filterArgs.value<DataPath>(k_SurfaceMeshFaceLabelsArrayPath_Key);
   auto pAvgQuatsArrayPathValue = filterArgs.value<DataPath>(k_AvgQuatsArrayPath_Key);
@@ -118,7 +118,7 @@ IFilter::PreflightResult ComputeFeatureFaceMisorientationFilter::preflightImpl(c
 
 //------------------------------------------------------------------------------
 Result<> ComputeFeatureFaceMisorientationFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeFeatureFaceMisorientationInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureFaceMisorientationFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureFaceMisorientationFilter.hpp
@@ -99,7 +99,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -111,8 +112,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureNeighborCAxisMisalignmentsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureNeighborCAxisMisalignmentsFilter.cpp
@@ -93,7 +93,7 @@ IFilter::UniquePointer ComputeFeatureNeighborCAxisMisalignmentsFilter::clone() c
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeFeatureNeighborCAxisMisalignmentsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                       const std::atomic_bool& shouldCancel) const
+                                                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFindAvgMisalsValue = filterArgs.value<bool>(k_FindAvgMisals_Key);
   auto pNeighborListArrayPathValue = filterArgs.value<DataPath>(k_NeighborListArrayPath_Key);
@@ -134,7 +134,7 @@ IFilter::PreflightResult ComputeFeatureNeighborCAxisMisalignmentsFilter::preflig
 
 //------------------------------------------------------------------------------
 Result<> ComputeFeatureNeighborCAxisMisalignmentsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode,
-                                                                     const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+                                                                     const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeFeatureNeighborCAxisMisalignmentsInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureNeighborCAxisMisalignmentsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureNeighborCAxisMisalignmentsFilter.hpp
@@ -100,7 +100,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceCAxisMisorientationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceCAxisMisorientationsFilter.cpp
@@ -94,7 +94,7 @@ IFilter::UniquePointer ComputeFeatureReferenceCAxisMisorientationsFilter::clone(
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeFeatureReferenceCAxisMisorientationsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                          const std::atomic_bool& shouldCancel) const
+                                                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_FeatureIdsArrayPath_Key);
   auto pCellPhasesArrayPathValue = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
@@ -140,7 +140,7 @@ IFilter::PreflightResult ComputeFeatureReferenceCAxisMisorientationsFilter::pref
 
 //------------------------------------------------------------------------------
 Result<> ComputeFeatureReferenceCAxisMisorientationsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode,
-                                                                        const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+                                                                        const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeFeatureReferenceCAxisMisorientationsInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceCAxisMisorientationsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceCAxisMisorientationsFilter.hpp
@@ -102,7 +102,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -114,8 +115,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceMisorientationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceMisorientationsFilter.cpp
@@ -115,7 +115,7 @@ IFilter::UniquePointer ComputeFeatureReferenceMisorientationsFilter::clone() con
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeFeatureReferenceMisorientationsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                     const std::atomic_bool& shouldCancel) const
+                                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pReferenceOrientationValue = filterArgs.value<ChoicesParameter::ValueType>(k_ReferenceOrientation_Key);
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
@@ -184,7 +184,7 @@ IFilter::PreflightResult ComputeFeatureReferenceMisorientationsFilter::preflight
 
 //------------------------------------------------------------------------------
 Result<> ComputeFeatureReferenceMisorientationsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                                   const std::atomic_bool& shouldCancel) const
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeFeatureReferenceMisorientationsInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceMisorientationsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceMisorientationsFilter.hpp
@@ -103,7 +103,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -115,8 +116,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDFilter.cpp
@@ -100,8 +100,8 @@ IFilter::UniquePointer ComputeGBCDFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ComputeGBCDFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ComputeGBCDFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto pGBCDResValue = filterArgs.value<float32>(k_GBCDRes_Key);
   auto pTriangleGeometryPathValue = filterArgs.value<DataPath>(k_SelectedTriangleGeometryPath_Key);
@@ -175,7 +175,7 @@ IFilter::PreflightResult ComputeGBCDFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> ComputeGBCDFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeGBCDInputValues inputValues;
   inputValues.GBCDRes = filterArgs.value<float32>(k_GBCDRes_Key);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDFilter.hpp
@@ -103,7 +103,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -115,8 +116,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDMetricBasedFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDMetricBasedFilter.cpp
@@ -125,7 +125,7 @@ IFilter::UniquePointer ComputeGBCDMetricBasedFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeGBCDMetricBasedFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pPhaseOfInterestValue = filterArgs.value<int32>(k_PhaseOfInterest_Key);
   auto pMisorientationRotationValue = filterArgs.value<VectorFloat32Parameter::ValueType>(k_MisorientationRotation_Key);
@@ -188,7 +188,7 @@ IFilter::PreflightResult ComputeGBCDMetricBasedFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> ComputeGBCDMetricBasedFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeGBCDMetricBasedInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDMetricBasedFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDMetricBasedFilter.hpp
@@ -110,7 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -122,8 +123,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDPoleFigureFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDPoleFigureFilter.cpp
@@ -90,7 +90,7 @@ IFilter::UniquePointer ComputeGBCDPoleFigureFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeGBCDPoleFigureFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pPhaseOfInterestValue = filterArgs.value<int32>(k_PhaseOfInterest_Key);
   auto pMisorientationRotationValue = filterArgs.value<VectorFloat32Parameter::ValueType>(k_MisorientationRotation_Key);
@@ -140,7 +140,7 @@ IFilter::PreflightResult ComputeGBCDPoleFigureFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> ComputeGBCDPoleFigureFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeGBCDPoleFigureInputValues inputValues;
   inputValues.PhaseOfInterest = filterArgs.value<int32>(k_PhaseOfInterest_Key);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDPoleFigureFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDPoleFigureFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -113,8 +114,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBPDMetricBasedFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBPDMetricBasedFilter.cpp
@@ -109,7 +109,7 @@ IFilter::UniquePointer ComputeGBPDMetricBasedFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeGBPDMetricBasedFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pPhaseOfInterestValue = filterArgs.value<int32>(k_PhaseOfInterest_Key);
   auto pNumSamplePtsValue = filterArgs.value<int32>(k_NumSamplPts_Key);
@@ -160,7 +160,7 @@ IFilter::PreflightResult ComputeGBPDMetricBasedFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> ComputeGBPDMetricBasedFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeGBPDMetricBasedInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBPDMetricBasedFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBPDMetricBasedFilter.hpp
@@ -109,7 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -121,8 +122,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeIPFColorsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeIPFColorsFilter.cpp
@@ -105,7 +105,7 @@ IFilter::UniquePointer ComputeIPFColorsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeIPFColorsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
 
   auto pReferenceDirValue = filterArgs.value<VectorFloat32Parameter::ValueType>(k_ReferenceDir_Key);
@@ -181,7 +181,7 @@ IFilter::PreflightResult ComputeIPFColorsFilter::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> ComputeIPFColorsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                             const std::atomic_bool& shouldCancel) const
+                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeIPFColorsInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeIPFColorsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeIPFColorsFilter.hpp
@@ -100,7 +100,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeKernelAvgMisorientationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeKernelAvgMisorientationsFilter.cpp
@@ -92,7 +92,7 @@ IFilter::UniquePointer ComputeKernelAvgMisorientationsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeKernelAvgMisorientationsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                              const std::atomic_bool& shouldCancel) const
+                                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pKernelSizeValue = filterArgs.value<VectorInt32Parameter::ValueType>(k_KernelSize_Key);
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
@@ -122,7 +122,7 @@ IFilter::PreflightResult ComputeKernelAvgMisorientationsFilter::preflightImpl(co
 
 //------------------------------------------------------------------------------
 Result<> ComputeKernelAvgMisorientationsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                            const std::atomic_bool& shouldCancel) const
+                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeKernelAvgMisorientationsInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeKernelAvgMisorientationsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeKernelAvgMisorientationsFilter.hpp
@@ -100,7 +100,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeMisorientationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeMisorientationsFilter.cpp
@@ -99,7 +99,7 @@ IFilter::UniquePointer ComputeMisorientationsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeMisorientationsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Write any preflight sanity checking codes in this function
@@ -162,7 +162,7 @@ IFilter::PreflightResult ComputeMisorientationsFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> ComputeMisorientationsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeMisorientationsInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeMisorientationsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeMisorientationsFilter.hpp
@@ -100,7 +100,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeQuaternionConjugateFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeQuaternionConjugateFilter.cpp
@@ -84,7 +84,7 @@ IFilter::UniquePointer ComputeQuaternionConjugateFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeQuaternionConjugateFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                         const std::atomic_bool& shouldCancel) const
+                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pQuaternionDataArrayPathValue = filterArgs.value<DataPath>(k_CellQuatsArrayPath_Key);
   auto pOutputDataArrayPathValue = pQuaternionDataArrayPathValue.replaceName(filterArgs.value<std::string>(k_OutputDataArrayName_Key));
@@ -117,7 +117,7 @@ IFilter::PreflightResult ComputeQuaternionConjugateFilter::preflightImpl(const D
 
 //------------------------------------------------------------------------------
 Result<> ComputeQuaternionConjugateFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                       const std::atomic_bool& shouldCancel) const
+                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeQuaternionConjugateInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeQuaternionConjugateFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeQuaternionConjugateFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -108,8 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSchmidsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSchmidsFilter.cpp
@@ -109,7 +109,7 @@ IFilter::UniquePointer ComputeSchmidsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeSchmidsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pLoadingDirectionValue = filterArgs.value<VectorFloat32Parameter::ValueType>(k_LoadingDirection_Key);
   auto pStoreAngleComponentsValue = filterArgs.value<bool>(k_StoreAngleComponents_Key);
@@ -185,7 +185,7 @@ IFilter::PreflightResult ComputeSchmidsFilter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> ComputeSchmidsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeSchmidsInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSchmidsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSchmidsFilter.hpp
@@ -106,7 +106,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -118,8 +119,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesFilter.cpp
@@ -89,8 +89,8 @@ IFilter::UniquePointer ComputeShapesFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ComputeShapesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                            const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ComputeShapesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                            const ExecutionContext& executionContext) const
 {
   auto pFeatureIdsArrayPath = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
   auto pCentroidsArrayPath = filterArgs.value<DataPath>(k_CentroidsArrayPath_Key);
@@ -159,7 +159,7 @@ IFilter::PreflightResult ComputeShapesFilter::preflightImpl(const DataStructure&
 
 //------------------------------------------------------------------------------
 Result<> ComputeShapesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                          const std::atomic_bool& shouldCancel) const
+                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeShapesInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesFilter.hpp
@@ -102,7 +102,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -114,8 +115,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesTriangleGeomFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesTriangleGeomFilter.cpp
@@ -90,7 +90,7 @@ IFilter::UniquePointer ComputeShapesTriangleGeomFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeShapesTriangleGeomFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                        const std::atomic_bool& shouldCancel) const
+                                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFaceLabelsArrayPathValue = filterArgs.value<DataPath>(k_FaceLabelsArrayPath_Key);
   auto pFeatureAttributeMatrixPath = filterArgs.value<DataPath>(k_FeatureAttributeMatrixPath_Key);
@@ -146,7 +146,7 @@ IFilter::PreflightResult ComputeShapesTriangleGeomFilter::preflightImpl(const Da
 
 //------------------------------------------------------------------------------
 Result<> ComputeShapesTriangleGeomFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                      const std::atomic_bool& shouldCancel) const
+                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeShapesTriangleGeomInputValues inputValues;
   inputValues.TriangleGeometryPath = filterArgs.value<DataPath>(k_TriGeometryDataPath_Key);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesTriangleGeomFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesTriangleGeomFilter.hpp
@@ -94,7 +94,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -106,8 +107,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSlipTransmissionMetricsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSlipTransmissionMetricsFilter.cpp
@@ -87,7 +87,7 @@ IFilter::UniquePointer ComputeSlipTransmissionMetricsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeSlipTransmissionMetricsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                             const std::atomic_bool& shouldCancel) const
+                                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pNeighborListPathValue = filterArgs.value<DataPath>(k_NeighborListArrayPath_Key);
   auto pFeaturePhasesPathValue = filterArgs.value<DataPath>(k_FeaturePhasesArrayPath_Key);
@@ -128,7 +128,7 @@ IFilter::PreflightResult ComputeSlipTransmissionMetricsFilter::preflightImpl(con
 
 //------------------------------------------------------------------------------
 Result<> ComputeSlipTransmissionMetricsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+                                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeSlipTransmissionMetricsInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSlipTransmissionMetricsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSlipTransmissionMetricsFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -113,8 +114,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeTwinBoundariesFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeTwinBoundariesFilter.cpp
@@ -107,7 +107,7 @@ IFilter::UniquePointer ComputeTwinBoundariesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeTwinBoundariesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFindCoherence = filterArgs.value<BoolParameter::ValueType>(k_FindCoherence_Key);
   auto pBoundariesArrayTypeChoice = filterArgs.value<ChoicesParameter::ValueType>(k_BoundariesArrayType_Key);
@@ -153,7 +153,7 @@ IFilter::PreflightResult ComputeTwinBoundariesFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> ComputeTwinBoundariesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeTwinBoundariesInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeTwinBoundariesFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeTwinBoundariesFilter.hpp
@@ -105,7 +105,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -117,8 +118,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertHexGridToSquareGridFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertHexGridToSquareGridFilter.cpp
@@ -117,7 +117,7 @@ IFilter::UniquePointer ConvertHexGridToSquareGridFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ConvertHexGridToSquareGridFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                         const std::atomic_bool& shouldCancel) const
+                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pUseMultipleFilesValue = filterArgs.value<bool>(k_MultipleFiles_Key);
   auto pInputFileListInfoValue = filterArgs.value<GeneratedFileListParameter::ValueType>(k_GeneratedFileList_Key);
@@ -189,7 +189,7 @@ IFilter::PreflightResult ConvertHexGridToSquareGridFilter::preflightImpl(const D
 
 //------------------------------------------------------------------------------
 Result<> ConvertHexGridToSquareGridFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                       const std::atomic_bool& shouldCancel) const
+                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ConvertHexGridToSquareGridInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertHexGridToSquareGridFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertHexGridToSquareGridFilter.hpp
@@ -92,7 +92,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -104,8 +105,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 
 private:
   int32 m_InstanceId;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertOrientationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertOrientationsFilter.cpp
@@ -364,7 +364,7 @@ IFilter::UniquePointer ConvertOrientationsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ConvertOrientationsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto inputType = static_cast<OrientationRepresentation::Type>(filterArgs.value<ChoicesParameter::ValueType>(k_InputType_Key));
   auto outputType = static_cast<OrientationRepresentation::Type>(filterArgs.value<ChoicesParameter::ValueType>(k_OutputType_Key));
@@ -413,7 +413,7 @@ IFilter::PreflightResult ConvertOrientationsFilter::preflightImpl(const DataStru
 
 //------------------------------------------------------------------------------
 Result<> ConvertOrientationsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Extract the actual input values from the 'filterArgs' object

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertOrientationsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertOrientationsFilter.hpp
@@ -108,7 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -120,8 +121,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertQuaternionFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertQuaternionFilter.cpp
@@ -89,7 +89,7 @@ IFilter::UniquePointer ConvertQuaternionFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ConvertQuaternionFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pQuaternionDataArrayPathValue = filterArgs.value<DataPath>(k_CellQuatsArrayPath_Key);
   auto pOutputDataArrayPathValue = pQuaternionDataArrayPathValue.replaceName(filterArgs.value<std::string>(k_OutputDataArrayName_Key));
@@ -122,7 +122,7 @@ IFilter::PreflightResult ConvertQuaternionFilter::preflightImpl(const DataStruct
 
 //------------------------------------------------------------------------------
 Result<> ConvertQuaternionFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                              const std::atomic_bool& shouldCancel) const
+                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ConvertQuaternionInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertQuaternionFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertQuaternionFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CreateEnsembleInfoFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CreateEnsembleInfoFilter.cpp
@@ -81,7 +81,7 @@ IFilter::UniquePointer CreateEnsembleInfoFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CreateEnsembleInfoFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                 const std::atomic_bool& shouldCancel) const
+                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pEnsembleValue = filterArgs.value<EnsembleInfoParameter::ValueType>(k_Ensemble_Key);
   auto pCellEnsembleAttributeMatrixNameValue = filterArgs.value<DataPath>(k_CellEnsembleAttributeMatrixPath_Key);
@@ -112,7 +112,7 @@ IFilter::PreflightResult CreateEnsembleInfoFilter::preflightImpl(const DataStruc
 
 //------------------------------------------------------------------------------
 Result<> CreateEnsembleInfoFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                               const std::atomic_bool& shouldCancel) const
+                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   CreateEnsembleInfoInputValues inputValues;
   inputValues.Ensemble = filterArgs.value<EnsembleInfoParameter::ValueType>(k_Ensemble_Key);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CreateEnsembleInfoFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CreateEnsembleInfoFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EBSDSegmentFeaturesFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EBSDSegmentFeaturesFilter.cpp
@@ -114,8 +114,8 @@ IFilter::UniquePointer EBSDSegmentFeaturesFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult EBSDSegmentFeaturesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult EBSDSegmentFeaturesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                                  const ExecutionContext& executionContext) const
 {
   auto pQuatsArrayPathValue = args.value<DataPath>(k_QuatsArrayPath_Key);
   auto pCellPhasesArrayPathValue = args.value<DataPath>(k_CellPhasesArrayPath_Key);
@@ -187,7 +187,7 @@ IFilter::PreflightResult EBSDSegmentFeaturesFilter::preflightImpl(const DataStru
 
 //------------------------------------------------------------------------------
 Result<> EBSDSegmentFeaturesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   EBSDSegmentFeaturesInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EBSDSegmentFeaturesFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EBSDSegmentFeaturesFilter.hpp
@@ -104,7 +104,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -116,8 +117,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EbsdToH5EbsdFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EbsdToH5EbsdFilter.cpp
@@ -84,8 +84,8 @@ IFilter::UniquePointer EbsdToH5EbsdFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult EbsdToH5EbsdFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult EbsdToH5EbsdFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                           const ExecutionContext& executionContext) const
 {
   auto generatedFileListInfo = filterArgs.value<GeneratedFileListParameter::ValueType>(k_InputFileListInfo_Key);
   auto referenceFrame = filterArgs.value<ChoicesParameter::ValueType>(k_ReferenceFrame_Key);
@@ -170,7 +170,7 @@ IFilter::PreflightResult EbsdToH5EbsdFilter::preflightImpl(const DataStructure& 
 
 //------------------------------------------------------------------------------
 Result<> EbsdToH5EbsdFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                         const std::atomic_bool& shouldCancel) const
+                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   EbsdToH5EbsdInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EbsdToH5EbsdFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EbsdToH5EbsdFilter.hpp
@@ -91,7 +91,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -103,8 +104,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/MergeTwinsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/MergeTwinsFilter.cpp
@@ -118,8 +118,8 @@ IFilter::UniquePointer MergeTwinsFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult MergeTwinsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                         const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult MergeTwinsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                         const ExecutionContext& executionContext) const
 {
   auto pContiguousNeighborListArrayPathValue = filterArgs.value<DataPath>(k_ContiguousNeighborListArrayPath_Key);
   auto pFeaturePhasesArrayPathValue = filterArgs.value<DataPath>(k_FeaturePhasesArrayPath_Key);
@@ -202,7 +202,7 @@ IFilter::PreflightResult MergeTwinsFilter::preflightImpl(const DataStructure& da
 
 //------------------------------------------------------------------------------
 Result<> MergeTwinsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                       const std::atomic_bool& shouldCancel) const
+                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto seed = filterArgs.value<std::mt19937_64::result_type>(k_SeedValue_Key);
   if(!filterArgs.value<bool>(k_UseSeed_Key))

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/MergeTwinsFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/MergeTwinsFilter.hpp
@@ -107,7 +107,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -119,8 +120,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.cpp
@@ -98,7 +98,7 @@ IFilter::UniquePointer NeighborOrientationCorrelationFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult NeighborOrientationCorrelationFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                             const std::atomic_bool& shouldCancel) const
+                                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pImageGeomPathValue = filterArgs.value<DataPath>(k_ImageGeometryPath_Key);
   auto pMinConfidenceValue = filterArgs.value<float32>(k_MinConfidence_Key);
@@ -239,7 +239,7 @@ IFilter::PreflightResult NeighborOrientationCorrelationFilter::preflightImpl(con
 
 //------------------------------------------------------------------------------
 Result<> NeighborOrientationCorrelationFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+                                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   NeighborOrientationCorrelationInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.hpp
@@ -102,7 +102,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -114,8 +115,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadAngDataFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadAngDataFilter.cpp
@@ -88,8 +88,8 @@ IFilter::UniquePointer ReadAngDataFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ReadAngDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ReadAngDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto pInputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFile_Key);
   auto pImageGeometryPath = filterArgs.value<DataPath>(k_CreatedImageGeometryPath_Key);
@@ -216,7 +216,7 @@ IFilter::PreflightResult ReadAngDataFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> ReadAngDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReadAngDataInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadAngDataFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadAngDataFilter.hpp
@@ -103,7 +103,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -115,8 +116,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 
 private:
   std::shared_ptr<ReadAngDataPrivate> m_AngDataPrivate;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadChannel5DataFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadChannel5DataFilter.cpp
@@ -96,7 +96,7 @@ IFilter::UniquePointer ReadChannel5DataFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ReadChannel5DataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pInputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFile_Key);
   auto pImageGeometryPath = filterArgs.value<DataPath>(k_CreatedImageGeometryPath_Key);
@@ -261,7 +261,7 @@ IFilter::PreflightResult ReadChannel5DataFilter::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> ReadChannel5DataFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                             const std::atomic_bool& shouldCancel) const
+                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReadChannel5DataInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadChannel5DataFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadChannel5DataFilter.hpp
@@ -100,7 +100,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadCtfDataFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadCtfDataFilter.cpp
@@ -94,8 +94,8 @@ IFilter::UniquePointer ReadCtfDataFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ReadCtfDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ReadCtfDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto pInputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFile_Key);
   auto pImageGeometryPath = filterArgs.value<DataPath>(k_CreatedImageGeometryPath_Key);
@@ -214,7 +214,7 @@ IFilter::PreflightResult ReadCtfDataFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> ReadCtfDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReadCtfDataInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadCtfDataFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadCtfDataFilter.hpp
@@ -100,7 +100,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadEnsembleInfoFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadEnsembleInfoFilter.cpp
@@ -86,7 +86,7 @@ IFilter::UniquePointer ReadEnsembleInfoFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ReadEnsembleInfoFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pInputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFile_Key).string();
   auto pDataContainerNameValue = filterArgs.value<DataPath>(k_ParentGroupPath_Key);
@@ -137,7 +137,7 @@ IFilter::PreflightResult ReadEnsembleInfoFilter::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> ReadEnsembleInfoFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                             const std::atomic_bool& shouldCancel) const
+                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReadEnsembleInfoInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadEnsembleInfoFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadEnsembleInfoFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadGrainMapper3DFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadGrainMapper3DFilter.cpp
@@ -112,7 +112,7 @@ IFilter::VersionType ReadGrainMapper3DFilter::parametersVersion() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ReadGrainMapper3DFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pInputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFile_Key);
   auto pConvertPhaseData = filterArgs.value<bool>(k_ConvertPhaseToInt32_Key);
@@ -238,7 +238,7 @@ IFilter::PreflightResult ReadGrainMapper3DFilter::preflightImpl(const DataStruct
 
 //------------------------------------------------------------------------------
 Result<> ReadGrainMapper3DFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                              const std::atomic_bool& shouldCancel) const
+                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReadGrainMapper3DInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadGrainMapper3DFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadGrainMapper3DFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -108,8 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EbsdFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EbsdFilter.cpp
@@ -90,8 +90,8 @@ IFilter::UniquePointer ReadH5EbsdFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ReadH5EbsdFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                         const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ReadH5EbsdFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                         const ExecutionContext& executionContext) const
 {
 
   auto pReadH5EbsdFilterValue = filterArgs.value<ReadH5EbsdFileParameter::ValueType>(k_ReadH5EbsdParameter_Key);
@@ -265,7 +265,7 @@ IFilter::PreflightResult ReadH5EbsdFilter::preflightImpl(const DataStructure& da
 
 //------------------------------------------------------------------------------
 Result<> ReadH5EbsdFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                       const std::atomic_bool& shouldCancel) const
+                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Extract the actual input values from the 'filterArgs' object

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EbsdFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EbsdFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EspritDataFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EspritDataFilter.cpp
@@ -100,7 +100,7 @@ IFilter::UniquePointer ReadH5EspritDataFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ReadH5EspritDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pSelectedScanNamesValue = filterArgs.value<OEMEbsdScanSelectionParameter::ValueType>(k_SelectedScanNames_Key);
   auto pZSpacingValue = filterArgs.value<float32>(k_ZSpacing_Key);
@@ -213,7 +213,7 @@ IFilter::PreflightResult ReadH5EspritDataFilter::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> ReadH5EspritDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                             const std::atomic_bool& shouldCancel) const
+                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReadH5DataInputValues inputValues;
   ReadH5EspritDataInputValues espritInputValues;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EspritDataFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EspritDataFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -113,8 +114,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OimDataFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OimDataFilter.cpp
@@ -95,8 +95,8 @@ IFilter::UniquePointer ReadH5OimDataFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ReadH5OimDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                            const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ReadH5OimDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                            const ExecutionContext& executionContext) const
 {
   auto pSelectedScanNamesValue = filterArgs.value<OEMEbsdScanSelectionParameter::ValueType>(k_SelectedScanNames_Key);
   auto pZSpacingValue = filterArgs.value<float32>(k_ZSpacing_Key);
@@ -205,7 +205,7 @@ IFilter::PreflightResult ReadH5OimDataFilter::preflightImpl(const DataStructure&
 
 //------------------------------------------------------------------------------
 Result<> ReadH5OimDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                          const std::atomic_bool& shouldCancel) const
+                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReadH5DataInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OimDataFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OimDataFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -113,8 +114,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OinaDataFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OinaDataFilter.cpp
@@ -98,7 +98,7 @@ IFilter::UniquePointer ReadH5OinaDataFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ReadH5OinaDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pSelectedScanNamesValue = filterArgs.value<OEMEbsdScanSelectionParameter::ValueType>(k_SelectedScanNames_Key);
   auto pZSpacingValue = filterArgs.value<float32>(k_ZSpacing_Key);
@@ -201,7 +201,7 @@ IFilter::PreflightResult ReadH5OinaDataFilter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> ReadH5OinaDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReadH5DataInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OinaDataFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OinaDataFilter.hpp
@@ -95,7 +95,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -107,8 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RodriguesConvertorFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RodriguesConvertorFilter.cpp
@@ -84,7 +84,7 @@ IFilter::UniquePointer RodriguesConvertorFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult RodriguesConvertorFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                 const std::atomic_bool& shouldCancel) const
+                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pRodriguesDataArrayPathValue = filterArgs.value<DataPath>(k_RodriguesDataArrayPath_Key);
   auto pOutputDataArrayPathValue = pRodriguesDataArrayPathValue.replaceName(filterArgs.value<std::string>(k_OutputDataArrayName_Key));
@@ -117,7 +117,7 @@ IFilter::PreflightResult RodriguesConvertorFilter::preflightImpl(const DataStruc
 
 //------------------------------------------------------------------------------
 Result<> RodriguesConvertorFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                               const std::atomic_bool& shouldCancel) const
+                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   RodriguesConvertorInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RodriguesConvertorFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RodriguesConvertorFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -108,8 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RotateEulerRefFrameFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RotateEulerRefFrameFilter.cpp
@@ -74,7 +74,7 @@ IFilter::UniquePointer RotateEulerRefFrameFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult RotateEulerRefFrameFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pRotationAxisAngleValue = filterArgs.value<VectorFloat32Parameter::ValueType>(k_RotationAxisAngle_Key);
   auto pCellEulerAnglesArrayPathValue = filterArgs.value<DataPath>(k_EulerAnglesArrayPath_Key);
@@ -92,7 +92,7 @@ IFilter::PreflightResult RotateEulerRefFrameFilter::preflightImpl(const DataStru
 
 //------------------------------------------------------------------------------
 Result<> RotateEulerRefFrameFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   nx::core::RotateEulerRefFrameInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RotateEulerRefFrameFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RotateEulerRefFrameFilter.hpp
@@ -95,7 +95,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -107,8 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDGMTFileFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDGMTFileFilter.cpp
@@ -86,7 +86,7 @@ IFilter::UniquePointer WriteGBCDGMTFileFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WriteGBCDGMTFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pPhaseOfInterestValue = filterArgs.value<int32>(k_PhaseOfInterest_Key);
   auto pMisorientationRotationValue = filterArgs.value<VectorFloat32Parameter::ValueType>(k_MisorientationRotation_Key);
@@ -128,7 +128,7 @@ IFilter::PreflightResult WriteGBCDGMTFileFilter::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> WriteGBCDGMTFileFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                             const std::atomic_bool& shouldCancel) const
+                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto atomicFileResult = AtomicFile::Create(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
   if(atomicFileResult.invalid())

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDGMTFileFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDGMTFileFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDTriangleDataFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDTriangleDataFilter.cpp
@@ -89,7 +89,7 @@ IFilter::UniquePointer WriteGBCDTriangleDataFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WriteGBCDTriangleDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pOutputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key);
   auto pSurfaceMeshFaceLabelsArrayPathValue = filterArgs.value<DataPath>(k_SurfaceMeshFaceLabelsArrayPath_Key);
@@ -114,7 +114,7 @@ IFilter::PreflightResult WriteGBCDTriangleDataFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> WriteGBCDTriangleDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto atomicFileResult = AtomicFile::Create(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
   if(atomicFileResult.invalid())

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDTriangleDataFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDTriangleDataFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteINLFileFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteINLFileFilter.cpp
@@ -95,8 +95,8 @@ IFilter::UniquePointer WriteINLFileFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult WriteINLFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult WriteINLFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                           const ExecutionContext& executionContext) const
 {
   auto pMaterialNameArrayPathValue = filterArgs.value<DataPath>(k_MaterialNameArrayPath_Key);
 
@@ -116,7 +116,7 @@ IFilter::PreflightResult WriteINLFileFilter::preflightImpl(const DataStructure& 
 
 //------------------------------------------------------------------------------
 Result<> WriteINLFileFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                         const std::atomic_bool& shouldCancel) const
+                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto atomicFileResult = AtomicFile::Create(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
   if(atomicFileResult.invalid())

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteINLFileFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteINLFileFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -113,8 +114,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WritePoleFigureFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WritePoleFigureFilter.cpp
@@ -167,7 +167,7 @@ IFilter::UniquePointer WritePoleFigureFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WritePoleFigureFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
 
   auto pTitleValue = filterArgs.value<StringParameter::ValueType>(k_Title_Key);
@@ -277,7 +277,7 @@ IFilter::PreflightResult WritePoleFigureFilter::preflightImpl(const DataStructur
 
 //------------------------------------------------------------------------------
 Result<> WritePoleFigureFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
 
   WritePoleFigureInputValues inputValues;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WritePoleFigureFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WritePoleFigureFilter.hpp
@@ -117,7 +117,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -129,8 +130,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteStatsGenOdfAngleFileFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteStatsGenOdfAngleFileFilter.cpp
@@ -97,7 +97,7 @@ IFilter::UniquePointer WriteStatsGenOdfAngleFileFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WriteStatsGenOdfAngleFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                        const std::atomic_bool& shouldCancel) const
+                                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pOutputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key);
   auto pWeightValue = filterArgs.value<float32>(k_Weight_Key);
@@ -139,7 +139,7 @@ IFilter::PreflightResult WriteStatsGenOdfAngleFileFilter::preflightImpl(const Da
 
 //------------------------------------------------------------------------------
 Result<> WriteStatsGenOdfAngleFileFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                      const std::atomic_bool& shouldCancel) const
+                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   WriteStatsGenOdfAngleFileInputValues inputValues;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteStatsGenOdfAngleFileFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteStatsGenOdfAngleFileFilter.hpp
@@ -108,7 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -120,8 +121,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Parameters/OEMEbsdScanSelectionParameter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Parameters/OEMEbsdScanSelectionParameter.cpp
@@ -48,6 +48,15 @@ IParameter::VersionType OEMEbsdScanSelectionParameter::getVersion() const
 }
 
 //-----------------------------------------------------------------------------
+std::any OEMEbsdScanSelectionParameter::construct(const Arguments& args, const ExecutionContext& executionContext) const
+{
+  auto value = args.value<ValueType>(name());
+  std::filesystem::path absolutePath = executionContext.getAbsolutePath(value.inputFilePath);
+  value.inputFilePath = absolutePath.string();
+  return value;
+}
+
+//-----------------------------------------------------------------------------
 nlohmann::json OEMEbsdScanSelectionParameter::toJsonImpl(const std::any& value) const
 {
   const auto& data = GetAnyRef<ValueType>(value);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Parameters/OEMEbsdScanSelectionParameter.h
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Parameters/OEMEbsdScanSelectionParameter.h
@@ -99,6 +99,16 @@ public:
   VersionType getVersion() const override;
 
   /**
+   * @brief Constructs an input value from the given arguments.
+   * By default, accesses a singular value by key and returns that.
+   * May be overriden by subclasses that depend on other parameters.
+   * @param args
+   * @param executionContext
+   * @return
+   */
+  std::any construct(const Arguments& args, const ExecutionContext& executionContext) const override;
+
+  /**
    * @brief
    * @param value
    * @return

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Parameters/ReadH5EbsdFileParameter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Parameters/ReadH5EbsdFileParameter.cpp
@@ -196,6 +196,15 @@ std::any ReadH5EbsdFileParameter::defaultValue() const
 }
 
 //-----------------------------------------------------------------------------
+std::any ReadH5EbsdFileParameter::construct(const Arguments& args, const ExecutionContext& executionContext) const
+{
+  auto value = args.value<ValueType>(name());
+  std::filesystem::path absolutePath = executionContext.getAbsolutePath(value.inputFilePath);
+  value.inputFilePath = absolutePath.string();
+  return value;
+}
+
+//-----------------------------------------------------------------------------
 Result<> ReadH5EbsdFileParameter::validate(const std::any& valueRef) const
 {
   std::vector<Error> errors;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Parameters/ReadH5EbsdFileParameter.h
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Parameters/ReadH5EbsdFileParameter.h
@@ -79,6 +79,16 @@ public:
   VersionType getVersion() const override;
 
   /**
+   * @brief Constructs an input value from the given arguments.
+   * By default, accesses a singular value by key and returns that.
+   * May be overriden by subclasses that depend on other parameters.
+   * @param args
+   * @param executionContext
+   * @return
+   */
+  std::any construct(const Arguments& args, const ExecutionContext& executionContext) const override;
+
+  /**
    * @brief
    * @param value
    * @return

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AddBadDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AddBadDataFilter.cpp
@@ -96,8 +96,8 @@ IFilter::UniquePointer AddBadDataFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult AddBadDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                         const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult AddBadDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                         const ExecutionContext& executionContext) const
 {
   auto pPoissonNoiseValue = filterArgs.value<bool>(k_PoissonNoise_Key);
   auto pPoissonVolFractionValue = filterArgs.value<float32>(k_PoissonVolFraction_Key);
@@ -144,7 +144,7 @@ IFilter::PreflightResult AddBadDataFilter::preflightImpl(const DataStructure& da
 
 //------------------------------------------------------------------------------
 Result<> AddBadDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                       const std::atomic_bool& shouldCancel) const
+                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto seed = filterArgs.value<uint64>(k_SeedValue_Key);
   if(!filterArgs.value<bool>(k_UseSeed_Key))

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AddBadDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AddBadDataFilter.hpp
@@ -102,7 +102,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -114,8 +115,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignGeometriesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignGeometriesFilter.cpp
@@ -427,7 +427,7 @@ IFilter::UniquePointer AlignGeometriesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult AlignGeometriesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto alignmentType = filterArgs.value<uint64>(k_AlignmentType_Key);
 
@@ -443,7 +443,7 @@ IFilter::PreflightResult AlignGeometriesFilter::preflightImpl(const DataStructur
 
 //------------------------------------------------------------------------------
 Result<> AlignGeometriesFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto movingGeometryPath = args.value<DataPath>(k_MovingGeometry_Key);
   auto targetGeometryPath = args.value<DataPath>(k_TargetGeometry_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignGeometriesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignGeometriesFilter.hpp
@@ -90,7 +90,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief
@@ -100,8 +101,8 @@ protected:
    * @param messageHandler
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignSectionsFeatureCentroidFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignSectionsFeatureCentroidFilter.cpp
@@ -135,7 +135,7 @@ IFilter::UniquePointer AlignSectionsFeatureCentroidFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult AlignSectionsFeatureCentroidFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                           const std::atomic_bool& shouldCancel) const
+                                                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pReferenceSliceValue = filterArgs.value<int32>(k_ReferenceSlice_Key);
   auto pGoodVoxelsArrayPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
@@ -204,7 +204,7 @@ IFilter::PreflightResult AlignSectionsFeatureCentroidFilter::preflightImpl(const
 
 //------------------------------------------------------------------------------
 Result<> AlignSectionsFeatureCentroidFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                         const std::atomic_bool& shouldCancel) const
+                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   AlignSectionsFeatureCentroidInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignSectionsFeatureCentroidFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignSectionsFeatureCentroidFilter.hpp
@@ -105,7 +105,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -117,8 +118,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignSectionsListFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignSectionsListFilter.cpp
@@ -95,7 +95,7 @@ IFilter::UniquePointer AlignSectionsListFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult AlignSectionsListFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pUseFileValue = filterArgs.value<ChoicesParameter::ValueType>(k_InputArrayType_Key);
   auto pSelectedImageGeometryPathValue = filterArgs.value<GeometrySelectionParameter::ValueType>(k_SelectedImageGeometryPath_Key);
@@ -138,7 +138,7 @@ IFilter::PreflightResult AlignSectionsListFilter::preflightImpl(const DataStruct
 
 //------------------------------------------------------------------------------
 Result<> AlignSectionsListFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                              const std::atomic_bool& shouldCancel) const
+                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   AlignSectionsListInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignSectionsListFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignSectionsListFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -108,8 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AppendImageGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AppendImageGeometryFilter.cpp
@@ -91,7 +91,7 @@ IFilter::UniquePointer AppendImageGeometryFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult AppendImageGeometryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pInputGeometriesPathsValue = filterArgs.value<std::vector<DataPath>>(k_InputGeometries_Key);
   auto pDestinationGeometryPathValue = filterArgs.value<DataPath>(k_DestinationGeometry_Key);
@@ -310,7 +310,7 @@ IFilter::PreflightResult AppendImageGeometryFilter::preflightImpl(const DataStru
 
 //------------------------------------------------------------------------------
 Result<> AppendImageGeometryFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   AppendImageGeometryInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AppendImageGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AppendImageGeometryFilter.hpp
@@ -100,7 +100,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApplyTransformationToGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApplyTransformationToGeometryFilter.cpp
@@ -150,7 +150,7 @@ IFilter::UniquePointer ApplyTransformationToGeometryFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ApplyTransformationToGeometryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                            const std::atomic_bool& shouldCancel) const
+                                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pTransformationMatrixTypeValue = filterArgs.value<ChoicesParameter::ValueType>(k_TransformationType_Key);
   auto tableData = filterArgs.value<DynamicTableParameter::ValueType>(k_ManualTransformationMatrix_Key);
@@ -469,7 +469,7 @@ IFilter::PreflightResult ApplyTransformationToGeometryFilter::preflightImpl(cons
 
 //------------------------------------------------------------------------------
 Result<> ApplyTransformationToGeometryFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ApplyTransformationToGeometryInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApplyTransformationToGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApplyTransformationToGeometryFilter.hpp
@@ -105,7 +105,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -117,8 +118,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApproximatePointCloudHullFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApproximatePointCloudHullFilter.cpp
@@ -89,7 +89,7 @@ IFilter::UniquePointer ApproximatePointCloudHullFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ApproximatePointCloudHullFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                        const std::atomic_bool& shouldCancel) const
+                                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto gridResolution = args.value<std::vector<float32>>(k_GridResolution_Key);
   auto vertexGeomPath = args.value<DataPath>(k_VertexGeomPath_Key);
@@ -114,7 +114,7 @@ IFilter::PreflightResult ApproximatePointCloudHullFilter::preflightImpl(const Da
 
 //------------------------------------------------------------------------------
 Result<> ApproximatePointCloudHullFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                      const std::atomic_bool& shouldCancel) const
+                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto gridResolution = args.value<std::vector<float32>>(k_GridResolution_Key);
   auto numberOfEmptyNeighbors = args.value<uint64>(k_MinEmptyNeighbors_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApproximatePointCloudHullFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApproximatePointCloudHullFilter.hpp
@@ -95,7 +95,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -107,8 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ArrayCalculatorFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ArrayCalculatorFilter.cpp
@@ -76,7 +76,7 @@ IFilter::UniquePointer ArrayCalculatorFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ArrayCalculatorFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pInfixEquationValue = filterArgs.value<CalculatorParameter::ValueType>(k_CalculatorParameter_Key);
   auto pScalarTypeValue = filterArgs.value<NumericTypeParameter::ValueType>(k_ScalarType_Key);
@@ -180,7 +180,7 @@ IFilter::PreflightResult ArrayCalculatorFilter::preflightImpl(const DataStructur
 
 //------------------------------------------------------------------------------
 Result<> ArrayCalculatorFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
 
   ArrayCalculatorInputValues inputValues;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ArrayCalculatorFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ArrayCalculatorFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -108,8 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ChangeAngleRepresentationFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ChangeAngleRepresentationFilter.cpp
@@ -113,7 +113,7 @@ IFilter::UniquePointer ChangeAngleRepresentationFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ChangeAngleRepresentationFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                        const std::atomic_bool& shouldCancel) const
+                                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pConversionTypeValue = filterArgs.value<ChoicesParameter::ValueType>(k_ConversionType_Key);
 
@@ -127,7 +127,7 @@ IFilter::PreflightResult ChangeAngleRepresentationFilter::preflightImpl(const Da
 
 //------------------------------------------------------------------------------
 Result<> ChangeAngleRepresentationFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                      const std::atomic_bool& shouldCancel) const
+                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /****************************************************************************
    * Extract the actual input values from the 'filterArgs' object

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ChangeAngleRepresentationFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ChangeAngleRepresentationFilter.hpp
@@ -95,7 +95,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -107,8 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineAttributeArraysFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineAttributeArraysFilter.cpp
@@ -87,7 +87,7 @@ IFilter::UniquePointer CombineAttributeArraysFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CombineAttributeArraysFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   // auto normalizeDataValue = filterArgs.value<bool>(k_NormalizeData_Key);
   auto moveValuesValue = filterArgs.value<bool>(k_MoveValues_Key);
@@ -149,7 +149,7 @@ IFilter::PreflightResult CombineAttributeArraysFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> CombineAttributeArraysFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   CombineAttributeArraysInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineAttributeArraysFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineAttributeArraysFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineNodeBasedGeometriesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineNodeBasedGeometriesFilter.cpp
@@ -83,53 +83,29 @@ std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindGeometryElements(cons
 
 std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindVertexElements(const IGeometry* geom)
 {
-  auto getVerticesArrayFunc = [](const INodeGeometry0D* ptr) -> auto
-  {
-    return ptr->getVertices();
-  };
-  auto getVertexAttrMatrixFunc = [](const INodeGeometry0D* ptr) -> auto
-  {
-    return ptr->getVertexAttributeMatrix();
-  };
+  auto getVerticesArrayFunc = [](const INodeGeometry0D* ptr) -> auto { return ptr->getVertices(); };
+  auto getVertexAttrMatrixFunc = [](const INodeGeometry0D* ptr) -> auto { return ptr->getVertexAttributeMatrix(); };
   return FindGeometryElements<INodeGeometry0D>(geom, getVerticesArrayFunc, getVertexAttrMatrixFunc);
 }
 
 std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindEdgeElements(const IGeometry* geom)
 {
-  auto getEdgesArrayFunc = [](const INodeGeometry1D* ptr) -> auto
-  {
-    return ptr->getEdges();
-  };
-  auto getEdgeAttrMatrixFunc = [](const INodeGeometry1D* ptr) -> auto
-  {
-    return ptr->getEdgeAttributeMatrix();
-  };
+  auto getEdgesArrayFunc = [](const INodeGeometry1D* ptr) -> auto { return ptr->getEdges(); };
+  auto getEdgeAttrMatrixFunc = [](const INodeGeometry1D* ptr) -> auto { return ptr->getEdgeAttributeMatrix(); };
   return FindGeometryElements<INodeGeometry1D>(geom, getEdgesArrayFunc, getEdgeAttrMatrixFunc);
 }
 
 std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindFaceElements(const IGeometry* geom)
 {
-  auto getFacesArrayFunc = [](const INodeGeometry2D* ptr) -> auto
-  {
-    return ptr->getFaces();
-  };
-  auto getFaceAttrMatrixFunc = [](const INodeGeometry2D* ptr) -> auto
-  {
-    return ptr->getFaceAttributeMatrix();
-  };
+  auto getFacesArrayFunc = [](const INodeGeometry2D* ptr) -> auto { return ptr->getFaces(); };
+  auto getFaceAttrMatrixFunc = [](const INodeGeometry2D* ptr) -> auto { return ptr->getFaceAttributeMatrix(); };
   return FindGeometryElements<INodeGeometry2D>(geom, getFacesArrayFunc, getFaceAttrMatrixFunc);
 }
 
 std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindPolyElements(const IGeometry* geom)
 {
-  auto getPolyArrayFunc = [](const INodeGeometry3D* ptr) -> auto
-  {
-    return ptr->getPolyhedra();
-  };
-  auto getPolyAttrMatrixFunc = [](const INodeGeometry3D* ptr) -> auto
-  {
-    return ptr->getPolyhedraAttributeMatrix();
-  };
+  auto getPolyArrayFunc = [](const INodeGeometry3D* ptr) -> auto { return ptr->getPolyhedra(); };
+  auto getPolyAttrMatrixFunc = [](const INodeGeometry3D* ptr) -> auto { return ptr->getPolyhedraAttributeMatrix(); };
   return FindGeometryElements<INodeGeometry3D>(geom, getPolyArrayFunc, getPolyAttrMatrixFunc);
 }
 
@@ -527,7 +503,7 @@ IFilter::UniquePointer CombineNodeBasedGeometriesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CombineNodeBasedGeometriesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                         const std::atomic_bool& shouldCancel) const
+                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto inputGeometryPaths = args.value<MultiPathSelectionParameter::ValueType>(k_InputGeometries_Key);
   auto outputGeometryPath = args.value<DataGroupCreationParameter::ValueType>(k_OutputGeometryPath_Key);
@@ -946,7 +922,7 @@ IFilter::PreflightResult CombineNodeBasedGeometriesFilter::preflightImpl(const D
 
 //------------------------------------------------------------------------------
 Result<> CombineNodeBasedGeometriesFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                       const std::atomic_bool& shouldCancel) const
+                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   CombineNodeBasedGeometriesInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineNodeBasedGeometriesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineNodeBasedGeometriesFilter.cpp
@@ -83,29 +83,53 @@ std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindGeometryElements(cons
 
 std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindVertexElements(const IGeometry* geom)
 {
-  auto getVerticesArrayFunc = [](const INodeGeometry0D* ptr) -> auto { return ptr->getVertices(); };
-  auto getVertexAttrMatrixFunc = [](const INodeGeometry0D* ptr) -> auto { return ptr->getVertexAttributeMatrix(); };
+  auto getVerticesArrayFunc = [](const INodeGeometry0D* ptr) -> auto
+  {
+    return ptr->getVertices();
+  };
+  auto getVertexAttrMatrixFunc = [](const INodeGeometry0D* ptr) -> auto
+  {
+    return ptr->getVertexAttributeMatrix();
+  };
   return FindGeometryElements<INodeGeometry0D>(geom, getVerticesArrayFunc, getVertexAttrMatrixFunc);
 }
 
 std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindEdgeElements(const IGeometry* geom)
 {
-  auto getEdgesArrayFunc = [](const INodeGeometry1D* ptr) -> auto { return ptr->getEdges(); };
-  auto getEdgeAttrMatrixFunc = [](const INodeGeometry1D* ptr) -> auto { return ptr->getEdgeAttributeMatrix(); };
+  auto getEdgesArrayFunc = [](const INodeGeometry1D* ptr) -> auto
+  {
+    return ptr->getEdges();
+  };
+  auto getEdgeAttrMatrixFunc = [](const INodeGeometry1D* ptr) -> auto
+  {
+    return ptr->getEdgeAttributeMatrix();
+  };
   return FindGeometryElements<INodeGeometry1D>(geom, getEdgesArrayFunc, getEdgeAttrMatrixFunc);
 }
 
 std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindFaceElements(const IGeometry* geom)
 {
-  auto getFacesArrayFunc = [](const INodeGeometry2D* ptr) -> auto { return ptr->getFaces(); };
-  auto getFaceAttrMatrixFunc = [](const INodeGeometry2D* ptr) -> auto { return ptr->getFaceAttributeMatrix(); };
+  auto getFacesArrayFunc = [](const INodeGeometry2D* ptr) -> auto
+  {
+    return ptr->getFaces();
+  };
+  auto getFaceAttrMatrixFunc = [](const INodeGeometry2D* ptr) -> auto
+  {
+    return ptr->getFaceAttributeMatrix();
+  };
   return FindGeometryElements<INodeGeometry2D>(geom, getFacesArrayFunc, getFaceAttrMatrixFunc);
 }
 
 std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindPolyElements(const IGeometry* geom)
 {
-  auto getPolyArrayFunc = [](const INodeGeometry3D* ptr) -> auto { return ptr->getPolyhedra(); };
-  auto getPolyAttrMatrixFunc = [](const INodeGeometry3D* ptr) -> auto { return ptr->getPolyhedraAttributeMatrix(); };
+  auto getPolyArrayFunc = [](const INodeGeometry3D* ptr) -> auto
+  {
+    return ptr->getPolyhedra();
+  };
+  auto getPolyAttrMatrixFunc = [](const INodeGeometry3D* ptr) -> auto
+  {
+    return ptr->getPolyhedraAttributeMatrix();
+  };
   return FindGeometryElements<INodeGeometry3D>(geom, getPolyArrayFunc, getPolyAttrMatrixFunc);
 }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineNodeBasedGeometriesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineNodeBasedGeometriesFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.
@@ -107,8 +108,8 @@ protected:
    * @param messageHandler
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineStlFilesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineStlFilesFilter.cpp
@@ -114,7 +114,7 @@ IFilter::UniquePointer CombineStlFilesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CombineStlFilesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pStlFilesPathValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_StlFilesPath_Key);
   auto pTriangleDataContainerNameValue = filterArgs.value<DataPath>(k_TriangleGeometryPath_Key);
@@ -210,7 +210,7 @@ IFilter::PreflightResult CombineStlFilesFilter::preflightImpl(const DataStructur
 
 //------------------------------------------------------------------------------
 Result<> CombineStlFilesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pVertexAttributeMatrixNameValue = filterArgs.value<std::string>(k_VertexAttributeMatrixName_Key);
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineStlFilesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineStlFilesFilter.hpp
@@ -107,7 +107,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -119,8 +120,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayHistogramFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayHistogramFilter.cpp
@@ -100,7 +100,7 @@ IFilter::UniquePointer ComputeArrayHistogramFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeArrayHistogramFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pNumberOfBinsValue = filterArgs.value<int32>(k_NumberOfBins_Key);
   auto pNewDataGroupValue = filterArgs.value<bool>(k_CreateNewDataGroup_Key);
@@ -147,7 +147,7 @@ IFilter::PreflightResult ComputeArrayHistogramFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> ComputeArrayHistogramFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeArrayHistogramInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayHistogramFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayHistogramFilter.hpp
@@ -103,7 +103,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -115,8 +116,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayStatisticsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayStatisticsFilter.cpp
@@ -333,7 +333,7 @@ IFilter::UniquePointer ComputeArrayStatisticsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeArrayStatisticsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFindHistogramValue = filterArgs.value<bool>(k_FindHistogram_Key);
   auto pNumBinsValue = filterArgs.value<int32>(k_NumBins_Key);
@@ -456,7 +456,7 @@ IFilter::PreflightResult ComputeArrayStatisticsFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> ComputeArrayStatisticsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeArrayStatisticsInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayStatisticsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayStatisticsFilter.hpp
@@ -131,7 +131,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -143,8 +144,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBiasedFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBiasedFeaturesFilter.cpp
@@ -87,7 +87,7 @@ IFilter::UniquePointer ComputeBiasedFeaturesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeBiasedFeaturesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pCalcByPhaseValue = filterArgs.value<bool>(k_CalcByPhase_Key);
   auto pImageGeometryPath = filterArgs.value<DataPath>(k_GeometryPath_Key);
@@ -121,7 +121,7 @@ IFilter::PreflightResult ComputeBiasedFeaturesFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> ComputeBiasedFeaturesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeBiasedFeaturesInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBiasedFeaturesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBiasedFeaturesFilter.hpp
@@ -99,7 +99,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -111,8 +112,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundaryCellsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundaryCellsFilter.cpp
@@ -85,7 +85,7 @@ IFilter::UniquePointer ComputeBoundaryCellsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeBoundaryCellsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                   const std::atomic_bool& shouldCancel) const
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pImageGeometryPath = filterArgs.value<DataPath>(k_GeometryPath_Key);
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_FeatureIdsArrayPath_Key);
@@ -116,7 +116,7 @@ IFilter::PreflightResult ComputeBoundaryCellsFilter::preflightImpl(const DataStr
 
 //------------------------------------------------------------------------------
 Result<> ComputeBoundaryCellsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                 const std::atomic_bool& shouldCancel) const
+                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeBoundaryCellsInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundaryCellsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundaryCellsFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundaryElementFractionsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundaryElementFractionsFilter.cpp
@@ -84,7 +84,7 @@ IFilter::UniquePointer ComputeBoundaryElementFractionsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeBoundaryElementFractionsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                              const std::atomic_bool& shouldCancel) const
+                                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFeatureDataAMPathValue = filterArgs.value<DataPath>(k_FeatureDataAMPath_Key);
   auto pBoundaryCellFractionsArrayPathValue = filterArgs.value<std::string>(k_BoundaryCellFractionsArrayName_Key);
@@ -105,7 +105,7 @@ IFilter::PreflightResult ComputeBoundaryElementFractionsFilter::preflightImpl(co
 
 //------------------------------------------------------------------------------
 Result<> ComputeBoundaryElementFractionsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                            const std::atomic_bool& shouldCancel) const
+                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto& featureIds = dataStructure.getDataRefAs<Int32Array>(filterArgs.value<DataPath>(k_FeatureIdsArrayPath_Key));
   auto& boundaryCells = dataStructure.getDataRefAs<Int8Array>(filterArgs.value<DataPath>(k_BoundaryCellsArrayPath_Key));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundaryElementFractionsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundaryElementFractionsFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeDifferencesMapFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeDifferencesMapFilter.cpp
@@ -160,7 +160,7 @@ IFilter::UniquePointer ComputeDifferencesMapFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeDifferencesMapFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto firstInputArrayPath = args.value<DataPath>(k_FirstInputArrayPath_Key);
   auto secondInputArrayPath = args.value<DataPath>(k_SecondInputArrayPath_Key);
@@ -231,7 +231,7 @@ IFilter::PreflightResult ComputeDifferencesMapFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> ComputeDifferencesMapFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto* firstInputArray = dataStructure.getDataAs<IDataArray>(args.value<DataPath>(k_FirstInputArrayPath_Key));
   auto* secondInputArray = dataStructure.getDataAs<IDataArray>(args.value<DataPath>(k_SecondInputArrayPath_Key));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeDifferencesMapFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeDifferencesMapFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel The atomic boolean that holds if the filter should be canceled
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeEuclideanDistMapFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeEuclideanDistMapFilter.cpp
@@ -106,7 +106,7 @@ IFilter::UniquePointer ComputeEuclideanDistMapFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeEuclideanDistMapFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                      const std::atomic_bool& shouldCancel) const
+                                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pCalcManhattanDistValue = filterArgs.value<bool>(k_CalcManhattanDist_Key);
   auto pSaveNearestNeighborsValue = filterArgs.value<bool>(k_SaveNearestNeighbors_Key);
@@ -178,7 +178,7 @@ IFilter::PreflightResult ComputeEuclideanDistMapFilter::preflightImpl(const Data
 
 //------------------------------------------------------------------------------
 Result<> ComputeEuclideanDistMapFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                    const std::atomic_bool& shouldCancel) const
+                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeEuclideanDistMapInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeEuclideanDistMapFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeEuclideanDistMapFilter.hpp
@@ -105,7 +105,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -117,8 +118,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureCentroidsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureCentroidsFilter.cpp
@@ -83,7 +83,7 @@ IFilter::UniquePointer ComputeFeatureCentroidsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeFeatureCentroidsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                      const std::atomic_bool& shouldCancel) const
+                                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
   auto featureAttrMatrixPath = filterArgs.value<DataPath>(k_FeatureAttributeMatrixPath_Key);
@@ -119,7 +119,7 @@ IFilter::PreflightResult ComputeFeatureCentroidsFilter::preflightImpl(const Data
 
 //------------------------------------------------------------------------------
 Result<> ComputeFeatureCentroidsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                    const std::atomic_bool& shouldCancel) const
+                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeFeatureCentroidsInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureCentroidsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureCentroidsFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureClusteringFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureClusteringFilter.cpp
@@ -108,7 +108,7 @@ IFilter::UniquePointer ComputeFeatureClusteringFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeFeatureClusteringFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                       const std::atomic_bool& shouldCancel) const
+                                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pNumberOfBinsValue = filterArgs.value<int32>(k_NumberOfBins_Key);
   auto pRemoveBiasedFeaturesValue = filterArgs.value<bool>(k_RemoveBiasedFeatures_Key);
@@ -166,7 +166,7 @@ IFilter::PreflightResult ComputeFeatureClusteringFilter::preflightImpl(const Dat
 
 //------------------------------------------------------------------------------
 Result<> ComputeFeatureClusteringFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                     const std::atomic_bool& shouldCancel) const
+                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto seed = filterArgs.value<uint64>(k_SeedValue_Key);
   if(!filterArgs.value<bool>(k_SetRandomSeed_Key))

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureClusteringFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureClusteringFilter.hpp
@@ -107,7 +107,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -119,8 +120,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureNeighborsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureNeighborsFilter.cpp
@@ -103,7 +103,7 @@ IFilter::UniquePointer ComputeFeatureNeighborsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeFeatureNeighborsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                      const std::atomic_bool& shouldCancel) const
+                                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto storeBoundaryCells = args.value<bool>(k_StoreBoundary_Key);
   auto storeSurfaceFeatures = args.value<bool>(k_StoreSurface_Key);
@@ -174,7 +174,7 @@ IFilter::PreflightResult ComputeFeatureNeighborsFilter::preflightImpl(const Data
 
 //------------------------------------------------------------------------------
 Result<> ComputeFeatureNeighborsFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                    const std::atomic_bool& shouldCancel) const
+                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto storeBoundaryCells = args.value<bool>(k_StoreBoundary_Key);
   auto storeSurfaceFeatures = args.value<bool>(k_StoreSurface_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureNeighborsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureNeighborsFilter.hpp
@@ -100,7 +100,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesBinaryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesBinaryFilter.cpp
@@ -83,7 +83,7 @@ IFilter::UniquePointer ComputeFeaturePhasesBinaryFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeFeaturePhasesBinaryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                         const std::atomic_bool& shouldCancel) const
+                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pCellDataAMPathValue = filterArgs.value<DataPath>(k_CellDataAMPath_Key);
   auto pFeaturePhasesArrayNameValue = filterArgs.value<std::string>(k_FeaturePhasesArrayName_Key);
@@ -104,7 +104,7 @@ IFilter::PreflightResult ComputeFeaturePhasesBinaryFilter::preflightImpl(const D
 
 //------------------------------------------------------------------------------
 Result<> ComputeFeaturePhasesBinaryFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                       const std::atomic_bool& shouldCancel) const
+                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto& featureIdsArray = dataStructure.getDataAs<Int32Array>(filterArgs.value<DataPath>(k_FeatureIdsArrayPath_Key))->getDataStoreRef();
   auto& featurePhasesArray =

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesBinaryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesBinaryFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesFilter.cpp
@@ -82,7 +82,7 @@ IFilter::UniquePointer ComputeFeaturePhasesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeFeaturePhasesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                   const std::atomic_bool& shouldCancel) const
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pCellPhasesArrayPathValue = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
@@ -113,7 +113,7 @@ IFilter::PreflightResult ComputeFeaturePhasesFilter::preflightImpl(const DataStr
 
 //------------------------------------------------------------------------------
 Result<> ComputeFeaturePhasesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                 const std::atomic_bool& shouldCancel) const
+                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pCellPhasesArrayPathValue = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -113,8 +114,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureRectFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureRectFilter.cpp
@@ -75,7 +75,7 @@ IFilter::UniquePointer ComputeFeatureRectFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeFeatureRectFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                 const std::atomic_bool& shouldCancel) const
+                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_FeatureIdsArrayPath_Key);
   auto pFeatureDataAttributeMatrixPathValue = filterArgs.value<DataPath>(k_FeatureDataAttributeMatrixPath_Key);
@@ -112,7 +112,7 @@ IFilter::PreflightResult ComputeFeatureRectFilter::preflightImpl(const DataStruc
 
 //------------------------------------------------------------------------------
 Result<> ComputeFeatureRectFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                               const std::atomic_bool& shouldCancel) const
+                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeFeatureRectInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureRectFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureRectFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
@@ -89,8 +89,8 @@ IFilter::UniquePointer ComputeFeatureSizesFilter::clone() const
   return std::make_unique<ComputeFeatureSizesFilter>();
 }
 
-IFilter::PreflightResult ComputeFeatureSizesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ComputeFeatureSizesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                                  const ExecutionContext& executionContext) const
 {
   auto geometryPath = args.value<DataPath>(k_GeometryPath_Key);
 
@@ -142,7 +142,7 @@ IFilter::PreflightResult ComputeFeatureSizesFilter::preflightImpl(const DataStru
 }
 
 Result<> ComputeFeatureSizesFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto saveElementSizes = args.value<bool>(k_SaveElementSizes_Key);
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.hpp
@@ -102,7 +102,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -114,8 +115,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMeansFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMeansFilter.cpp
@@ -114,8 +114,8 @@ IFilter::UniquePointer ComputeKMeansFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ComputeKMeansFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                            const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ComputeKMeansFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                            const ExecutionContext& executionContext) const
 {
   auto pInitClustersValue = filterArgs.value<uint64>(k_InitClusters_Key);
   auto pUseMaskValue = filterArgs.value<bool>(k_UseMask_Key);
@@ -173,7 +173,7 @@ IFilter::PreflightResult ComputeKMeansFilter::preflightImpl(const DataStructure&
 
 //------------------------------------------------------------------------------
 Result<> ComputeKMeansFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                          const std::atomic_bool& shouldCancel) const
+                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto maskPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
   if(!filterArgs.value<bool>(k_UseMask_Key))

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMeansFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMeansFilter.hpp
@@ -104,7 +104,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -116,8 +117,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMedoidsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMedoidsFilter.cpp
@@ -111,7 +111,7 @@ IFilter::UniquePointer ComputeKMedoidsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeKMedoidsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pInitClustersValue = filterArgs.value<uint64>(k_InitClusters_Key);
   auto pUseMaskValue = filterArgs.value<bool>(k_UseMask_Key);
@@ -169,7 +169,7 @@ IFilter::PreflightResult ComputeKMedoidsFilter::preflightImpl(const DataStructur
 
 //------------------------------------------------------------------------------
 Result<> ComputeKMedoidsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto maskPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
   if(!filterArgs.value<bool>(k_UseMask_Key))

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMedoidsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMedoidsFilter.hpp
@@ -104,7 +104,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -116,8 +117,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeLargestCrossSectionsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeLargestCrossSectionsFilter.cpp
@@ -85,7 +85,7 @@ IFilter::UniquePointer ComputeLargestCrossSectionsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeLargestCrossSectionsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                          const std::atomic_bool& shouldCancel) const
+                                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_FeatureIdsArrayPath_Key);
   auto pImageGeometryPath = filterArgs.value<DataPath>(k_ImageGeometryPath_Key);
@@ -116,7 +116,7 @@ IFilter::PreflightResult ComputeLargestCrossSectionsFilter::preflightImpl(const 
 
 //------------------------------------------------------------------------------
 Result<> ComputeLargestCrossSectionsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                        const std::atomic_bool& shouldCancel) const
+                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeLargestCrossSectionsInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeLargestCrossSectionsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeLargestCrossSectionsFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeMomentInvariants2DFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeMomentInvariants2DFilter.cpp
@@ -89,7 +89,7 @@ IFilter::UniquePointer ComputeMomentInvariants2DFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeMomentInvariants2DFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                        const std::atomic_bool& shouldCancel) const
+                                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pGeometryPathValue = filterArgs.value<DataPath>(k_ImageGeometryPath_Key);
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_FeatureIdsArrayPath_Key);
@@ -142,7 +142,7 @@ IFilter::PreflightResult ComputeMomentInvariants2DFilter::preflightImpl(const Da
 
 //------------------------------------------------------------------------------
 Result<> ComputeMomentInvariants2DFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                      const std::atomic_bool& shouldCancel) const
+                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeMomentInvariants2DInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeMomentInvariants2DFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeMomentInvariants2DFilter.hpp
@@ -103,7 +103,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -115,8 +116,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborListStatisticsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborListStatisticsFilter.cpp
@@ -167,7 +167,7 @@ IFilter::UniquePointer ComputeNeighborListStatisticsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeNeighborListStatisticsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                            const std::atomic_bool& shouldCancel) const
+                                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto findLength = args.value<bool>(k_FindLength_Key);
   auto findMin = args.value<bool>(k_FindMinimum_Key);
@@ -199,7 +199,7 @@ IFilter::PreflightResult ComputeNeighborListStatisticsFilter::preflightImpl(cons
 
 //------------------------------------------------------------------------------
 Result<> ComputeNeighborListStatisticsFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeNeighborListStatisticsInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborListStatisticsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborListStatisticsFilter.hpp
@@ -109,7 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -121,8 +122,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborhoodsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborhoodsFilter.cpp
@@ -96,7 +96,7 @@ IFilter::UniquePointer ComputeNeighborhoodsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeNeighborhoodsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                   const std::atomic_bool& shouldCancel) const
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pEquivalentDiametersArrayPathValue = filterArgs.value<DataPath>(k_EquivalentDiametersArrayPath_Key);
   auto pFeaturePhasesArrayPathValue = filterArgs.value<DataPath>(k_FeaturePhasesArrayPath_Key);
@@ -143,7 +143,7 @@ IFilter::PreflightResult ComputeNeighborhoodsFilter::preflightImpl(const DataStr
 
 //------------------------------------------------------------------------------
 Result<> ComputeNeighborhoodsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                 const std::atomic_bool& shouldCancel) const
+                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeNeighborhoodsInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborhoodsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborhoodsFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -113,8 +114,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNumFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNumFeaturesFilter.cpp
@@ -79,7 +79,7 @@ IFilter::UniquePointer ComputeNumFeaturesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeNumFeaturesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                 const std::atomic_bool& shouldCancel) const
+                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFeaturePhasesArrayPathValue = filterArgs.value<DataPath>(k_FeaturePhasesArrayPath_Key);
   auto pEnsembleDataPathValue = filterArgs.value<DataPath>(k_EnsembleAttributeMatrixPath_Key);
@@ -103,7 +103,7 @@ IFilter::PreflightResult ComputeNumFeaturesFilter::preflightImpl(const DataStruc
 
 //------------------------------------------------------------------------------
 Result<> ComputeNumFeaturesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                               const std::atomic_bool& shouldCancel) const
+                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFeaturePhasesArrayPathValue = filterArgs.value<DataPath>(k_FeaturePhasesArrayPath_Key);
   auto pEnsembleDataPathValue = filterArgs.value<DataPath>(k_EnsembleAttributeMatrixPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNumFeaturesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNumFeaturesFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -108,8 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceAreaToVolumeFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceAreaToVolumeFilter.cpp
@@ -90,7 +90,7 @@ IFilter::UniquePointer ComputeSurfaceAreaToVolumeFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeSurfaceAreaToVolumeFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                         const std::atomic_bool& shouldCancel) const
+                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
   auto pNumCellsArrayPathValue = filterArgs.value<DataPath>(k_NumCellsArrayPath_Key);
@@ -136,7 +136,7 @@ IFilter::PreflightResult ComputeSurfaceAreaToVolumeFilter::preflightImpl(const D
 
 //------------------------------------------------------------------------------
 Result<> ComputeSurfaceAreaToVolumeFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                       const std::atomic_bool& shouldCancel) const
+                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeSurfaceAreaToVolumeInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceAreaToVolumeFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceAreaToVolumeFilter.hpp
@@ -100,7 +100,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceFeaturesFilter.cpp
@@ -262,7 +262,7 @@ IFilter::UniquePointer ComputeSurfaceFeaturesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeSurfaceFeaturesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFeatureGeometryPathValue = filterArgs.value<DataPath>(k_FeatureGeometryPath_Key);
   auto pCellFeaturesAttributeMatrixPathValue = filterArgs.value<DataPath>(k_CellFeatureAttributeMatrixPath_Key);
@@ -293,7 +293,7 @@ IFilter::PreflightResult ComputeSurfaceFeaturesFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> ComputeSurfaceFeaturesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   const auto pMarkFeature0NeighborsValue = filterArgs.value<bool>(k_MarkFeature0Neighbors);
   const auto pFeatureGeometryPathValue = filterArgs.value<DataPath>(k_FeatureGeometryPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceFeaturesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceFeaturesFilter.hpp
@@ -113,7 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -125,8 +126,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleAreasFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleAreasFilter.cpp
@@ -129,7 +129,7 @@ IFilter::UniquePointer ComputeTriangleAreasFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeTriangleAreasFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                   const std::atomic_bool& shouldCancel) const
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pTriangleGeometryDataPath = filterArgs.value<DataPath>(k_TriangleGeometryDataPath_Key);
   auto pCalculatedAreasName = filterArgs.value<std::string>(k_CalculatedAreasDataName_Key);
@@ -162,7 +162,7 @@ IFilter::PreflightResult ComputeTriangleAreasFilter::preflightImpl(const DataStr
 
 //------------------------------------------------------------------------------
 Result<> ComputeTriangleAreasFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                 const std::atomic_bool& shouldCancel) const
+                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pCalculatedAreasName = filterArgs.value<std::string>(k_CalculatedAreasDataName_Key);
   auto pTriangleGeometryDataPath = filterArgs.value<DataPath>(k_TriangleGeometryDataPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleAreasFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleAreasFilter.hpp
@@ -95,7 +95,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -107,8 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleGeomCentroidsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleGeomCentroidsFilter.cpp
@@ -78,7 +78,7 @@ IFilter::UniquePointer ComputeTriangleGeomCentroidsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeTriangleGeomCentroidsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                           const std::atomic_bool& shouldCancel) const
+                                                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFaceLabelsArrayPath = filterArgs.value<DataPath>(k_FaceLabelsArrayPath_Key);
   auto pFeatureAttributeMatrixPath = filterArgs.value<DataPath>(k_FeatureAttributeMatrixPath_Key);
@@ -112,7 +112,7 @@ IFilter::PreflightResult ComputeTriangleGeomCentroidsFilter::preflightImpl(const
 
 //------------------------------------------------------------------------------
 Result<> ComputeTriangleGeomCentroidsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                         const std::atomic_bool& shouldCancel) const
+                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeTriangleGeomCentroidsInputValues inputValues;
   inputValues.TriangleGeometryPath = filterArgs.value<DataPath>(k_TriGeometryDataPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleGeomCentroidsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleGeomCentroidsFilter.hpp
@@ -90,7 +90,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -102,8 +103,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleGeomVolumesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleGeomVolumesFilter.cpp
@@ -79,7 +79,7 @@ IFilter::UniquePointer ComputeTriangleGeomVolumesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeTriangleGeomVolumesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                         const std::atomic_bool& shouldCancel) const
+                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFaceLabelsArrayPath = filterArgs.value<DataPath>(k_FaceLabelsArrayPath_Key);
   auto pFeatureAttributeMatrixPath = filterArgs.value<DataPath>(k_FeatureAttributeMatrixPath_Key);
@@ -113,7 +113,7 @@ IFilter::PreflightResult ComputeTriangleGeomVolumesFilter::preflightImpl(const D
 
 //------------------------------------------------------------------------------
 Result<> ComputeTriangleGeomVolumesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                       const std::atomic_bool& shouldCancel) const
+                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeTriangleGeomVolumesInputValues inputValues;
   inputValues.TriangleGeometryPath = filterArgs.value<DataPath>(k_TriGeometryDataPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleGeomVolumesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeTriangleGeomVolumesFilter.hpp
@@ -90,7 +90,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -102,8 +103,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVectorColorsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVectorColorsFilter.cpp
@@ -90,7 +90,7 @@ IFilter::UniquePointer ComputeVectorColorsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeVectorColorsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pUseGoodVoxelsValue = filterArgs.value<bool>(k_UseMask_Key);
   auto pVectorsArrayPathValue = filterArgs.value<DataPath>(k_VectorsArrayPath_Key);
@@ -119,7 +119,7 @@ IFilter::PreflightResult ComputeVectorColorsFilter::preflightImpl(const DataStru
 
 //------------------------------------------------------------------------------
 Result<> ComputeVectorColorsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeVectorColorsInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVectorColorsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVectorColorsFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVertexToTriangleDistancesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVertexToTriangleDistancesFilter.cpp
@@ -88,7 +88,7 @@ IFilter::UniquePointer ComputeVertexToTriangleDistancesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeVertexToTriangleDistancesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                               const std::atomic_bool& shouldCancel) const
+                                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pVertexGeometryDataPath = filterArgs.value<DataPath>(k_SelectedVertexGeometryPath_Key);
   auto pTriangleGeometryDataPath = filterArgs.value<DataPath>(k_SelectedTriangleGeometryPath_Key);
@@ -139,7 +139,7 @@ IFilter::PreflightResult ComputeVertexToTriangleDistancesFilter::preflightImpl(c
 
 //------------------------------------------------------------------------------
 Result<> ComputeVertexToTriangleDistancesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeVertexToTriangleDistancesInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVertexToTriangleDistancesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVertexToTriangleDistancesFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVolumeFractionsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVolumeFractionsFilter.cpp
@@ -79,7 +79,7 @@ IFilter::UniquePointer ComputeVolumeFractionsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ComputeVolumeFractionsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pCellEnsembleAttributeMatrixPathValue = filterArgs.value<DataPath>(k_CellEnsembleAttributeMatrixPath_Key);
   auto pVolFractionsArrayNameValue = filterArgs.value<std::string>(k_VolFractionsArrayName_Key);
@@ -104,7 +104,7 @@ IFilter::PreflightResult ComputeVolumeFractionsFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> ComputeVolumeFractionsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pCellEnsembleAttributeMatrixPathValue = filterArgs.value<DataPath>(k_CellEnsembleAttributeMatrixPath_Key);
   auto pVolFractionsArrayNameValue = filterArgs.value<std::string>(k_VolFractionsArrayName_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVolumeFractionsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVolumeFractionsFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -108,8 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConcatenateDataArraysFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConcatenateDataArraysFilter.cpp
@@ -76,7 +76,7 @@ IFilter::UniquePointer ConcatenateDataArraysFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ConcatenateDataArraysFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto inputArrayPaths = filterArgs.value<MultiArraySelectionParameter::ValueType>(k_InputArrays_Key);
   auto outputArrayPath = filterArgs.value<ArrayCreationParameter::ValueType>(k_OutputArray_Key);
@@ -167,7 +167,7 @@ IFilter::PreflightResult ConcatenateDataArraysFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> ConcatenateDataArraysFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ConcatenateDataArraysInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConcatenateDataArraysFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConcatenateDataArraysFilter.hpp
@@ -81,7 +81,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief
@@ -91,8 +92,8 @@ protected:
    * @param messageHandler
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConditionalSetValueFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConditionalSetValueFilter.cpp
@@ -119,7 +119,7 @@ IFilter::UniquePointer ConditionalSetValueFilter::clone() const
 }
 
 IFilter::PreflightResult ConditionalSetValueFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto useConditionalValue = filterArgs.value<bool>(k_UseConditional_Key);
   auto removeValueString = filterArgs.value<std::string>(k_RemoveValue_Key);
@@ -171,7 +171,7 @@ IFilter::PreflightResult ConditionalSetValueFilter::preflightImpl(const DataStru
 }
 
 Result<> ConditionalSetValueFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto useConditionalValue = filterArgs.value<bool>(k_UseConditional_Key);
   auto replaceValueString = filterArgs.value<std::string>(k_ReplaceValue_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConditionalSetValueFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConditionalSetValueFilter.hpp
@@ -99,7 +99,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param messageHandler The MessageHandler object
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertColorToGrayScaleFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertColorToGrayScaleFilter.cpp
@@ -88,7 +88,7 @@ IFilter::UniquePointer ConvertColorToGrayScaleFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ConvertColorToGrayScaleFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                      const std::atomic_bool& shouldCancel) const
+                                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pConversionAlgorithmValue = filterArgs.value<ChoicesParameter::ValueType>(k_ConversionAlgorithm_Key);
   auto pColorWeightsValue = filterArgs.value<VectorFloat32Parameter::ValueType>(k_ColorWeights_Key);
@@ -155,7 +155,7 @@ IFilter::PreflightResult ConvertColorToGrayScaleFilter::preflightImpl(const Data
 
 //------------------------------------------------------------------------------
 Result<> ConvertColorToGrayScaleFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                    const std::atomic_bool& shouldCancel) const
+                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ConvertColorToGrayScaleInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertColorToGrayScaleFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertColorToGrayScaleFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertDataFilter.cpp
@@ -78,8 +78,8 @@ IFilter::UniquePointer ConvertDataFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ConvertDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ConvertDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto pScalarTypeIndex = filterArgs.value<ChoicesParameter::ValueType>(k_ScalarType_Key);
   auto pInputArrayPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_ArrayToConvertPath_Key);
@@ -115,7 +115,7 @@ IFilter::PreflightResult ConvertDataFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> ConvertDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ConvertDataInputValues inputValues;
   auto scalarTypeIndex = filterArgs.value<ChoicesParameter::ValueType>(k_ScalarType_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertDataFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CopyDataObjectFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CopyDataObjectFilter.cpp
@@ -78,8 +78,8 @@ IFilter::UniquePointer CopyDataObjectFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult CopyDataObjectFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult CopyDataObjectFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                             const ExecutionContext& executionContext) const
 {
   auto dataArrayPaths = args.value<MultiPathSelectionParameter::ValueType>(k_DataPath_Key);
   auto useNewParent = args.value<bool>(k_UseNewParent_Key);
@@ -145,7 +145,7 @@ IFilter::PreflightResult CopyDataObjectFilter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> CopyDataObjectFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CopyDataObjectFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CopyDataObjectFilter.hpp
@@ -94,7 +94,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -106,8 +107,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CopyFeatureArrayToElementArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CopyFeatureArrayToElementArrayFilter.cpp
@@ -127,7 +127,7 @@ IFilter::UniquePointer CopyFeatureArrayToElementArrayFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CopyFeatureArrayToElementArrayFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                             const std::atomic_bool& shouldCancel) const
+                                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   const auto pSelectedFeatureArrayPathsValue = filterArgs.value<MultiArraySelectionParameter::ValueType>(k_SelectedFeatureArrayPath_Key);
   const auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
@@ -165,7 +165,7 @@ IFilter::PreflightResult CopyFeatureArrayToElementArrayFilter::preflightImpl(con
 
 //------------------------------------------------------------------------------
 Result<> CopyFeatureArrayToElementArrayFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+                                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   const auto pSelectedFeatureArrayPathsValue = filterArgs.value<MultiArraySelectionParameter::ValueType>(k_SelectedFeatureArrayPath_Key);
   const auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CopyFeatureArrayToElementArrayFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CopyFeatureArrayToElementArrayFilter.hpp
@@ -99,7 +99,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -111,8 +112,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateAMScanPathsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateAMScanPathsFilter.cpp
@@ -91,7 +91,7 @@ IFilter::UniquePointer CreateAMScanPathsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CreateAMScanPathsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pCADSliceDataContainerNameValue = filterArgs.value<DataPath>(k_CADSliceDataContainerPath_Key);
   auto pCADSliceIdsArrayPathValue = filterArgs.value<DataPath>(k_CADSliceIdsArrayPath_Key);
@@ -129,7 +129,7 @@ IFilter::PreflightResult CreateAMScanPathsFilter::preflightImpl(const DataStruct
 
 //------------------------------------------------------------------------------
 Result<> CreateAMScanPathsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                              const std::atomic_bool& shouldCancel) const
+                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   CreateAMScanPathsInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateAMScanPathsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateAMScanPathsFilter.hpp
@@ -103,7 +103,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -115,8 +116,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateAttributeMatrixFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateAttributeMatrixFilter.cpp
@@ -62,7 +62,7 @@ IFilter::UniquePointer CreateAttributeMatrixFilter::clone() const
 }
 
 IFilter::PreflightResult CreateAttributeMatrixFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto dataObjectPath = args.value<DataPath>(k_DataObjectPath);
   auto tableData = args.value<DynamicTableParameter::ValueType>(k_TupleDims_Key);
@@ -84,7 +84,7 @@ IFilter::PreflightResult CreateAttributeMatrixFilter::preflightImpl(const DataSt
 }
 
 Result<> CreateAttributeMatrixFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateAttributeMatrixFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateAttributeMatrixFilter.hpp
@@ -92,7 +92,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.
@@ -103,8 +104,8 @@ protected:
    * @param messageHandler
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateColorMapFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateColorMapFilter.cpp
@@ -102,7 +102,7 @@ IFilter::UniquePointer CreateColorMapFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CreateColorMapFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pSelectedDataArrayPathValue = filterArgs.value<DataPath>(k_SelectedDataArrayPath_Key);
   auto pRgbArrayPathValue = pSelectedDataArrayPathValue.replaceName(filterArgs.value<std::string>(k_RgbArrayPath_Key));
@@ -151,7 +151,7 @@ IFilter::PreflightResult CreateColorMapFilter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> CreateColorMapFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   CreateColorMapInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateColorMapFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateColorMapFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -113,8 +114,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayAdvancedFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayAdvancedFilter.cpp
@@ -154,7 +154,7 @@ IFilter::UniquePointer CreateDataArrayAdvancedFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CreateDataArrayAdvancedFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                      const std::atomic_bool& shouldCancel) const
+                                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto useDims = filterArgs.value<bool>(k_AdvancedOptions_Key);
   auto numericType = filterArgs.value<NumericType>(k_NumericType_Key);
@@ -296,7 +296,7 @@ IFilter::PreflightResult CreateDataArrayAdvancedFilter::preflightImpl(const Data
 
 //------------------------------------------------------------------------------
 Result<> CreateDataArrayAdvancedFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                    const std::atomic_bool& shouldCancel) const
+                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto path = filterArgs.value<DataPath>(k_DataPath_Key);
   auto initType = static_cast<InitializeType>(filterArgs.value<uint64>(k_InitType_Key));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayAdvancedFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayAdvancedFilter.hpp
@@ -104,7 +104,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief
@@ -114,8 +115,8 @@ protected:
    * @param messageHandler
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayFilter.cpp
@@ -114,7 +114,7 @@ IFilter::UniquePointer CreateDataArrayFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CreateDataArrayFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto useDims = filterArgs.value<bool>(k_AdvancedOptions_Key);
   auto numericType = filterArgs.value<NumericType>(k_NumericType_Key);
@@ -184,7 +184,7 @@ IFilter::PreflightResult CreateDataArrayFilter::preflightImpl(const DataStructur
 
 //------------------------------------------------------------------------------
 Result<> CreateDataArrayFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto path = args.value<DataPath>(k_DataPath_Key);
   auto initValue = args.value<std::string>(k_InitializationValue_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayFilter.hpp
@@ -94,7 +94,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief
@@ -104,8 +105,8 @@ protected:
    * @param messageHandler
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataGroupFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataGroupFilter.cpp
@@ -54,8 +54,8 @@ IFilter::UniquePointer CreateDataGroupFilter::clone() const
   return std::make_unique<CreateDataGroupFilter>();
 }
 
-IFilter::PreflightResult CreateDataGroupFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult CreateDataGroupFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                              const ExecutionContext& executionContext) const
 {
   DataPath dataObjectPath = args.value<DataPath>(k_DataObjectPath);
 
@@ -68,7 +68,7 @@ IFilter::PreflightResult CreateDataGroupFilter::preflightImpl(const DataStructur
 }
 
 Result<> CreateDataGroupFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataGroupFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataGroupFilter.hpp
@@ -91,7 +91,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.
@@ -102,8 +103,8 @@ protected:
    * @param messageHandler
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateFeatureArrayFromElementArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateFeatureArrayFromElementArrayFilter.cpp
@@ -137,7 +137,7 @@ IFilter::UniquePointer CreateFeatureArrayFromElementArrayFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CreateFeatureArrayFromElementArrayFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                 const std::atomic_bool& shouldCancel) const
+                                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pSelectedCellArrayPathValue = filterArgs.value<DataPath>(k_SelectedCellArrayPath_Key);
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
@@ -172,7 +172,7 @@ IFilter::PreflightResult CreateFeatureArrayFromElementArrayFilter::preflightImpl
 
 //------------------------------------------------------------------------------
 Result<> CreateFeatureArrayFromElementArrayFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pSelectedCellArrayPathValue = filterArgs.value<DataPath>(k_SelectedCellArrayPath_Key);
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateFeatureArrayFromElementArrayFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateFeatureArrayFromElementArrayFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateGeometryFilter.cpp
@@ -214,7 +214,7 @@ IFilter::UniquePointer CreateGeometryFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CreateGeometryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pGeometryPath = filterArgs.value<DataPath>(k_GeometryPath_Key);
   auto pGeometryType = filterArgs.value<ChoicesParameter::ValueType>(k_GeometryType_Key);
@@ -376,7 +376,7 @@ IFilter::PreflightResult CreateGeometryFilter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> CreateGeometryFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto geometryPath = filterArgs.value<DataPath>(k_GeometryPath_Key);
   auto geometryType = filterArgs.value<ChoicesParameter::ValueType>(k_GeometryType_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateGeometryFilter.hpp
@@ -131,7 +131,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -143,8 +144,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateImageGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateImageGeometryFilter.cpp
@@ -83,7 +83,7 @@ IFilter::UniquePointer CreateImageGeometryFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CreateImageGeometryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   /**
    * These are the values that were gathered from the UI or the pipeline file or
@@ -132,7 +132,7 @@ IFilter::PreflightResult CreateImageGeometryFilter::preflightImpl(const DataStru
 
 //------------------------------------------------------------------------------
 Result<> CreateImageGeometryFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateImageGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateImageGeometryFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreatePythonSkeletonFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreatePythonSkeletonFilter.cpp
@@ -86,7 +86,7 @@ IFilter::UniquePointer CreatePythonSkeletonFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CreatePythonSkeletonFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                   const std::atomic_bool& shouldCancel) const
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto useExistingPlugin = filterArgs.value<BoolParameter::ValueType>(k_UseExistingPlugin_Key);
   auto pluginOutputDir = filterArgs.value<FileSystemPathParameter::ValueType>(k_PluginOutputDirectory_Key);
@@ -165,7 +165,7 @@ IFilter::PreflightResult CreatePythonSkeletonFilter::preflightImpl(const DataStr
 
 //------------------------------------------------------------------------------
 Result<> CreatePythonSkeletonFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                 const std::atomic_bool& shouldCancel) const
+                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   CreatePythonSkeletonInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreatePythonSkeletonFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreatePythonSkeletonFilter.hpp
@@ -99,7 +99,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -111,8 +112,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropEdgeGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropEdgeGeometryFilter.cpp
@@ -111,7 +111,7 @@ IFilter::UniquePointer CropEdgeGeometryFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult CropEdgeGeometryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto srcEdgeGeomPath = filterArgs.value<DataPath>(k_SelectedEdgeGeometryPath_Key);
   auto destEdgeGeomPath = filterArgs.value<DataPath>(k_CreatedEdgeGeometryPath_Key);
@@ -285,7 +285,7 @@ IFilter::PreflightResult CropEdgeGeometryFilter::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> CropEdgeGeometryFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                             const std::atomic_bool& shouldCancel) const
+                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   CropEdgeGeometryInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropEdgeGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropEdgeGeometryFilter.hpp
@@ -90,7 +90,8 @@ protected:
    * @param shouldCancel
    * @return PreflightResult
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief
@@ -101,8 +102,8 @@ protected:
    * @param shouldCancel
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 
 private:
   int32 m_InstanceId;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropImageGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropImageGeometryFilter.cpp
@@ -236,7 +236,7 @@ IFilter::UniquePointer CropImageGeometryFilter::clone() const
 }
 
 IFilter::PreflightResult CropImageGeometryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto srcImagePath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
   auto destImagePath = filterArgs.value<DataPath>(k_CreatedImageGeometryPath_Key);
@@ -563,7 +563,7 @@ IFilter::PreflightResult CropImageGeometryFilter::preflightImpl(const DataStruct
 }
 
 Result<> CropImageGeometryFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                              const std::atomic_bool& shouldCancel) const
+                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto srcImagePath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
   auto destImagePath = filterArgs.value<DataPath>(k_CreatedImageGeometryPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropImageGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropImageGeometryFilter.hpp
@@ -103,7 +103,8 @@ protected:
    * @param shouldCancel
    * @return PreflightResult
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief
@@ -114,8 +115,8 @@ protected:
    * @param shouldCancel
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 
 private:
   int32 m_InstanceId;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropVertexGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropVertexGeometryFilter.cpp
@@ -101,8 +101,8 @@ IFilter::UniquePointer CropVertexGeometryFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult CropVertexGeometryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                 const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult CropVertexGeometryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                                 const ExecutionContext& executionContext) const
 {
   auto vertexGeomPath = args.value<DataPath>(k_SelectedVertexGeometryPath_Key);
   auto croppedGeomPath = args.value<DataPath>(k_CreatedVertexGeometryPath_Key);
@@ -201,7 +201,7 @@ IFilter::PreflightResult CropVertexGeometryFilter::preflightImpl(const DataStruc
 
 //------------------------------------------------------------------------------
 Result<> CropVertexGeometryFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                               const std::atomic_bool& shouldCancel) const
+                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto vertexGeomPath = args.value<DataPath>(k_SelectedVertexGeometryPath_Key);
   auto croppedGeomPath = args.value<DataPath>(k_CreatedVertexGeometryPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropVertexGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropVertexGeometryFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -108,8 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/DBSCANFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/DBSCANFilter.cpp
@@ -120,7 +120,8 @@ IFilter::UniquePointer DBSCANFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult DBSCANFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult DBSCANFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                     const ExecutionContext& executionContext) const
 {
   auto pUseMaskValue = filterArgs.value<bool>(k_UseMask_Key);
   auto pSelectedArrayPathValue = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
@@ -173,7 +174,7 @@ IFilter::PreflightResult DBSCANFilter::preflightImpl(const DataStructure& dataSt
 
 //------------------------------------------------------------------------------
 Result<> DBSCANFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                   const std::atomic_bool& shouldCancel) const
+                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto maskPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
   if(!filterArgs.value<bool>(k_UseMask_Key))

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/DBSCANFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/DBSCANFilter.hpp
@@ -112,7 +112,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -124,8 +125,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/DeleteDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/DeleteDataFilter.cpp
@@ -74,7 +74,8 @@ IFilter::UniquePointer DeleteDataFilter::clone() const
   return std::make_unique<DeleteDataFilter>();
 }
 
-IFilter::PreflightResult DeleteDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult DeleteDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                         const ExecutionContext& executionContext) const
 {
   // auto deletionType = static_cast<DeletionType>(args.value<ChoicesParameter::ValueType>(k_DeletionType_Key));
   const auto dataObjectPaths = args.value<MultiPathSelectionParameter::ValueType>(k_DataPath_Key);
@@ -199,7 +200,7 @@ IFilter::PreflightResult DeleteDataFilter::preflightImpl(const DataStructure& da
 }
 
 Result<> DeleteDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                       const std::atomic_bool& shouldCancel) const
+                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/DeleteDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/DeleteDataFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -113,8 +114,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateBadDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateBadDataFilter.cpp
@@ -92,7 +92,7 @@ IFilter::UniquePointer ErodeDilateBadDataFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ErodeDilateBadDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                 const std::atomic_bool& shouldCancel) const
+                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pOperationValue = filterArgs.value<ChoicesParameter::ValueType>(k_Operation_Key);
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
@@ -124,7 +124,7 @@ IFilter::PreflightResult ErodeDilateBadDataFilter::preflightImpl(const DataStruc
 
 //------------------------------------------------------------------------------
 Result<> ErodeDilateBadDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                               const std::atomic_bool& shouldCancel) const
+                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ErodeDilateBadDataInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateBadDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateBadDataFilter.hpp
@@ -103,7 +103,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -115,8 +116,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateCoordinationNumberFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateCoordinationNumberFilter.cpp
@@ -83,7 +83,7 @@ IFilter::UniquePointer ErodeDilateCoordinationNumberFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ErodeDilateCoordinationNumberFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                            const std::atomic_bool& shouldCancel) const
+                                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pCoordinationNumberValue = filterArgs.value<int32>(k_CoordinationNumber_Key);
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
@@ -103,7 +103,7 @@ IFilter::PreflightResult ErodeDilateCoordinationNumberFilter::preflightImpl(cons
 
 //------------------------------------------------------------------------------
 Result<> ErodeDilateCoordinationNumberFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ErodeDilateCoordinationNumberInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateCoordinationNumberFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateCoordinationNumberFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateMaskFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateMaskFilter.cpp
@@ -82,14 +82,14 @@ IFilter::UniquePointer ErodeDilateMaskFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ErodeDilateMaskFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }
 
 //------------------------------------------------------------------------------
 Result<> ErodeDilateMaskFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ErodeDilateMaskInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateMaskFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateMaskFilter.hpp
@@ -102,7 +102,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -114,8 +115,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExecuteProcessFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExecuteProcessFilter.cpp
@@ -76,7 +76,7 @@ IFilter::UniquePointer ExecuteProcessFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ExecuteProcessFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pArgumentsValue = filterArgs.value<StringParameter::ValueType>(k_Arguments_Key);
 
@@ -91,7 +91,7 @@ IFilter::PreflightResult ExecuteProcessFilter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> ExecuteProcessFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ExecuteProcessInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExecuteProcessFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExecuteProcessFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractComponentAsArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractComponentAsArrayFilter.cpp
@@ -86,7 +86,7 @@ IFilter::UniquePointer ExtractComponentAsArrayFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ExtractComponentAsArrayFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                      const std::atomic_bool& shouldCancel) const
+                                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pMoveComponentsToNewArrayValue = filterArgs.value<bool>(k_MoveComponentsToNewArray_Key);
   auto pRemoveComponentsFromArrayValue = filterArgs.value<bool>(k_RemoveComponentsFromArray_Key);
@@ -145,7 +145,7 @@ IFilter::PreflightResult ExtractComponentAsArrayFilter::preflightImpl(const Data
 
 //------------------------------------------------------------------------------
 Result<> ExtractComponentAsArrayFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                    const std::atomic_bool& shouldCancel) const
+                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ExtractComponentAsArrayInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractComponentAsArrayFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractComponentAsArrayFilter.hpp
@@ -99,7 +99,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -111,8 +112,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractInternalSurfacesFromTriangleGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractInternalSurfacesFromTriangleGeometryFilter.cpp
@@ -166,7 +166,7 @@ IFilter::UniquePointer ExtractInternalSurfacesFromTriangleGeometryFilter::clone(
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ExtractInternalSurfacesFromTriangleGeometryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                          const std::atomic_bool& shouldCancel) const
+                                                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto triangleGeomPath = filterArgs.value<DataPath>(k_SelectedTriangleGeometryPath_Key);
   auto internalTrianglesGeomPath = filterArgs.value<DataPath>(k_CreatedTriangleGeometryPath_Key);
@@ -262,7 +262,7 @@ IFilter::PreflightResult ExtractInternalSurfacesFromTriangleGeometryFilter::pref
 
 //------------------------------------------------------------------------------
 Result<> ExtractInternalSurfacesFromTriangleGeometryFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                                        const std::atomic_bool& shouldCancel) const
+                                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto nodeTypesArrayPath = args.value<DataPath>(k_NodeTypesPath_Key);
   auto triangleGeomPath = args.value<DataPath>(k_SelectedTriangleGeometryPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractInternalSurfacesFromTriangleGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractInternalSurfacesFromTriangleGeometryFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief
@@ -107,8 +108,8 @@ protected:
    * @param shouldCancel
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.cpp
@@ -74,7 +74,7 @@ IFilter::UniquePointer ExtractPipelineToFileFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ExtractPipelineToFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   const auto importFile = args.value<FileSystemPathParameter::ValueType>(k_ImportFileData);
   auto outputFile = args.value<FileSystemPathParameter::ValueType>(k_OutputFile);
@@ -112,7 +112,7 @@ IFilter::PreflightResult ExtractPipelineToFileFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> ExtractPipelineToFileFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   const auto importFile = args.value<FileSystemPathParameter::ValueType>(k_ImportFileData);
   auto outputFile = args.value<FileSystemPathParameter::ValueType>(k_OutputFile);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractPipelineToFileFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.
@@ -107,8 +108,8 @@ protected:
    * @param messageHandler
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractVertexGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractVertexGeometryFilter.cpp
@@ -106,7 +106,7 @@ IFilter::UniquePointer ExtractVertexGeometryFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ExtractVertexGeometryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pArrayHandlingValue = filterArgs.value<ChoicesParameter::ValueType>(k_ArrayHandling_Key);
   auto pUseGoodVoxelsValue = filterArgs.value<bool>(k_UseMask_Key);
@@ -195,7 +195,7 @@ IFilter::PreflightResult ExtractVertexGeometryFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> ExtractVertexGeometryFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ExtractVertexGeometryInputValues inputValues;
   inputValues.ArrayHandling = filterArgs.value<ChoicesParameter::ValueType>(k_ArrayHandling_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractVertexGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractVertexGeometryFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -108,8 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FeatureFaceCurvatureFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FeatureFaceCurvatureFilter.cpp
@@ -119,7 +119,7 @@ IFilter::UniquePointer FeatureFaceCurvatureFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult FeatureFaceCurvatureFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                   const std::atomic_bool& shouldCancel) const
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto triangleGeomPath = filterArgs.value<DataPath>(k_TriangleGeomPath_Key);
   auto surfaceMeshPrincipalCurvature1Path = filterArgs.value<DataPath>(k_PrincipalCurvature1Path_Key);
@@ -211,7 +211,7 @@ IFilter::PreflightResult FeatureFaceCurvatureFilter::preflightImpl(const DataStr
 
 //------------------------------------------------------------------------------
 Result<> FeatureFaceCurvatureFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                 const std::atomic_bool& shouldCancel) const
+                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   FeatureFaceCurvatureInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FeatureFaceCurvatureFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FeatureFaceCurvatureFilter.hpp
@@ -106,7 +106,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -118,8 +119,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FillBadDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FillBadDataFilter.cpp
@@ -88,8 +88,8 @@ IFilter::UniquePointer FillBadDataFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult FillBadDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult FillBadDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto pMinAllowedDefectSizeValue = filterArgs.value<int32>(k_MinAllowedDefectSize_Key);
   auto cellPhasesArrayPath = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
@@ -121,7 +121,7 @@ IFilter::PreflightResult FillBadDataFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> FillBadDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   FillBadDataInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FillBadDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FillBadDataFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -113,8 +114,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FlyingEdges3DFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FlyingEdges3DFilter.cpp
@@ -85,8 +85,8 @@ IFilter::UniquePointer FlyingEdges3DFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult FlyingEdges3DFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                            const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult FlyingEdges3DFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                            const ExecutionContext& executionContext) const
 {
   auto pImageGeomPath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
   auto pTriangleGeomName = filterArgs.value<DataPath>(k_CreatedTriangleGeometryPath_Key);
@@ -110,7 +110,7 @@ IFilter::PreflightResult FlyingEdges3DFilter::preflightImpl(const DataStructure&
 
 //------------------------------------------------------------------------------
 Result<> FlyingEdges3DFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                          const std::atomic_bool& shouldCancel) const
+                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   FlyingEdges3DInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FlyingEdges3DFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FlyingEdges3DFilter.hpp
@@ -90,7 +90,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -102,8 +103,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IdentifySampleFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IdentifySampleFilter.cpp
@@ -485,8 +485,8 @@ IFilter::UniquePointer IdentifySampleFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult IdentifySampleFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult IdentifySampleFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                             const ExecutionContext& executionContext) const
 {
   const auto imageGeomPath = args.value<DataPath>(k_SelectedImageGeometryPath_Key);
   const auto goodVoxelsArrayPath = args.value<DataPath>(k_MaskArrayPath_Key);
@@ -505,7 +505,7 @@ IFilter::PreflightResult IdentifySampleFilter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> IdentifySampleFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   const auto fillHoles = args.value<bool>(k_FillHoles_Key);
   const auto sliceBySlice = args.value<bool>(k_SliceBySlice_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IdentifySampleFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IdentifySampleFilter.hpp
@@ -95,7 +95,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -107,8 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeDataFilter.cpp
@@ -130,7 +130,7 @@ IFilter::UniquePointer InitializeDataFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult InitializeDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto seedArrayNameValue = filterArgs.value<std::string>(k_SeedArrayName_Key);
   auto initializeTypeValue = static_cast<InitializeType>(filterArgs.value<uint64>(k_InitType_Key));
@@ -264,7 +264,7 @@ IFilter::PreflightResult InitializeDataFilter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> InitializeDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto initType = static_cast<InitializeType>(filterArgs.value<uint64>(k_InitType_Key));
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeDataFilter.hpp
@@ -93,7 +93,8 @@ protected:
    * @param shouldCancel
    * @return PreflightResult
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief
@@ -104,8 +105,8 @@ protected:
    * @param shouldCancel
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 
 private:
   uint64 m_Seed = 0;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeImageGeomCellDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeImageGeomCellDataFilter.cpp
@@ -231,7 +231,7 @@ IFilter::UniquePointer InitializeImageGeomCellDataFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult InitializeImageGeomCellDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                          const std::atomic_bool& shouldCancel) const
+                                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto cellArrayPaths = args.value<MultiArraySelectionParameter::ValueType>(k_CellArrayPaths_Key);
   auto imageGeomPath = args.value<DataPath>(k_ImageGeometryPath_Key);
@@ -327,7 +327,7 @@ IFilter::PreflightResult InitializeImageGeomCellDataFilter::preflightImpl(const 
 
 //------------------------------------------------------------------------------
 Result<> InitializeImageGeomCellDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                        const std::atomic_bool& shouldCancel) const
+                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto cellArrayPaths = args.value<MultiArraySelectionParameter::ValueType>(k_CellArrayPaths_Key);
   auto imageGeomPath = args.value<DataPath>(k_ImageGeometryPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeImageGeomCellDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeImageGeomCellDataFilter.hpp
@@ -105,7 +105,8 @@ protected:
    * @param shouldCancel
    * @return PreflightResult
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief
@@ -116,8 +117,8 @@ protected:
    * @param shouldCancel
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 
 private:
   uint64 m_Seed = 0;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
@@ -230,7 +230,7 @@ IFilter::UniquePointer InterpolatePointCloudToRegularGridFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult InterpolatePointCloudToRegularGridFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                                 const std::atomic_bool& shouldCancel) const
+                                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto useMask = args.value<bool>(k_UseMask_Key);
   auto storeKernelDistances = args.value<bool>(k_StoreKernelDistances_Key);
@@ -344,7 +344,7 @@ IFilter::PreflightResult InterpolatePointCloudToRegularGridFilter::preflightImpl
 
 //------------------------------------------------------------------------------
 Result<> InterpolatePointCloudToRegularGridFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto useMask = args.value<bool>(k_UseMask_Key);
   auto storeKernelDistances = args.value<bool>(k_StoreKernelDistances_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp
@@ -106,7 +106,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -118,8 +119,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IterativeClosestPointFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IterativeClosestPointFilter.cpp
@@ -130,7 +130,7 @@ IFilter::UniquePointer IterativeClosestPointFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult IterativeClosestPointFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto movingVertexPath = args.value<DataPath>(k_MovingVertexPath_Key);
   auto targetVertexPath = args.value<DataPath>(k_TargetVertexPath_Key);
@@ -165,7 +165,7 @@ IFilter::PreflightResult IterativeClosestPointFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> IterativeClosestPointFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto movingVertexPath = args.value<DataPath>(k_MovingVertexPath_Key);
   auto targetVertexPath = args.value<DataPath>(k_TargetVertexPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IterativeClosestPointFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IterativeClosestPointFilter.hpp
@@ -92,7 +92,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -104,8 +105,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LabelTriangleGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LabelTriangleGeometryFilter.cpp
@@ -83,7 +83,7 @@ IFilter::UniquePointer LabelTriangleGeometryFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult LabelTriangleGeometryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pTriangleGeomPathValue = filterArgs.value<DataPath>(k_TriangleGeomPath_Key);
   auto pRegionIdsNameValue = filterArgs.value<DataPath>(k_CreatedRegionIdsPath_Key);
@@ -123,7 +123,7 @@ IFilter::PreflightResult LabelTriangleGeometryFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> LabelTriangleGeometryFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   LabelTriangleGeometryInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LabelTriangleGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LabelTriangleGeometryFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LaplacianSmoothingFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LaplacianSmoothingFilter.cpp
@@ -94,14 +94,14 @@ IFilter::UniquePointer LaplacianSmoothingFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult LaplacianSmoothingFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                 const std::atomic_bool& shouldCancel) const
+                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }
 
 //------------------------------------------------------------------------------
 Result<> LaplacianSmoothingFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                               const std::atomic_bool& shouldCancel) const
+                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   nx::core::LaplacianSmoothingInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LaplacianSmoothingFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LaplacianSmoothingFilter.hpp
@@ -105,7 +105,8 @@ protected:
    * @param shouldCancel The atomic boolean that holds if the filter should be canceled
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -117,8 +118,8 @@ protected:
    * @param shouldCancel The atomic boolean that holds if the filter should be canceled
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MapPointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MapPointCloudToRegularGridFilter.cpp
@@ -387,7 +387,7 @@ IFilter::UniquePointer MapPointCloudToRegularGridFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult MapPointCloudToRegularGridFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                         const std::atomic_bool& shouldCancel) const
+                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto samplingGridType = args.value<uint64>(k_SamplingGridType_Key);
   auto vertexGeomPath = args.value<DataPath>(k_SelectedVertexGeometryPath_Key);
@@ -456,7 +456,7 @@ IFilter::PreflightResult MapPointCloudToRegularGridFilter::preflightImpl(const D
 
 //------------------------------------------------------------------------------
 Result<> MapPointCloudToRegularGridFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                       const std::atomic_bool& shouldCancel) const
+                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   // Get the target image as a pointer
   const auto samplingGridType = args.value<uint64>(k_SamplingGridType_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MapPointCloudToRegularGridFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MapPointCloudToRegularGridFilter.hpp
@@ -102,7 +102,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -114,8 +115,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MoveDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MoveDataFilter.cpp
@@ -65,7 +65,8 @@ IFilter::UniquePointer MoveDataFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult MoveDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult MoveDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                       const ExecutionContext& executionContext) const
 {
   auto dataPaths = args.value<MultiPathSelectionParameter::ValueType>(k_SourceDataPaths_Key);
   auto newParentPath = args.value<DataPath>(k_DestinationParentPath_Key);
@@ -105,7 +106,7 @@ IFilter::PreflightResult MoveDataFilter::preflightImpl(const DataStructure& data
 
 //------------------------------------------------------------------------------
 Result<> MoveDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                     const std::atomic_bool& shouldCancel) const
+                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MoveDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MoveDataFilter.hpp
@@ -92,7 +92,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -104,8 +105,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MultiThresholdObjectsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MultiThresholdObjectsFilter.cpp
@@ -349,7 +349,7 @@ IFilter::UniquePointer MultiThresholdObjectsFilter::clone() const
 
 // -----------------------------------------------------------------------------
 IFilter::PreflightResult MultiThresholdObjectsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto thresholdsObject = args.value<ArrayThresholdSet>(k_ArrayThresholdsObject_Key);
   auto maskArrayName = args.value<std::string>(k_CreatedDataName_Key);
@@ -441,7 +441,7 @@ IFilter::PreflightResult MultiThresholdObjectsFilter::preflightImpl(const DataSt
 
 // -----------------------------------------------------------------------------
 Result<> MultiThresholdObjectsFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto thresholdsObject = args.value<ArrayThresholdSet>(k_ArrayThresholdsObject_Key);
   auto maskArrayName = args.value<std::string>(k_CreatedDataName_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MultiThresholdObjectsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MultiThresholdObjectsFilter.hpp
@@ -107,7 +107,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -119,8 +120,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/NearestPointFuseRegularGridsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/NearestPointFuseRegularGridsFilter.cpp
@@ -91,7 +91,7 @@ IFilter::UniquePointer NearestPointFuseRegularGridsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult NearestPointFuseRegularGridsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                           const std::atomic_bool& shouldCancel) const
+                                                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pSamplingGeometryPathValue = filterArgs.value<DataPath>(k_SamplingGeometryPath_Key);
   auto pReferenceGeometryPathValue = filterArgs.value<DataPath>(k_ReferenceGeometryPath_Key);
@@ -142,7 +142,7 @@ IFilter::PreflightResult NearestPointFuseRegularGridsFilter::preflightImpl(const
 
 //------------------------------------------------------------------------------
 Result<> NearestPointFuseRegularGridsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                         const std::atomic_bool& shouldCancel) const
+                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   NearestPointFuseRegularGridsInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/NearestPointFuseRegularGridsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/NearestPointFuseRegularGridsFilter.hpp
@@ -99,7 +99,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -111,8 +112,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PartitionGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PartitionGeometryFilter.cpp
@@ -335,7 +335,7 @@ IFilter::UniquePointer PartitionGeometryFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult PartitionGeometryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pPartitioningModeValue = filterArgs.value<ChoicesParameter::ValueType>(k_PartitioningMode_Key);
   auto pNumberOfCellsPerAxisValue = filterArgs.value<VectorInt32Parameter::ValueType>(k_NumberOfCellsPerAxis_Key);
@@ -719,7 +719,7 @@ Result<> PartitionGeometryFilter::DataCheckNumberOfPartitions(const SizeVec3& nu
 
 //------------------------------------------------------------------------------
 Result<> PartitionGeometryFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                              const std::atomic_bool& shouldCancel) const
+                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
 
   PartitionGeometryInputValues inputValues;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PartitionGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PartitionGeometryFilter.hpp
@@ -132,7 +132,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -144,8 +145,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 
   template <typename GeomType>
   Result<> dataCheckPartitioningMode(const DataStructure& dataStructure, const Arguments& filterArgs, const GeomType& geometryToPartition) const;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PointSampleTriangleGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PointSampleTriangleGeometryFilter.cpp
@@ -110,7 +110,7 @@ IFilter::UniquePointer PointSampleTriangleGeometryFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult PointSampleTriangleGeometryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                          const std::atomic_bool& shouldCancel) const
+                                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pUseMask = filterArgs.value<bool>(k_UseMask_Key);
   auto pTriangleGeometry = filterArgs.value<DataPath>(k_TriangleGeometry_Key);
@@ -176,7 +176,7 @@ IFilter::PreflightResult PointSampleTriangleGeometryFilter::preflightImpl(const 
 
 //------------------------------------------------------------------------------
 Result<> PointSampleTriangleGeometryFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                        const std::atomic_bool& shouldCancel) const
+                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto seed = filterArgs.value<std::mt19937_64::result_type>(k_SeedValue_Key);
   if(!filterArgs.value<bool>(k_UseSeed_Key))

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PointSampleTriangleGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PointSampleTriangleGeometryFilter.hpp
@@ -107,7 +107,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -119,8 +120,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/QuickSurfaceMeshFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/QuickSurfaceMeshFilter.cpp
@@ -108,7 +108,7 @@ IFilter::UniquePointer QuickSurfaceMeshFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult QuickSurfaceMeshFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pGridGeomDataPath = filterArgs.value<DataPath>(k_GridGeometryDataPath_Key);
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
@@ -180,7 +180,7 @@ IFilter::PreflightResult QuickSurfaceMeshFilter::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> QuickSurfaceMeshFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                             const std::atomic_bool& shouldCancel) const
+                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   nx::core::QuickSurfaceMeshInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/QuickSurfaceMeshFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/QuickSurfaceMeshFilter.hpp
@@ -108,7 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -120,8 +121,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadBinaryCTNorthstarFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadBinaryCTNorthstarFilter.cpp
@@ -404,7 +404,7 @@ IFilter::UniquePointer ReadBinaryCTNorthstarFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ReadBinaryCTNorthstarFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pInputHeaderFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputHeaderFile_Key);
   auto pImageGeometryPathValue = filterArgs.value<DataPath>(k_ImageGeometryPath_Key);
@@ -531,7 +531,7 @@ IFilter::PreflightResult ReadBinaryCTNorthstarFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> ReadBinaryCTNorthstarFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReadBinaryCTNorthstarInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadBinaryCTNorthstarFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadBinaryCTNorthstarFilter.hpp
@@ -117,7 +117,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -129,8 +130,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 
 private:
   int32 m_InstanceId;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadCSVFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadCSVFileFilter.cpp
@@ -455,8 +455,8 @@ IFilter::UniquePointer ReadCSVFileFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ReadCSVFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ReadCSVFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto readCSVData = filterArgs.value<ReadCSVData>(k_ReadCSVData_Key);
   auto useExistingGroupOrAM = filterArgs.value<bool>(k_UseExistingGroup_Key);
@@ -672,7 +672,7 @@ IFilter::PreflightResult ReadCSVFileFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> ReadCSVFileFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto readCSVData = filterArgs.value<ReadCSVData>(k_ReadCSVData_Key);
   auto useExistingGroup = filterArgs.value<bool>(k_UseExistingGroup_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadCSVFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadCSVFileFilter.hpp
@@ -107,7 +107,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -119,8 +120,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 
 private:
   int32 m_InstanceId;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadDREAM3DFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadDREAM3DFilter.cpp
@@ -69,7 +69,8 @@ IFilter::UniquePointer ReadDREAM3DFilter::clone() const
   return std::make_unique<ReadDREAM3DFilter>();
 }
 
-IFilter::PreflightResult ReadDREAM3DFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ReadDREAM3DFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto importData = args.value<Dream3dImportParameter::ImportData>(k_ImportFileData);
   if(importData.FilePath.empty())
@@ -89,7 +90,7 @@ IFilter::PreflightResult ReadDREAM3DFilter::preflightImpl(const DataStructure& d
 }
 
 Result<> ReadDREAM3DFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadDREAM3DFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadDREAM3DFilter.hpp
@@ -102,7 +102,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.
@@ -113,8 +114,8 @@ protected:
    * @param messageHandler
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadDeformKeyFileV12Filter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadDeformKeyFileV12Filter.cpp
@@ -98,7 +98,7 @@ IFilter::UniquePointer ReadDeformKeyFileV12Filter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ReadDeformKeyFileV12Filter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                   const std::atomic_bool& shouldCancel) const
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pInputFilePathValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFilePath_Key);
   auto pQuadGeomPathValue = filterArgs.value<DataPath>(k_QuadGeomPath_Key);
@@ -176,7 +176,7 @@ IFilter::PreflightResult ReadDeformKeyFileV12Filter::preflightImpl(const DataStr
 
 //------------------------------------------------------------------------------
 Result<> ReadDeformKeyFileV12Filter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                 const std::atomic_bool& shouldCancel) const
+                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReadDeformKeyFileV12InputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadDeformKeyFileV12Filter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadDeformKeyFileV12Filter.hpp
@@ -102,7 +102,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -114,8 +115,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 
 private:
   int32 m_InstanceId;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadHDF5DatasetFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadHDF5DatasetFilter.cpp
@@ -102,7 +102,7 @@ IFilter::UniquePointer ReadHDF5DatasetFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ReadHDF5DatasetFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pImportHDF5FileValue = filterArgs.value<ReadHDF5DatasetParameter::ValueType>(k_ImportHDF5File_Key);
   auto pSelectedAttributeMatrixValue = pImportHDF5FileValue.parent;
@@ -304,7 +304,7 @@ IFilter::PreflightResult ReadHDF5DatasetFilter::preflightImpl(const DataStructur
 
 //------------------------------------------------------------------------------
 Result<> ReadHDF5DatasetFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pImportHDF5FileValue = filterArgs.value<ReadHDF5DatasetParameter::ValueType>(k_ImportHDF5File_Key);
   auto pSelectedAttributeMatrixValue = pImportHDF5FileValue.parent;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadHDF5DatasetFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadHDF5DatasetFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -108,8 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadRawBinaryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadRawBinaryFilter.cpp
@@ -95,8 +95,8 @@ IFilter::UniquePointer ReadRawBinaryFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ReadRawBinaryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                            const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ReadRawBinaryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                            const ExecutionContext& executionContext) const
 {
   auto pInputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFile_Key);
   auto pScalarTypeValue = filterArgs.value<NumericType>(k_ScalarType_Key);
@@ -175,7 +175,7 @@ IFilter::PreflightResult ReadRawBinaryFilter::preflightImpl(const DataStructure&
 
 //------------------------------------------------------------------------------
 Result<> ReadRawBinaryFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                          const std::atomic_bool& shouldCancel) const
+                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReadRawBinaryInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadRawBinaryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadRawBinaryFilter.hpp
@@ -105,7 +105,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -117,8 +118,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStlFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStlFileFilter.cpp
@@ -99,8 +99,8 @@ IFilter::UniquePointer ReadStlFileFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ReadStlFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ReadStlFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto pStlFilePathValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_StlFilePath_Key);
   auto pTriangleGeometryPath = filterArgs.value<DataPath>(k_CreatedTriangleGeometryPath_Key);
@@ -177,7 +177,7 @@ IFilter::PreflightResult ReadStlFileFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> ReadStlFileFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pStlFilePathValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_StlFilePath_Key);
   auto pTriangleGeometryPath = filterArgs.value<DataPath>(k_CreatedTriangleGeometryPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStlFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStlFileFilter.hpp
@@ -106,7 +106,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -118,8 +119,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStringDataArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStringDataArrayFilter.cpp
@@ -91,8 +91,8 @@ IFilter::UniquePointer ReadStringDataArrayFilter::clone() const
   return std::make_unique<ReadStringDataArrayFilter>();
 }
 
-IFilter::PreflightResult ReadStringDataArrayFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ReadStringDataArrayFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                                  const ExecutionContext& executionContext) const
 {
   auto arrayPath = args.value<DataPath>(k_DataArrayPath_Key);
 
@@ -147,7 +147,7 @@ IFilter::PreflightResult ReadStringDataArrayFilter::preflightImpl(const DataStru
 }
 
 Result<> ReadStringDataArrayFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReadStringDataArrayInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStringDataArrayFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStringDataArrayFilter.hpp
@@ -92,7 +92,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -104,8 +105,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadTextDataArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadTextDataArrayFilter.cpp
@@ -106,8 +106,8 @@ IFilter::UniquePointer ReadTextDataArrayFilter::clone() const
   return std::make_unique<ReadTextDataArrayFilter>();
 }
 
-IFilter::PreflightResult ReadTextDataArrayFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult ReadTextDataArrayFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                                const ExecutionContext& executionContext) const
 {
   auto numericType = args.value<NumericType>(k_ScalarType_Key);
   auto arrayPath = args.value<DataPath>(k_DataArrayPath_Key);
@@ -164,7 +164,7 @@ IFilter::PreflightResult ReadTextDataArrayFilter::preflightImpl(const DataStruct
 }
 
 Result<> ReadTextDataArrayFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                              const std::atomic_bool& shouldCancel) const
+                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto inputFilePath = args.value<fs::path>(k_InputFile_Key);
   auto skipLines = args.value<uint64>(k_NSkipLines_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadTextDataArrayFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadTextDataArrayFilter.hpp
@@ -94,7 +94,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -106,8 +107,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadVolumeGraphicsFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadVolumeGraphicsFileFilter.cpp
@@ -416,7 +416,7 @@ IFilter::UniquePointer ReadVolumeGraphicsFileFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ReadVolumeGraphicsFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pVGHeaderFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_VGHeaderFile_Key);
   auto pNewImageGeometryPathValue = filterArgs.value<DataPath>(k_CreatedImageGeometryPath_Key);
@@ -456,7 +456,7 @@ IFilter::PreflightResult ReadVolumeGraphicsFileFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> ReadVolumeGraphicsFileFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
 
   ReadVolumeGraphicsFileInputValues inputValues;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadVolumeGraphicsFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadVolumeGraphicsFileFilter.hpp
@@ -110,7 +110,8 @@ protected:
    * @param shouldCancel Should the current filter be canceled.
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -122,8 +123,8 @@ protected:
    * @param shouldCancel Should the current filter be canceled.
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 
 private:
   int32 m_InstanceId;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadVtkStructuredPointsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadVtkStructuredPointsFilter.cpp
@@ -108,7 +108,7 @@ IFilter::UniquePointer ReadVtkStructuredPointsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ReadVtkStructuredPointsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                      const std::atomic_bool& shouldCancel) const
+                                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pInputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFile_Key);
   auto pVertexGeometryPath = filterArgs.value<DataPath>(k_CreatedVertexGeometryPath_Key);
@@ -143,7 +143,7 @@ IFilter::PreflightResult ReadVtkStructuredPointsFilter::preflightImpl(const Data
 
 //------------------------------------------------------------------------------
 Result<> ReadVtkStructuredPointsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                    const std::atomic_bool& shouldCancel) const
+                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReadVtkStructuredPointsInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadVtkStructuredPointsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadVtkStructuredPointsFilter.hpp
@@ -100,7 +100,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RegularGridSampleSurfaceMeshFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RegularGridSampleSurfaceMeshFilter.cpp
@@ -101,7 +101,7 @@ IFilter::UniquePointer RegularGridSampleSurfaceMeshFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult RegularGridSampleSurfaceMeshFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                           const std::atomic_bool& shouldCancel) const
+                                                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pSurfaceMeshFaceLabelsArrayPathValue = filterArgs.value<DataPath>(k_SurfaceMeshFaceLabelsArrayPath_Key);
   auto pDimensionsValue = filterArgs.value<VectorUInt64Parameter::ValueType>(k_Dimensions_Key);
@@ -190,7 +190,7 @@ IFilter::PreflightResult RegularGridSampleSurfaceMeshFilter::preflightImpl(const
 
 //------------------------------------------------------------------------------
 Result<> RegularGridSampleSurfaceMeshFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                         const std::atomic_bool& shouldCancel) const
+                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   RegularGridSampleSurfaceMeshInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RegularGridSampleSurfaceMeshFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RegularGridSampleSurfaceMeshFilter.hpp
@@ -102,7 +102,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -114,8 +115,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedEdgesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedEdgesFilter.cpp
@@ -104,7 +104,7 @@ IFilter::UniquePointer RemoveFlaggedEdgesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult RemoveFlaggedEdgesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                 const std::atomic_bool& shouldCancel) const
+                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pInitialGeometryPathValue = filterArgs.value<DataPath>(k_InputEdgeGeometryPath_Key);
   auto pReducedGeometryPathValue = filterArgs.value<DataPath>(k_OutputEdgeGeometryPath_Key);
@@ -202,7 +202,7 @@ IFilter::PreflightResult RemoveFlaggedEdgesFilter::preflightImpl(const DataStruc
 
 //------------------------------------------------------------------------------
 Result<> RemoveFlaggedEdgesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                               const std::atomic_bool& shouldCancel) const
+                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   RemoveFlaggedEdgesInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedEdgesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedEdgesFilter.hpp
@@ -104,7 +104,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -116,8 +117,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedFeaturesFilter.cpp
@@ -113,7 +113,7 @@ IFilter::UniquePointer RemoveFlaggedFeaturesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult RemoveFlaggedFeaturesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
   auto pFlaggedFeaturesArrayPathValue = filterArgs.value<DataPath>(k_FlaggedFeaturesArrayPath_Key);
@@ -187,7 +187,7 @@ IFilter::PreflightResult RemoveFlaggedFeaturesFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> RemoveFlaggedFeaturesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   RemoveFlaggedFeaturesInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedFeaturesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedFeaturesFilter.hpp
@@ -100,7 +100,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedTrianglesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedTrianglesFilter.cpp
@@ -103,7 +103,7 @@ IFilter::UniquePointer RemoveFlaggedTrianglesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult RemoveFlaggedTrianglesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pInitialGeometryPathValue = filterArgs.value<DataPath>(k_SelectedTriangleGeometryPath_Key);
   auto pReducedGeometryPathValue = filterArgs.value<DataPath>(k_CreatedTriangleGeometryPath_Key);
@@ -210,7 +210,7 @@ IFilter::PreflightResult RemoveFlaggedTrianglesFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> RemoveFlaggedTrianglesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   RemoveFlaggedTrianglesInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedTrianglesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedTrianglesFilter.hpp
@@ -104,7 +104,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -116,8 +117,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedVerticesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedVerticesFilter.cpp
@@ -114,7 +114,7 @@ IFilter::UniquePointer RemoveFlaggedVerticesFilter::clone() const
 }
 
 IFilter::PreflightResult RemoveFlaggedVerticesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto vertexGeomPath = filterArgs.value<DataPath>(k_SelectedVertexGeometryPath_Key);
   auto reducedVertexPath = filterArgs.value<DataPath>(k_CreatedVertexGeometryPath_Key);
@@ -213,7 +213,7 @@ IFilter::PreflightResult RemoveFlaggedVerticesFilter::preflightImpl(const DataSt
 }
 
 Result<> RemoveFlaggedVerticesFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto vertexGeomPath = args.value<DataPath>(k_SelectedVertexGeometryPath_Key);
   auto maskArrayPath = args.value<DataPath>(k_InputMaskPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedVerticesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedVerticesFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -108,8 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RenameDataObjectFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RenameDataObjectFilter.cpp
@@ -81,7 +81,7 @@ IFilter::UniquePointer RenameDataObjectFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult RenameDataObjectFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto allowOverwrite = filterArgs.value<bool>(k_AllowOverwrite_Key);
   auto dataGroupPath = filterArgs.value<DataPath>(k_SourceDataObjectPath_Key);
@@ -96,7 +96,7 @@ IFilter::PreflightResult RenameDataObjectFilter::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> RenameDataObjectFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                             const std::atomic_bool& shouldCancel) const
+                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RenameDataObjectFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RenameDataObjectFilter.hpp
@@ -95,7 +95,8 @@ protected:
    * @param shouldCancel
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief
@@ -106,8 +107,8 @@ protected:
    * @param shouldCancel
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.cpp
@@ -81,7 +81,7 @@ IFilter::UniquePointer ReplaceElementAttributesWithNeighborValuesFilter::clone()
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ReplaceElementAttributesWithNeighborValuesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                         const std::atomic_bool& shouldCancel) const
+                                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pComparisonDataPath = filterArgs.value<DataPath>(k_ComparisonDataPath);
 
@@ -96,7 +96,7 @@ IFilter::PreflightResult ReplaceElementAttributesWithNeighborValuesFilter::prefl
 
 //------------------------------------------------------------------------------
 Result<> ReplaceElementAttributesWithNeighborValuesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode,
-                                                                       const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+                                                                       const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReplaceElementAttributesWithNeighborValuesInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.hpp
@@ -99,7 +99,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -111,8 +112,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinNumNeighborsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinNumNeighborsFilter.cpp
@@ -375,7 +375,7 @@ IFilter::UniquePointer RequireMinNumNeighborsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult RequireMinNumNeighborsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = args.value<DataPath>(k_SelectedImageGeometryPath_Key);
   auto applyToSinglePhase = args.value<bool>(k_ApplyToSinglePhase_Key);
@@ -437,7 +437,7 @@ IFilter::PreflightResult RequireMinNumNeighborsFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 Result<> RequireMinNumNeighborsFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto featurePhasesPath = args.value<DataPath>(k_FeaturePhasesPath_Key);
   auto applyToSinglePhase = args.value<bool>(k_ApplyToSinglePhase_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinNumNeighborsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinNumNeighborsFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel The atomic boolean that holds if the filter should be canceled
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.cpp
@@ -311,7 +311,7 @@ IFilter::UniquePointer RequireMinimumSizeFeaturesFilter::clone() const
 }
 
 IFilter::PreflightResult RequireMinimumSizeFeaturesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                         const std::atomic_bool& shouldCancel) const
+                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto featurePhasesPath = args.value<DataPath>(k_FeaturePhasesPath_Key);
   auto featureIdsPath = args.value<DataPath>(k_FeatureIdsPath_Key);
@@ -379,7 +379,7 @@ IFilter::PreflightResult RequireMinimumSizeFeaturesFilter::preflightImpl(const D
 
 // -----------------------------------------------------------------------------
 Result<> RequireMinimumSizeFeaturesFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                       const std::atomic_bool& shouldCancel) const
+                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto featurePhasesPath = args.value<DataPath>(k_FeaturePhasesPath_Key);
   auto featureIdsPath = args.value<DataPath>(k_FeatureIdsPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.hpp
@@ -100,7 +100,8 @@ protected:
    * @param shouldCancel The atomic boolean that holds if the filter should be canceled
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleImageGeomFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleImageGeomFilter.cpp
@@ -134,7 +134,8 @@ IFilter::UniquePointer ResampleImageGeomFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ResampleImageGeomFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& msgHandler, const std::atomic_bool&) const
+IFilter::PreflightResult ResampleImageGeomFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pResamplingModeValue = filterArgs.value<ChoicesParameter::ValueType>(k_ResamplingMode_Key);
   auto pSpacingValue = filterArgs.value<VectorFloat32Parameter::ValueType>(k_Spacing_Key);
@@ -349,7 +350,7 @@ IFilter::PreflightResult ResampleImageGeomFilter::preflightImpl(const DataStruct
 
 //------------------------------------------------------------------------------
 Result<> ResampleImageGeomFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter*, const MessageHandler& messageHandler,
-                                              const std::atomic_bool& shouldCancel) const
+                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ResampleImageGeomInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleImageGeomFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleImageGeomFilter.hpp
@@ -102,7 +102,8 @@ protected:
    * @param messageHandler The MessageHandler object
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -112,8 +113,8 @@ protected:
    * @param messageHandler The MessageHandler object
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleRectGridToImageGeomFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleRectGridToImageGeomFilter.cpp
@@ -87,7 +87,7 @@ IFilter::UniquePointer ResampleRectGridToImageGeomFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ResampleRectGridToImageGeomFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                          const std::atomic_bool& shouldCancel) const
+                                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pRectilinearGridPathValue = filterArgs.value<DataPath>(k_RectilinearGridPath_Key);
   auto pSelectedDataArrayPathsValue = filterArgs.value<MultiArraySelectionParameter::ValueType>(k_SelectedDataArrayPaths_Key);
@@ -201,7 +201,7 @@ IFilter::PreflightResult ResampleRectGridToImageGeomFilter::preflightImpl(const 
 
 //------------------------------------------------------------------------------
 Result<> ResampleRectGridToImageGeomFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                        const std::atomic_bool& shouldCancel) const
+                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ResampleRectGridToImageGeomInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleRectGridToImageGeomFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleRectGridToImageGeomFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReshapeDataArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReshapeDataArrayFilter.cpp
@@ -81,7 +81,7 @@ IFilter::UniquePointer ReshapeDataArrayFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ReshapeDataArrayFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto inputArrayPath = filterArgs.value<DataPath>(k_Input_Array_Key);
   auto tupleDimsData = filterArgs.value<DynamicTableParameter::ValueType>(k_TupleDims_Key);
@@ -192,7 +192,7 @@ IFilter::PreflightResult ReshapeDataArrayFilter::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> ReshapeDataArrayFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                             const std::atomic_bool& shouldCancel) const
+                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ReshapeDataArrayInputValues inputValues;
   inputValues.InputArrayPath = filterArgs.value<DataPath>(k_Input_Array_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReshapeDataArrayFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReshapeDataArrayFilter.hpp
@@ -89,7 +89,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief
@@ -99,8 +100,8 @@ protected:
    * @param messageHandler
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReverseTriangleWindingFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReverseTriangleWindingFilter.cpp
@@ -110,14 +110,14 @@ IFilter::UniquePointer ReverseTriangleWindingFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ReverseTriangleWindingFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }
 
 //------------------------------------------------------------------------------
 Result<> ReverseTriangleWindingFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto& triangleGeom = dataStructure.getDataRefAs<TriangleGeom>(filterArgs.value<DataPath>(k_TriGeomPath_Key));
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReverseTriangleWindingFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReverseTriangleWindingFilter.hpp
@@ -95,7 +95,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -107,8 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RobustAutomaticThresholdFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RobustAutomaticThresholdFilter.cpp
@@ -104,7 +104,7 @@ IFilter::UniquePointer RobustAutomaticThresholdFilter::clone() const
 }
 
 IFilter::PreflightResult RobustAutomaticThresholdFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                       const std::atomic_bool& shouldCancel) const
+                                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto inputArrayPath = args.value<DataPath>(k_InputArrayPath_Key);
   auto gradientArrayPath = args.value<DataPath>(k_GradientMagnitudePath_Key);
@@ -150,7 +150,7 @@ IFilter::PreflightResult RobustAutomaticThresholdFilter::preflightImpl(const Dat
 }
 
 Result<> RobustAutomaticThresholdFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                     const std::atomic_bool& shouldCancel) const
+                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto inputArrayPath = args.value<DataPath>(k_InputArrayPath_Key);
   auto gradientArrayPath = args.value<DataPath>(k_GradientMagnitudePath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RobustAutomaticThresholdFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RobustAutomaticThresholdFilter.hpp
@@ -88,7 +88,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -100,8 +101,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RotateSampleRefFrameFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RotateSampleRefFrameFilter.cpp
@@ -359,7 +359,8 @@ IFilter::UniquePointer RotateSampleRefFrameFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult RotateSampleRefFrameFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler&, const std::atomic_bool&) const
+IFilter::PreflightResult RotateSampleRefFrameFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
+                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
 
   auto srcImagePath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
@@ -491,7 +492,7 @@ IFilter::PreflightResult RotateSampleRefFrameFilter::preflightImpl(const DataStr
 }
 
 Result<> RotateSampleRefFrameFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                 const std::atomic_bool& shouldCancel) const
+                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto srcImagePath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
   auto destImagePath = filterArgs.value<DataPath>(k_CreatedImageGeometryPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RotateSampleRefFrameFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RotateSampleRefFrameFilter.hpp
@@ -105,7 +105,8 @@ protected:
    * @param shouldCancel
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief
@@ -116,8 +117,8 @@ protected:
    * @param shouldCancel
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ScalarSegmentFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ScalarSegmentFeaturesFilter.cpp
@@ -100,7 +100,7 @@ IFilter::UniquePointer ScalarSegmentFeaturesFilter::clone() const
 }
 
 IFilter::PreflightResult ScalarSegmentFeaturesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto inputDataPath = args.value<DataPath>(k_InputArrayPathKey);
   auto featureIdsName = args.value<std::string>(k_FeatureIdsName_Key);
@@ -182,7 +182,7 @@ IFilter::PreflightResult ScalarSegmentFeaturesFilter::preflightImpl(const DataSt
 
 // -----------------------------------------------------------------------------
 Result<> ScalarSegmentFeaturesFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ScalarSegmentFeaturesInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ScalarSegmentFeaturesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ScalarSegmentFeaturesFilter.hpp
@@ -106,7 +106,8 @@ protected:
    * @param shouldCancel The atomic boolean that holds if the filter should be canceled
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -118,8 +119,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SetImageGeomOriginScalingFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SetImageGeomOriginScalingFilter.cpp
@@ -82,7 +82,7 @@ IFilter::UniquePointer SetImageGeomOriginScalingFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult SetImageGeomOriginScalingFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                        const std::atomic_bool& shouldCancel) const
+                                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto imageGeomPath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
   auto shouldChangeOrigin = filterArgs.value<bool>(k_ChangeOrigin_Key);
@@ -130,7 +130,7 @@ IFilter::PreflightResult SetImageGeomOriginScalingFilter::preflightImpl(const Da
 
 //------------------------------------------------------------------------------
 Result<> SetImageGeomOriginScalingFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                      const std::atomic_bool& shouldCancel) const
+                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SetImageGeomOriginScalingFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SetImageGeomOriginScalingFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief
@@ -107,8 +108,8 @@ protected:
    * @param messageHandler
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SharedFeatureFaceFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SharedFeatureFaceFilter.cpp
@@ -86,7 +86,7 @@ IFilter::UniquePointer SharedFeatureFaceFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult SharedFeatureFaceFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto triangleGeometryPath = filterArgs.value<DataPath>(k_TriGeometryDataPath_Key);
   auto pFaceLabelsArrayPathValue = filterArgs.value<DataPath>(k_FaceLabelsArrayPath_Key);
@@ -142,7 +142,7 @@ IFilter::PreflightResult SharedFeatureFaceFilter::preflightImpl(const DataStruct
 
 //------------------------------------------------------------------------------
 Result<> SharedFeatureFaceFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                              const std::atomic_bool& shouldCancel) const
+                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   SharedFeatureFaceInputValues inputValues;
   inputValues.TriangleGeometryPath = filterArgs.value<DataPath>(k_TriGeometryDataPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SharedFeatureFaceFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SharedFeatureFaceFilter.hpp
@@ -93,7 +93,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -105,8 +106,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SilhouetteFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SilhouetteFilter.cpp
@@ -97,8 +97,8 @@ IFilter::UniquePointer SilhouetteFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult SilhouetteFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                         const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult SilhouetteFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                         const ExecutionContext& executionContext) const
 {
   auto pUseMaskValue = filterArgs.value<bool>(k_UseMask_Key);
   auto pSelectedArrayPathValue = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
@@ -138,7 +138,7 @@ IFilter::PreflightResult SilhouetteFilter::preflightImpl(const DataStructure& da
 
 //------------------------------------------------------------------------------
 Result<> SilhouetteFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                       const std::atomic_bool& shouldCancel) const
+                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto maskPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
   if(!filterArgs.value<bool>(k_UseMask_Key))

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SilhouetteFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SilhouetteFilter.hpp
@@ -99,7 +99,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -111,8 +112,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SliceTriangleGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SliceTriangleGeometryFilter.cpp
@@ -107,7 +107,7 @@ IFilter::UniquePointer SliceTriangleGeometryFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult SliceTriangleGeometryFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pSliceRangeValue = filterArgs.value<ChoicesParameter::ValueType>(k_SliceRange_Key);
   auto pZStartValue = filterArgs.value<float32>(k_Zstart_Key);
@@ -164,7 +164,7 @@ IFilter::PreflightResult SliceTriangleGeometryFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> SliceTriangleGeometryFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   SliceTriangleGeometryInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SliceTriangleGeometryFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SliceTriangleGeometryFilter.hpp
@@ -108,7 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -120,8 +121,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitAttributeArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitAttributeArrayFilter.cpp
@@ -82,7 +82,7 @@ IFilter::UniquePointer SplitAttributeArrayFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult SplitAttributeArrayFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pInputArrayPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_MultiCompArrayPath_Key);
   auto pPostfix = filterArgs.value<std::string>(k_Postfix_Key);
@@ -144,7 +144,7 @@ IFilter::PreflightResult SplitAttributeArrayFilter::preflightImpl(const DataStru
 
 //------------------------------------------------------------------------------
 Result<> SplitAttributeArrayFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   SplitAttributeArrayInputValues inputValues;
   inputValues.InputArrayPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_MultiCompArrayPath_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitAttributeArrayFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitAttributeArrayFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SurfaceNetsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SurfaceNetsFilter.cpp
@@ -114,8 +114,8 @@ IFilter::UniquePointer SurfaceNetsFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult SurfaceNetsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult SurfaceNetsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                          const ExecutionContext& executionContext) const
 {
   auto pGridGeomDataPath = filterArgs.value<DataPath>(k_GridGeometryDataPath_Key);
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
@@ -186,7 +186,7 @@ IFilter::PreflightResult SurfaceNetsFilter::preflightImpl(const DataStructure& d
 
 //------------------------------------------------------------------------------
 Result<> SurfaceNetsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   SurfaceNetsInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SurfaceNetsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SurfaceNetsFilter.hpp
@@ -103,7 +103,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -115,8 +116,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleCentroidFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleCentroidFilter.cpp
@@ -78,7 +78,7 @@ IFilter::UniquePointer TriangleCentroidFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult TriangleCentroidFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                               const std::atomic_bool& shouldCancel) const
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pTriangleGeometryDataPath = filterArgs.value<DataPath>(k_TriGeometryDataPath_Key);
   auto pCentroidsArrayName = filterArgs.value<std::string>(k_CentroidsArrayName_Key);
@@ -107,7 +107,7 @@ IFilter::PreflightResult TriangleCentroidFilter::preflightImpl(const DataStructu
 
 //------------------------------------------------------------------------------
 Result<> TriangleCentroidFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                             const std::atomic_bool& shouldCancel) const
+                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   TriangleCentroidInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleCentroidFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleCentroidFilter.hpp
@@ -95,7 +95,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -107,8 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleDihedralAngleFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleDihedralAngleFilter.cpp
@@ -161,7 +161,7 @@ IFilter::UniquePointer TriangleDihedralAngleFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult TriangleDihedralAngleFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pTriangleGeometryDataPath = filterArgs.value<DataPath>(k_TGeometryDataPath_Key);
   auto pMinDihedralAnglesName = filterArgs.value<std::string>(k_SurfaceMeshTriangleDihedralAnglesArrayName_Key);
@@ -194,7 +194,7 @@ IFilter::PreflightResult TriangleDihedralAngleFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> TriangleDihedralAngleFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pTriangleGeometryDataPath = filterArgs.value<DataPath>(k_TGeometryDataPath_Key);
   auto pMinDihedralAnglesName = filterArgs.value<std::string>(k_SurfaceMeshTriangleDihedralAnglesArrayName_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleDihedralAngleFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleDihedralAngleFilter.hpp
@@ -95,7 +95,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -107,8 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleNormalFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleNormalFilter.cpp
@@ -132,7 +132,7 @@ IFilter::UniquePointer TriangleNormalFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult TriangleNormalFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pTriangleGeometryDataPath = filterArgs.value<DataPath>(k_TriGeometryDataPath_Key);
   auto pNormalsArrayName = filterArgs.value<std::string>(k_SurfaceMeshTriangleNormalsArrayName_Key);
@@ -161,7 +161,7 @@ IFilter::PreflightResult TriangleNormalFilter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> TriangleNormalFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pTriangleGeometryDataPath = filterArgs.value<DataPath>(k_TriGeometryDataPath_Key);
   auto pNormalsName = filterArgs.value<std::string>(k_SurfaceMeshTriangleNormalsArrayName_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleNormalFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleNormalFilter.hpp
@@ -95,7 +95,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -107,8 +108,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/UncertainRegularGridSampleSurfaceMeshFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/UncertainRegularGridSampleSurfaceMeshFilter.cpp
@@ -107,7 +107,7 @@ IFilter::UniquePointer UncertainRegularGridSampleSurfaceMeshFilter::clone() cons
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult UncertainRegularGridSampleSurfaceMeshFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                                    const std::atomic_bool& shouldCancel) const
+                                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pSurfaceMeshFaceLabelsArrayPathValue = filterArgs.value<DataPath>(k_SurfaceMeshFaceLabelsArrayPath_Key);
   auto pDimensionsValue = filterArgs.value<VectorUInt64Parameter::ValueType>(k_Dimensions_Key);
@@ -150,7 +150,7 @@ IFilter::PreflightResult UncertainRegularGridSampleSurfaceMeshFilter::preflightI
 
 //------------------------------------------------------------------------------
 Result<> UncertainRegularGridSampleSurfaceMeshFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto seed = filterArgs.value<std::mt19937_64::result_type>(k_SeedValue_Key);
   if(!filterArgs.value<bool>(k_UseSeed_Key))

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/UncertainRegularGridSampleSurfaceMeshFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/UncertainRegularGridSampleSurfaceMeshFilter.hpp
@@ -105,7 +105,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -117,8 +118,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteASCIIDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteASCIIDataFilter.cpp
@@ -107,7 +107,7 @@ IFilter::UniquePointer WriteASCIIDataFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WriteASCIIDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pOutputStyleValue = filterArgs.value<ChoicesParameter::ValueType>(k_OutputStyle_Key);
 
@@ -132,7 +132,7 @@ IFilter::PreflightResult WriteASCIIDataFilter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> WriteASCIIDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   const auto includes = static_cast<WriteASCIIDataFilter::Includes>(filterArgs.value<ChoicesParameter::ValueType>(k_Includes_Key));
   bool includeHeaders;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteASCIIDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteASCIIDataFilter.hpp
@@ -115,7 +115,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -127,8 +128,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAbaqusHexahedronFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAbaqusHexahedronFilter.cpp
@@ -84,7 +84,7 @@ IFilter::UniquePointer WriteAbaqusHexahedronFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WriteAbaqusHexahedronFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                    const std::atomic_bool& shouldCancel) const
+                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pOutputPathValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputPath_Key);
 
@@ -106,7 +106,7 @@ IFilter::PreflightResult WriteAbaqusHexahedronFilter::preflightImpl(const DataSt
 
 //------------------------------------------------------------------------------
 Result<> WriteAbaqusHexahedronFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                  const std::atomic_bool& shouldCancel) const
+                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   WriteAbaqusHexahedronInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAbaqusHexahedronFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAbaqusHexahedronFilter.hpp
@@ -99,7 +99,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -111,8 +112,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoRectilinearCoordinateFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoRectilinearCoordinateFilter.cpp
@@ -83,14 +83,14 @@ IFilter::UniquePointer WriteAvizoRectilinearCoordinateFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WriteAvizoRectilinearCoordinateFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                              const std::atomic_bool& shouldCancel) const
+                                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }
 
 //------------------------------------------------------------------------------
 Result<> WriteAvizoRectilinearCoordinateFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                            const std::atomic_bool& shouldCancel) const
+                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   AvizoWriterInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoRectilinearCoordinateFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoRectilinearCoordinateFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoUniformCoordinateFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoUniformCoordinateFilter.cpp
@@ -83,14 +83,14 @@ IFilter::UniquePointer WriteAvizoUniformCoordinateFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WriteAvizoUniformCoordinateFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                          const std::atomic_bool& shouldCancel) const
+                                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }
 
 //------------------------------------------------------------------------------
 Result<> WriteAvizoUniformCoordinateFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                        const std::atomic_bool& shouldCancel) const
+                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   AvizoWriterInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoUniformCoordinateFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteAvizoUniformCoordinateFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteBinaryDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteBinaryDataFilter.cpp
@@ -100,14 +100,14 @@ IFilter::UniquePointer WriteBinaryDataFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WriteBinaryDataFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }
 
 //------------------------------------------------------------------------------
 Result<> WriteBinaryDataFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   const auto endianess = static_cast<endian>(filterArgs.value<ChoicesParameter::ValueType>(k_Endianess_Key));
   auto selectedDataArrayPaths = filterArgs.value<MultiArraySelectionParameter::ValueType>(k_SelectedDataArrayPaths_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteBinaryDataFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteBinaryDataFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteDREAM3DFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteDREAM3DFilter.cpp
@@ -75,7 +75,8 @@ IFilter::UniquePointer WriteDREAM3DFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult WriteDREAM3DFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult WriteDREAM3DFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                           const ExecutionContext& executionContext) const
 {
   auto exportFilePath = args.value<std::filesystem::path>(k_ExportFilePath);
   if(exportFilePath.empty())
@@ -87,7 +88,7 @@ IFilter::PreflightResult WriteDREAM3DFilter::preflightImpl(const DataStructure& 
 
 //------------------------------------------------------------------------------
 Result<> WriteDREAM3DFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                         const std::atomic_bool& shouldCancel) const
+                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto atomicFileResult = AtomicFile::Create(args.value<FileSystemPathParameter::ValueType>(k_ExportFilePath));
   if(atomicFileResult.invalid())

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteDREAM3DFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteDREAM3DFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.
@@ -107,8 +108,8 @@ protected:
    * @param messageHandler
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteFeatureDataCSVFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteFeatureDataCSVFilter.cpp
@@ -83,14 +83,14 @@ IFilter::UniquePointer WriteFeatureDataCSVFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WriteFeatureDataCSVFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }
 
 //------------------------------------------------------------------------------
 Result<> WriteFeatureDataCSVFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto atomicFileResult = AtomicFile::Create(filterArgs.value<FileSystemPathParameter::ValueType>(k_FeatureDataFile_Key));
   if(atomicFileResult.invalid())

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteFeatureDataCSVFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteFeatureDataCSVFilter.hpp
@@ -107,7 +107,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -119,8 +120,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteLosAlamosFFTFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteLosAlamosFFTFilter.cpp
@@ -86,7 +86,7 @@ IFilter::UniquePointer WriteLosAlamosFFTFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WriteLosAlamosFFTFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_FeatureIdsArrayPath_Key);
   auto pCellEulerAnglesArrayPathValue = filterArgs.value<DataPath>(k_CellEulerAnglesArrayPath_Key);
@@ -106,7 +106,7 @@ IFilter::PreflightResult WriteLosAlamosFFTFilter::preflightImpl(const DataStruct
 
 //------------------------------------------------------------------------------
 Result<> WriteLosAlamosFFTFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                              const std::atomic_bool& shouldCancel) const
+                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto atomicFileResult = AtomicFile::Create(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
   if(atomicFileResult.invalid())

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteLosAlamosFFTFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteLosAlamosFFTFilter.hpp
@@ -98,7 +98,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -110,8 +111,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteNodesAndElementsFilesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteNodesAndElementsFilesFilter.cpp
@@ -93,7 +93,7 @@ IFilter::UniquePointer WriteNodesAndElementsFilesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WriteNodesAndElementsFilesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                         const std::atomic_bool& shouldCancel) const
+                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   DataPath selectedGeometryPath = args.value<GeometrySelectionParameter::ValueType>(k_SelectedGeometry);
   bool writeNodeFile = args.value<BoolParameter::ValueType>(k_WriteNodeFile);
@@ -122,7 +122,7 @@ IFilter::PreflightResult WriteNodesAndElementsFilesFilter::preflightImpl(const D
 
 //------------------------------------------------------------------------------
 Result<> WriteNodesAndElementsFilesFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                       const std::atomic_bool& shouldCancel) const
+                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   WriteNodesAndElementsFilesInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteNodesAndElementsFilesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteNodesAndElementsFilesFilter.hpp
@@ -103,7 +103,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.
@@ -114,8 +115,8 @@ protected:
    * @param messageHandler
    * @return Result<>
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteSPParksSitesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteSPParksSitesFilter.cpp
@@ -81,7 +81,7 @@ IFilter::UniquePointer WriteSPParksSitesFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WriteSPParksSitesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                const std::atomic_bool& shouldCancel) const
+                                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_FeatureIdsArrayPath_Key);
 
@@ -92,7 +92,7 @@ IFilter::PreflightResult WriteSPParksSitesFilter::preflightImpl(const DataStruct
 
 //------------------------------------------------------------------------------
 Result<> WriteSPParksSitesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                              const std::atomic_bool& shouldCancel) const
+                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto atomicFileResult = AtomicFile::Create(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
   if(atomicFileResult.invalid())

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteSPParksSitesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteSPParksSitesFilter.hpp
@@ -96,7 +96,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -108,8 +109,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteStlFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteStlFileFilter.cpp
@@ -112,8 +112,8 @@ IFilter::UniquePointer WriteStlFileFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult WriteStlFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                           const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult WriteStlFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                           const ExecutionContext& executionContext) const
 {
   auto pGroupingTypeValue = static_cast<GroupingType>(filterArgs.value<ChoicesParameter::ValueType>(k_GroupingType_Key));
   auto pOutputStlDirectoryValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputStlDirectory_Key);
@@ -166,7 +166,7 @@ IFilter::PreflightResult WriteStlFileFilter::preflightImpl(const DataStructure& 
 
 //------------------------------------------------------------------------------
 Result<> WriteStlFileFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                         const std::atomic_bool& shouldCancel) const
+                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   WriteStlFileInputValues inputValues;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteStlFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteStlFileFilter.hpp
@@ -101,7 +101,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -113,8 +114,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteVtkRectilinearGridFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteVtkRectilinearGridFilter.cpp
@@ -80,7 +80,7 @@ IFilter::UniquePointer WriteVtkRectilinearGridFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WriteVtkRectilinearGridFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                      const std::atomic_bool& shouldCancel) const
+                                                                      const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pOutputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key);
   auto pImageGeometryPathValue = filterArgs.value<DataPath>(k_ImageGeometryPath_Key);
@@ -112,7 +112,7 @@ IFilter::PreflightResult WriteVtkRectilinearGridFilter::preflightImpl(const Data
 
 //------------------------------------------------------------------------------
 Result<> WriteVtkRectilinearGridFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                    const std::atomic_bool& shouldCancel) const
+                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto atomicFileResult = AtomicFile::Create(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
   if(atomicFileResult.invalid())

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteVtkRectilinearGridFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteVtkRectilinearGridFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteVtkStructuredPointsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteVtkStructuredPointsFilter.cpp
@@ -79,7 +79,7 @@ IFilter::UniquePointer WriteVtkStructuredPointsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult WriteVtkStructuredPointsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                                       const std::atomic_bool& shouldCancel) const
+                                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pOutputFileValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key);
   auto pImageGeometryPathValue = filterArgs.value<DataPath>(k_ImageGeometryPath_Key);
@@ -111,7 +111,7 @@ IFilter::PreflightResult WriteVtkStructuredPointsFilter::preflightImpl(const Dat
 
 //------------------------------------------------------------------------------
 Result<> WriteVtkStructuredPointsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                     const std::atomic_bool& shouldCancel) const
+                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto atomicFileResult = AtomicFile::Create(filterArgs.value<FileSystemPathParameter::ValueType>(k_OutputFile_Key));
   if(atomicFileResult.invalid())

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteVtkStructuredPointsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteVtkStructuredPointsFilter.hpp
@@ -97,7 +97,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -109,8 +110,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/SimplnxCore/test/PipelineTest.cpp
+++ b/src/Plugins/SimplnxCore/test/PipelineTest.cpp
@@ -91,7 +91,8 @@ public:
   }
 
 protected:
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override
   {
     OutputActions outputActions;
     outputActions.appendAction(std::make_unique<CreateArrayAction>(DataType::int32, std::vector<usize>{10}, std::vector<usize>{1}, k_DeferredActionPath));
@@ -99,8 +100,8 @@ protected:
     return {std::move(outputActions)};
   }
 
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override
   {
     // object should exist because the delete should happen after execute
     if(dataStructure.getData(k_DeferredActionPath) == nullptr)

--- a/src/Plugins/TestOne/src/TestOne/Filters/CreateOutOfCoreArrayFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/CreateOutOfCoreArrayFilter.cpp
@@ -74,7 +74,7 @@ IFilter::UniquePointer CreateOutOfCoreArray::clone() const
 }
 
 IFilter::PreflightResult CreateOutOfCoreArray::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto numericType = filterArgs.value<NumericType>(k_NumericType_Key);
   auto numComponents = filterArgs.value<uint64>(k_NumComps_Key);
@@ -116,7 +116,7 @@ IFilter::PreflightResult CreateOutOfCoreArray::preflightImpl(const DataStructure
 }
 
 Result<> CreateOutOfCoreArray::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto numericType = args.value<NumericType>(k_NumericType_Key);
   auto path = args.value<DataPath>(k_DataPath_Key);

--- a/src/Plugins/TestOne/src/TestOne/Filters/CreateOutOfCoreArrayFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/CreateOutOfCoreArrayFilter.cpp
@@ -74,7 +74,7 @@ IFilter::UniquePointer CreateOutOfCoreArray::clone() const
 }
 
 IFilter::PreflightResult CreateOutOfCoreArray::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto numericType = filterArgs.value<NumericType>(k_NumericType_Key);
   auto numComponents = filterArgs.value<uint64>(k_NumComps_Key);
@@ -116,7 +116,7 @@ IFilter::PreflightResult CreateOutOfCoreArray::preflightImpl(const DataStructure
 }
 
 Result<> CreateOutOfCoreArray::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto numericType = args.value<NumericType>(k_NumericType_Key);
   auto path = args.value<DataPath>(k_DataPath_Key);

--- a/src/Plugins/TestOne/src/TestOne/Filters/CreateOutOfCoreArrayFilter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/CreateOutOfCoreArrayFilter.hpp
@@ -70,7 +70,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -82,8 +83,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/TestOne/src/TestOne/Filters/CreateOutOfCoreArrayFilter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/CreateOutOfCoreArrayFilter.hpp
@@ -70,7 +70,7 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -83,7 +83,7 @@ protected:
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExampleFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExampleFilter.cpp
@@ -100,8 +100,8 @@ IFilter::UniquePointer DynamicTableExampleFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult DynamicTableExampleFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+IFilter::PreflightResult DynamicTableExampleFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                                  const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExampleFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExampleFilter.cpp
@@ -101,14 +101,14 @@ IFilter::UniquePointer DynamicTableExampleFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult DynamicTableExampleFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                  const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }
 
 //------------------------------------------------------------------------------
 Result<> DynamicTableExampleFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineFilter, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExampleFilter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExampleFilter.hpp
@@ -77,7 +77,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -89,8 +90,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExampleFilter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/DynamicTableExampleFilter.hpp
@@ -77,7 +77,7 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -90,7 +90,7 @@ protected:
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.cpp
@@ -92,7 +92,7 @@ IFilter::UniquePointer ErrorWarningFilter::clone() const
 
 //------------------------------------------------------------------------------
 nx::core::IFilter::PreflightResult ErrorWarningFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto preflightWarning = args.value<bool>(k_PreflightWarning_Key);
   auto preflightError = args.value<bool>(k_PreflightError_Key);
@@ -118,7 +118,7 @@ nx::core::IFilter::PreflightResult ErrorWarningFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 nx::core::Result<> ErrorWarningFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto executeWarning = args.value<bool>(k_ExecuteWarning_Key);
   auto executeError = args.value<bool>(k_ExecuteError_Key);

--- a/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.cpp
@@ -92,7 +92,7 @@ IFilter::UniquePointer ErrorWarningFilter::clone() const
 
 //------------------------------------------------------------------------------
 nx::core::IFilter::PreflightResult ErrorWarningFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                                     const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto preflightWarning = args.value<bool>(k_PreflightWarning_Key);
   auto preflightError = args.value<bool>(k_PreflightError_Key);
@@ -118,7 +118,7 @@ nx::core::IFilter::PreflightResult ErrorWarningFilter::preflightImpl(const DataS
 
 //------------------------------------------------------------------------------
 nx::core::Result<> ErrorWarningFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                   const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto executeWarning = args.value<bool>(k_ExecuteWarning_Key);
   auto executeError = args.value<bool>(k_ExecuteError_Key);

--- a/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.hpp
@@ -81,9 +81,10 @@ public:
   UniquePointer clone() const override;
 
 protected:
-  PreflightResult preflightImpl(const nx::core::DataStructure& data, const nx::core::Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const nx::core::DataStructure& data, const nx::core::Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
   nx::core::Result<> executeImpl(nx::core::DataStructure& data, const nx::core::Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                 const std::atomic_bool& shouldCancel) const override;
+                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1Filter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1Filter.cpp
@@ -126,7 +126,7 @@ IFilter::UniquePointer ExampleFilter1Filter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ExampleFilter1Filter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   //  auto inputDir = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputDir_Key);
   //  std::cout << "[ExampleFilter1Filter::PreflightImpl] inputDir=" << inputDir << std::endl;
@@ -180,7 +180,7 @@ IFilter::PreflightResult ExampleFilter1Filter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> ExampleFilter1Filter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return MakeWarningVoidResult(-100, "Example Warning from within an execute message");
 }

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1Filter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1Filter.cpp
@@ -126,7 +126,7 @@ IFilter::UniquePointer ExampleFilter1Filter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ExampleFilter1Filter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   //  auto inputDir = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputDir_Key);
   //  std::cout << "[ExampleFilter1Filter::PreflightImpl] inputDir=" << inputDir << std::endl;
@@ -180,7 +180,7 @@ IFilter::PreflightResult ExampleFilter1Filter::preflightImpl(const DataStructure
 
 //------------------------------------------------------------------------------
 Result<> ExampleFilter1Filter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return MakeWarningVoidResult(-100, "Example Warning from within an execute message");
 }

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1Filter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1Filter.hpp
@@ -83,7 +83,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -95,8 +96,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1Filter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter1Filter.hpp
@@ -83,7 +83,7 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -96,7 +96,7 @@ protected:
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2Filter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2Filter.cpp
@@ -123,15 +123,15 @@ IFilter::UniquePointer ExampleFilter2Filter::clone() const
 }
 
 //------------------------------------------------------------------------------
-IFilter::PreflightResult ExampleFilter2Filter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+IFilter::PreflightResult ExampleFilter2Filter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                             const ExecutionContext& executionContext) const
 {
   return {};
 }
 
 //------------------------------------------------------------------------------
 Result<> ExampleFilter2Filter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineFilter, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2Filter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2Filter.cpp
@@ -124,14 +124,14 @@ IFilter::UniquePointer ExampleFilter2Filter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult ExampleFilter2Filter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }
 
 //------------------------------------------------------------------------------
 Result<> ExampleFilter2Filter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineFilter, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2Filter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2Filter.hpp
@@ -77,7 +77,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -89,8 +90,8 @@ protected:
    * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2Filter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ExampleFilter2Filter.hpp
@@ -77,7 +77,7 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -90,7 +90,7 @@ protected:
    * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
    */
   Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override;
+                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/TestOne/src/TestOne/Filters/TestFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/TestFilter.cpp
@@ -73,14 +73,14 @@ nx::core::IFilter::UniquePointer TestFilter::clone() const
 
 //------------------------------------------------------------------------------
 nx::core::IFilter::PreflightResult TestFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                             const std::atomic_bool& shouldCancel) const
+                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }
 
 //------------------------------------------------------------------------------
 nx::core::Result<> TestFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                           const std::atomic_bool& shouldCancel) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/TestOne/src/TestOne/Filters/TestFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/TestFilter.cpp
@@ -72,15 +72,15 @@ nx::core::IFilter::UniquePointer TestFilter::clone() const
 }
 
 //------------------------------------------------------------------------------
-nx::core::IFilter::PreflightResult TestFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+nx::core::IFilter::PreflightResult TestFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                             const ExecutionContext& executionContext) const
 {
   return {};
 }
 
 //------------------------------------------------------------------------------
 nx::core::Result<> TestFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                           const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/TestOne/src/TestOne/Filters/TestFilter.hpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/TestFilter.hpp
@@ -64,9 +64,10 @@ public:
   UniquePointer clone() const override;
 
 protected:
-  PreflightResult preflightImpl(const nx::core::DataStructure& data, const nx::core::Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const nx::core::DataStructure& data, const nx::core::Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
   nx::core::Result<> executeImpl(nx::core::DataStructure& data, const nx::core::Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                 const std::atomic_bool& shouldCancel) const override;
+                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/Plugins/TestTwo/src/TestTwo/Filters/Test2Filter.cpp
+++ b/src/Plugins/TestTwo/src/TestTwo/Filters/Test2Filter.cpp
@@ -71,15 +71,15 @@ nx::core::IFilter::UniquePointer Test2Filter::clone() const
 }
 
 //------------------------------------------------------------------------------
-nx::core::IFilter::PreflightResult Test2Filter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel) const
+nx::core::IFilter::PreflightResult Test2Filter::preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                              const ExecutionContext& executionContext) const
 {
   return {};
 }
 
 //------------------------------------------------------------------------------
 nx::core::Result<> Test2Filter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel) const
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   return {};
 }

--- a/src/Plugins/TestTwo/src/TestTwo/Filters/Test2Filter.hpp
+++ b/src/Plugins/TestTwo/src/TestTwo/Filters/Test2Filter.hpp
@@ -70,7 +70,8 @@ protected:
    * @param messageHandler
    * @return Result<OutputActions>
    */
-  PreflightResult preflightImpl(const nx::core::DataStructure& data, const nx::core::Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override;
+  PreflightResult preflightImpl(const nx::core::DataStructure& data, const nx::core::Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
 
   /**
    * @brief Filter-specifics for performing execute.
@@ -81,7 +82,7 @@ protected:
    * @return Result<>
    */
   nx::core::Result<> executeImpl(nx::core::DataStructure& data, const nx::core::Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                 const std::atomic_bool& shouldCancel) const override;
+                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override;
 };
 } // namespace nx::core
 

--- a/src/simplnx/Filter/ExecutionContext.hpp
+++ b/src/simplnx/Filter/ExecutionContext.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <filesystem>
+#include <functional>
+#include <stdexcept>
+#include <utility>
+
+namespace nx::core
+{
+class ExecutionContext
+{
+public:
+  using FunctionType = std::function<std::filesystem::path(const std::filesystem::path&)>;
+
+  ExecutionContext()
+  : m_PathFunc([](const std::filesystem::path& path) { return path; })
+  {
+  }
+
+  ExecutionContext(FunctionType func)
+  : m_PathFunc(std::move(func))
+  {
+  }
+
+  ExecutionContext(std::filesystem::path path)
+  {
+    if(path.is_relative())
+    {
+      throw std::runtime_error("ExecutionContext(): Path cannot be relative");
+    }
+    m_PathFunc = [relativeRoot = std::move(path)](const std::filesystem::path& inputPath) { return relativeRoot / inputPath; };
+  }
+
+  std::filesystem::path getAbsolutePath(const std::filesystem::path& path) const
+  {
+    if(path.is_absolute())
+    {
+      return path;
+    }
+    return m_PathFunc(path);
+  }
+
+private:
+  FunctionType m_PathFunc;
+};
+} // namespace nx::core

--- a/src/simplnx/Filter/IFilter.cpp
+++ b/src/simplnx/Filter/IFilter.cpp
@@ -30,7 +30,7 @@ void moveResult(nx::core::Result<T>& result, std::vector<nx::core::Error>& error
   }
 }
 
-std::pair<Arguments, std::vector<Warning>> GetResolvedArgs(const Arguments& args, const Parameters& params, const IFilter& filter)
+std::pair<Arguments, std::vector<Warning>> GetResolvedArgs(const Arguments& args, const Parameters& params, const IFilter& filter, const ExecutionContext& executionContext)
 {
   Arguments resolvedArgs;
   std::vector<Warning> warnings;
@@ -58,7 +58,7 @@ std::pair<Arguments, std::vector<Warning>> GetResolvedArgs(const Arguments& args
   Arguments constructedArgs;
   for(const auto& [name, parameter] : params)
   {
-    constructedArgs.insert(name, parameter->construct(resolvedArgs));
+    constructedArgs.insert(name, parameter->construct(resolvedArgs, executionContext));
   }
 
   return {std::move(constructedArgs), std::move(warnings)};
@@ -129,13 +129,14 @@ namespace nx::core
 {
 IFilter::~IFilter() noexcept = default;
 
-IFilter::PreflightResult IFilter::preflight(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const
+IFilter::PreflightResult IFilter::preflight(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                            const ExecutionContext& executionContext) const
 {
   Parameters params = parameters();
 
   std::vector<Error> errors;
 
-  auto [resolvedArgs, warnings] = GetResolvedArgs(args, params, *this);
+  auto [resolvedArgs, warnings] = GetResolvedArgs(args, params, *this, executionContext);
 
   auto [groupedParameters, ungroupedParameters] = GetGroupedParameters(params, resolvedArgs);
 
@@ -180,7 +181,7 @@ IFilter::PreflightResult IFilter::preflight(const DataStructure& data, const Arg
     return {nonstd::make_unexpected(std::move(errors)), std::move(warnings)};
   }
 
-  PreflightResult implResult = preflightImpl(data, resolvedArgs, messageHandler, shouldCancel);
+  PreflightResult implResult = preflightImpl(data, resolvedArgs, messageHandler, shouldCancel, executionContext);
   if(shouldCancel)
   {
     return {MakeErrorResult<OutputActions>(-1, "Filter cancelled")};
@@ -195,9 +196,9 @@ IFilter::PreflightResult IFilter::preflight(const DataStructure& data, const Arg
 }
 
 IFilter::ExecuteResult IFilter::execute(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineFilter, const MessageHandler& messageHandler,
-                                        const std::atomic_bool& shouldCancel) const
+                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
-  PreflightResult preflightResult = preflight(dataStructure, args, messageHandler, shouldCancel);
+  PreflightResult preflightResult = preflight(dataStructure, args, messageHandler, shouldCancel, executionContext);
   if(preflightResult.outputActions.invalid())
   {
     return ExecuteResult{ConvertResult(std::move(preflightResult.outputActions)), std::move(preflightResult.outputValues)};
@@ -218,9 +219,9 @@ IFilter::ExecuteResult IFilter::execute(DataStructure& dataStructure, const Argu
 
   Parameters params = parameters();
   // We can discard the warnings since they're already reported in preflight
-  auto [resolvedArgs, warnings] = GetResolvedArgs(args, params, *this);
+  auto [resolvedArgs, warnings] = GetResolvedArgs(args, params, *this, executionContext);
 
-  Result<> executeImplResult = executeImpl(dataStructure, resolvedArgs, pipelineFilter, messageHandler, shouldCancel);
+  Result<> executeImplResult = executeImpl(dataStructure, resolvedArgs, pipelineFilter, messageHandler, shouldCancel, executionContext);
   if(shouldCancel)
   {
     return {MakeErrorResult(-1, "Filter cancelled")};

--- a/src/simplnx/Filter/IFilter.hpp
+++ b/src/simplnx/Filter/IFilter.hpp
@@ -168,7 +168,8 @@ public:
    * @param shouldCancel
    * @return PreflightResult
    */
-  PreflightResult preflight(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler = {}, const std::atomic_bool& shouldCancel = false) const;
+  PreflightResult preflight(const DataStructure& data, const Arguments& args, const MessageHandler& messageHandler = {}, const std::atomic_bool& shouldCancel = false,
+                            const ExecutionContext& executionContext = ExecutionContext()) const;
 
   /**
    * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
@@ -181,7 +182,7 @@ public:
    * @return ExecuteResult
    */
   ExecuteResult execute(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode = nullptr, const MessageHandler& messageHandler = {},
-                        const std::atomic_bool& shouldCancel = false) const;
+                        const std::atomic_bool& shouldCancel = false, const ExecutionContext& executionContext = ExecutionContext()) const;
 
   /**
    * @brief Converts the given arguments to a JSON representation using the filter's parameters.
@@ -215,7 +216,8 @@ protected:
    * @param shouldCancel
    * @return PreflightResult
    */
-  virtual PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const = 0;
+  virtual PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                        const ExecutionContext& executionContext) const = 0;
 
   /**
    * @brief Classes that implement IFilter must provide this function for execute.
@@ -227,8 +229,8 @@ protected:
    * @param shouldCancel
    * @return Result<>
    */
-  virtual Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                               const std::atomic_bool& shouldCancel) const = 0;
+  virtual Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                               const ExecutionContext& executionContext) const = 0;
 };
 
 using FilterCreationFunc = std::function<IFilter::UniquePointer()>;

--- a/src/simplnx/Filter/IParameter.cpp
+++ b/src/simplnx/Filter/IParameter.cpp
@@ -13,7 +13,7 @@ constexpr StringLiteral k_ValueKey = "value";
 constexpr StringLiteral k_VersionKey = "version";
 } // namespace
 
-std::any IParameter::construct(const Arguments& args) const
+std::any IParameter::construct(const Arguments& args, const ExecutionContext& executionContext) const
 {
   return args.at(name());
 }

--- a/src/simplnx/Filter/IParameter.hpp
+++ b/src/simplnx/Filter/IParameter.hpp
@@ -5,6 +5,7 @@
 #include "simplnx/Common/Uuid.hpp"
 #include "simplnx/Filter/AnyCloneable.hpp"
 #include "simplnx/Filter/Arguments.hpp"
+#include "simplnx/Filter/ExecutionContext.hpp"
 #include "simplnx/simplnx_export.hpp"
 
 #include <nlohmann/json_fwd.hpp>
@@ -143,9 +144,11 @@ public:
    * @brief Constructs an input value from the given arguments.
    * By default, accesses a singular value by key and returns that.
    * May be overriden by subclasses that depend on other parameters.
+   * @param args
+   * @param executionContext
    * @return
    */
-  virtual std::any construct(const Arguments& args) const;
+  virtual std::any construct(const Arguments& args, const ExecutionContext& executionContext) const;
 
 protected:
   IParameter() = default;

--- a/src/simplnx/Parameters/Dream3dImportParameter.cpp
+++ b/src/simplnx/Parameters/Dream3dImportParameter.cpp
@@ -46,6 +46,15 @@ IParameter::VersionType Dream3dImportParameter::getVersion() const
 }
 
 //-----------------------------------------------------------------------------
+std::any Dream3dImportParameter::construct(const Arguments& args, const ExecutionContext& executionContext) const
+{
+  auto value = args.value<ValueType>(name());
+  std::filesystem::path absolutePath = executionContext.getAbsolutePath(value.FilePath);
+  value.FilePath = absolutePath;
+  return value;
+}
+
+//-----------------------------------------------------------------------------
 nlohmann::json Dream3dImportParameter::toJsonImpl(const std::any& value) const
 {
   const auto& importData = GetAnyRef<ValueType>(value);

--- a/src/simplnx/Parameters/Dream3dImportParameter.hpp
+++ b/src/simplnx/Parameters/Dream3dImportParameter.hpp
@@ -79,6 +79,16 @@ public:
   VersionType getVersion() const override;
 
   /**
+   * @brief Constructs an input value from the given arguments.
+   * By default, accesses a singular value by key and returns that.
+   * May be overriden by subclasses that depend on other parameters.
+   * @param args
+   * @param executionContext
+   * @return
+   */
+  std::any construct(const Arguments& args, const ExecutionContext& executionContext) const override;
+
+  /**
    * @brief
    * @param value
    * @return

--- a/src/simplnx/Parameters/FileSystemPathParameter.cpp
+++ b/src/simplnx/Parameters/FileSystemPathParameter.cpp
@@ -197,6 +197,12 @@ IParameter::UniquePointer FileSystemPathParameter::clone() const
 }
 
 //-----------------------------------------------------------------------------
+std::any FileSystemPathParameter::construct(const Arguments& args, const ExecutionContext& executionContext) const
+{
+  return executionContext.getAbsolutePath(args.valueRef<ValueType>(name()));
+}
+
+//-----------------------------------------------------------------------------
 std::any FileSystemPathParameter::defaultValue() const
 {
   return defaultPath();

--- a/src/simplnx/Parameters/FileSystemPathParameter.hpp
+++ b/src/simplnx/Parameters/FileSystemPathParameter.hpp
@@ -91,6 +91,16 @@ public:
   VersionType getVersion() const override;
 
   /**
+   * @brief Constructs an input value from the given arguments.
+   * By default, accesses a singular value by key and returns that.
+   * May be overriden by subclasses that depend on other parameters.
+   * @param args
+   * @param executionContext
+   * @return
+   */
+  std::any construct(const Arguments& args, const ExecutionContext& executionContext) const override;
+
+  /**
    * @brief
    * @return
    */

--- a/src/simplnx/Parameters/GeneratedFileListParameter.cpp
+++ b/src/simplnx/Parameters/GeneratedFileListParameter.cpp
@@ -148,6 +148,15 @@ std::any GeneratedFileListParameter::defaultValue() const
 }
 
 //-----------------------------------------------------------------------------
+std::any GeneratedFileListParameter::construct(const Arguments& args, const ExecutionContext& executionContext) const
+{
+  auto value = args.value<ValueType>(name());
+  std::filesystem::path absolutePath = executionContext.getAbsolutePath(value.inputPath);
+  value.inputPath = absolutePath.string();
+  return value;
+}
+
+//-----------------------------------------------------------------------------
 Result<> GeneratedFileListParameter::validate(const std::any& valueRef) const
 {
   try

--- a/src/simplnx/Parameters/GeneratedFileListParameter.hpp
+++ b/src/simplnx/Parameters/GeneratedFileListParameter.hpp
@@ -84,6 +84,16 @@ public:
   VersionType getVersion() const override;
 
   /**
+   * @brief Constructs an input value from the given arguments.
+   * By default, accesses a singular value by key and returns that.
+   * May be overriden by subclasses that depend on other parameters.
+   * @param args
+   * @param executionContext
+   * @return
+   */
+  std::any construct(const Arguments& args, const ExecutionContext& executionContext) const override;
+
+  /**
    * @brief
    * @param value
    * @return

--- a/src/simplnx/Parameters/ReadCSVFileParameter.cpp
+++ b/src/simplnx/Parameters/ReadCSVFileParameter.cpp
@@ -85,6 +85,15 @@ std::any ReadCSVFileParameter::defaultValue() const
   return m_DefaultValue;
 }
 
+//-----------------------------------------------------------------------------
+std::any ReadCSVFileParameter::construct(const Arguments& args, const ExecutionContext& executionContext) const
+{
+  auto value = args.value<ValueType>(name());
+  std::filesystem::path absolutePath = executionContext.getAbsolutePath(value.inputFilePath);
+  value.inputFilePath = absolutePath.string();
+  return value;
+}
+
 // -----------------------------------------------------------------------------
 Result<> ReadCSVFileParameter::validate(const std::any& value) const
 {

--- a/src/simplnx/Parameters/ReadCSVFileParameter.hpp
+++ b/src/simplnx/Parameters/ReadCSVFileParameter.hpp
@@ -85,6 +85,16 @@ public:
   VersionType getVersion() const override;
 
   /**
+   * @brief Constructs an input value from the given arguments.
+   * By default, accesses a singular value by key and returns that.
+   * May be overriden by subclasses that depend on other parameters.
+   * @param args
+   * @param executionContext
+   * @return
+   */
+  std::any construct(const Arguments& args, const ExecutionContext& executionContext) const override;
+
+  /**
    * @brief Validates the given value. Returns warnings/errors.
    * @param value
    * @return Result<>

--- a/src/simplnx/Parameters/ReadHDF5DatasetParameter.cpp
+++ b/src/simplnx/Parameters/ReadHDF5DatasetParameter.cpp
@@ -118,6 +118,15 @@ IParameter::VersionType ReadHDF5DatasetParameter::getVersion() const
   return 1;
 }
 
+//-----------------------------------------------------------------------------
+std::any ReadHDF5DatasetParameter::construct(const Arguments& args, const ExecutionContext& executionContext) const
+{
+  auto value = args.value<ValueType>(name());
+  std::filesystem::path absolutePath = executionContext.getAbsolutePath(value.inputFile);
+  value.inputFile = absolutePath.string();
+  return value;
+}
+
 // -----------------------------------------------------------------------------
 nlohmann::json ReadHDF5DatasetParameter::toJsonImpl(const std::any& value) const
 {

--- a/src/simplnx/Parameters/ReadHDF5DatasetParameter.hpp
+++ b/src/simplnx/Parameters/ReadHDF5DatasetParameter.hpp
@@ -111,6 +111,16 @@ public:
   VersionType getVersion() const override;
 
   /**
+   * @brief Constructs an input value from the given arguments.
+   * By default, accesses a singular value by key and returns that.
+   * May be overriden by subclasses that depend on other parameters.
+   * @param args
+   * @param executionContext
+   * @return
+   */
+  std::any construct(const Arguments& args, const ExecutionContext& executionContext) const override;
+
+  /**
    * @brief Validates the given value. Returns warnings/errors.
    * @param value
    * @return Result<>

--- a/src/simplnx/Pipeline/AbstractPipelineNode.cpp
+++ b/src/simplnx/Pipeline/AbstractPipelineNode.cpp
@@ -329,3 +329,12 @@ bool AbstractPipelineNode::ReadDisabledState(const nlohmann::json& json)
   }
   return json[k_IsDisabledKey].get<bool>();
 }
+
+ExecutionContext AbstractPipelineNode::getPipelineExecutionContext() const
+{
+  if(m_Parent == nullptr)
+  {
+    throw std::runtime_error("Called AbstractPipelineNode::getPipelineExecutionContext() when parent is null");
+  }
+  return m_Parent->getExecutionContext();
+}

--- a/src/simplnx/Pipeline/AbstractPipelineNode.hpp
+++ b/src/simplnx/Pipeline/AbstractPipelineNode.hpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/Common/Types.hpp"
 #include "simplnx/DataStructure/DataStructure.hpp"
+#include "simplnx/Filter/ExecutionContext.hpp"
 #include "simplnx/simplnx_export.hpp"
 
 #include <nlohmann/json_fwd.hpp>
@@ -245,6 +246,12 @@ public:
    * @return std::unique_ptr<Pipeline>
    */
   std::unique_ptr<Pipeline> getPrecedingPipeline() const;
+
+  /**
+   * @brief Gets the executionContext for the pipeline.
+   * @return
+   */
+  ExecutionContext getPipelineExecutionContext() const;
 
 protected:
   /**

--- a/src/simplnx/Pipeline/Pipeline.cpp
+++ b/src/simplnx/Pipeline/Pipeline.cpp
@@ -59,10 +59,16 @@ nlohmann::json CreatePipelineJson(std::string_view name, nlohmann::json filterAr
 }
 } // namespace
 
-Pipeline::Pipeline(const std::string& name, FilterList* filterList)
+Pipeline::Pipeline(ExecutionContext executionContext, const std::string& name, FilterList* filterList)
 : AbstractPipelineNode()
 , m_Name(name)
 , m_FilterList(filterList)
+, m_ExecutionContext(std::move(executionContext))
+{
+}
+
+Pipeline::Pipeline(const std::string& name, FilterList* filterList)
+: Pipeline(Application::Instance()->getCurrentDir(), name, filterList)
 {
 }
 
@@ -71,6 +77,7 @@ Pipeline::Pipeline(const Pipeline& other)
 , m_Name(other.m_Name)
 , m_Collection(other.m_Collection)
 , m_FilterList(other.m_FilterList)
+, m_ExecutionContext(other.m_ExecutionContext)
 {
   resetCollectionParent();
 }
@@ -80,6 +87,7 @@ Pipeline::Pipeline(Pipeline&& other) noexcept
 , m_Name(std::move(other.m_Name))
 , m_Collection(std::move(other.m_Collection))
 , m_FilterList(std::move(other.m_FilterList))
+, m_ExecutionContext(std::move(other.m_ExecutionContext))
 {
   resetCollectionParent();
 }
@@ -950,4 +958,14 @@ uint64 Pipeline::checkMemoryRequired()
 {
   preflight();
   return m_MemoryRequired;
+}
+
+void Pipeline::setExecutionContext(ExecutionContext executionContext)
+{
+  m_ExecutionContext = std::move(executionContext);
+}
+
+ExecutionContext Pipeline::getExecutionContext() const
+{
+  return m_ExecutionContext;
 }

--- a/src/simplnx/Pipeline/Pipeline.cpp
+++ b/src/simplnx/Pipeline/Pipeline.cpp
@@ -68,7 +68,7 @@ Pipeline::Pipeline(ExecutionContext executionContext, const std::string& name, F
 }
 
 Pipeline::Pipeline(const std::string& name, FilterList* filterList)
-: Pipeline(Application::Instance()->getCurrentDir(), name, filterList)
+: Pipeline(ExecutionContext(), name, filterList)
 {
 }
 

--- a/src/simplnx/Pipeline/Pipeline.hpp
+++ b/src/simplnx/Pipeline/Pipeline.hpp
@@ -99,7 +99,17 @@ public:
   /**
    * @brief Constructs a pipeline with the specified name. If no name is
    * provided, a default name of "Unnamed Pipeline" will be used.
+   * @param executionContext
+   * @param name
+   * @param filterList
+   */
+  Pipeline(ExecutionContext executionContext, const std::string& name = "Untitled Pipeline", FilterList* filterList = nullptr);
+
+  /**
+   * @brief Constructs a pipeline with the specified name. If no name is
+   * provided, a default name of "Unnamed Pipeline" will be used.
    * @param name = "Unnamed Pipeline"
+   * @param filterList
    */
   Pipeline(const std::string& name = "Untitled Pipeline", FilterList* filterList = nullptr);
 
@@ -606,6 +616,18 @@ public:
    */
   uint64 checkMemoryRequired();
 
+  /**
+   * @brief Sets the ExecutionContext for the pipeline.
+   * @param executionContext
+   */
+  void setExecutionContext(ExecutionContext executionContext);
+
+  /**
+   * @brief Gets the ExecutionContext for the pipeline.
+   * @return
+   */
+  ExecutionContext getExecutionContext() const;
+
 protected:
   /**
    * @brief Returns implementation-specific json value for the node.
@@ -657,5 +679,6 @@ private:
   collection_type m_Collection;
   FilterList* m_FilterList = nullptr;
   uint64 m_MemoryRequired = 0;
+  ExecutionContext m_ExecutionContext;
 };
 } // namespace nx::core

--- a/src/simplnx/Pipeline/PipelineFilter.cpp
+++ b/src/simplnx/Pipeline/PipelineFilter.cpp
@@ -159,7 +159,7 @@ bool PipelineFilter::preflight(DataStructure& dataStructure, RenamedPaths& renam
     return false;
   }
 
-  IFilter::PreflightResult result = m_Filter->preflight(dataStructure, getArguments(), messageHandler, shouldCancel);
+  IFilter::PreflightResult result = m_Filter->preflight(dataStructure, getArguments(), messageHandler, shouldCancel, getPipelineExecutionContext());
   m_Warnings = std::move(result.outputActions.warnings());
   setHasWarnings(!m_Warnings.empty());
   m_PreflightValues = std::move(result.outputValues);
@@ -254,7 +254,7 @@ bool PipelineFilter::execute(DataStructure& dataStructure, const std::atomic_boo
   IFilter::ExecuteResult result;
   if(m_Filter != nullptr)
   {
-    result = m_Filter->execute(dataStructure, getArguments(), this, messageHandler, shouldCancel);
+    result = m_Filter->execute(dataStructure, getArguments(), this, messageHandler, shouldCancel, getPipelineExecutionContext());
     m_Warnings = result.result.warnings();
     m_PreflightValues = std::move(result.outputValues);
     if(result.result.invalid())

--- a/test/PipelineSaveTest.cpp
+++ b/test/PipelineSaveTest.cpp
@@ -61,12 +61,13 @@ public:
   }
 
 protected:
-  PreflightResult preflightImpl(const nx::core::DataStructure& data, const nx::core::Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override
+  PreflightResult preflightImpl(const nx::core::DataStructure& data, const nx::core::Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override
   {
     return {};
   }
   nx::core::Result<> executeImpl(nx::core::DataStructure& data, const nx::core::Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                 const std::atomic_bool& shouldCancel) const override
+                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const override
   {
     return {};
   }

--- a/wrapping/python/CxPybind/CxPybind/CxPybind.hpp
+++ b/wrapping/python/CxPybind/CxPybind/CxPybind.hpp
@@ -590,7 +590,8 @@ public:
   }
 
 protected:
-  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel) const override
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& args, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override
   {
     try
     {
@@ -611,8 +612,8 @@ protected:
     }
   }
 
-  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                       const std::atomic_bool& shouldCancel) const override
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override
   {
     try
     {


### PR DESCRIPTION
Added support for interpreting relative paths in pipelines as relative to the pipeline file itself. Filters and filter parameter need to have support manually added. Currently only `FileSystemPathParameter` is added.