### PR TITLE
BUG: Fix incorrect logic to validate usage of existing attribute matrix

### DIFF
--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceFeaturesFilter.cpp
@@ -298,28 +298,28 @@ Result<> ComputeSurfaceFeaturesFilter::executeImpl(DataStructure& dataStructure,
   const auto pMarkFeature0NeighborsValue = filterArgs.value<bool>(k_MarkFeature0Neighbors);
   const auto pFeatureGeometryPathValue = filterArgs.value<DataPath>(k_FeatureGeometryPath_Key);
   const auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
-  const auto pCellFeaturesAttributeMatrixPathValue = filterArgs.value<DataPath>(k_CellFeatureAttributeMatrixPath_Key);
-  const auto pSurfaceFeaturesArrayPathValue = pCellFeaturesAttributeMatrixPathValue.createChildPath(filterArgs.value<std::string>(k_SurfaceFeaturesArrayName_Key));
+  const auto pFeaturesAttributeMatrixPathValue = filterArgs.value<DataPath>(k_CellFeatureAttributeMatrixPath_Key);
+  const auto pSurfaceFeaturesArrayPathValue = pFeaturesAttributeMatrixPathValue.createChildPath(filterArgs.value<std::string>(k_SurfaceFeaturesArrayName_Key));
 
   // Resize the surface features array to the proper size
-  const auto& featureIds = dataStructure.getDataAs<Int32Array>(pFeatureIdsArrayPathValue)->getDataStoreRef();
-  auto& surfaceFeatures = dataStructure.getDataAs<UInt8Array>(pSurfaceFeaturesArrayPathValue)->getDataStoreRef();
+  const auto& featureIdsDataStore = dataStructure.getDataAs<Int32Array>(pFeatureIdsArrayPathValue)->getDataStoreRef();
+  auto& surfaceFeaturesDataStore = dataStructure.getDataAs<UInt8Array>(pSurfaceFeaturesArrayPathValue)->getDataStoreRef();
 
-  const usize featureIdsMaxIdx = std::distance(featureIds.begin(), std::max_element(featureIds.cbegin(), featureIds.cend()));
-  const usize maxFeature = featureIds[featureIdsMaxIdx];
-  const std::vector<usize> surfaceFeaturesTupleShape = {maxFeature + 1};
+  const usize featureIdsMaxIdx = std::distance(featureIdsDataStore.begin(), std::max_element(featureIdsDataStore.cbegin(), featureIdsDataStore.cend()));
+  const usize maxFeature = featureIdsDataStore[featureIdsMaxIdx];
 
-  Result<> resizeResults = ResizeDataArray<uint8>(dataStructure, pSurfaceFeaturesArrayPathValue, surfaceFeaturesTupleShape);
-  if(resizeResults.invalid())
+  const auto* featuresAttrMatPtr = dataStructure.getDataAs<AttributeMatrix>(pFeaturesAttributeMatrixPathValue);
+
+  if(maxFeature >= featuresAttrMatPtr->getNumTuples())
   {
-    return resizeResults;
+    return MakeErrorResult(-17500, fmt::format("Max Feature index '{}' must be less than {}.", maxFeature, featuresAttrMatPtr->getNumTuples()));
   }
-  surfaceFeatures.fill(0);
+  // Initialize all values to 'false' or ZERO.
+  surfaceFeaturesDataStore.fill(0);
 
   // Find surface features
   const auto& featureGeometry = dataStructure.getDataRefAs<ImageGeom>(pFeatureGeometryPathValue);
-  const usize geometryDimensionality = featureGeometry.getDimensionality();
-  if(geometryDimensionality == 3)
+  if(const usize geometryDimensionality = featureGeometry.getDimensionality(); geometryDimensionality == 3)
   {
     findSurfaceFeatures3D(dataStructure, pFeatureGeometryPathValue, pFeatureIdsArrayPathValue, pSurfaceFeaturesArrayPathValue, pMarkFeature0NeighborsValue, shouldCancel);
   }

--- a/src/simplnx/Utilities/DataArrayUtilities.hpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.hpp
@@ -773,38 +773,6 @@ SIMPLNX_EXPORT bool CheckArraysHaveSameTupleCount(const DataStructure& dataStruc
 SIMPLNX_EXPORT Result<> ValidateNumFeaturesInArray(const DataStructure& dataStructure, const DataPath& arrayPath, const Int32Array& featureIds);
 
 /**
- * @brief This function will ensure that a DataArray can be safely resized to the user entered numeric value
- *
- * @param dataStructure
- * @param arrayPath The path to the DataArray to be reshaped.
- * @param newShape The new tuple shape to resize the array to
- * @return
- */
-template <typename T>
-Result<> ResizeDataArray(DataStructure& dataStructure, const DataPath& arrayPath, const std::vector<usize>& newShape)
-{
-  auto* dataArrayPtr = dataStructure.getDataAs<DataArray<T>>(arrayPath);
-  if(dataArrayPtr == nullptr)
-  {
-    return MakeErrorResult(-4830, fmt::format("Could not find array path '{}' in the given data structure", arrayPath.toString()));
-  }
-  if(dataArrayPtr->getTupleShape() == newShape) // array does not need to be reshaped
-  {
-    return {};
-  }
-  const auto& surfaceFeaturesParent = dataStructure.getDataAs<AttributeMatrix>(arrayPath.getParent());
-  if(surfaceFeaturesParent != nullptr) // tuple shape of the parent attribute matrix doesn't match the new tuple shape
-  {
-    return MakeErrorResult(-4831, fmt::format("Cannot resize array at path '{}' to tuple shape {} because the parent is an Attribute Matrix with a tuple shape of {} which does not match.",
-                                              arrayPath.toString(), newShape, surfaceFeaturesParent->getShape()));
-  }
-
-  // the array's parent is not in an Attribute Matrix, so we can safely reshape to the new tuple shape
-  dataArrayPtr->template getIDataStoreRefAs<DataStore<T>>().resizeTuples(newShape);
-  return {};
-}
-
-/**
  * @brief This function resize the outermost vector of the NeighborList's underlying data to the NeighborList's set
  * number of tuples and initializes each item in the vector to a (non null) pointer to an empty vector
  *


### PR DESCRIPTION
The logic now simply validates that the max feature id is less than the number of tuples of the feature Attribute Matrix.

Removed function from DataArrayUtilities because there were bugs in the logic of the function and it is not used anywhere in the code.
