### PR TITLE
COMP: Update EbsdLib to 1.0.37

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -33,7 +33,7 @@
         "zlib",
         "zstd"
       ],
-      "baseline": "f3ad41f2d8bf809b5b21f5658e6bda664025caf7"
+      "baseline": "5cd1bdc5a8e258edd76d03441dce18224c5ec015"
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -74,7 +74,7 @@
       "dependencies": [
         {
           "name": "ebsdlib",
-          "version>=": "1.0.35"
+          "version>=": "1.0.37"
         }
       ]
     },


### PR DESCRIPTION
This fixes potential NaN values when using EbsdLib::qu2ax() functions
