### PR TITLE
ENH: Add Fill Functionality to Create Array Action & Utility File Refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,11 +526,13 @@ set(SIMPLNX_HDRS
   ${SIMPLNX_SOURCE_DIR}/Plugin/AbstractPlugin.hpp
   ${SIMPLNX_SOURCE_DIR}/Plugin/PluginLoader.hpp
 
+  ${SIMPLNX_SOURCE_DIR}/Utilities/ArrayCreationUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/AlignSections.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/ArrayThreshold.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/DataArrayUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/DataGroupUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/DataObjectUtilities.hpp
+  ${SIMPLNX_SOURCE_DIR}/Utilities/DataStoreUtilities.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/FilePathGenerator.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/ColorTableUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/FileUtilities.hpp
@@ -540,6 +542,7 @@ set(SIMPLNX_HDRS
   ${SIMPLNX_SOURCE_DIR}/Utilities/HistogramUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/MemoryUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/StringUtilities.hpp
+  ${SIMPLNX_SOURCE_DIR}/Utilities/StringInterpretationUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/IntersectionUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/IParallelAlgorithm.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/ParallelDataAlgorithm.hpp
@@ -728,6 +731,7 @@ set(SIMPLNX_SRCS
   ${SIMPLNX_SOURCE_DIR}/Plugin/AbstractPlugin.cpp
   ${SIMPLNX_SOURCE_DIR}/Plugin/PluginLoader.cpp
 
+  ${SIMPLNX_SOURCE_DIR}/Utilities/ArrayCreationUtilities.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/ArrayThreshold.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/FilePathGenerator.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/FilterUtilities.cpp
@@ -736,6 +740,7 @@ set(SIMPLNX_SRCS
   ${SIMPLNX_SOURCE_DIR}/Utilities/TooltipRowItem.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/DataArrayUtilities.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/DataGroupUtilities.cpp
+  ${SIMPLNX_SOURCE_DIR}/Utilities/DataStoreUtilities.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/MemoryUtilities.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/IParallelAlgorithm.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/ParallelDataAlgorithm.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,6 +540,7 @@ set(SIMPLNX_HDRS
   ${SIMPLNX_SOURCE_DIR}/Utilities/GeometryUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/GeometryHelpers.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/HistogramUtilities.hpp
+  ${SIMPLNX_SOURCE_DIR}/Utilities/MaskCompareUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/MemoryUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/StringUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/StringInterpretationUtilities.hpp
@@ -741,6 +742,7 @@ set(SIMPLNX_SRCS
   ${SIMPLNX_SOURCE_DIR}/Utilities/DataArrayUtilities.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/DataGroupUtilities.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/DataStoreUtilities.cpp
+  ${SIMPLNX_SOURCE_DIR}/Utilities/MaskCompareUtilities.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/MemoryUtilities.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/IParallelAlgorithm.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/ParallelDataAlgorithm.cpp
@@ -748,6 +750,7 @@ set(SIMPLNX_SRCS
   ${SIMPLNX_SOURCE_DIR}/Utilities/ParallelData3DAlgorithm.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/ParallelTaskAlgorithm.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/SegmentFeatures.cpp
+  ${SIMPLNX_SOURCE_DIR}/Utilities/StringInterpretationUtilities.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/AlignSections.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/OStreamUtilities.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/GeometryHelpers.cpp

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/AlignSectionsMisorientation.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/AlignSectionsMisorientation.cpp
@@ -3,8 +3,8 @@
 #include "simplnx/Common/Numbers.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/Geometry/IGridGeometry.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 
 #include "EbsdLib/LaueOps/LaueOps.h"
 
@@ -37,12 +37,12 @@ Result<> AlignSectionsMisorientation::operator()()
 // -----------------------------------------------------------------------------
 Result<> AlignSectionsMisorientation::findShifts(std::vector<int64_t>& xShifts, std::vector<int64_t>& yShifts)
 {
-  std::unique_ptr<MaskCompare> maskCompare = nullptr;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare = nullptr;
   if(m_InputValues->UseMask)
   {
     try
     {
-      maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+      maskCompare = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
     } catch(const std::out_of_range& exception)
     {
       // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/AlignSectionsMutualInformation.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/AlignSectionsMutualInformation.cpp
@@ -47,7 +47,7 @@ Result<> AlignSectionsMutualInformation::findShifts(std::vector<int64>& xShifts,
   {
     try
     {
-      m_MaskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+      m_MaskCompare = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
     } catch(const std::out_of_range& exception)
     {
       // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/AlignSectionsMutualInformation.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/AlignSectionsMutualInformation.hpp
@@ -9,7 +9,7 @@
 #include "simplnx/Parameters/FileSystemPathParameter.hpp"
 #include "simplnx/Parameters/NumberParameter.hpp"
 #include "simplnx/Utilities/AlignSections.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 
 namespace nx::core
 {
@@ -59,7 +59,7 @@ private:
   const std::atomic_bool& m_ShouldCancel;
   const IFilter::MessageHandler& m_MessageHandler;
 
-  std::unique_ptr<MaskCompare> m_MaskCompare = nullptr;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> m_MaskCompare = nullptr;
 };
 
 } // namespace nx::core

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/BadDataNeighborOrientationCheck.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/BadDataNeighborOrientationCheck.cpp
@@ -4,7 +4,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 
 #include "EbsdLib/Core/Orientation.hpp"
 #include "EbsdLib/LaueOps/LaueOps.h"
@@ -42,10 +42,10 @@ Result<> BadDataNeighborOrientationCheck::operator()()
   const auto& crystalStructures = m_DataStructure.getDataRefAs<UInt32Array>(m_InputValues->CrystalStructuresArrayPath);
   size_t totalPoints = quats.getNumberOfTuples();
 
-  std::unique_ptr<MaskCompare> maskCompare = nullptr;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare = nullptr;
   try
   {
-    maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+    maskCompare = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.cpp
@@ -38,7 +38,7 @@ Result<> CAxisSegmentFeatures::operator()()
   {
     try
     {
-      m_GoodVoxelsArray = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+      m_GoodVoxelsArray = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
     } catch(const std::out_of_range&)
     {
       // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.hpp
@@ -5,7 +5,7 @@
 #include "simplnx/DataStructure/DataPath.hpp"
 #include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/Filter/IFilter.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 #include "simplnx/Utilities/SegmentFeatures.hpp"
 
 namespace nx::core
@@ -55,7 +55,7 @@ private:
 
   Float32Array* m_QuatsArray = nullptr;
   Int32Array* m_CellPhases = nullptr;
-  std::unique_ptr<MaskCompare> m_GoodVoxelsArray = nullptr;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> m_GoodVoxelsArray = nullptr;
   Int32Array* m_FeatureIdsArray = nullptr;
 };
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeTwinBoundaries.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeTwinBoundaries.cpp
@@ -3,7 +3,7 @@
 #include "simplnx/Common/Array.hpp"
 #include "simplnx/Common/Constants.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 #include "simplnx/Utilities/Math/GeometryMath.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
@@ -151,7 +151,7 @@ class CalculateTwinBoundaryWithIncoherenceImpl
 public:
   CalculateTwinBoundaryWithIncoherenceImpl(float32 angtol, float32 axistol, const Int32AbstractDataStore& faceLabels, const Float64AbstractDataStore& faceNormals,
                                            const Float32AbstractDataStore& avgQuats, const Int32AbstractDataStore& featurePhases, const UInt32AbstractDataStore& crystalStructures,
-                                           std::unique_ptr<MaskCompare>& twinBoundaries, Float32AbstractDataStore& twinBoundaryIncoherence, const std::atomic_bool& shouldCancel,
+                                           std::unique_ptr<MaskCompareUtilities::MaskCompare>& twinBoundaries, Float32AbstractDataStore& twinBoundaryIncoherence, const std::atomic_bool& shouldCancel,
                                            std::atomic_bool& hasNaN)
   : m_AxisTol(axistol)
   , m_AngTol(angtol)
@@ -225,7 +225,7 @@ private:
   const Float32AbstractDataStore& m_AvgQuats;
   const Int32AbstractDataStore& m_FeaturePhases;
   const UInt32AbstractDataStore& m_CrystalStructures;
-  std::unique_ptr<MaskCompare>& m_TwinBoundaries;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare>& m_TwinBoundaries;
   Float32AbstractDataStore& m_TwinBoundaryIncoherence;
   const std::atomic_bool& m_ShouldCancel;
   std::atomic_bool& m_HasNaN;
@@ -240,7 +240,7 @@ class CalculateTwinBoundaryImpl
 {
 public:
   CalculateTwinBoundaryImpl(float32 angtol, float32 axistol, const Int32AbstractDataStore& faceLabels, const Float32AbstractDataStore& avgQuats, const Int32AbstractDataStore& featurePhases,
-                            const UInt32AbstractDataStore& crystalStructures, std::unique_ptr<MaskCompare>& twinBoundaries, const std::atomic_bool& shouldCancel)
+                            const UInt32AbstractDataStore& crystalStructures, std::unique_ptr<MaskCompareUtilities::MaskCompare>& twinBoundaries, const std::atomic_bool& shouldCancel)
   : m_AxisTol(axistol)
   , m_AngTol(angtol)
   , m_FaceLabels(faceLabels)
@@ -292,7 +292,7 @@ private:
   const Float32AbstractDataStore& m_AvgQuats;
   const Int32AbstractDataStore& m_FeaturePhases;
   const UInt32AbstractDataStore& m_CrystalStructures;
-  std::unique_ptr<MaskCompare>& m_TwinBoundaries;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare>& m_TwinBoundaries;
   const std::atomic_bool& m_ShouldCancel;
   std::vector<LaueOps::Pointer> m_OrientationOps;
 };
@@ -347,10 +347,10 @@ Result<> ComputeTwinBoundaries::operator()()
   const auto& avgQuats = m_DataStructure.getDataAs<Float32Array>(m_InputValues->AvgQuatsArrayPath)->getDataStoreRef();
   const auto& featurePhases = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeaturePhasesArrayPath)->getDataStoreRef();
 
-  std::unique_ptr<MaskCompare> twinBoundaries;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> twinBoundaries;
   try
   {
-    twinBoundaries = InstantiateMaskCompare(m_DataStructure, m_InputValues->TwinBoundariesArrayPath);
+    twinBoundaries = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->TwinBoundariesArrayPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
@@ -29,7 +29,7 @@ Result<> EBSDSegmentFeatures::operator()()
   {
     try
     {
-      m_GoodVoxelsArray = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+      m_GoodVoxelsArray = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
     } catch(const std::out_of_range& exception)
     {
       // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.hpp
@@ -7,7 +7,7 @@
 #include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/DataStructure/IDataArray.hpp"
 #include "simplnx/Filter/IFilter.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 #include "simplnx/Utilities/SegmentFeatures.hpp"
 
 #include "EbsdLib/LaueOps/LaueOps.h"
@@ -79,7 +79,7 @@ private:
   const EBSDSegmentFeaturesInputValues* m_InputValues = nullptr;
   Float32Array* m_QuatsArray = nullptr;
   FeatureIdsArrayType* m_CellPhases = nullptr;
-  std::unique_ptr<MaskCompare> m_GoodVoxelsArray = nullptr;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> m_GoodVoxelsArray = nullptr;
   DataArray<uint32>* m_CrystalStructures = nullptr;
 
   FeatureIdsArrayType* m_FeatureIdsArray = nullptr;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WritePoleFigure.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WritePoleFigure.cpp
@@ -12,9 +12,11 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
+#include "simplnx/DataStructure/StringArray.hpp"
 #include "simplnx/Pipeline/Pipeline.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 #include "simplnx/Utilities/IntersectionUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 #include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
 #include "simplnx/Utilities/RTree.hpp"
@@ -272,7 +274,7 @@ public:
     using DimensionType = std::vector<size_t>;
 
     DimensionType faceTupleShape = {0};
-    Result result = CreateArray<IGeometry::MeshIndexType>(dataStructure, faceTupleShape, {3ULL}, sharedFaceListPath, IDataAction::Mode::Execute);
+    Result result = ArrayCreationUtilities::CreateArray<IGeometry::MeshIndexType>(dataStructure, faceTupleShape, {3ULL}, sharedFaceListPath, IDataAction::Mode::Execute);
     if(result.invalid())
     {
       return -1;
@@ -285,13 +287,17 @@ public:
     DataPath vertexPath({"Delaunay", "SharedVertexList"});
 
     DimensionType vertexTupleShape = {0};
-    result = CreateArray<float>(dataStructure, vertexTupleShape, {3}, vertexPath, IDataAction::Mode::Execute);
+    result = ArrayCreationUtilities::CreateArray<float>(dataStructure, vertexTupleShape, {3}, vertexPath, IDataAction::Mode::Execute);
     if(result.invalid())
     {
       return -2;
       // return MergeResults(result, MakeErrorResult(-5510, fmt::format("{}CreateGeometry2DAction: Could not allocate SharedVertList '{}'", prefix, vertexPath.toString())));
     }
-    Float32Array* vertexArray = ArrayFromPath<float>(dataStructure, vertexPath);
+    auto* vertexArray = dataStructure.getDataAs<Float32Array>(vertexPath);
+    if(vertexArray == nullptr)
+    {
+      throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", vertexPath.toString()));
+    }
     triangleGeom.setVertices(*vertexArray);
     triangleGeom.resizeVertexList(numPts);
 
@@ -674,12 +680,12 @@ Result<> WritePoleFigure::operator()()
   auto& crystalStructures = m_DataStructure.getDataRefAs<UInt32Array>(m_InputValues->CrystalStructuresArrayPath);
   auto& materialNames = m_DataStructure.getDataRefAs<StringArray>(m_InputValues->MaterialNameArrayPath);
 
-  std::unique_ptr<MaskCompare> maskCompare = nullptr;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare = nullptr;
   if(m_InputValues->UseMask)
   {
     try
     {
-      maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+      maskCompare = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
     } catch(const std::out_of_range& exception)
     {
       // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from
@@ -819,13 +825,13 @@ Result<> WritePoleFigure::operator()()
       {
         const std::vector<size_t> intensityImageDims = {static_cast<usize>(config.imageDim), static_cast<usize>(config.imageDim), 1ULL};
         DataPath arrayDataPath = amPath.createChildPath(fmt::format("Phase_{}_{}", phase, m_InputValues->IntensityPlot1Name));
-        Result<> result = CreateArray<float64>(m_DataStructure, intensityImageDims, {1ULL}, arrayDataPath, IDataAction::Mode::Execute);
+        Result<> result = ArrayCreationUtilities::CreateArray<float64>(m_DataStructure, intensityImageDims, {1ULL}, arrayDataPath, IDataAction::Mode::Execute);
 
         arrayDataPath = amPath.createChildPath(fmt::format("Phase_{}_{}", phase, m_InputValues->IntensityPlot2Name));
-        result = CreateArray<float64>(m_DataStructure, intensityImageDims, {1ULL}, arrayDataPath, IDataAction::Mode::Execute);
+        result = ArrayCreationUtilities::CreateArray<float64>(m_DataStructure, intensityImageDims, {1ULL}, arrayDataPath, IDataAction::Mode::Execute);
 
         arrayDataPath = amPath.createChildPath(fmt::format("Phase_{}_{}", phase, m_InputValues->IntensityPlot3Name));
-        result = CreateArray<float64>(m_DataStructure, intensityImageDims, {1ULL}, arrayDataPath, IDataAction::Mode::Execute);
+        result = ArrayCreationUtilities::CreateArray<float64>(m_DataStructure, intensityImageDims, {1ULL}, arrayDataPath, IDataAction::Mode::Execute);
       }
 
       auto intensityPlot1Array = m_DataStructure.getDataRefAs<Float64Array>(amPath.createChildPath(fmt::format("Phase_{}_{}", phase, m_InputValues->IntensityPlot1Name)));
@@ -1069,7 +1075,7 @@ Result<> WritePoleFigure::operator()()
         tupleShape[2] = pageWidth;
         // Create an output array to hold the RGB formatted color image
         auto imageArrayPath = cellAttrMatPath.createChildPath(fmt::format("Phase_{}", phase));
-        auto arrayCreationResult = nx::core::CreateArray<uint8>(m_DataStructure, tupleShape, {3ULL}, imageArrayPath, IDataAction::Mode::Execute);
+        auto arrayCreationResult = ArrayCreationUtilities::CreateArray<uint8>(m_DataStructure, tupleShape, {3ULL}, imageArrayPath, IDataAction::Mode::Execute);
         if(arrayCreationResult.invalid())
         {
           return arrayCreationResult;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteStatsGenOdfAngleFile.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteStatsGenOdfAngleFile.cpp
@@ -47,10 +47,10 @@ Result<> WriteStatsGenOdfAngleFile::operator()()
   }
 
   const auto& cellPhases = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->CellPhasesArrayPath);
-  std::unique_ptr<MaskCompare> maskPtr = nullptr;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskPtr = nullptr;
   if(m_InputValues->UseMask)
   {
-    maskPtr = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+    maskPtr = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
   }
 
   // Figure out how many unique phase values we have by looping over all the phase values
@@ -100,7 +100,7 @@ Result<> WriteStatsGenOdfAngleFile::operator()()
 }
 
 // -----------------------------------------------------------------------------
-int WriteStatsGenOdfAngleFile::determineOutputLineCount(const Int32Array& cellPhases, const std::unique_ptr<MaskCompare>& mask, usize totalPoints, int32 phase) const
+int WriteStatsGenOdfAngleFile::determineOutputLineCount(const Int32Array& cellPhases, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& mask, usize totalPoints, int32 phase) const
 {
   int32 lineCount = 0;
   for(usize i = 0; i < totalPoints; i++)
@@ -118,7 +118,8 @@ int WriteStatsGenOdfAngleFile::determineOutputLineCount(const Int32Array& cellPh
 }
 
 // -----------------------------------------------------------------------------
-Result<> WriteStatsGenOdfAngleFile::writeOutputFile(std::ofstream& out, const Int32Array& cellPhases, const std::unique_ptr<MaskCompare>& mask, int32 lineCount, usize totalPoints, int32 phase) const
+Result<> WriteStatsGenOdfAngleFile::writeOutputFile(std::ofstream& out, const Int32Array& cellPhases, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& mask, int32 lineCount,
+                                                    usize totalPoints, int32 phase) const
 {
   const auto& eulerAngles = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->CellEulerAnglesArrayPath);
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteStatsGenOdfAngleFile.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteStatsGenOdfAngleFile.hpp
@@ -8,7 +8,7 @@
 #include "simplnx/Filter/IFilter.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
 #include "simplnx/Parameters/FileSystemPathParameter.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 
 namespace nx::core
 {
@@ -46,8 +46,8 @@ public:
 
   const std::atomic_bool& getCancel();
 
-  int determineOutputLineCount(const Int32Array& cellPhases, const std::unique_ptr<MaskCompare>& mask, usize totalPoints, int32 phase) const;
-  Result<> writeOutputFile(std::ofstream& out, const Int32Array& cellPhases, const std::unique_ptr<MaskCompare>& mask, int32 lineCount, usize totalPoints, int32 phase) const;
+  int determineOutputLineCount(const Int32Array& cellPhases, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& mask, usize totalPoints, int32 phase) const;
+  Result<> writeOutputFile(std::ofstream& out, const Int32Array& cellPhases, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& mask, int32 lineCount, usize totalPoints, int32 phase) const;
 
 private:
   DataStructure& m_DataStructure;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/AlignSectionsFeatureCentroid.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/AlignSectionsFeatureCentroid.cpp
@@ -3,8 +3,8 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/IGridGeometry.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 
 #include <iostream>
 
@@ -35,10 +35,10 @@ Result<> AlignSectionsFeatureCentroid::operator()()
 // -----------------------------------------------------------------------------
 Result<> AlignSectionsFeatureCentroid::findShifts(std::vector<int64_t>& xShifts, std::vector<int64_t>& yShifts)
 {
-  std::unique_ptr<MaskCompare> maskCompare;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;
   try
   {
-    maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+    maskCompare = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeArrayStatistics.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeArrayStatistics.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/HistogramUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 #include "simplnx/Utilities/Math/StatisticsCalculations.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
@@ -42,7 +43,7 @@ class ComputeArrayStatisticsByIndexImpl
 {
 public:
   ComputeArrayStatisticsByIndexImpl(bool length, bool min, bool max, bool mean, bool mode, bool stdDeviation, bool summation, bool hist, float64 histmin, float64 histmax, bool histfullrange,
-                                    int32 numBins, bool modalBinRanges, const std::unique_ptr<MaskCompare>& mask, const Int32Array* featureIds, const DataArray<T>& source,
+                                    int32 numBins, bool modalBinRanges, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& mask, const Int32Array* featureIds, const DataArray<T>& source,
                                     BoolArray* featureHasDataArray, UInt64Array* lengthArray, DataArray<T>* minArray, DataArray<T>* maxArray, Float32Array* meanArray, NeighborList<T>* modeArray,
                                     Float32Array* stdDevArray, Float32Array* summationArray, UInt64Array* histBinCountsArray, DataArray<T>* histBinRangesArray, UInt64Array* mostPopulatedBinArray,
                                     NeighborList<T>* modalBinRangesArray, ComputeArrayStatistics* filter)
@@ -392,7 +393,7 @@ private:
   float64 m_HistMax;
   bool m_HistFullRange;
   int32 m_NumBins;
-  const std::unique_ptr<MaskCompare>& m_Mask = nullptr;
+  const std::unique_ptr<MaskCompareUtilities::MaskCompare>& m_Mask = nullptr;
   const Int32Array* m_FeatureIds = nullptr;
   const DataArray<T>& m_Source;
   BoolArray* m_FeatureHasDataArray = nullptr;
@@ -414,8 +415,8 @@ template <typename T>
 class FindArrayMedianUniqueByIndexImpl
 {
 public:
-  FindArrayMedianUniqueByIndexImpl(const std::unique_ptr<MaskCompare>& mask, const Int32Array* featureIds, const DataArray<T>& source, bool findMedian, bool findNumUnique, Float32Array* medianArray,
-                                   Int32Array* numUniqueValuesArray, DataArray<uint64>* lengthArray, ComputeArrayStatistics* filter)
+  FindArrayMedianUniqueByIndexImpl(const std::unique_ptr<MaskCompareUtilities::MaskCompare>& mask, const Int32Array* featureIds, const DataArray<T>& source, bool findMedian, bool findNumUnique,
+                                   Float32Array* medianArray, Int32Array* numUniqueValuesArray, DataArray<uint64>* lengthArray, ComputeArrayStatistics* filter)
   : m_FindMedian(findMedian)
   , m_FindNumUniqueValues(findNumUnique)
   , m_MedianArray(medianArray)
@@ -491,7 +492,7 @@ private:
   bool m_FindNumUniqueValues;
   Float32Array* m_MedianArray;
   Int32Array* m_NumUniqueValuesArray;
-  const std::unique_ptr<MaskCompare>& m_Mask = nullptr;
+  const std::unique_ptr<MaskCompareUtilities::MaskCompare>& m_Mask = nullptr;
   const Int32Array* m_FeatureIds = nullptr;
   const DataArray<T>& m_Source;
   const DataArray<uint64>* m_LengthArray = nullptr;
@@ -691,7 +692,7 @@ void FindStatisticsImpl(const ContainerType& data, std::vector<IArray*>& arrays,
 
 // -----------------------------------------------------------------------------
 template <typename T>
-void FindStatistics(const DataArray<T>& source, const Int32Array* featureIds, const std::unique_ptr<MaskCompare>& mask, const ComputeArrayStatisticsInputValues* inputValues,
+void FindStatistics(const DataArray<T>& source, const Int32Array* featureIds, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& mask, const ComputeArrayStatisticsInputValues* inputValues,
                     std::vector<IArray*>& arrays, usize numFeatures, ComputeArrayStatistics* filter)
 {
   if(inputValues->ComputeByIndex)
@@ -802,7 +803,7 @@ void FindStatistics(const DataArray<T>& source, const Int32Array* featureIds, co
 
 // -----------------------------------------------------------------------------
 template <typename T>
-void StandardizeDataByIndex(const DataArray<T>& dataArray, bool useMask, const std::unique_ptr<MaskCompare>& mask, const Int32Array* featureIdsArray, const Float32Array& muArray,
+void StandardizeDataByIndex(const DataArray<T>& dataArray, bool useMask, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& mask, const Int32Array* featureIdsArray, const Float32Array& muArray,
                             const Float32Array& sigArray, Float32Array& standardizedArray)
 {
   auto& data = dataArray.getDataStoreRef();
@@ -830,7 +831,8 @@ void StandardizeDataByIndex(const DataArray<T>& dataArray, bool useMask, const s
 
 // -----------------------------------------------------------------------------
 template <typename T>
-void StandardizeData(const DataArray<T>& dataArray, bool useMask, const std::unique_ptr<MaskCompare>& mask, const Float32Array& muArray, const Float32Array& sigArray, Float32Array& standardizedArray)
+void StandardizeData(const DataArray<T>& dataArray, bool useMask, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& mask, const Float32Array& muArray, const Float32Array& sigArray,
+                     Float32Array& standardizedArray)
 {
   auto& data = dataArray.getDataStoreRef();
   auto& standardized = standardizedArray.getDataStoreRef();
@@ -868,12 +870,12 @@ struct ComputeArrayStatisticsFunctor
     {
       featureIdsPtr = dataStructure.getDataAs<Int32Array>(inputValues->FeatureIdsArrayPath);
     }
-    std::unique_ptr<MaskCompare> maskCompare = nullptr;
+    std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare = nullptr;
     if(inputValues->UseMask)
     {
       try
       {
-        maskCompare = InstantiateMaskCompare(dataStructure, inputValues->MaskArrayPath);
+        maskCompare = MaskCompareUtilities::InstantiateMaskCompare(dataStructure, inputValues->MaskArrayPath);
       } catch(const std::out_of_range& exception)
       {
         // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBiasedFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBiasedFeatures.cpp
@@ -2,7 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 
 using namespace nx::core;
 
@@ -55,10 +55,10 @@ Result<> ComputeBiasedFeatures::findBoundingBoxFeatures()
   auto& biasedFeaturesStore = m_DataStructure.getDataAsUnsafe<BoolArray>(m_InputValues->BiasedFeaturesArrayName)->getDataStoreRef();
   biasedFeaturesStore.fill(false);
 
-  std::unique_ptr<MaskCompare> surfaceFeatures = nullptr;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> surfaceFeatures = nullptr;
   try
   {
-    surfaceFeatures = InstantiateMaskCompare(m_DataStructure, m_InputValues->SurfaceFeaturesArrayPath);
+    surfaceFeatures = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->SurfaceFeaturesArrayPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from
@@ -196,10 +196,10 @@ Result<> ComputeBiasedFeatures::findBoundingBoxFeatures2D()
   auto& biasedFeaturesStore = m_DataStructure.getDataAs<BoolArray>(m_InputValues->BiasedFeaturesArrayName)->getDataStoreRef();
   biasedFeaturesStore.fill(false);
 
-  std::unique_ptr<MaskCompare> maskCompare = nullptr;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare = nullptr;
   try
   {
-    maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->SurfaceFeaturesArrayPath);
+    maskCompare = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->SurfaceFeaturesArrayPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureClustering.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureClustering.cpp
@@ -3,9 +3,9 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/NeighborList.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 
 #include <random>
-#include <simplnx/Utilities/DataArrayUtilities.hpp>
 
 using namespace nx::core;
 
@@ -137,12 +137,12 @@ Result<> ComputeFeatureClustering::operator()()
   auto& clusteringList = m_DataStructure.getDataRefAs<NeighborList<float32>>(m_InputValues->ClusteringListArrayName);
   auto& rdfStore = m_DataStructure.getDataAs<Float32Array>(m_InputValues->RDFArrayName)->getDataStoreRef();
   auto& minMaxDistancesStore = m_DataStructure.getDataAs<Float32Array>(m_InputValues->MaxMinArrayName)->getDataStoreRef();
-  std::unique_ptr<MaskCompare> maskCompare;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;
   if(m_InputValues->RemoveBiasedFeatures)
   {
     try
     {
-      maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->BiasedFeaturesArrayPath);
+      maskCompare = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->BiasedFeaturesArrayPath);
     } catch(const std::out_of_range& exception)
     {
       // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeKMeans.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeKMeans.cpp
@@ -2,8 +2,8 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/ClusteringUtilities.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 
 #include <random>
 
@@ -15,8 +15,8 @@ template <typename T>
 class ComputeKMeansTemplate
 {
 public:
-  ComputeKMeansTemplate(ComputeKMeans* filter, const IDataArray* inputIDataArray, IDataArray* meansIDataArray, const std::unique_ptr<MaskCompare>& maskDataArray, usize numClusters,
-                        Int32AbstractDataStore& fIds, ClusterUtilities::DistanceMetric distMetric, std::mt19937_64::result_type seed)
+  ComputeKMeansTemplate(ComputeKMeans* filter, const IDataArray* inputIDataArray, IDataArray* meansIDataArray, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& maskDataArray,
+                        usize numClusters, Int32AbstractDataStore& fIds, ClusterUtilities::DistanceMetric distMetric, std::mt19937_64::result_type seed)
   : m_Filter(filter)
   , m_InputArray(inputIDataArray->template getIDataStoreRefAs<AbstractDataStoreT>())
   , m_Means(meansIDataArray->template getIDataStoreRefAs<AbstractDataStoreT>())
@@ -104,7 +104,7 @@ private:
   ComputeKMeans* m_Filter;
   const AbstractDataStoreT& m_InputArray;
   AbstractDataStoreT& m_Means;
-  const std::unique_ptr<MaskCompare>& m_Mask;
+  const std::unique_ptr<MaskCompareUtilities::MaskCompare>& m_Mask;
   usize m_NumClusters;
   Int32AbstractDataStore& m_FeatureIds;
   ClusterUtilities::DistanceMetric m_DistMetric;
@@ -209,10 +209,10 @@ Result<> ComputeKMeans::operator()()
 {
   auto* clusteringArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->ClusteringArrayPath);
 
-  std::unique_ptr<MaskCompare> maskCompare;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;
   try
   {
-    maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+    maskCompare = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeKMedoids.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeKMedoids.cpp
@@ -2,8 +2,8 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/ClusteringUtilities.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 
 #include <random>
 
@@ -15,8 +15,8 @@ template <typename T>
 class KMedoidsTemplate
 {
 public:
-  KMedoidsTemplate(ComputeKMedoids* filter, const IDataArray* inputIDataArray, IDataArray* medoidsIDataArray, const std::unique_ptr<MaskCompare>& maskDataArray, usize numClusters,
-                   Int32AbstractDataStore& fIds, ClusterUtilities::DistanceMetric distMetric, std::mt19937_64::result_type seed)
+  KMedoidsTemplate(ComputeKMedoids* filter, const IDataArray* inputIDataArray, IDataArray* medoidsIDataArray, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& maskDataArray,
+                   usize numClusters, Int32AbstractDataStore& fIds, ClusterUtilities::DistanceMetric distMetric, std::mt19937_64::result_type seed)
   : m_Filter(filter)
   , m_InputArray(inputIDataArray->template getIDataStoreRefAs<AbstractDataStore<T>>())
   , m_Medoids(medoidsIDataArray->template getIDataStoreRefAs<AbstractDataStore<T>>())
@@ -93,7 +93,7 @@ private:
   ComputeKMedoids* m_Filter;
   const AbstractDataStoreT& m_InputArray;
   AbstractDataStoreT& m_Medoids;
-  const std::unique_ptr<MaskCompare>& m_Mask;
+  const std::unique_ptr<MaskCompareUtilities::MaskCompare>& m_Mask;
   usize m_NumClusters;
   Int32AbstractDataStore& m_FeatureIds;
   ClusterUtilities::DistanceMetric m_DistMetric;
@@ -209,10 +209,10 @@ const std::atomic_bool& ComputeKMedoids::getCancel()
 Result<> ComputeKMedoids::operator()()
 {
   auto* clusteringArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->ClusteringArrayPath);
-  std::unique_ptr<MaskCompare> maskCompare;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;
   try
   {
-    maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+    maskCompare = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeVectorColors.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeVectorColors.cpp
@@ -4,7 +4,7 @@
 #include "simplnx/Common/RgbColor.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 
 #include <Eigen/Dense>
 
@@ -37,10 +37,10 @@ const std::atomic_bool& ComputeVectorColors::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ComputeVectorColors::operator()()
 {
-  std::unique_ptr<MaskCompare> maskCompare;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;
   try
   {
-    maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+    maskCompare = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CropEdgeGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CropEdgeGeometry.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/Geometry/EdgeGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
+#include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
 using namespace nx::core;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/DBSCAN.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/DBSCAN.cpp
@@ -1,10 +1,11 @@
 #include "DBSCAN.hpp"
 
 #include "simplnx/Common/Range.hpp"
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/ClusteringUtilities.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 #include <fmt/format.h>
@@ -20,7 +21,7 @@ private:
   using AbstractDataStoreT = AbstractDataStore<T>;
 
 public:
-  FindEpsilonNeighborhoodsImpl(DBSCAN* filter, float64 epsilon, const AbstractDataStoreT& inputData, const std::unique_ptr<MaskCompare>& mask, usize numCompDims, usize numTuples,
+  FindEpsilonNeighborhoodsImpl(DBSCAN* filter, float64 epsilon, const AbstractDataStoreT& inputData, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& mask, usize numCompDims, usize numTuples,
                                ClusterUtilities::DistanceMetric distMetric, std::vector<std::list<usize>>& neighborhoods)
   : m_Filter(filter)
   , m_Epsilon(epsilon)
@@ -77,7 +78,7 @@ private:
   DBSCAN* m_Filter;
   float64 m_Epsilon;
   const AbstractDataStoreT& m_InputDataStore;
-  const std::unique_ptr<MaskCompare>& m_Mask;
+  const std::unique_ptr<MaskCompareUtilities::MaskCompare>& m_Mask;
   usize m_NumCompDims;
   usize m_NumTuples;
   ClusterUtilities::DistanceMetric m_DistMetric;
@@ -91,8 +92,8 @@ private:
   using AbstractDataStoreT = AbstractDataStore<T>;
 
 public:
-  DBSCANTemplate(DBSCAN* filter, const AbstractDataStoreT& inputDataStore, const std::unique_ptr<MaskCompare>& maskDataArray, AbstractDataStore<int32>& fIdsDataStore, float32 epsilon, int32 minPoints,
-                 ClusterUtilities::DistanceMetric distMetric, std::mt19937_64::result_type seed)
+  DBSCANTemplate(DBSCAN* filter, const AbstractDataStoreT& inputDataStore, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& maskDataArray, AbstractDataStore<int32>& fIdsDataStore,
+                 float32 epsilon, int32 minPoints, ClusterUtilities::DistanceMetric distMetric, std::mt19937_64::result_type seed)
   : m_Filter(filter)
   , m_InputDataStore(inputDataStore)
   , m_Mask(maskDataArray)
@@ -288,7 +289,7 @@ public:
 private:
   DBSCAN* m_Filter;
   const AbstractDataStoreT& m_InputDataStore;
-  const std::unique_ptr<MaskCompare>& m_Mask;
+  const std::unique_ptr<MaskCompareUtilities::MaskCompare>& m_Mask;
   AbstractDataStore<int32>& m_FeatureIds;
   float32 m_Epsilon;
   int32 m_MinPoints;
@@ -299,8 +300,8 @@ private:
 struct DBSCANFunctor
 {
   template <typename T>
-  void operator()(bool cache, bool useRandom, DBSCAN* filter, const IDataArray& inputIDataArray, const std::unique_ptr<MaskCompare>& maskCompare, Int32Array& fIds, float32 epsilon, int32 minPoints,
-                  ClusterUtilities::DistanceMetric distMetric, std::mt19937_64::result_type seed)
+  void operator()(bool cache, bool useRandom, DBSCAN* filter, const IDataArray& inputIDataArray, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& maskCompare, Int32Array& fIds,
+                  float32 epsilon, int32 minPoints, ClusterUtilities::DistanceMetric distMetric, std::mt19937_64::result_type seed)
   {
     if(cache)
     {
@@ -358,10 +359,10 @@ Result<> DBSCAN::operator()()
   auto& clusteringArray = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->ClusteringArrayPath);
   auto& featureIds = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->FeatureIdsArrayPath);
 
-  std::unique_ptr<MaskCompare> maskCompare;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;
   try
   {
-    maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+    maskCompare = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExtractVertexGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExtractVertexGeometry.cpp
@@ -3,8 +3,8 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/IGridGeometry.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 
 using namespace nx::core;
 
@@ -99,10 +99,10 @@ Result<> ExtractVertexGeometry::operator()()
   std::vector<bool> maskedPoints;
   if(m_InputValues->UseMask)
   {
-    std::unique_ptr<MaskCompare> maskArrayPtr = nullptr;
+    std::unique_ptr<MaskCompareUtilities::MaskCompare> maskArrayPtr = nullptr;
     try
     {
-      maskArrayPtr = InstantiateMaskCompare(m_DataStructure, maskArrayPath);
+      maskArrayPtr = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, maskArrayPath);
     } catch(const std::out_of_range& exception)
     {
       // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InitializeData.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InitializeData.cpp
@@ -1,12 +1,10 @@
-
-
 #include "InitializeData.hpp"
 
 #include "simplnx/Common/TypeTraits.hpp"
 #include "simplnx/DataStructure/AbstractDataStore.hpp"
 #include "simplnx/DataStructure/IDataArray.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 
 #include <chrono>
 #include <limits>
@@ -39,7 +37,7 @@ void ValueFill(AbstractDataStore<T>& dataStore, const std::vector<std::string>& 
 
     for(const auto& str : stringValues)
     {
-      values.emplace_back(ConvertTo<T>::convert(str).value());
+      values.emplace_back(StringInterpretationUtilities::Convert<T>(str).value());
     }
 
     usize numTup = dataStore.getNumberOfTuples();
@@ -54,7 +52,7 @@ void ValueFill(AbstractDataStore<T>& dataStore, const std::vector<std::string>& 
   }
   else
   {
-    Result<T> result = ConvertTo<T>::convert(stringValues[0]);
+    Result<T> result = StringInterpretationUtilities::Convert<T>(stringValues[0]);
     T value = result.value();
     dataStore.fill(value);
   }
@@ -70,11 +68,11 @@ void IncrementalFill(AbstractDataStore<T>& dataStore, const std::vector<std::str
 
   for(usize comp = 0; comp < numComp; comp++)
   {
-    Result<T> result = ConvertTo<T>::convert(startValues[comp]);
+    Result<T> result = StringInterpretationUtilities::Convert<T>(startValues[comp]);
     values[comp] = result.value();
     if constexpr(!std::is_same_v<T, bool>)
     {
-      result = ConvertTo<T>::convert(stepValues[comp]);
+      result = StringInterpretationUtilities::Convert<T>(stepValues[comp]);
       steps[comp] = result.value();
     }
   }
@@ -89,11 +87,11 @@ void IncrementalFill(AbstractDataStore<T>& dataStore, const std::vector<std::str
 
       if constexpr(IncrementalOptions::UsingAddition)
       {
-        values[comp] = ConvertTo<uint8>::convert(stepValues[comp]).value() != 0 ? true : values[comp];
+        values[comp] = StringInterpretationUtilities::Convert<T>(stepValues[comp]).value() != 0 ? true : values[comp];
       }
       if constexpr(IncrementalOptions::UsingSubtraction)
       {
-        values[comp] = ConvertTo<uint8>::convert(stepValues[comp]).value() != 0 ? false : values[comp];
+        values[comp] = StringInterpretationUtilities::Convert<T>(stepValues[comp]).value() != 0 ? false : values[comp];
       }
     }
 
@@ -293,9 +291,9 @@ struct FillArrayFunctor
       std::vector<T> range;
       for(usize comp = 0; comp < numComp; comp++)
       {
-        Result<T> result = ConvertTo<T>::convert(randBegin[comp]);
+        Result<T> result = StringInterpretationUtilities::Convert<T>(randBegin[comp]);
         range.push_back(result.value());
-        result = ConvertTo<T>::convert(randEnd[comp]);
+        result = StringInterpretationUtilities::Convert<T>(randEnd[comp]);
         range.push_back(result.value());
       }
       return ::FillRandomForwarder<T, true>(range, numComp, dataStore, inputValues.seed, inputValues.standardizeSeed);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InitializeData.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InitializeData.hpp
@@ -3,7 +3,7 @@
 #include "SimplnxCore/SimplnxCore_export.hpp"
 
 #include "simplnx/Filter/IFilter.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 namespace nx::core
@@ -181,8 +181,7 @@ struct SIMPLNXCORE_EXPORT ValidateMultiInputFunctor
         return IFilter::MakePreflightErrorResult(-11611, fmt::format("Empty value found after '{}' components were converted. Check for duplicate '{}' next to one another.", comp, k_DelimiterChar));
       }
 
-      Result<T> result = ConvertTo<T>::convert(splitVals[comp]);
-
+      Result<T> result = StringInterpretationUtilities::Convert<T>(splitVals[comp]);
       if(result.invalid())
       {
         return IFilter::MakePreflightErrorResult(-11612, fmt::format("Unable to process '{}' into a {} value.", splitVals[comp], DataTypeToString(GetDataType<T>())));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/PointSampleTriangleGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/PointSampleTriangleGeometry.cpp
@@ -36,7 +36,7 @@
 #include "TupleTransfer.hpp"
 
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 
 using namespace nx::core;
 
@@ -84,12 +84,12 @@ Result<> PointSampleTriangleGeometry::operator()()
   // We get the pointer to the Array instead of a reference because it might not have been set because
   // the bool "use_mask" might have been false, but we do NOT want to try to get the array
   // 'on demand' in the loop. That is a BAD idea as is it really slow to do that. (10x slower).
-  std::unique_ptr<MaskCompare> maskArray = nullptr;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskArray = nullptr;
   if(m_Inputs->pUseMask)
   {
     try
     {
-      maskArray = InstantiateMaskCompare(m_DataStructure, m_Inputs->pMaskArrayPath);
+      maskArray = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_Inputs->pMaskArrayPath);
     } catch(const std::out_of_range& exception)
     {
       // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadVtkStructuredPoints.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadVtkStructuredPoints.cpp
@@ -2,8 +2,8 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Filter/Actions/CreateArrayAction.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/Parsing/Text/CsvParser.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include <iostream>
@@ -221,7 +221,7 @@ Result<> readDataChunk(DataStructure* dataStructurePtr, std::istream& in, bool b
       std::fill(buffer.begin(), buffer.begin() + bytesRead, 0);
       for(const auto& token : tokens)
       {
-        auto result = nx::core::ConvertTo<T>::convert(token);
+        auto result = StringInterpretationUtilities::Convert<T>(token);
         if(result.invalid())
         {
           return ConvertResult(std::move(result));
@@ -589,19 +589,19 @@ Result<> ReadVtkStructuredPoints::readFile()
   }
 
   CreateImageGeometryAction::DimensionType pointDims(3, 0);
-  auto convertResultSizeT = nx::core::ConvertTo<usize>::convert(tokens[1]);
+  auto convertResultSizeT = StringInterpretationUtilities::Convert<usize>(tokens[1]);
   if(convertResultSizeT.invalid())
   {
     return ConvertResult(std::move(convertResultSizeT));
   }
   pointDims[0] = convertResultSizeT.value();
-  convertResultSizeT = nx::core::ConvertTo<usize>::convert(tokens[2]);
+  convertResultSizeT = StringInterpretationUtilities::Convert<usize>(tokens[2]);
   if(convertResultSizeT.invalid())
   {
     return ConvertResult(std::move(convertResultSizeT));
   }
   pointDims[1] = convertResultSizeT.value();
-  convertResultSizeT = nx::core::ConvertTo<usize>::convert(tokens[3]);
+  convertResultSizeT = StringInterpretationUtilities::Convert<usize>(tokens[3]);
   if(convertResultSizeT.invalid())
   {
     return ConvertResult(std::move(convertResultSizeT));
@@ -634,19 +634,19 @@ Result<> ReadVtkStructuredPoints::readFile()
 
   CreateImageGeometryAction::SpacingType spacing(3, 0.0f);
 
-  auto convertResultF32 = nx::core::ConvertTo<float32>::convert(tokens[1]);
+  auto convertResultF32 = StringInterpretationUtilities::Convert<float32>(tokens[1]);
   if(convertResultF32.invalid())
   {
     return ConvertResult(std::move(convertResultF32));
   }
   spacing[0] = convertResultF32.value();
-  convertResultF32 = nx::core::ConvertTo<float32>::convert(tokens[2]);
+  convertResultF32 = StringInterpretationUtilities::Convert<float32>(tokens[2]);
   if(convertResultF32.invalid())
   {
     return ConvertResult(std::move(convertResultF32));
   }
   spacing[1] = convertResultF32.value();
-  convertResultF32 = nx::core::ConvertTo<float32>::convert(tokens[3]);
+  convertResultF32 = StringInterpretationUtilities::Convert<float32>(tokens[3]);
   if(convertResultF32.invalid())
   {
     return ConvertResult(std::move(convertResultF32));
@@ -673,19 +673,19 @@ Result<> ReadVtkStructuredPoints::readFile()
   }
 
   CreateImageGeometryAction::OriginType origin(3, 0.0f);
-  convertResultF32 = nx::core::ConvertTo<float32>::convert(tokens[1]);
+  convertResultF32 = StringInterpretationUtilities::Convert<float32>(tokens[1]);
   if(convertResultF32.invalid())
   {
     return ConvertResult(std::move(convertResultF32));
   }
   origin[0] = convertResultF32.value();
-  convertResultF32 = nx::core::ConvertTo<float32>::convert(tokens[2]);
+  convertResultF32 = StringInterpretationUtilities::Convert<float32>(tokens[2]);
   if(convertResultF32.invalid())
   {
     return ConvertResult(std::move(convertResultF32));
   }
   origin[1] = convertResultF32.value();
-  convertResultF32 = nx::core::ConvertTo<float32>::convert(tokens[3]);
+  convertResultF32 = StringInterpretationUtilities::Convert<float32>(tokens[3]);
   if(convertResultF32.invalid())
   {
     return ConvertResult(std::move(convertResultF32));
@@ -726,7 +726,7 @@ Result<> ReadVtkStructuredPoints::readFile()
   }
 
   std::string sectionType = std::string(tokens[0]);
-  auto convertResultI32 = nx::core::ConvertTo<int32>::convert(tokens[1]);
+  auto convertResultI32 = StringInterpretationUtilities::Convert<int32>(tokens[1]);
   if(convertResultI32.invalid())
   {
     return ConvertResult(std::move(convertResultI32));
@@ -902,7 +902,7 @@ Result<int32> ReadVtkStructuredPoints::readDataTypeSection(std::istream& in, int
       // Read the number of values
       std::fill(buf.begin(), buf.end(), '\0'); // Splat nulls across the vector
       ReadString(in, buf.data(), kBufferSize);
-      auto convertResultI32 = nx::core::ConvertTo<int32>::convert({buf.data()});
+      auto convertResultI32 = StringInterpretationUtilities::Convert<int32>({buf.data()});
       return {convertResultI32.value()};
     }
     else

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedEdges.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedEdges.cpp
@@ -1,10 +1,10 @@
 #include "RemoveFlaggedEdges.hpp"
 
-#include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/Geometry/EdgeGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
@@ -85,10 +85,10 @@ Result<> RemoveFlaggedEdges::operator()()
 {
   // Remove Edges from reduced according to removeEdgesIndex
   const auto& originalEdgeGeom = m_DataStructure.getDataRefAs<EdgeGeom>(m_InputValues->EdgeGeometry);
-  std::unique_ptr<MaskCompare> maskCompare;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;
   try
   {
-    maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+    maskCompare = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedFeatures.cpp
@@ -6,8 +6,8 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataStore.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
 using namespace nx::core;
@@ -119,7 +119,7 @@ bool IdentifyNeighbors(ImageGeom& imageGeom, Int32AbstractDataStore& featureIds,
   return shouldLoop;
 }
 
-std::vector<bool> FlagFeatures(Int32AbstractDataStore& featureIds, std::unique_ptr<MaskCompare>& flaggedFeatures, const bool fillRemovedFeatures)
+std::vector<bool> FlagFeatures(Int32AbstractDataStore& featureIds, std::unique_ptr<MaskCompareUtilities::MaskCompare>& flaggedFeatures, const bool fillRemovedFeatures)
 {
   bool good = false;
   usize totalPoints = featureIds.getNumberOfTuples();
@@ -290,10 +290,10 @@ Result<> RemoveFlaggedFeatures::operator()()
   auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ImageGeometryPath);
   auto function = static_cast<Functionality>(m_InputValues->ExtractFeatures);
 
-  std::unique_ptr<MaskCompare> flaggedFeatures = nullptr;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> flaggedFeatures = nullptr;
   try
   {
-    flaggedFeatures = InstantiateMaskCompare(m_DataStructure, m_InputValues->FlaggedFeaturesArrayPath);
+    flaggedFeatures = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->FlaggedFeaturesArrayPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedTriangles.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedTriangles.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -83,10 +84,10 @@ Result<> RemoveFlaggedTriangles::operator()()
 {
   // Remove Triangles from reduced according to removeTrianglesIndex
   const auto& originalTriangle = m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues->TriangleGeometry);
-  std::unique_ptr<MaskCompare> maskCompare;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;
   try
   {
-    maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+    maskCompare = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
@@ -146,7 +146,6 @@ Result<> ScalarSegmentFeatures::operator()()
   auto* gridGeom = m_DataStructure.getDataAs<IGridGeometry>(m_InputValues->ImageGeometryPath);
 
   m_FeatureIdsArray = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsArrayPath);
-  m_FeatureIdsArray->fill(0); // initialize the output array with zeros
 
   auto* inputDataArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->InputDataPath);
   size_t inDataPoints = inputDataArray->getNumberOfTuples();
@@ -223,7 +222,6 @@ Result<> ScalarSegmentFeatures::operator()()
 
   // make sure all values are initialized and "re-reserve" index 0
   auto& activeStore = m_DataStructure.getDataAs<UInt8Array>(m_InputValues->ActiveArrayPath)->getDataStoreRef();
-  activeStore.fill(1);
   activeStore[0] = 0;
 
   // Randomize the feature Ids for purely visual clarify. Having random Feature Ids

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
@@ -133,7 +133,7 @@ Result<> ScalarSegmentFeatures::operator()()
   {
     try
     {
-      m_GoodVoxels = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+      m_GoodVoxels = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
     } catch(const std::out_of_range& exception)
     {
       // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.hpp
@@ -7,7 +7,7 @@
 #include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/DataStructure/IDataArray.hpp"
 #include "simplnx/Filter/IFilter.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 #include "simplnx/Utilities/SegmentFeatures.hpp"
 
 #include <random>
@@ -75,6 +75,6 @@ private:
   FeatureIdsArrayType* m_FeatureIdsArray = nullptr;
   GoodVoxelsArrayType* m_GoodVoxelsArray = nullptr;
   std::shared_ptr<SegmentFeatures::CompareFunctor> m_CompareFunctor;
-  std::unique_ptr<MaskCompare> m_GoodVoxels = nullptr;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> m_GoodVoxels = nullptr;
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/Silhouette.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/Silhouette.cpp
@@ -2,8 +2,8 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/ClusteringUtilities.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 
 #include <unordered_set>
 
@@ -26,7 +26,7 @@ public:
     return Pointer(static_cast<Self*>(nullptr));
   }
 
-  SilhouetteTemplate(const IDataArray& inputIDataArray, Float64AbstractDataStore& outputDataArray, const std::unique_ptr<MaskCompare>& maskDataArray, usize numClusters,
+  SilhouetteTemplate(const IDataArray& inputIDataArray, Float64AbstractDataStore& outputDataArray, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& maskDataArray, usize numClusters,
                      const Int32AbstractDataStore& featureIds, ClusterUtilities::DistanceMetric distMetric)
   : m_InputData(inputIDataArray.template getIDataStoreRefAs<AbstractDataStoreT>())
   , m_OutputData(outputDataArray)
@@ -125,7 +125,7 @@ private:
   const AbstractDataStoreT& m_InputData;
   Float64AbstractDataStore& m_OutputData;
   const Int32AbstractDataStore& m_FeatureIds;
-  const std::unique_ptr<MaskCompare>& m_Mask;
+  const std::unique_ptr<MaskCompareUtilities::MaskCompare>& m_Mask;
   usize m_NumClusters;
   ClusterUtilities::DistanceMetric m_DistMetric;
 };
@@ -168,10 +168,10 @@ Result<> Silhouette::operator()()
   }
 
   auto& clusteringArray = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->ClusteringArrayPath);
-  std::unique_ptr<MaskCompare> maskCompare;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;
   try
   {
-    maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
+    maskCompare = MaskCompareUtilities::InstantiateMaskCompare(m_DataStructure, m_InputValues->MaskArrayPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesBinaryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesBinaryFilter.cpp
@@ -1,5 +1,6 @@
 #include "ComputeFeaturePhasesBinaryFilter.hpp"
 
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataPath.hpp"
 #include "simplnx/Filter/Actions/CreateArrayAction.hpp"
@@ -7,10 +8,9 @@
 #include "simplnx/Parameters/AttributeMatrixSelectionParameter.hpp"
 #include "simplnx/Parameters/DataGroupCreationParameter.hpp"
 #include "simplnx/Parameters/DataObjectNameParameter.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 
 #include "simplnx/Utilities/SIMPLConversion.hpp"
-
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 
 using namespace nx::core;
 
@@ -110,10 +110,10 @@ Result<> ComputeFeaturePhasesBinaryFilter::executeImpl(DataStructure& dataStruct
   auto& featurePhasesArray =
       dataStructure.getDataAs<Int32Array>(filterArgs.value<DataPath>(k_CellDataAMPath_Key).createChildPath(filterArgs.value<std::string>(k_FeaturePhasesArrayName_Key)))->getDataStoreRef();
 
-  std::unique_ptr<MaskCompare> goodVoxelsMask;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> goodVoxelsMask;
   try
   {
-    goodVoxelsMask = InstantiateMaskCompare(dataStructure, filterArgs.value<DataPath>(k_MaskArrayPath_Key));
+    goodVoxelsMask = MaskCompareUtilities::InstantiateMaskCompare(dataStructure, filterArgs.value<DataPath>(k_MaskArrayPath_Key));
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMeansFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMeansFilter.cpp
@@ -137,7 +137,8 @@ IFilter::PreflightResult ComputeKMeansFilter::preflightImpl(const DataStructure&
   }
 
   {
-    auto createAction = std::make_unique<CreateArrayAction>(DataType::int32, clusterArray->getTupleShape(), std::vector<usize>{1}, pSelectedArrayPathValue.replaceName(pFeatureIdsArrayNameValue));
+    auto createAction = std::make_unique<CreateArrayAction>(DataType::int32, clusterArray->getTupleShape(), std::vector<usize>{1}, pSelectedArrayPathValue.replaceName(pFeatureIdsArrayNameValue),
+                                                            CreateArrayAction::k_DefaultDataFormat, "0");
     resultOutputActions.value().appendAction(std::move(createAction));
   }
 
@@ -145,7 +146,7 @@ IFilter::PreflightResult ComputeKMeansFilter::preflightImpl(const DataStructure&
   {
     DataPath tempPath = DataPath({k_MaskName});
     {
-      auto createAction = std::make_unique<CreateArrayAction>(DataType::boolean, clusterArray->getTupleShape(), std::vector<usize>{1}, tempPath);
+      auto createAction = std::make_unique<CreateArrayAction>(DataType::boolean, clusterArray->getTupleShape(), std::vector<usize>{1}, tempPath, CreateArrayAction::k_DefaultDataFormat, "true");
       resultOutputActions.value().appendAction(std::move(createAction));
     }
 
@@ -179,7 +180,6 @@ Result<> ComputeKMeansFilter::executeImpl(DataStructure& dataStructure, const Ar
   if(!filterArgs.value<bool>(k_UseMask_Key))
   {
     maskPath = DataPath({k_MaskName});
-    dataStructure.getDataRefAs<BoolArray>(maskPath).fill(true);
   }
 
   auto seed = filterArgs.value<std::mt19937_64::result_type>(k_SeedValue_Key);
@@ -200,9 +200,7 @@ Result<> ComputeKMeansFilter::executeImpl(DataStructure& dataStructure, const Ar
   inputValues.Seed = seed;
 
   inputValues.ClusteringArrayPath = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
-  auto fIdsPath = inputValues.ClusteringArrayPath.replaceName(filterArgs.value<std::string>(k_FeatureIdsArrayName_Key));
-  dataStructure.getDataAs<Int32Array>(fIdsPath)->fill(0);
-  inputValues.FeatureIdsArrayPath = fIdsPath;
+  inputValues.FeatureIdsArrayPath = inputValues.ClusteringArrayPath.replaceName(filterArgs.value<std::string>(k_FeatureIdsArrayName_Key));
 
   return ComputeKMeans(dataStructure, messageHandler, shouldCancel, &inputValues)();
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMedoidsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeKMedoidsFilter.cpp
@@ -122,7 +122,6 @@ IFilter::PreflightResult ComputeKMedoidsFilter::preflightImpl(const DataStructur
   auto pMedoidsArrayNameValue = filterArgs.value<std::string>(k_MedoidsArrayName_Key);
   auto pSeedArrayNameValue = filterArgs.value<std::string>(k_SeedArrayName_Key);
 
-  PreflightResult preflightResult;
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
@@ -133,7 +132,8 @@ IFilter::PreflightResult ComputeKMedoidsFilter::preflightImpl(const DataStructur
   }
 
   {
-    auto createAction = std::make_unique<CreateArrayAction>(DataType::int32, clusterArray->getTupleShape(), std::vector<usize>{1}, pSelectedArrayPathValue.replaceName(pFeatureIdsArrayNameValue));
+    auto createAction = std::make_unique<CreateArrayAction>(DataType::int32, clusterArray->getTupleShape(), std::vector<usize>{1}, pSelectedArrayPathValue.replaceName(pFeatureIdsArrayNameValue),
+                                                            CreateArrayAction::k_DefaultDataFormat, "0");
     resultOutputActions.value().appendAction(std::move(createAction));
   }
 
@@ -141,7 +141,7 @@ IFilter::PreflightResult ComputeKMedoidsFilter::preflightImpl(const DataStructur
   {
     DataPath tempPath = DataPath({k_MaskName});
     {
-      auto createAction = std::make_unique<CreateArrayAction>(DataType::boolean, clusterArray->getTupleShape(), std::vector<usize>{1}, tempPath);
+      auto createAction = std::make_unique<CreateArrayAction>(DataType::boolean, clusterArray->getTupleShape(), std::vector<usize>{1}, tempPath, CreateArrayAction::k_DefaultDataFormat, "true");
       resultOutputActions.value().appendAction(std::move(createAction));
     }
 
@@ -175,7 +175,6 @@ Result<> ComputeKMedoidsFilter::executeImpl(DataStructure& dataStructure, const 
   if(!filterArgs.value<bool>(k_UseMask_Key))
   {
     maskPath = DataPath({k_MaskName});
-    dataStructure.getDataRefAs<BoolArray>(maskPath).fill(true);
   }
 
   auto seed = filterArgs.value<std::mt19937_64::result_type>(k_SeedValue_Key);
@@ -196,9 +195,7 @@ Result<> ComputeKMedoidsFilter::executeImpl(DataStructure& dataStructure, const 
   inputValues.Seed = seed;
 
   inputValues.ClusteringArrayPath = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
-  auto fIdsPath = inputValues.ClusteringArrayPath.replaceName(filterArgs.value<std::string>(k_FeatureIdsArrayName_Key));
-  dataStructure.getDataAs<Int32Array>(fIdsPath)->fill(0);
-  inputValues.FeatureIdsArrayPath = fIdsPath;
+  inputValues.FeatureIdsArrayPath = inputValues.ClusteringArrayPath.replaceName(filterArgs.value<std::string>(k_FeatureIdsArrayName_Key));
 
   return ComputeKMedoids(dataStructure, messageHandler, shouldCancel, &inputValues)();
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceFeaturesFilter.cpp
@@ -284,8 +284,8 @@ IFilter::PreflightResult ComputeSurfaceFeaturesFilter::preflightImpl(const DataS
     tupleDims = surfaceFeaturesParent->getShape();
   }
 
-  auto createSurfaceFeaturesAction =
-      std::make_unique<CreateArrayAction>(DataType::uint8, tupleDims, std::vector<usize>{1}, pCellFeaturesAttributeMatrixPathValue.createChildPath(pSurfaceFeaturesArrayNameValue));
+  auto createSurfaceFeaturesAction = std::make_unique<CreateArrayAction>(
+      DataType::uint8, tupleDims, std::vector<usize>{1}, pCellFeaturesAttributeMatrixPathValue.createChildPath(pSurfaceFeaturesArrayNameValue), CreateArrayAction::k_DefaultDataFormat, "0");
   resultOutputActions.value().appendAction(std::move(createSurfaceFeaturesAction));
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
@@ -302,8 +302,6 @@ Result<> ComputeSurfaceFeaturesFilter::executeImpl(DataStructure& dataStructure,
   const auto pSurfaceFeaturesArrayPathValue = pFeaturesAttributeMatrixPathValue.createChildPath(filterArgs.value<std::string>(k_SurfaceFeaturesArrayName_Key));
 
   // Resize the surface features array to the proper size
-  auto& surfaceFeaturesDataStore = dataStructure.getDataAs<UInt8Array>(pSurfaceFeaturesArrayPathValue)->getDataStoreRef();
-
   const auto& featureIdsArray = dataStructure.getDataRefAs<Int32Array>(pFeatureIdsArrayPathValue);
 
   auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(dataStructure, pFeaturesAttributeMatrixPathValue, featureIdsArray, messageHandler);
@@ -311,9 +309,6 @@ Result<> ComputeSurfaceFeaturesFilter::executeImpl(DataStructure& dataStructure,
   {
     return validateNumFeatResult;
   }
-
-  // Initialize all values to 'false' or ZERO.Ï
-  surfaceFeaturesDataStore.fill(0);
 
   // Find surface features
   const auto& featureGeometry = dataStructure.getDataRefAs<ImageGeom>(pFeatureGeometryPathValue);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVectorColorsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVectorColorsFilter.cpp
@@ -109,7 +109,7 @@ IFilter::PreflightResult ComputeVectorColorsFilter::preflightImpl(const DataStru
 
   if(!pUseGoodVoxelsValue)
   {
-    auto action = std::make_unique<CreateArrayAction>(DataType::boolean, vectorsTupShape, std::vector<usize>{1}, k_MaskArrayPath);
+    auto action = std::make_unique<CreateArrayAction>(DataType::boolean, vectorsTupShape, std::vector<usize>{1}, k_MaskArrayPath, CreateArrayAction::k_DefaultDataFormat, "true");
     resultOutputActions.value().appendAction(std::move(action));
   }
 
@@ -128,7 +128,6 @@ Result<> ComputeVectorColorsFilter::executeImpl(DataStructure& dataStructure, co
   if(!inputValues.UseMask)
   {
     inputValues.MaskArrayPath = k_MaskArrayPath;
-    dataStructure.getDataAs<BoolArray>(k_MaskArrayPath)->fill(true);
   }
   else
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConditionalSetValueFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConditionalSetValueFilter.cpp
@@ -18,19 +18,6 @@ constexpr int32 k_EmptyParameterValue = -123;
 constexpr int32 k_IncorrectInputArrayType = -124;
 constexpr int32 k_ConvertReplaceValueTypeError = -125;
 
-template <typename ScalarType>
-ScalarType convertFromStringToType(const std::string& convertValue)
-{
-  Result<ScalarType> convertResult = StringInterpretationUtilities::Convert<ScalarType>(convertValue);
-
-  if(convertResult.invalid())
-  {
-    throw std::runtime_error(fmt::format("{}({}): Function {}: Error. Cannot convert {} from string.", "ReplaceValueInArrayFunctor", __FILE__, __LINE__, convertValue));
-  }
-
-  return static_cast<ScalarType>(convertResult.value());
-}
-
 struct ReplaceValueInArrayFunctor
 {
   template <typename ScalarType>
@@ -38,8 +25,8 @@ struct ReplaceValueInArrayFunctor
   {
     auto& dataStore = workingArray.template getIDataStoreRefAs<AbstractDataStore<ScalarType>>();
 
-    auto removeVal = convertFromStringToType<ScalarType>(removeValue);
-    auto replaceVal = convertFromStringToType<ScalarType>(replaceValue);
+    ScalarType removeVal = StringInterpretationUtilities::Convert<ScalarType>(removeValue).value();
+    ScalarType replaceVal = StringInterpretationUtilities::Convert<ScalarType>(replaceValue).value();
 
     const auto size = dataStore.getNumberOfTuples() * dataStore.getNumberOfComponents();
 
@@ -128,7 +115,7 @@ IFilter::PreflightResult ConditionalSetValueFilter::preflightImpl(const DataStru
   auto selectedArrayPath = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
   auto pConditionalPath = filterArgs.value<DataPath>(k_ConditionalArrayPath_Key);
 
-  const DataObject& inputDataObject = dataStructure.getDataRef(selectedArrayPath);
+  const auto& inputDataObject = dataStructure.getDataAs<IDataArray>(selectedArrayPath);
 
   if(replaceValueString.empty())
   {
@@ -152,7 +139,7 @@ IFilter::PreflightResult ConditionalSetValueFilter::preflightImpl(const DataStru
   }
 
   // Sanity check all the inputs here
-  Result<> result = CheckValueConvertsToArrayType(replaceValueString, inputDataObject);
+  Result<> result = StringInterpretationUtilities::CheckValueConverts(inputDataObject->getDataType(), replaceValueString);
   // We can do this because nothing happens to the DataStructure. *IF* the filter is
   // modifying the DataStructure then we should be using a custom OutputActions instance
   // or hopefully an existing Actions subclass
@@ -160,10 +147,10 @@ IFilter::PreflightResult ConditionalSetValueFilter::preflightImpl(const DataStru
   if(result.invalid())
   {
     return {MakeErrorResult<OutputActions>(::k_ConvertReplaceValueTypeError, fmt::format("{}({}): Function {}: Error. Cannot convert {} to the type {}.", "ReplaceValueInArrayFunctor", __FILE__,
-                                                                                         __LINE__, replaceValueString, fmt::underlying(inputDataObject.getDataObjectType())))};
+                                                                                         __LINE__, replaceValueString, fmt::underlying(inputDataObject->getDataObjectType())))};
   }
 
-  result = CheckValueConvertsToArrayType(removeValueString, inputDataObject);
+  result = StringInterpretationUtilities::CheckValueConverts(inputDataObject->getDataType(), removeValueString);
 
   // convert the result from above to a Result<OutputActions> object and return. Note the
   // std::move() used for the `result` variable. We can do this because we will *NOT* be

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConditionalSetValueFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConditionalSetValueFilter.cpp
@@ -17,6 +17,7 @@ namespace
 constexpr int32 k_EmptyParameterValue = -123;
 constexpr int32 k_IncorrectInputArrayType = -124;
 constexpr int32 k_ConvertReplaceValueTypeError = -125;
+constexpr int32 k_ConvertRemoveValueTypeError = -126;
 
 struct ReplaceValueInArrayFunctor
 {
@@ -119,11 +120,11 @@ IFilter::PreflightResult ConditionalSetValueFilter::preflightImpl(const DataStru
 
   if(replaceValueString.empty())
   {
-    return {MakeErrorResult<OutputActions>(::k_EmptyParameterValue, fmt::format("{}: Replacement parameter cannot be empty.{}({})", humanName(), __FILE__, __LINE__)), {}};
+    return MakePreflightErrorResult(::k_EmptyParameterValue, fmt::format("{}: Replacement parameter cannot be empty.{}({})", humanName(), __FILE__, __LINE__));
   }
   if(removeValueString.empty())
   {
-    return {MakeErrorResult<OutputActions>(::k_EmptyParameterValue, fmt::format("{}: Remove parameter cannot be empty.{}({})", humanName(), __FILE__, __LINE__)), {}};
+    return MakePreflightErrorResult(::k_EmptyParameterValue, fmt::format("{}: Remove parameter cannot be empty.{}({})", humanName(), __FILE__, __LINE__));
   }
 
   if(useConditionalValue)
@@ -133,29 +134,27 @@ IFilter::PreflightResult ConditionalSetValueFilter::preflightImpl(const DataStru
 
     if(dataObject->getDataType() != nx::core::DataType::boolean && dataObject->getDataType() != nx::core::DataType::uint8 && dataObject->getDataType() != nx::core::DataType::int8)
     {
-      return {MakeErrorResult<OutputActions>(
-          ::k_IncorrectInputArrayType, fmt::format("Conditional Array must be of type [Bool|UInt8|Int8]. The object at path '{}' is '{}'", pConditionalPath.toString(), dataObject->getTypeName()))};
+      return MakePreflightErrorResult(::k_IncorrectInputArrayType,
+                                      fmt::format("Conditional Array must be of type [Bool|UInt8|Int8]. The object at path '{}' is '{}'", pConditionalPath.toString(), dataObject->getTypeName()));
     }
   }
 
   // Sanity check all the inputs here
   Result<> result = StringInterpretationUtilities::CheckValueConverts(inputDataObject->getDataType(), replaceValueString);
-  // We can do this because nothing happens to the DataStructure. *IF* the filter is
-  // modifying the DataStructure then we should be using a custom OutputActions instance
-  // or hopefully an existing Actions subclass
-
   if(result.invalid())
   {
-    return {MakeErrorResult<OutputActions>(::k_ConvertReplaceValueTypeError, fmt::format("{}({}): Function {}: Error. Cannot convert {} to the type {}.", "ReplaceValueInArrayFunctor", __FILE__,
-                                                                                         __LINE__, replaceValueString, fmt::underlying(inputDataObject->getDataObjectType())))};
+    return MakePreflightErrorResult(::k_ConvertReplaceValueTypeError, fmt::format("{}({}): Function {}: Error. Cannot convert replace value {} to the type {}.", "ReplaceValueInArrayFunctor", __FILE__,
+                                                                                  __LINE__, replaceValueString, fmt::underlying(inputDataObject->getDataObjectType())));
   }
 
   result = StringInterpretationUtilities::CheckValueConverts(inputDataObject->getDataType(), removeValueString);
+  if(result.invalid())
+  {
+    return MakePreflightErrorResult(::k_ConvertRemoveValueTypeError, fmt::format("{}({}): Function {}: Error. Cannot convert remove value {} to the type {}.", "ReplaceValueInArrayFunctor", __FILE__,
+                                                                                 __LINE__, removeValueString, fmt::underlying(inputDataObject->getDataObjectType())));
+  }
 
-  // convert the result from above to a Result<OutputActions> object and return. Note the
-  // std::move() used for the `result` variable. We can do this because we will *NOT* be
-  // using the variable past this line.
-  return {ConvertResultTo<OutputActions>(std::move(result), {})};
+  return {};
 }
 
 Result<> ConditionalSetValueFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConditionalSetValueFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConditionalSetValueFilter.cpp
@@ -5,9 +5,9 @@
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/StringParameter.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 
 using namespace nx::core;
 
@@ -20,7 +20,7 @@ constexpr int32 k_ConvertReplaceValueTypeError = -125;
 template <typename ScalarType>
 ScalarType convertFromStringToType(const std::string& convertValue)
 {
-  Result<ScalarType> convertResult = ConvertTo<ScalarType>::convert(convertValue);
+  Result<ScalarType> convertResult = StringInterpretationUtilities::Convert<ScalarType>(convertValue);
 
   if(convertResult.invalid())
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConditionalSetValueFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConditionalSetValueFilter.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/StringParameter.hpp"
+#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
 #include "simplnx/Utilities/StringInterpretationUtilities.hpp"

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayFilter.cpp
@@ -11,9 +11,7 @@
 #include "simplnx/Parameters/NumberParameter.hpp"
 #include "simplnx/Parameters/NumericTypeParameter.hpp"
 #include "simplnx/Parameters/StringParameter.hpp"
-#include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
-#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 
 #include <stdexcept>
 
@@ -22,19 +20,7 @@ using namespace nx::core;
 namespace
 {
 constexpr int32 k_EmptyParameterError = -123;
-
-struct CreateAndInitArrayFunctor
-{
-  template <class T>
-  void operator()(IDataArray* iDataArray, const std::string& initValue)
-  {
-    Result<T> result = StringInterpretationUtilities::Convert<T>(initValue);
-
-    auto* dataStore = iDataArray->template getIDataStoreAs<AbstractDataStore<T>>();
-    dataStore->fill(result.value());
-  }
-};
-} // namespace
+}
 
 namespace nx::core
 {
@@ -132,12 +118,6 @@ IFilter::PreflightResult CreateDataArrayFilter::preflightImpl(const DataStructur
   {
     return MakePreflightErrorResult(k_EmptyParameterError, fmt::format("{}: Init Value cannot be empty.{}({})", humanName(), __FILE__, __LINE__));
   }
-  // Sanity check that what the user entered for an init value can be converted safely to the final numeric type
-  Result<> result = StringInterpretationUtilities::CheckValueConverts(ConvertNumericTypeToDataType(numericType), initValue);
-  if(result.invalid())
-  {
-    return {ConvertResultTo<OutputActions>(std::move(result), {})};
-  }
 
   std::vector<usize> compDims = std::vector<usize>{numComponents};
   std::vector<usize> tupleDims = {};
@@ -177,7 +157,8 @@ IFilter::PreflightResult CreateDataArrayFilter::preflightImpl(const DataStructur
     }
   }
 
-  auto action = std::make_unique<CreateArrayAction>(ConvertNumericTypeToDataType(numericType), tupleDims, compDims, dataArrayPath, dataFormat);
+  // Sanity check that init value can be converted safely to the final numeric type integrated into action
+  auto action = std::make_unique<CreateArrayAction>(ConvertNumericTypeToDataType(numericType), tupleDims, compDims, dataArrayPath, dataFormat, initValue);
 
   resultOutputActions.value().appendAction(std::move(action));
 
@@ -188,11 +169,6 @@ IFilter::PreflightResult CreateDataArrayFilter::preflightImpl(const DataStructur
 Result<> CreateDataArrayFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
-  auto path = args.value<DataPath>(k_DataPath_Key);
-  auto initValue = args.value<std::string>(k_InitializationValue_Key);
-
-  ExecuteNeighborFunction(CreateAndInitArrayFunctor{}, ConvertNumericTypeToDataType(args.value<NumericType>(k_NumericType_Key)), dataStructure.getDataAs<IDataArray>(path), initValue);
-
   return {};
 }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayFilter.cpp
@@ -1,6 +1,8 @@
 #include "CreateDataArrayFilter.hpp"
 
 #include "simplnx/Common/TypesUtility.hpp"
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
+#include "simplnx/DataStructure/IDataArray.hpp"
 #include "simplnx/Filter/Actions/CreateArrayAction.hpp"
 #include "simplnx/Parameters/ArrayCreationParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
@@ -9,11 +11,9 @@
 #include "simplnx/Parameters/NumberParameter.hpp"
 #include "simplnx/Parameters/NumericTypeParameter.hpp"
 #include "simplnx/Parameters/StringParameter.hpp"
-#include "simplnx/DataStructure/IDataArray.hpp"
-#include "simplnx/DataStructure/AttributeMatrix.hpp"
-#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 
 #include <stdexcept>
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayFilter.cpp
@@ -9,7 +9,9 @@
 #include "simplnx/Parameters/NumberParameter.hpp"
 #include "simplnx/Parameters/NumericTypeParameter.hpp"
 #include "simplnx/Parameters/StringParameter.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/DataStructure/IDataArray.hpp"
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
 
@@ -26,7 +28,7 @@ struct CreateAndInitArrayFunctor
   template <class T>
   void operator()(IDataArray* iDataArray, const std::string& initValue)
   {
-    Result<T> result = ConvertTo<T>::convert(initValue);
+    Result<T> result = StringInterpretationUtilities::Convert<T>(initValue);
 
     auto* dataStore = iDataArray->template getIDataStoreAs<AbstractDataStore<T>>();
     dataStore->fill(result.value());
@@ -131,7 +133,7 @@ IFilter::PreflightResult CreateDataArrayFilter::preflightImpl(const DataStructur
     return MakePreflightErrorResult(k_EmptyParameterError, fmt::format("{}: Init Value cannot be empty.{}({})", humanName(), __FILE__, __LINE__));
   }
   // Sanity check that what the user entered for an init value can be converted safely to the final numeric type
-  Result<> result = CheckValueConverts(initValue, numericType);
+  Result<> result = StringInterpretationUtilities::CheckValueConverts(ConvertNumericTypeToDataType(numericType), initValue);
   if(result.invalid())
   {
     return {ConvertResultTo<OutputActions>(std::move(result), {})};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateFeatureArrayFromElementArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateFeatureArrayFromElementArrayFilter.cpp
@@ -23,9 +23,6 @@ struct CopyCellDataFunctor
     const auto& selectedCellStore = selectedCellArray->template getIDataStoreRefAs<AbstractDataStore<T>>();
     auto& createdDataStore = createdArray->template getIDataStoreRefAs<AbstractDataStore<T>>();
 
-    // Initialize the output array with a default value
-    createdDataStore.fill(0);
-
     usize totalCellArrayComponents = selectedCellStore.getNumberOfComponents();
 
     std::map<int32, usize> featureMap;
@@ -162,8 +159,8 @@ IFilter::PreflightResult CreateFeatureArrayFromElementArrayFilter::preflightImpl
 
   {
     DataType dataType = selectedCellArray.getDataType();
-    auto createArrayAction =
-        std::make_unique<CreateArrayAction>(dataType, amTupleShape, selectedCellArrayStore.getComponentShape(), pCellFeatureAttributeMatrixPathValue.createChildPath(pCreatedArrayNameValue));
+    auto createArrayAction = std::make_unique<CreateArrayAction>(dataType, amTupleShape, selectedCellArrayStore.getComponentShape(),
+                                                                 pCellFeatureAttributeMatrixPathValue.createChildPath(pCreatedArrayNameValue), CreateArrayAction::k_DefaultDataFormat, "0");
     resultOutputActions.value().appendAction(std::move(createArrayAction));
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/DBSCANFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/DBSCANFilter.cpp
@@ -140,7 +140,8 @@ IFilter::PreflightResult DBSCANFilter::preflightImpl(const DataStructure& dataSt
   }
 
   {
-    auto createAction = std::make_unique<CreateArrayAction>(DataType::int32, clusterArray->getTupleShape(), std::vector<usize>{1}, pSelectedArrayPathValue.replaceName(pFeatureIdsArrayNameValue));
+    auto createAction = std::make_unique<CreateArrayAction>(DataType::int32, clusterArray->getTupleShape(), std::vector<usize>{1}, pSelectedArrayPathValue.replaceName(pFeatureIdsArrayNameValue),
+                                                            CreateArrayAction::k_DefaultDataFormat, "0");
     resultOutputActions.value().appendAction(std::move(createAction));
   }
 
@@ -148,7 +149,7 @@ IFilter::PreflightResult DBSCANFilter::preflightImpl(const DataStructure& dataSt
   {
     DataPath tempPath = DataPath({k_MaskName});
     {
-      auto createAction = std::make_unique<CreateArrayAction>(DataType::boolean, clusterArray->getTupleShape(), std::vector<usize>{1}, tempPath);
+      auto createAction = std::make_unique<CreateArrayAction>(DataType::boolean, clusterArray->getTupleShape(), std::vector<usize>{1}, tempPath, CreateArrayAction::k_DefaultDataFormat, "true");
       resultOutputActions.value().appendAction(std::move(createAction));
     }
 
@@ -180,7 +181,6 @@ Result<> DBSCANFilter::executeImpl(DataStructure& dataStructure, const Arguments
   if(!filterArgs.value<bool>(k_UseMask_Key))
   {
     maskPath = DataPath({k_MaskName});
-    dataStructure.getDataRefAs<BoolArray>(maskPath).fill(true);
   }
 
   auto seed = filterArgs.value<std::mt19937_64::result_type>(k_SeedValue_Key);
@@ -202,9 +202,7 @@ Result<> DBSCANFilter::executeImpl(DataStructure& dataStructure, const Arguments
   inputValues.DistanceMetric = static_cast<ClusterUtilities::DistanceMetric>(filterArgs.value<ChoicesParameter::ValueType>(k_DistanceMetric_Key));
   inputValues.MaskArrayPath = maskPath;
   inputValues.ClusteringArrayPath = filterArgs.value<DataPath>(k_SelectedArrayPath_Key);
-  auto fIdsPath = inputValues.ClusteringArrayPath.replaceName(filterArgs.value<std::string>(k_FeatureIdsArrayName_Key));
-  dataStructure.getDataAs<Int32Array>(fIdsPath)->fill(0);
-  inputValues.FeatureIdsArrayPath = fIdsPath;
+  inputValues.FeatureIdsArrayPath = inputValues.ClusteringArrayPath.replaceName(filterArgs.value<std::string>(k_FeatureIdsArrayName_Key));
   inputValues.FeatureAM = filterArgs.value<DataPath>(k_FeatureAMPath_Key);
   inputValues.AllowCaching = filterArgs.value<bool>(k_UsePrecaching_Key);
   inputValues.UseRandom = static_cast<AlgType>(filterArgs.value<ChoicesParameter::ValueType>(k_InitTypeIndex_Key)) != AlgType::Iterative;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MapPointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MapPointCloudToRegularGridFilter.cpp
@@ -441,7 +441,7 @@ IFilter::PreflightResult MapPointCloudToRegularGridFilter::preflightImpl(const D
   {
     DataPath tempPath = DataPath({k_MaskName});
     {
-      auto createAction = std::make_unique<CreateArrayAction>(DataType::boolean, vertexData->getShape(), std::vector<usize>{1}, tempPath);
+      auto createAction = std::make_unique<CreateArrayAction>(DataType::boolean, vertexData->getShape(), std::vector<usize>{1}, tempPath, CreateArrayAction::k_DefaultDataFormat, "true");
       actions.appendAction(std::move(createAction));
     }
 
@@ -483,7 +483,6 @@ Result<> MapPointCloudToRegularGridFilter::executeImpl(DataStructure& dataStruct
   if(!args.value<bool>(k_UseMask_Key))
   {
     maskPath = DataPath({k_MaskName});
-    dataStructure.getDataRefAs<BoolArray>(maskPath).fill(true);
   }
   std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;
   try

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MapPointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MapPointCloudToRegularGridFilter.cpp
@@ -15,7 +15,7 @@
 #include "simplnx/Parameters/GeometrySelectionParameter.hpp"
 #include "simplnx/Parameters/NumberParameter.hpp"
 #include "simplnx/Parameters/VectorParameter.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
 
 #include <chrono>
@@ -226,7 +226,7 @@ using ErrorType = OutOfBoundsType<false, false, true>;
 
 template <class OutOfBoundsType = SilentType, bool UseMask = false>
 Result<> ProcessVertices(const IFilter::MessageHandler& messageHandler, const VertexGeom& vertices, const ImageGeom* image, UInt64AbstractDataStore& voxelIndices,
-                         const std::unique_ptr<MaskCompare>& maskCompare, uint64 outOfBoundsValue)
+                         const std::unique_ptr<MaskCompareUtilities::MaskCompare>& maskCompare, uint64 outOfBoundsValue)
 {
   // Validation
   if(image == nullptr)
@@ -485,10 +485,10 @@ Result<> MapPointCloudToRegularGridFilter::executeImpl(DataStructure& dataStruct
     maskPath = DataPath({k_MaskName});
     dataStructure.getDataRefAs<BoolArray>(maskPath).fill(true);
   }
-  std::unique_ptr<MaskCompare> maskCompare;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;
   try
   {
-    maskCompare = InstantiateMaskCompare(dataStructure, maskPath);
+    maskCompare = MaskCompareUtilities::InstantiateMaskCompare(dataStructure, maskPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadBinaryCTNorthstarFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadBinaryCTNorthstarFilter.cpp
@@ -11,8 +11,8 @@
 #include "simplnx/Parameters/DataObjectNameParameter.hpp"
 #include "simplnx/Parameters/FileSystemPathParameter.hpp"
 #include "simplnx/Parameters/VectorParameter.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include <fstream>
@@ -109,7 +109,7 @@ Result<std::vector<std::pair<fs::path, usize>>> ReadFileList(std::ifstream& inSt
 
       if(tokens[0] == "<NbSlices>")
       {
-        Result<usize> result = ConvertTo<usize>::convert(tokens[1]);
+        Result<usize> result = StringInterpretationUtilities::Convert<usize>(tokens[1]);
         if(result.invalid())
         {
           const Error& err = result.errors()[0];
@@ -145,7 +145,7 @@ Result<std::pair<std::vector<float32>, std::vector<float32>>> ReadLocation(std::
   {
     if(tokens[0] == "<Min>")
     {
-      Result<float32> result = ConvertTo<float32>::convert(tokens[1]);
+      Result<float32> result = StringInterpretationUtilities::Convert<float32>(tokens[1]);
       if(result.invalid())
       {
         const Error& err = result.errors()[0];
@@ -154,7 +154,7 @@ Result<std::pair<std::vector<float32>, std::vector<float32>>> ReadLocation(std::
       }
       minLocation[1] = result.value();
 
-      result = ConvertTo<float32>::convert(tokens[2]);
+      result = StringInterpretationUtilities::Convert<float32>(tokens[2]);
       if(result.invalid())
       {
         const Error& err = result.errors()[0];
@@ -163,7 +163,7 @@ Result<std::pair<std::vector<float32>, std::vector<float32>>> ReadLocation(std::
       }
       minLocation[2] = result.value();
 
-      result = ConvertTo<float32>::convert(tokens[3]);
+      result = StringInterpretationUtilities::Convert<float32>(tokens[3]);
       if(result.invalid())
       {
         const Error& err = result.errors()[0];
@@ -174,7 +174,7 @@ Result<std::pair<std::vector<float32>, std::vector<float32>>> ReadLocation(std::
     }
     else if(tokens[0] == "<Max>")
     {
-      Result<float32> result = ConvertTo<float32>::convert(tokens[1]);
+      Result<float32> result = StringInterpretationUtilities::Convert<float32>(tokens[1]);
       if(result.invalid())
       {
         const Error& err = result.errors()[0];
@@ -183,7 +183,7 @@ Result<std::pair<std::vector<float32>, std::vector<float32>>> ReadLocation(std::
       }
       maxLocation[1] = result.value();
 
-      result = ConvertTo<float32>::convert(tokens[2]);
+      result = StringInterpretationUtilities::Convert<float32>(tokens[2]);
       if(result.invalid())
       {
         const Error& err = result.errors()[0];
@@ -192,7 +192,7 @@ Result<std::pair<std::vector<float32>, std::vector<float32>>> ReadLocation(std::
       }
       maxLocation[2] = result.value();
 
-      result = ConvertTo<float32>::convert(tokens[3]);
+      result = StringInterpretationUtilities::Convert<float32>(tokens[3]);
       if(result.invalid())
       {
         const Error& err = result.errors()[0];
@@ -218,7 +218,7 @@ Result<std::vector<usize>> ReadVoxels(const std::vector<std::string>& tokens, co
 {
   std::vector<usize> voxels = {0, 0, 0};
 
-  Result<usize> result = ConvertTo<usize>::convert(tokens[1]);
+  Result<usize> result = StringInterpretationUtilities::Convert<usize>(tokens[1]);
   if(result.invalid())
   {
     const Error& err = result.errors()[0];
@@ -227,7 +227,7 @@ Result<std::vector<usize>> ReadVoxels(const std::vector<std::string>& tokens, co
   }
   voxels[1] = result.value();
 
-  result = ConvertTo<usize>::convert(tokens[2]);
+  result = StringInterpretationUtilities::Convert<usize>(tokens[2]);
   if(result.invalid())
   {
     const Error& err = result.errors()[0];
@@ -236,7 +236,7 @@ Result<std::vector<usize>> ReadVoxels(const std::vector<std::string>& tokens, co
   }
   voxels[2] = result.value();
 
-  result = ConvertTo<usize>::convert(tokens[3]);
+  result = StringInterpretationUtilities::Convert<usize>(tokens[3]);
   if(result.invalid())
   {
     const Error& err = result.errors()[0];

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedEdgesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedEdgesFilter.cpp
@@ -11,6 +11,7 @@
 #include "simplnx/Parameters/DataGroupCreationParameter.hpp"
 #include "simplnx/Parameters/GeometrySelectionParameter.hpp"
 #include "simplnx/Parameters/StringParameter.hpp"
+#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedTrianglesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedTrianglesFilter.cpp
@@ -10,6 +10,7 @@
 #include "simplnx/Parameters/DataGroupCreationParameter.hpp"
 #include "simplnx/Parameters/GeometrySelectionParameter.hpp"
 #include "simplnx/Parameters/StringParameter.hpp"
+#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedVerticesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedVerticesFilter.cpp
@@ -11,8 +11,10 @@
 #include "simplnx/Parameters/DataGroupSelectionParameter.hpp"
 #include "simplnx/Parameters/DataObjectNameParameter.hpp"
 #include "simplnx/Parameters/GeometrySelectionParameter.hpp"
+#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include <fmt/format.h>
@@ -31,7 +33,7 @@ struct RemoveFlaggedVerticesFunctor
 {
   // copy data to masked geometry
   template <class T>
-  void operator()(const IDataArray& sourceIDataArray, IDataArray& destIDataArray, const std::unique_ptr<MaskCompare>& maskCompare, size_t numVerticesToKeep) const
+  void operator()(const IDataArray& sourceIDataArray, IDataArray& destIDataArray, const std::unique_ptr<MaskCompareUtilities::MaskCompare>& maskCompare, size_t numVerticesToKeep) const
   {
     const auto& sourceDataStore = sourceIDataArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
     auto& destinationDataStore = destIDataArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
@@ -222,10 +224,10 @@ Result<> RemoveFlaggedVerticesFilter::executeImpl(DataStructure& dataStructure, 
   const VertexGeom& vertexGeom = dataStructure.getDataRefAs<VertexGeom>(vertexGeomPath);
   const std::string vertexDataName = vertexGeom.getVertexAttributeMatrixDataPath().getTargetName();
 
-  std::unique_ptr<MaskCompare> maskCompare;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;
   try
   {
-    maskCompare = InstantiateMaskCompare(dataStructure, maskArrayPath);
+    maskCompare = MaskCompareUtilities::InstantiateMaskCompare(dataStructure, maskArrayPath);
   } catch(const std::out_of_range& exception)
   {
     // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ScalarSegmentFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ScalarSegmentFeaturesFilter.cpp
@@ -165,11 +165,11 @@ IFilter::PreflightResult ScalarSegmentFeaturesFilter::preflightImpl(const DataSt
   }
 
   // Create the Cell Level FeatureIds array
-  auto createFeatureIdsAction = std::make_unique<CreateArrayAction>(DataType::int32, cellTupleDims, std::vector<usize>{1}, featureIdsPath, createdArrayFormat);
+  auto createFeatureIdsAction = std::make_unique<CreateArrayAction>(DataType::int32, cellTupleDims, std::vector<usize>{1}, featureIdsPath, createdArrayFormat, "0");
 
   // Create the Feature Attribute Matrix
   auto createFeatureGroupAction = std::make_unique<CreateAttributeMatrixAction>(cellFeaturesPath, std::vector<usize>{1});
-  auto createActiveAction = std::make_unique<CreateArrayAction>(DataType::uint8, std::vector<usize>{1}, std::vector<usize>{1}, activeArrayPath, createdArrayFormat);
+  auto createActiveAction = std::make_unique<CreateArrayAction>(DataType::uint8, std::vector<usize>{1}, std::vector<usize>{1}, activeArrayPath, createdArrayFormat, "1");
 
   nx::core::Result<OutputActions> resultOutputActions;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SilhouetteFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SilhouetteFilter.cpp
@@ -120,7 +120,7 @@ IFilter::PreflightResult SilhouetteFilter::preflightImpl(const DataStructure& da
   {
     DataPath tempPath = DataPath({k_MaskName});
     {
-      auto createAction = std::make_unique<CreateArrayAction>(DataType::boolean, clusterArray->getTupleShape(), std::vector<usize>{1}, tempPath);
+      auto createAction = std::make_unique<CreateArrayAction>(DataType::boolean, clusterArray->getTupleShape(), std::vector<usize>{1}, tempPath, CreateArrayAction::k_DefaultDataFormat, "true");
       resultOutputActions.value().appendAction(std::move(createAction));
     }
 
@@ -144,7 +144,6 @@ Result<> SilhouetteFilter::executeImpl(DataStructure& dataStructure, const Argum
   if(!filterArgs.value<bool>(k_UseMask_Key))
   {
     maskPath = DataPath({k_MaskName});
-    dataStructure.getDataRefAs<BoolArray>(maskPath).fill(true);
   }
 
   SilhouetteInputValues inputValues;

--- a/src/Plugins/SimplnxCore/test/ArrayCalculatorTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ArrayCalculatorTest.cpp
@@ -322,8 +322,8 @@ void SingleComponentArrayCalculatorTest1()
 
   SECTION("Single Array Tests (Force Incorrect Tuple Counts)")
   {
-    runTest("-InputArray1", k_NumericArrayPath, -265, CalculatorItem::WarningCode::None);
-    runTest(k_InputArray2, k_NumericArrayPath, -265, CalculatorItem::WarningCode::None);
+    runTest("-InputArray1", k_NumericArrayPath, -268, CalculatorItem::WarningCode::None);
+    runTest(k_InputArray2, k_NumericArrayPath, -268, CalculatorItem::WarningCode::None);
 
     int numTuple = 10;
     double value = 18;

--- a/src/Plugins/SimplnxCore/test/ConditionalSetValueTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ConditionalSetValueTest.cpp
@@ -2,8 +2,8 @@
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
 
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 
 #include <catch2/catch.hpp>
 
@@ -300,14 +300,13 @@ TEST_CASE("SimplnxCore::ConditionalSetValueFilter: No Conditional", "[Conditiona
   nx::core::SizeVec3 imageGeomDims = imageGeometry->getDimensions();
 
   DataPath ciDataPath = DataPath({k_SmallIN100, k_EbsdScanData, k_ConfidenceIndex});
-  DataObject* ciDataObject = dataStructure.getData(ciDataPath);
 
-  DataArray<float32>* ciDataArray = dynamic_cast<Float32Array*>(ciDataObject);
+  auto* ciDataArray = dataStructure.getDataAs<Float32Array>(ciDataPath);
   // Fill every value with 10.0 into the ciArray
   ciDataArray->fill(10.0);
 
   const std::string removeStr = "10.0";
-  const auto removeVal = static_cast<float32>(ConvertTo<float32>::convert(removeStr).value());
+  const auto removeVal = static_cast<float32>(StringInterpretationUtilities::Convert<float32>(removeStr).value());
 
   args.insertOrAssign(ConditionalSetValueFilter::k_UseConditional_Key, std::make_any<bool>(false));
   args.insertOrAssign(ConditionalSetValueFilter::k_RemoveValue_Key, std::make_any<std::string>(removeStr));

--- a/src/Plugins/SimplnxCore/test/ConditionalSetValueTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ConditionalSetValueTest.cpp
@@ -2,7 +2,6 @@
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
 
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
-#include "simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp"
 #include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 
 #include <catch2/catch.hpp>

--- a/src/Plugins/SimplnxCore/test/ConditionalSetValueTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ConditionalSetValueTest.cpp
@@ -272,6 +272,21 @@ TEST_CASE("SimplnxCore::ConditionalSetValueFilter: Overflow/Underflow", "[Condit
   ConditionalSetValueOverFlowTest<uint64>(dataStructure, selectedDataPath, conditionalDataPath, "-1");                    // underflow
   ConditionalSetValueOverFlowTest<uint64>(dataStructure, selectedDataPath, conditionalDataPath, "184467440737095516150"); // overflow
 
+#if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER)
+  /**
+   * The following tests will not pass on windows because the standard allows for
+   * processing of subnormal floating point numbers: https://en.wikipedia.org/wiki/Subnormal_number
+   *
+   * Unix string to numeric disallows these subnormal float values due to the err being
+   * higher in the denormalized values.
+   *
+   * These subnormal numbers can be processed on unix with some workarounds or
+   * we can enforce err on windows with other workarounds. Until a clear stance is taken
+   * by a majority of project maintainers we are temporarily removing tests.
+   *
+   * Unix-like systems will err out with underflow in line with original test assumptions
+   */
+#else
   selectedDataPath = DataPath({k_LevelZero, k_LevelOne, k_Float32DataSet});
   ConditionalSetValueOverFlowTest<float32>(dataStructure, selectedDataPath, conditionalDataPath, "1.17549e-039");  // underflow
   ConditionalSetValueOverFlowTest<float32>(dataStructure, selectedDataPath, conditionalDataPath, "3.40282e+039");  // overflow
@@ -283,6 +298,7 @@ TEST_CASE("SimplnxCore::ConditionalSetValueFilter: Overflow/Underflow", "[Condit
   ConditionalSetValueOverFlowTest<float64>(dataStructure, selectedDataPath, conditionalDataPath, "1.79769e+309");  // overflow
   ConditionalSetValueOverFlowTest<float64>(dataStructure, selectedDataPath, conditionalDataPath, "-2.22507e-309"); // underflow
   ConditionalSetValueOverFlowTest<float64>(dataStructure, selectedDataPath, conditionalDataPath, "-1.79769e+309"); // overflow
+#endif
 }
 
 TEST_CASE("SimplnxCore::ConditionalSetValueFilter: No Conditional", "[ConditionalSetValueFilter]")

--- a/src/Plugins/SimplnxCore/test/ConditionalSetValueTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ConditionalSetValueTest.cpp
@@ -26,7 +26,7 @@ void ConditionalSetValueOverFlowTest(DataStructure& dataStructure, const DataPat
 
   // Preflight the filter and check result
   auto preflightResult = filter.preflight(dataStructure, args);
-  REQUIRE(!preflightResult.outputActions.valid());
+  SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
 }
 
 template <class T>

--- a/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
@@ -142,11 +142,8 @@ DataStructure CreateTestDataStructure()
   std::vector<usize> tupleShape = {10};
   auto* attributeMatrix = AttributeMatrix::Create(dataStructure, DataNames::k_AttributeMatrixName, tupleShape, group1->getId());
 
-  Result<> arrayCreationResults = ArrayCreationUtilities::CreateArray<int8>(dataStructure, tupleShape, std::vector<usize>{1},
-                                                                            DataPath({DataNames::k_Group1Name, DataNames::k_AttributeMatrixName, DataNames::k_Array2Name}), IDataAction::Mode::Execute);
-  auto& dataArray = dataStructure.getDataRefAs<Int8Array>(DataPath({DataNames::k_Group1Name, DataNames::k_AttributeMatrixName, DataNames::k_Array2Name}));
-  auto& dataStore = dataArray.getDataStoreRef();
-  std::fill(dataStore.begin(), dataStore.end(), 1);
+  Result<> arrayCreationResults = ArrayCreationUtilities::CreateArray<int8>(
+      dataStructure, tupleShape, std::vector<usize>{1}, DataPath({DataNames::k_Group1Name, DataNames::k_AttributeMatrixName, DataNames::k_Array2Name}), IDataAction::Mode::Execute, "", "1");
   return dataStructure;
 }
 

--- a/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
@@ -142,8 +142,9 @@ DataStructure CreateTestDataStructure()
   std::vector<usize> tupleShape = {10};
   auto* attributeMatrix = AttributeMatrix::Create(dataStructure, DataNames::k_AttributeMatrixName, tupleShape, group1->getId());
 
-  Result<> arrayCreationResults = ArrayCreationUtilities::CreateArray<int8>(
-      dataStructure, tupleShape, std::vector<usize>{1}, DataPath({DataNames::k_Group1Name, DataNames::k_AttributeMatrixName, DataNames::k_Array2Name}), IDataAction::Mode::Execute, "", "1");
+  Result<> arrayCreationResults =
+      ArrayCreationUtilities::CreateArray<int8>(dataStructure, tupleShape, std::vector<usize>{1}, DataPath({DataNames::k_Group1Name, DataNames::k_AttributeMatrixName, DataNames::k_Array2Name}),
+                                                IDataAction::Mode::Execute, ArrayCreationUtilities::k_DefaultDataFormat, "1");
   return dataStructure;
 }
 

--- a/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
@@ -14,7 +14,7 @@
 #include "simplnx/Parameters/DynamicTableParameter.hpp"
 #include "simplnx/Pipeline/Pipeline.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 #include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp"
 
@@ -142,8 +142,8 @@ DataStructure CreateTestDataStructure()
   std::vector<usize> tupleShape = {10};
   auto* attributeMatrix = AttributeMatrix::Create(dataStructure, DataNames::k_AttributeMatrixName, tupleShape, group1->getId());
 
-  Result<> arrayCreationResults =
-      CreateArray<int8>(dataStructure, tupleShape, std::vector<usize>{1}, DataPath({DataNames::k_Group1Name, DataNames::k_AttributeMatrixName, DataNames::k_Array2Name}), IDataAction::Mode::Execute);
+  Result<> arrayCreationResults = ArrayCreationUtilities::CreateArray<int8>(dataStructure, tupleShape, std::vector<usize>{1},
+                                                                            DataPath({DataNames::k_Group1Name, DataNames::k_AttributeMatrixName, DataNames::k_Array2Name}), IDataAction::Mode::Execute);
   auto& dataArray = dataStructure.getDataRefAs<Int8Array>(DataPath({DataNames::k_Group1Name, DataNames::k_AttributeMatrixName, DataNames::k_Array2Name}));
   auto& dataStore = dataArray.getDataStoreRef();
   std::fill(dataStore.begin(), dataStore.end(), 1);

--- a/src/Plugins/SimplnxCore/test/ReadCSVFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReadCSVFileTest.cpp
@@ -7,7 +7,7 @@
 #include "simplnx/Parameters/DynamicTableParameter.hpp"
 #include "simplnx/Parameters/ReadCSVFileParameter.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include <catch2/catch.hpp>
@@ -153,7 +153,7 @@ void TestCase_TestPrimitives(nonstd::span<std::string> values)
   REQUIRE(values.size() == array->getSize());
   for(int i = 0; i < values.size(); i++)
   {
-    Result<T> parseResult = ConvertTo<T>::convert(values[i]);
+    Result<T> parseResult = StringInterpretationUtilities::Convert<T>(values[i]);
     SIMPLNX_RESULT_REQUIRE_VALID(parseResult);
     const auto& exemplaryValue = parseResult.value();
     const auto& testValue = array->at(i);
@@ -319,52 +319,52 @@ TEST_CASE("SimplnxCore::ReadCSVFileFilter (Case 3): Invalid filter execution - O
 
   // Int64 - Out of bounds
   v = {"-9223372036854775809"};
-  TestCase_TestPrimitives_Error<int64>(v, k_OverflowErrorCode);
+  TestCase_TestPrimitives_Error<int64>(v, -10352);
 
   v = {"9223372036854775808"};
-  TestCase_TestPrimitives_Error<int64>(v, k_OverflowErrorCode);
+  TestCase_TestPrimitives_Error<int64>(v, -10352);
 
   // UInt8 - Out of bounds
   v = {"-1"};
-  TestCase_TestPrimitives_Error<uint8>(v, k_OverflowErrorCode);
+  TestCase_TestPrimitives_Error<uint8>(v, -10350);
 
   v = {"256"};
   TestCase_TestPrimitives_Error<uint8>(v, k_OverflowErrorCode);
 
   // UInt16 - Out of bounds
   v = {"-1"};
-  TestCase_TestPrimitives_Error<uint16>(v, k_OverflowErrorCode);
+  TestCase_TestPrimitives_Error<uint16>(v, -10350);
 
   v = {"65536"};
   TestCase_TestPrimitives_Error<uint16>(v, k_OverflowErrorCode);
 
   // UInt32 - Out of bounds
   v = {"-1"};
-  TestCase_TestPrimitives_Error<uint32>(v, k_OverflowErrorCode);
+  TestCase_TestPrimitives_Error<uint32>(v, -10350);
 
   v = {"4294967296"};
   TestCase_TestPrimitives_Error<uint32>(v, k_OverflowErrorCode);
 
   // UInt64 - Out of bounds
   v = {"-1"};
-  TestCase_TestPrimitives_Error<uint64>(v, k_OverflowErrorCode);
+  TestCase_TestPrimitives_Error<uint64>(v, -10350);
 
   v = {"18446744073709551616"};
-  TestCase_TestPrimitives_Error<uint64>(v, k_OverflowErrorCode);
+  TestCase_TestPrimitives_Error<uint64>(v, -10352);
 
   // Float32 - Out of bounds
   v = {"-3.5E38"};
-  TestCase_TestPrimitives_Error<float32>(v, k_OverflowErrorCode);
+  TestCase_TestPrimitives_Error<float32>(v, -10352);
 
   v = {"3.5E38"};
-  TestCase_TestPrimitives_Error<float32>(v, k_OverflowErrorCode);
+  TestCase_TestPrimitives_Error<float32>(v, -10352);
 
   // Float64 - Out of bounds
   v = {"-1.8E308"};
-  TestCase_TestPrimitives_Error<float64>(v, k_OverflowErrorCode);
+  TestCase_TestPrimitives_Error<float64>(v, -10352);
 
   v = {"1.8E308"};
-  TestCase_TestPrimitives_Error<float64>(v, k_OverflowErrorCode);
+  TestCase_TestPrimitives_Error<float64>(v, -10352);
 }
 
 TEST_CASE("SimplnxCore::ReadCSVFileFilter (Case 4): Invalid filter execution - Invalid arguments")

--- a/src/simplnx/DataStructure/DataStore.hpp
+++ b/src/simplnx/DataStructure/DataStore.hpp
@@ -211,10 +211,10 @@ public:
   /**
    * @brief This method copies a value to the member variable m_InitValue
    */
-   void setInitValue(T value)
-   {
-     m_InitValue = value;
-   }
+  void setInitValue(T value)
+  {
+    m_InitValue = value;
+  }
 
   /**
    * @brief This method sets the shape of the dimensions to `tupleShape`.

--- a/src/simplnx/DataStructure/DataStore.hpp
+++ b/src/simplnx/DataStructure/DataStore.hpp
@@ -209,6 +209,14 @@ public:
   }
 
   /**
+   * @brief This method copies a value to the member variable m_InitValue
+   */
+   void setInitValue(T value)
+   {
+     m_InitValue = value;
+   }
+
+  /**
    * @brief This method sets the shape of the dimensions to `tupleShape`.
    *
    * There are 3 possibilities when using this function:

--- a/src/simplnx/DataStructure/IO/HDF5/DataStoreIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataStoreIO.hpp
@@ -2,7 +2,7 @@
 
 #include "simplnx/DataStructure/DataStore.hpp"
 #include "simplnx/DataStructure/IO/HDF5/IDataStoreIO.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/DataStoreUtilities.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp"
 
 #include "fmt/format.h"
@@ -55,7 +55,7 @@ inline std::shared_ptr<AbstractDataStore<T>> ReadDataStore(const nx::core::HDF5:
   auto componentShape = IDataStoreIO::ReadComponentShape(datasetReader);
 
   // Create DataStore
-  auto dataStore = CreateDataStore<T>(tupleShape, componentShape, IDataAction::Mode::Execute);
+  auto dataStore = DataStoreUtilities::CreateDataStore<T>(tupleShape, componentShape, IDataAction::Mode::Execute);
   dataStore->readHdf5(datasetReader);
   return dataStore;
 }

--- a/src/simplnx/Filter/Actions/CopyArrayInstanceAction.cpp
+++ b/src/simplnx/Filter/Actions/CopyArrayInstanceAction.cpp
@@ -2,17 +2,26 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/IDataStore.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 #include "simplnx/Utilities/TemplateHelpers.hpp"
 
 #include <fmt/core.h>
+
+using namespace nx::core;
 
 namespace
 {
 constexpr int32_t k_UnsupportedTypeError = -5001;
 
+template <typename T>
+Result<> DoCopy(IDataArray* inputDataArray, DataStructure& dataStructure, DataPath&& path, IDataAction::Mode mode)
+{
+  auto* castInputArray = dynamic_cast<DataArray<T>*>(inputDataArray);
+  IDataStore::ShapeType tupleShape = castInputArray->getDataStore()->getTupleShape();
+  IDataStore::ShapeType componentShape = castInputArray->getDataStore()->getComponentShape();
+  return ArrayCreationUtilities::CreateArray<T>(dataStructure, tupleShape, componentShape, path, mode);
 }
-using namespace nx::core;
+} // namespace
 
 namespace nx::core
 {
@@ -24,59 +33,53 @@ CopyArrayInstanceAction::CopyArrayInstanceAction(const DataPath& selectedDataPat
 
 CopyArrayInstanceAction::~CopyArrayInstanceAction() noexcept = default;
 
-#define CAI_BODY(type)                                                                                                                                                                                 \
-  DataArray<type>* castInputArray = dynamic_cast<DataArray<type>*>(inputDataArray);                                                                                                                    \
-  IDataStore::ShapeType tupleShape = castInputArray->getDataStore()->getTupleShape();                                                                                                                  \
-  IDataStore::ShapeType componentShape = castInputArray->getDataStore()->getComponentShape();                                                                                                          \
-  return CreateArray<type>(dataStructure, tupleShape, componentShape, getCreatedPath(), mode);
-
 Result<> CopyArrayInstanceAction::apply(DataStructure& dataStructure, Mode mode) const
 {
   auto* inputDataArray = dataStructure.getDataAs<IDataArray>(m_SelectedDataPath);
 
   if(TemplateHelpers::CanDynamicCast<Float32Array>()(inputDataArray))
   {
-    CAI_BODY(float)
+    return ::DoCopy<float32>(inputDataArray, dataStructure, getCreatedPath(), mode);
   }
   if(TemplateHelpers::CanDynamicCast<Float64Array>()(inputDataArray))
   {
-    CAI_BODY(double)
+    return ::DoCopy<float64>(inputDataArray, dataStructure, getCreatedPath(), mode);
   }
   if(TemplateHelpers::CanDynamicCast<Int8Array>()(inputDataArray))
   {
-    CAI_BODY(int8_t)
+    return ::DoCopy<int8>(inputDataArray, dataStructure, getCreatedPath(), mode);
   }
   if(TemplateHelpers::CanDynamicCast<UInt8Array>()(inputDataArray))
   {
-    CAI_BODY(uint8_t)
+    return ::DoCopy<uint8>(inputDataArray, dataStructure, getCreatedPath(), mode);
   }
   if(TemplateHelpers::CanDynamicCast<Int16Array>()(inputDataArray))
   {
-    CAI_BODY(int16_t)
+    return ::DoCopy<int16>(inputDataArray, dataStructure, getCreatedPath(), mode);
   }
   if(TemplateHelpers::CanDynamicCast<UInt16Array>()(inputDataArray))
   {
-    CAI_BODY(uint16_t)
+    return ::DoCopy<uint16>(inputDataArray, dataStructure, getCreatedPath(), mode);
   }
   if(TemplateHelpers::CanDynamicCast<Int32Array>()(inputDataArray))
   {
-    CAI_BODY(int32_t)
+    return ::DoCopy<int32>(inputDataArray, dataStructure, getCreatedPath(), mode);
   }
   if(TemplateHelpers::CanDynamicCast<UInt32Array>()(inputDataArray))
   {
-    CAI_BODY(uint32_t)
+    return ::DoCopy<uint32>(inputDataArray, dataStructure, getCreatedPath(), mode);
   }
   if(TemplateHelpers::CanDynamicCast<Int64Array>()(inputDataArray))
   {
-    CAI_BODY(int64_t)
+    return ::DoCopy<int64>(inputDataArray, dataStructure, getCreatedPath(), mode);
   }
   if(TemplateHelpers::CanDynamicCast<UInt64Array>()(inputDataArray))
   {
-    CAI_BODY(uint64_t)
+    return ::DoCopy<uint64>(inputDataArray, dataStructure, getCreatedPath(), mode);
   }
   if(TemplateHelpers::CanDynamicCast<BoolArray>()(inputDataArray))
   {
-    CAI_BODY(bool)
+    return ::DoCopy<bool>(inputDataArray, dataStructure, getCreatedPath(), mode);
   }
 
   static constexpr StringLiteral prefix = "CopyArrayInstanceAction: ";

--- a/src/simplnx/Filter/Actions/CreateArrayAction.cpp
+++ b/src/simplnx/Filter/Actions/CreateArrayAction.cpp
@@ -1,21 +1,32 @@
 #include "CreateArrayAction.hpp"
 
-#include "simplnx/Common/TypeTraits.hpp"
-#include "simplnx/DataStructure/EmptyDataStore.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
-
-#include <fmt/core.h>
+#include "simplnx/Utilities/ArrayCreationUtilities.hpp"
+#include "simplnx/Utilities/FilterUtilities.hpp"
 
 using namespace nx::core;
 
+namespace
+{
+struct CreateArrayFunctor
+{
+  template <typename T>
+  Result<> operator()(DataStructure& dataStructure, const std::vector<usize>& tDims, const std::vector<usize>& cDims, const DataPath& path, IDataAction::Mode mode, std::string dataFormat,
+                      std::string fillValue)
+  {
+    return ArrayCreationUtilities::CreateArray<T>(dataStructure, tDims, cDims, path, mode, dataFormat, fillValue);
+  }
+};
+} // namespace
+
 namespace nx::core
 {
-CreateArrayAction::CreateArrayAction(DataType type, const std::vector<usize>& tDims, const std::vector<usize>& cDims, const DataPath& path, std::string dataFormat)
+CreateArrayAction::CreateArrayAction(DataType type, const std::vector<usize>& tDims, const std::vector<usize>& cDims, const DataPath& path, std::string dataFormat, std::string fillValue)
 : IDataCreationAction(path)
 , m_Type(type)
 , m_Dims(tDims)
 , m_CDims(cDims)
 , m_DataFormat(dataFormat)
+, m_FillValue(fillValue)
 {
 }
 
@@ -23,46 +34,7 @@ CreateArrayAction::~CreateArrayAction() noexcept = default;
 
 Result<> CreateArrayAction::apply(DataStructure& dataStructure, Mode mode) const
 {
-  switch(m_Type)
-  {
-  case DataType::int8: {
-    return CreateArray<int8>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode, m_DataFormat);
-  }
-  case DataType::uint8: {
-    return CreateArray<uint8>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode, m_DataFormat);
-  }
-  case DataType::int16: {
-    return CreateArray<int16>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode, m_DataFormat);
-  }
-  case DataType::uint16: {
-    return CreateArray<uint16>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode, m_DataFormat);
-  }
-  case DataType::int32: {
-    return CreateArray<int32>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode, m_DataFormat);
-  }
-  case DataType::uint32: {
-    return CreateArray<uint32>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode, m_DataFormat);
-  }
-  case DataType::int64: {
-    return CreateArray<int64>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode, m_DataFormat);
-  }
-  case DataType::uint64: {
-    return CreateArray<uint64>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode, m_DataFormat);
-  }
-  case DataType::float32: {
-    return CreateArray<float32>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode, m_DataFormat);
-  }
-  case DataType::float64: {
-    return CreateArray<float64>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode, m_DataFormat);
-  }
-  case DataType::boolean: {
-    return CreateArray<bool>(dataStructure, m_Dims, m_CDims, getCreatedPath(), mode, m_DataFormat);
-  }
-  default: {
-    static constexpr StringLiteral prefix = "CreateArrayAction: ";
-    throw std::runtime_error(fmt::format("{}CreateArrayAction: Invalid DataType '{}'", prefix, to_underlying(m_Type)));
-  }
-  }
+  return ExecuteDataFunction(::CreateArrayFunctor{}, m_Type, dataStructure, m_Dims, m_CDims, getCreatedPath(), mode, m_DataFormat, m_FillValue);
 }
 
 IDataAction::UniquePointer CreateArrayAction::clone() const

--- a/src/simplnx/Filter/Actions/CreateArrayAction.hpp
+++ b/src/simplnx/Filter/Actions/CreateArrayAction.hpp
@@ -20,7 +20,7 @@ class SIMPLNX_EXPORT CreateArrayAction : public IDataCreationAction
 public:
   CreateArrayAction() = delete;
 
-  CreateArrayAction(DataType type, const std::vector<usize>& tDims, const std::vector<usize>& cDims, const DataPath& path, std::string dataFormat = "", std::string fillValue = "0");
+  CreateArrayAction(DataType type, const std::vector<usize>& tDims, const std::vector<usize>& cDims, const DataPath& path, std::string dataFormat = "", std::string fillValue = "");
 
   ~CreateArrayAction() noexcept override;
 
@@ -86,6 +86,6 @@ private:
   std::vector<usize> m_Dims;
   std::vector<usize> m_CDims;
   std::string m_DataFormat = "";
-  std::string m_FillValue = "0";
+  std::string m_FillValue = "";
 };
 } // namespace nx::core

--- a/src/simplnx/Filter/Actions/CreateArrayAction.hpp
+++ b/src/simplnx/Filter/Actions/CreateArrayAction.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
+#include "simplnx/simplnx_export.hpp"
+
 #include "simplnx/Common/Types.hpp"
 #include "simplnx/DataStructure/DataPath.hpp"
 #include "simplnx/Filter/Output.hpp"
-#include "simplnx/simplnx_export.hpp"
 
 #include <string>
 #include <vector>
@@ -12,13 +13,14 @@ namespace nx::core
 {
 /**
  * @brief Action for creating DataArrays in a DataStructure
+ * @tparam T the type of the fill value being supplied
  */
 class SIMPLNX_EXPORT CreateArrayAction : public IDataCreationAction
 {
 public:
   CreateArrayAction() = delete;
 
-  CreateArrayAction(DataType type, const std::vector<usize>& tDims, const std::vector<usize>& cDims, const DataPath& path, std::string dataFormat = "");
+  CreateArrayAction(DataType type, const std::vector<usize>& tDims, const std::vector<usize>& cDims, const DataPath& path, std::string dataFormat = "", std::string fillValue = "0");
 
   ~CreateArrayAction() noexcept override;
 
@@ -84,5 +86,6 @@ private:
   std::vector<usize> m_Dims;
   std::vector<usize> m_CDims;
   std::string m_DataFormat = "";
+  std::string m_FillValue = "0";
 };
 } // namespace nx::core

--- a/src/simplnx/Filter/Actions/CreateArrayAction.hpp
+++ b/src/simplnx/Filter/Actions/CreateArrayAction.hpp
@@ -13,11 +13,12 @@ namespace nx::core
 {
 /**
  * @brief Action for creating DataArrays in a DataStructure
- * @tparam T the type of the fill value being supplied
  */
 class SIMPLNX_EXPORT CreateArrayAction : public IDataCreationAction
 {
 public:
+  inline static constexpr StringLiteral k_DefaultDataFormat = "";
+
   CreateArrayAction() = delete;
 
   CreateArrayAction(DataType type, const std::vector<usize>& tDims, const std::vector<usize>& cDims, const DataPath& path, std::string dataFormat = "", std::string fillValue = "");

--- a/src/simplnx/Filter/Actions/CreateGeometry1DAction.hpp
+++ b/src/simplnx/Filter/Actions/CreateGeometry1DAction.hpp
@@ -6,7 +6,7 @@
 #include "simplnx/DataStructure/Geometry/EdgeGeom.hpp"
 #include "simplnx/DataStructure/Geometry/IGeometry.hpp"
 #include "simplnx/Filter/Output.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 #include "simplnx/simplnx_export.hpp"
 
 #include <fmt/core.h>
@@ -197,23 +197,31 @@ public:
       DataPath edgesPath = getCreatedPath().createChildPath(m_SharedEdgesName);
       // Create the default DataArray that will hold the EdgeList and Vertices. We
       // size these to 1 because the Csv parser will resize them to the appropriate number of tuples
-      Result result = CreateArray<MeshIndexType>(dataStructure, edgeTupleShape, {2}, edgesPath, mode, m_CreatedDataStoreFormat);
+      Result result = ArrayCreationUtilities::CreateArray<MeshIndexType>(dataStructure, edgeTupleShape, {2}, edgesPath, mode, m_CreatedDataStoreFormat);
       if(result.invalid())
       {
         return MergeResults(result, MakeErrorResult(-5409, fmt::format("{}CreateGeometry1DAction: Could not allocate SharedEdgeList '{}'", prefix, edgesPath.toString())));
       }
-      SharedEdgeList* createdEdges = ArrayFromPath<MeshIndexType>(dataStructure, edgesPath);
+      auto* createdEdges = dataStructure.getDataAs<SharedEdgeList>(edgesPath);
+      if(createdEdges == nullptr)
+      {
+        throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", edgesPath.toString()));
+      }
       geometry1d->setEdgeList(*createdEdges);
 
       // Create the Vertex Array with a component size of 3
       DataPath vertexPath = getCreatedPath().createChildPath(m_SharedVerticesName);
 
-      result = CreateArray<float>(dataStructure, vertexTupleShape, {3}, vertexPath, mode, m_CreatedDataStoreFormat);
+      result = ArrayCreationUtilities::CreateArray<float32>(dataStructure, vertexTupleShape, {3}, vertexPath, mode, m_CreatedDataStoreFormat);
       if(result.invalid())
       {
         return MergeResults(result, MakeErrorResult(-5410, fmt::format("{}CreateGeometry1DAction: Could not allocate SharedVertList '{}'", prefix, vertexPath.toString())));
       }
-      Float32Array* vertexArray = ArrayFromPath<float>(dataStructure, vertexPath);
+      auto* vertexArray = dataStructure.getDataAs<Float32Array>(vertexPath);
+      if(vertexArray == nullptr)
+      {
+        throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", vertexPath.toString()));
+      }
       geometry1d->setVertices(*vertexArray);
     }
 

--- a/src/simplnx/Filter/Actions/CreateGeometry2DAction.hpp
+++ b/src/simplnx/Filter/Actions/CreateGeometry2DAction.hpp
@@ -7,7 +7,7 @@
 #include "simplnx/DataStructure/Geometry/QuadGeom.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Filter/Output.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 #include "simplnx/simplnx_export.hpp"
 
 #include <fmt/core.h>
@@ -197,23 +197,31 @@ public:
       DataPath trianglesPath = getCreatedPath().createChildPath(m_SharedFacesName);
       // Create the default DataArray that will hold the FaceList and Vertices. We
       // size these to 1 because the Csv parser will resize them to the appropriate number of tuples
-      Result result = CreateArray<MeshIndexType>(dataStructure, faceTupleShape, {Geometry2DType::k_NumVerts}, trianglesPath, mode, m_CreatedDataStoreFormat);
+      Result result = ArrayCreationUtilities::CreateArray<MeshIndexType>(dataStructure, faceTupleShape, {Geometry2DType::k_NumVerts}, trianglesPath, mode, m_CreatedDataStoreFormat);
       if(result.invalid())
       {
         return MergeResults(result, MakeErrorResult(-5509, fmt::format("{}CreateGeometry2DAction: Could not allocate SharedTriList '{}'", prefix, trianglesPath.toString())));
       }
-      SharedTriList* triangles = ArrayFromPath<MeshIndexType>(dataStructure, trianglesPath);
+      auto* triangles = dataStructure.getDataAs<SharedTriList>(trianglesPath);
+      if(triangles == nullptr)
+      {
+        throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", trianglesPath.toString()));
+      }
       geometry2d->setFaceList(*triangles);
 
       // Create the Vertex Array with a component size of 3
       DataPath vertexPath = getCreatedPath().createChildPath(m_SharedVerticesName);
 
-      result = CreateArray<float>(dataStructure, vertexTupleShape, {3}, vertexPath, mode, m_CreatedDataStoreFormat);
+      result = ArrayCreationUtilities::CreateArray<float32>(dataStructure, vertexTupleShape, {3}, vertexPath, mode, m_CreatedDataStoreFormat);
       if(result.invalid())
       {
         return MergeResults(result, MakeErrorResult(-5510, fmt::format("{}CreateGeometry2DAction: Could not allocate SharedVertList '{}'", prefix, vertexPath.toString())));
       }
-      Float32Array* vertexArray = ArrayFromPath<float>(dataStructure, vertexPath);
+      auto* vertexArray = dataStructure.getDataAs<Float32Array>(vertexPath);
+      if(vertexArray == nullptr)
+      {
+        throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", vertexPath.toString()));
+      }
       geometry2d->setVertices(*vertexArray);
     }
 

--- a/src/simplnx/Filter/Actions/CreateGeometry3DAction.hpp
+++ b/src/simplnx/Filter/Actions/CreateGeometry3DAction.hpp
@@ -7,7 +7,7 @@
 #include "simplnx/DataStructure/Geometry/IGeometry.hpp"
 #include "simplnx/DataStructure/Geometry/TetrahedralGeom.hpp"
 #include "simplnx/Filter/Output.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 #include "simplnx/simplnx_export.hpp"
 
 #include <fmt/core.h>
@@ -196,23 +196,31 @@ public:
     {
       const DataPath cellsPath = getCreatedPath().createChildPath(m_SharedCellsName);
       // Create the default DataArray that will hold the CellList and Vertices.
-      Result result = CreateArray<MeshIndexType>(dataStructure, cellTupleShape, {Geometry3DType::k_NumVerts}, cellsPath, mode, m_CreatedDataStoreFormat);
+      Result result = ArrayCreationUtilities::CreateArray<MeshIndexType>(dataStructure, cellTupleShape, {Geometry3DType::k_NumVerts}, cellsPath, mode, m_CreatedDataStoreFormat);
       if(result.invalid())
       {
         return MergeResults(result, MakeErrorResult(-5609, fmt::format("{}CreateGeometry3DAction: Could not allocate SharedCellList '{}'", prefix, cellsPath.toString())));
       }
-      SharedCellList* polyhedronList = ArrayFromPath<MeshIndexType>(dataStructure, cellsPath);
+      auto* polyhedronList = dataStructure.getDataAs<SharedCellList>(cellsPath);
+      if(polyhedronList == nullptr)
+      {
+        throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", cellsPath.toString()));
+      }
       geometry3d->setPolyhedraList(*polyhedronList);
 
       // Create the Vertex Array with a component size of 3
       const DataPath vertexPath = getCreatedPath().createChildPath(m_SharedVerticesName);
 
-      result = CreateArray<float>(dataStructure, vertexTupleShape, {3}, vertexPath, mode, m_CreatedDataStoreFormat);
+      result = ArrayCreationUtilities::CreateArray<float>(dataStructure, vertexTupleShape, {3}, vertexPath, mode, m_CreatedDataStoreFormat);
       if(result.invalid())
       {
         return MergeResults(result, MakeErrorResult(-5610, fmt::format("{}CreateGeometry3DAction: Could not allocate SharedVertList '{}'", prefix, vertexPath.toString())));
       }
-      Float32Array* vertexArray = ArrayFromPath<float>(dataStructure, vertexPath);
+      auto* vertexArray = dataStructure.getDataAs<Float32Array>(vertexPath);
+      if(vertexArray == nullptr)
+      {
+        throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", vertexPath.toString()));
+      }
       geometry3d->setVertices(*vertexArray);
     }
 

--- a/src/simplnx/Filter/Actions/CreateRectGridGeometryAction.cpp
+++ b/src/simplnx/Filter/Actions/CreateRectGridGeometryAction.cpp
@@ -2,7 +2,6 @@
 
 #include "simplnx/DataStructure/Geometry/RectGridGeom.hpp"
 #include "simplnx/Utilities/ArrayCreationUtilities.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 
 #include <fmt/core.h>
 
@@ -191,7 +190,11 @@ Float32Array* CreateRectGridGeometryAction::createBoundArray(DataStructure& data
     errors.insert(errors.end(), result.errors().begin(), result.errors().end());
     return nullptr;
   }
-  Float32Array* boundsArray = ArrayFromPath<float>(dataStructure, boundsPath);
+  auto* boundsArray = dataStructure.getDataAs<Float32Array>(boundsPath);
+  if(boundsArray == nullptr)
+  {
+    throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", boundsPath.toString()));
+  }
 
   return boundsArray;
 }

--- a/src/simplnx/Filter/Actions/CreateRectGridGeometryAction.cpp
+++ b/src/simplnx/Filter/Actions/CreateRectGridGeometryAction.cpp
@@ -1,6 +1,7 @@
 #include "CreateRectGridGeometryAction.hpp"
 
 #include "simplnx/DataStructure/Geometry/RectGridGeom.hpp"
+#include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 
 #include <fmt/core.h>
@@ -185,7 +186,7 @@ Float32Array* CreateRectGridGeometryAction::createBoundArray(DataStructure& data
 {
   const DimensionType componentShape = {1};
   const DataPath boundsPath = getCreatedPath().createChildPath(arrayName);
-  if(Result<> result = CreateArray<float32>(dataStructure, {numTuples}, componentShape, boundsPath, mode, m_CreatedDataStoreFormat); result.invalid())
+  if(Result<> result = ArrayCreationUtilities::CreateArray<float32>(dataStructure, {numTuples}, componentShape, boundsPath, mode, m_CreatedDataStoreFormat); result.invalid())
   {
     errors.insert(errors.end(), result.errors().begin(), result.errors().end());
     return nullptr;

--- a/src/simplnx/Filter/Actions/CreateVertexGeometryAction.hpp
+++ b/src/simplnx/Filter/Actions/CreateVertexGeometryAction.hpp
@@ -6,6 +6,7 @@
 #include "simplnx/DataStructure/Geometry/IGeometry.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/Filter/Output.hpp"
+#include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/simplnx_export.hpp"
 
@@ -149,7 +150,7 @@ public:
       const DataPath vertexPath = getCreatedPath().createChildPath(m_SharedVertexListName);
       const std::vector<usize> componentShape = {3};
 
-      Result<> result = nx::core::CreateArray<float>(dataStructure, tupleShape, componentShape, vertexPath, mode, m_CreatedDataStoreFormat);
+      Result<> result = ArrayCreationUtilities::CreateArray<float32>(dataStructure, tupleShape, componentShape, vertexPath, mode, m_CreatedDataStoreFormat);
       if(result.invalid())
       {
         return result;

--- a/src/simplnx/Filter/Actions/CreateVertexGeometryAction.hpp
+++ b/src/simplnx/Filter/Actions/CreateVertexGeometryAction.hpp
@@ -7,7 +7,6 @@
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/Filter/Output.hpp"
 #include "simplnx/Utilities/ArrayCreationUtilities.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/simplnx_export.hpp"
 
 #include <fmt/core.h>
@@ -155,7 +154,11 @@ public:
       {
         return result;
       }
-      const Float32Array* vertexArray = nx::core::ArrayFromPath<float>(dataStructure, vertexPath);
+      auto* vertexArray = dataStructure.getDataAs<Float32Array>(vertexPath);
+      if(vertexArray == nullptr)
+      {
+        throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", vertexPath.toString()));
+      }
       vertexGeom->setVertices(*vertexArray);
     }
 

--- a/src/simplnx/Utilities/ArrayCreationUtilities.cpp
+++ b/src/simplnx/Utilities/ArrayCreationUtilities.cpp
@@ -1,0 +1,37 @@
+#include "ArrayCreationUtilities.hpp"
+
+#include "simplnx/Core/Application.hpp"
+#include "simplnx/Utilities/MemoryUtilities.hpp"
+
+using namespace nx::core;
+
+//-----------------------------------------------------------------------------
+bool ArrayCreationUtilities::CheckMemoryRequirement(DataStructure& dataStructure, uint64 requiredMemory, std::string& format)
+{
+  static const uint64 k_AvailableMemory = Memory::GetTotalMemory();
+
+  // Only check if format is set to in-memory
+  if(!format.empty())
+  {
+    return true;
+  }
+
+  Preferences* preferencesPtr = Application::GetOrCreateInstance()->getPreferences();
+
+  const uint64 memoryUsage = dataStructure.memoryUsage() + requiredMemory;
+  const uint64 largeDataStructureSize = preferencesPtr->largeDataStructureSize();
+  const std::string largeDataFormat = preferencesPtr->largeDataFormat();
+
+  if(memoryUsage >= largeDataStructureSize)
+  {
+    // Check if out-of-core is available / enabled
+    if(largeDataFormat.empty() && memoryUsage >= k_AvailableMemory)
+    {
+      return false;
+    }
+    // Use out-of-core
+    format = largeDataFormat;
+  }
+
+  return true;
+}

--- a/src/simplnx/Utilities/ArrayCreationUtilities.hpp
+++ b/src/simplnx/Utilities/ArrayCreationUtilities.hpp
@@ -18,6 +18,8 @@
 
 namespace nx::core::ArrayCreationUtilities
 {
+inline static constexpr StringLiteral k_DefaultDataFormat = "";
+
 SIMPLNX_EXPORT bool CheckMemoryRequirement(DataStructure& dataStructure, uint64 requiredMemory, std::string& format);
 
 /**
@@ -85,7 +87,7 @@ Result<> CreateArray(DataStructure& dataStructure, const std::vector<usize>& tup
   {
     return MakeErrorResult(-265, fmt::format("CreateArray: Unable to create DataStore<T> at '{}' of DataStore format '{}'", path.toString(), dataFormat));
   }
-  if(mode == IDataAction::Mode::Execute && !fillValue.empty())
+  if(!fillValue.empty())
   {
     Result<T> conversionResult = StringInterpretationUtilities::Convert<T>(fillValue);
 
@@ -93,13 +95,16 @@ Result<> CreateArray(DataStructure& dataStructure, const std::vector<usize>& tup
     {
       return ConvertResult(std::move(conversionResult));
     }
-    store->fill(conversionResult.value());
+    if(mode == IDataAction::Mode::Execute)
     {
-      // Only base data store has initialization value
-      std::weak_ptr<DataStore<T>> weakDataStorePtr = std::dynamic_pointer_cast<DataStore<T>>(store);
-      if(auto dataStorePtr = weakDataStorePtr.lock(); dataStorePtr != nullptr)
+      store->fill(conversionResult.value());
       {
-        dataStorePtr->setInitValue(conversionResult.value());
+        // Only base data store has initialization value
+        std::weak_ptr<DataStore<T>> weakDataStorePtr = std::dynamic_pointer_cast<DataStore<T>>(store);
+        if(auto dataStorePtr = weakDataStorePtr.lock(); dataStorePtr != nullptr)
+        {
+          dataStorePtr->setInitValue(conversionResult.value());
+        }
       }
     }
   }

--- a/src/simplnx/Utilities/ArrayCreationUtilities.hpp
+++ b/src/simplnx/Utilities/ArrayCreationUtilities.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include "simplnx/simplnx_export.hpp"
+
+#include "simplnx/Common/Result.hpp"
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/DataStructure/DataStructure.hpp"
+#include "simplnx/DataStructure/IO/Generic/DataIOCollection.hpp"
+#include "simplnx/Filter/Output.hpp"
+#include "simplnx/Utilities/DataStoreUtilities.hpp"
+#include "simplnx/Utilities/MemoryUtilities.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
+
+#include <fmt/format.h>
+
+#include <numeric>
+
+namespace nx::core::ArrayCreationUtilities
+{
+SIMPLNX_EXPORT bool CheckMemoryRequirement(DataStructure& dataStructure, uint64 requiredMemory, std::string& format);
+
+/**
+ * @brief Creates a DataArray with the given properties
+ * @tparam T Primitive Type (int, float, ...)
+ * @param dataStructure The DataStructure to use
+ * @param tupleShape The Tuple Dimensions
+ * @param nComp The number of components in the DataArray
+ * @param path The DataPath to where the data will be stored.
+ * @param mode The mode to assume: PREFLIGHT or EXECUTE. Preflight will NOT allocate any storage. EXECUTE will allocate the memory/storage
+ * @return
+ */
+template <class T>
+Result<> CreateArray(DataStructure& dataStructure, const std::vector<usize>& tupleShape, const std::vector<usize>& compShape, const DataPath& path, IDataAction::Mode mode, std::string dataFormat = "",
+                     std::string fillValue = "0")
+{
+  auto parentPath = path.getParent();
+
+  std::optional<DataObject::IdType> dataObjectId;
+
+  DataObject* parentObjectPtr = nullptr;
+  if(parentPath.getLength() != 0)
+  {
+    parentObjectPtr = dataStructure.getData(parentPath);
+    if(parentObjectPtr == nullptr)
+    {
+      return MakeErrorResult(-260, fmt::format("CreateArray: Parent object '{}' does not exist", parentPath.toString()));
+    }
+
+    dataObjectId = parentObjectPtr->getId();
+  }
+
+  if(tupleShape.empty())
+  {
+    return MakeErrorResult(-261, fmt::format("CreateArray: Tuple Shape was empty. Please set the number of tuples."));
+  }
+
+  // Validate Number of Components
+  if(compShape.empty())
+  {
+    return MakeErrorResult(-262, fmt::format("CreateArray: Component Shape was empty. Please set the number of components."));
+  }
+  const usize numComponents = std::accumulate(compShape.cbegin(), compShape.cend(), static_cast<usize>(1), std::multiplies<>());
+  if(numComponents == 0 && mode == IDataAction::Mode::Execute)
+  {
+    return MakeErrorResult(-263, fmt::format("CreateArray: Number of components is ZERO. Please set the number of components."));
+  }
+
+  const usize last = path.getLength() - 1;
+
+  std::string name = path[last];
+
+  const usize numTuples = std::accumulate(tupleShape.cbegin(), tupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
+  uint64 requiredMemory = numTuples * numComponents * sizeof(T);
+  if(!CheckMemoryRequirement(dataStructure, requiredMemory, dataFormat))
+  {
+    uint64 totalMemory = requiredMemory + dataStructure.memoryUsage();
+    uint64 availableMemory = Memory::GetTotalMemory();
+    return MakeErrorResult(-264, fmt::format("CreateArray: Cannot create DataArray '{}'.\n\tTotal memory required for DataStructure: '{}' Bytes.\n\tTotal reported memory: '{}' Bytes", name,
+                                             totalMemory, availableMemory));
+  }
+
+  Result<T> conversionResult = StringInterpretationUtilities::Convert<T>(fillValue);
+  if(conversionResult.invalid())
+  {
+    return ConvertResult(std::move(conversionResult));
+  }
+
+  auto store = DataStoreUtilities::CreateDataStore<T>(tupleShape, compShape, mode, dataFormat);
+  if(nullptr == store)
+  {
+    return MakeErrorResult(-265, fmt::format("CreateArray: Unable to create DataStore<T> at '{}' of DataStore format '{}'", path.toString(), dataFormat));
+  }
+  if(mode == IDataAction::Mode::Execute)
+  {
+    store->fill(conversionResult.value());
+    {
+      // Only base data store has initialization value
+      std::weak_ptr<DataStore<T>> weakDataStorePtr = std::dynamic_pointer_cast<DataStore<T>>(store);
+      if(auto dataStorePtr = weakDataStorePtr.lock(); dataStorePtr != nullptr)
+      {
+        dataStorePtr->setInitValue(conversionResult.value());
+      }
+    }
+  }
+
+  auto dataArray = DataArray<T>::Create(dataStructure, name, store, dataObjectId);
+  if(dataArray == nullptr)
+  {
+    if(dataStructure.getId(path).has_value())
+    {
+      return MakeErrorResult(-266, fmt::format("CreateArray: Cannot create Data Array at path '{}' because it already exists. Choose a different name.", path.toString()));
+    }
+
+    if(parentObjectPtr == nullptr)
+    {
+      return MakeErrorResult(-267, fmt::format("CreateArray: Parent object '{}' does not exist", parentPath.toString()));
+    }
+    if(parentObjectPtr->getDataObjectType() == DataObject::Type::AttributeMatrix)
+    {
+      auto* attrMatrixPtr = dynamic_cast<AttributeMatrix*>(parentObjectPtr);
+      std::string amShape = fmt::format("Attribute Matrix Tuple Dims: {}", fmt::join(attrMatrixPtr->getShape(), " x "));
+      std::string arrayShape = fmt::format("Data Array Tuple Shape: {}", fmt::join(store->getTupleShape(), " x "));
+      return MakeErrorResult(-268,
+                             fmt::format("CreateArray: Unable to create Data Array '{}' inside Attribute matrix '{}'. Mismatch of tuple dimensions. The created Data Array must have the same tuple "
+                                         "dimensions or the same total number of tuples.\n{}\n{}",
+                                         name, dataStructure.getDataPathsForId(parentObjectPtr->getId()).front().toString(), amShape, arrayShape));
+    }
+
+    return MakeErrorResult(-269, fmt::format("CreateArray: Unable to create DataArray at '{}'", path.toString()));
+  }
+
+  return {};
+}
+} // namespace nx::core::ArrayCreationUtilities

--- a/src/simplnx/Utilities/ArrayCreationUtilities.hpp
+++ b/src/simplnx/Utilities/ArrayCreationUtilities.hpp
@@ -32,7 +32,7 @@ SIMPLNX_EXPORT bool CheckMemoryRequirement(DataStructure& dataStructure, uint64 
  */
 template <class T>
 Result<> CreateArray(DataStructure& dataStructure, const std::vector<usize>& tupleShape, const std::vector<usize>& compShape, const DataPath& path, IDataAction::Mode mode, std::string dataFormat = "",
-                     std::string fillValue = "0")
+                     std::string fillValue = "")
 {
   auto parentPath = path.getParent();
 
@@ -80,19 +80,19 @@ Result<> CreateArray(DataStructure& dataStructure, const std::vector<usize>& tup
                                              totalMemory, availableMemory));
   }
 
-  Result<T> conversionResult = StringInterpretationUtilities::Convert<T>(fillValue);
-  if(conversionResult.invalid())
-  {
-    return ConvertResult(std::move(conversionResult));
-  }
-
   auto store = DataStoreUtilities::CreateDataStore<T>(tupleShape, compShape, mode, dataFormat);
   if(nullptr == store)
   {
     return MakeErrorResult(-265, fmt::format("CreateArray: Unable to create DataStore<T> at '{}' of DataStore format '{}'", path.toString(), dataFormat));
   }
-  if(mode == IDataAction::Mode::Execute)
+  if(mode == IDataAction::Mode::Execute && !fillValue.empty())
   {
+    Result<T> conversionResult = StringInterpretationUtilities::Convert<T>(fillValue);
+
+    if(conversionResult.invalid())
+    {
+      return ConvertResult(std::move(conversionResult));
+    }
     store->fill(conversionResult.value());
     {
       // Only base data store has initialization value

--- a/src/simplnx/Utilities/DataArrayUtilities.cpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.cpp
@@ -37,53 +37,6 @@ struct InitializeNeighborListFunctor
 namespace nx::core
 {
 //-----------------------------------------------------------------------------
-Result<> CheckValueConvertsToArrayType(const std::string& value, const DataObject& inputDataArray)
-{
-  if(TemplateHelpers::CanDynamicCast<Float32Array>()(&inputDataArray))
-  {
-    return ConvertResult(StringInterpretationUtilities::Convert<float32>(value));
-  }
-  if(TemplateHelpers::CanDynamicCast<Float64Array>()(&inputDataArray))
-  {
-    return ConvertResult(StringInterpretationUtilities::Convert<float64>(value));
-  }
-  if(TemplateHelpers::CanDynamicCast<Int8Array>()(&inputDataArray))
-  {
-    return ConvertResult(StringInterpretationUtilities::Convert<int8>(value));
-  }
-  if(TemplateHelpers::CanDynamicCast<UInt8Array>()(&inputDataArray))
-  {
-    return ConvertResult(StringInterpretationUtilities::Convert<uint8>(value));
-  }
-  if(TemplateHelpers::CanDynamicCast<Int16Array>()(&inputDataArray))
-  {
-    return ConvertResult(StringInterpretationUtilities::Convert<int16>(value));
-  }
-  if(TemplateHelpers::CanDynamicCast<UInt16Array>()(&inputDataArray))
-  {
-    return ConvertResult(StringInterpretationUtilities::Convert<uint16>(value));
-  }
-  if(TemplateHelpers::CanDynamicCast<Int32Array>()(&inputDataArray))
-  {
-    return ConvertResult(StringInterpretationUtilities::Convert<int32>(value));
-  }
-  if(TemplateHelpers::CanDynamicCast<UInt32Array>()(&inputDataArray))
-  {
-    return ConvertResult(StringInterpretationUtilities::Convert<uint32>(value));
-  }
-  if(TemplateHelpers::CanDynamicCast<Int64Array>()(&inputDataArray))
-  {
-    return ConvertResult(StringInterpretationUtilities::Convert<int64>(value));
-  }
-  if(TemplateHelpers::CanDynamicCast<UInt64Array>()(&inputDataArray))
-  {
-    return ConvertResult(StringInterpretationUtilities::Convert<uint64>(value));
-  }
-
-  return {MakeErrorResult(-259, fmt::format("Input DataObject could not be cast to any primitive type."))};
-}
-
-//-----------------------------------------------------------------------------
 bool CheckArraysAreSameType(const DataStructure& dataStructure, const std::vector<DataPath>& dataArrayPaths)
 {
   std::set<nx::core::DataType> types;

--- a/src/simplnx/Utilities/DataArrayUtilities.cpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.cpp
@@ -3,10 +3,12 @@
 #include "simplnx/Common/Types.hpp"
 #include "simplnx/Common/TypesUtility.hpp"
 #include "simplnx/Core/Application.hpp"
+#include "simplnx/Filter/Actions/CreateArrayAction.hpp"
 #include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
-
-#include <set>
+#include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
+#include "simplnx/Utilities/TemplateHelpers.hpp"
 
 using namespace nx::core;
 
@@ -35,50 +37,11 @@ struct InitializeNeighborListFunctor
 namespace nx::core
 {
 //-----------------------------------------------------------------------------
-Result<> CheckValueConverts(const std::string& value, NumericType numericType)
-{
-  switch(numericType)
-  {
-  case NumericType::int8: {
-    return ConvertResult(StringInterpretationUtilities::Convert<int8>(value));
-  }
-  case NumericType::uint8: {
-    return ConvertResult(StringInterpretationUtilities::Convert<uint8>(value));
-  }
-  case NumericType::int16: {
-    return ConvertResult(StringInterpretationUtilities::Convert<int16>(value));
-  }
-  case NumericType::uint16: {
-    return ConvertResult(StringInterpretationUtilities::Convert<uint16>(value));
-  }
-  case NumericType::int32: {
-    return ConvertResult(StringInterpretationUtilities::Convert<int32>(value));
-  }
-  case NumericType::uint32: {
-    return ConvertResult(StringInterpretationUtilities::Convert<uint32>(value));;
-  }
-  case NumericType::int64: {
-    return ConvertResult(StringInterpretationUtilities::Convert<int64>(value));
-  }
-  case NumericType::uint64: {
-    return ConvertResult(StringInterpretationUtilities::Convert<uint64>(value));
-  }
-  case NumericType::float32: {
-    return ConvertResult(StringInterpretationUtilities::Convert<float32>(value));
-  }
-  case NumericType::float64: {
-    return ConvertResult(StringInterpretationUtilities::Convert<float64>(value));;
-  }
-  }
-  return MakeErrorResult(-10102, fmt::format("CheckInitValueConverts: Cannot convert input value '{}' to type '{}'", value, NumericTypeToString(numericType)));
-}
-
-//-----------------------------------------------------------------------------
 Result<> CheckValueConvertsToArrayType(const std::string& value, const DataObject& inputDataArray)
 {
   if(TemplateHelpers::CanDynamicCast<Float32Array>()(&inputDataArray))
   {
-    return ConvertResult(StringInterpretationUtilities::Convert<float32>(value));;
+    return ConvertResult(StringInterpretationUtilities::Convert<float32>(value));
   }
   if(TemplateHelpers::CanDynamicCast<Float64Array>()(&inputDataArray))
   {
@@ -251,30 +214,6 @@ void InitializeNeighborList(DataStructure& dataStructure, const DataPath& neighb
 {
   auto* neighborListPtr = dataStructure.getDataAs<INeighborList>(neighborListPath);
   ExecuteNeighborFunction(InitializeNeighborListFunctor{}, neighborListPtr->getDataType(), neighborListPtr);
-}
-
-//-----------------------------------------------------------------------------
-std::unique_ptr<MaskCompare> InstantiateMaskCompare(DataStructure& dataStructure, const DataPath& maskArrayPath)
-{
-  auto& maskArray = dataStructure.getDataRefAs<IDataArray>(maskArrayPath);
-
-  return InstantiateMaskCompare(maskArray);
-}
-
-//-----------------------------------------------------------------------------
-std::unique_ptr<MaskCompare> InstantiateMaskCompare(IDataArray& maskArray)
-{
-  switch(maskArray.getDataType())
-  {
-  case DataType::boolean: {
-    return std::make_unique<BoolMaskCompare>(dynamic_cast<BoolArray&>(maskArray).getDataStoreRef());
-  }
-  case DataType::uint8: {
-    return std::make_unique<UInt8MaskCompare>(dynamic_cast<UInt8Array&>(maskArray).getDataStoreRef());
-  }
-  default:
-    throw std::runtime_error("InstantiateMaskCompare: The Mask Array being used is NOT of type bool or uint8.");
-  }
 }
 
 //-----------------------------------------------------------------------------

--- a/src/simplnx/Utilities/DataArrayUtilities.cpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Common/Types.hpp"
 #include "simplnx/Common/TypesUtility.hpp"
 #include "simplnx/Core/Application.hpp"
+#include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 
 #include <set>
@@ -17,7 +18,7 @@ Result<> ReplaceArray(DataStructure& dataStructure, const DataPath& dataPath, co
   auto& castInputArray = dynamic_cast<const DataArray<T>&>(inputDataArray);
   const IDataStore::ShapeType componentShape = castInputArray.getDataStoreRef().getComponentShape();
   dataStructure.removeData(dataPath);
-  return CreateArray<T>(dataStructure, tupleShape, componentShape, dataPath, mode);
+  return ArrayCreationUtilities::CreateArray<T>(dataStructure, tupleShape, componentShape, dataPath, mode);
 }
 
 struct InitializeNeighborListFunctor
@@ -34,55 +35,39 @@ struct InitializeNeighborListFunctor
 namespace nx::core
 {
 //-----------------------------------------------------------------------------
-void TryForceLargeDataFormatFromPrefs(std::string& dataFormat)
-{
-  auto* preferencesPtr = Application::GetOrCreateInstance()->getPreferences();
-  if(preferencesPtr->forceOocData())
-  {
-    dataFormat = preferencesPtr->largeDataFormat();
-  }
-}
-
-//-----------------------------------------------------------------------------
-std::shared_ptr<DataIOCollection> GetIOCollection()
-{
-  return Application::GetOrCreateInstance()->getIOCollection();
-}
-
-//-----------------------------------------------------------------------------
 Result<> CheckValueConverts(const std::string& value, NumericType numericType)
 {
   switch(numericType)
   {
   case NumericType::int8: {
-    return CheckValuesSignedInt<int8>(value, Constants::k_Int8);
+    return ConvertResult(StringInterpretationUtilities::Convert<int8>(value));
   }
   case NumericType::uint8: {
-    return CheckValuesUnsignedInt<uint8>(value, Constants::k_UInt8);
+    return ConvertResult(StringInterpretationUtilities::Convert<uint8>(value));
   }
   case NumericType::int16: {
-    return CheckValuesSignedInt<int16>(value, Constants::k_Int16);
+    return ConvertResult(StringInterpretationUtilities::Convert<int16>(value));
   }
   case NumericType::uint16: {
-    return CheckValuesUnsignedInt<uint16>(value, Constants::k_UInt16);
+    return ConvertResult(StringInterpretationUtilities::Convert<uint16>(value));
   }
   case NumericType::int32: {
-    return CheckValuesSignedInt<int32>(value, Constants::k_Int32);
+    return ConvertResult(StringInterpretationUtilities::Convert<int32>(value));
   }
   case NumericType::uint32: {
-    return CheckValuesUnsignedInt<uint32>(value, Constants::k_UInt32);
+    return ConvertResult(StringInterpretationUtilities::Convert<uint32>(value));;
   }
   case NumericType::int64: {
-    return CheckValuesSignedInt<int64>(value, Constants::k_Int64);
+    return ConvertResult(StringInterpretationUtilities::Convert<int64>(value));
   }
   case NumericType::uint64: {
-    return CheckValuesUnsignedInt<uint64>(value, Constants::k_UInt64);
+    return ConvertResult(StringInterpretationUtilities::Convert<uint64>(value));
   }
   case NumericType::float32: {
-    return CheckValuesFloatDouble<float32>(value, Constants::k_Float32);
+    return ConvertResult(StringInterpretationUtilities::Convert<float32>(value));
   }
   case NumericType::float64: {
-    return CheckValuesFloatDouble<float64>(value, Constants::k_Float64);
+    return ConvertResult(StringInterpretationUtilities::Convert<float64>(value));;
   }
   }
   return MakeErrorResult(-10102, fmt::format("CheckInitValueConverts: Cannot convert input value '{}' to type '{}'", value, NumericTypeToString(numericType)));
@@ -93,43 +78,43 @@ Result<> CheckValueConvertsToArrayType(const std::string& value, const DataObjec
 {
   if(TemplateHelpers::CanDynamicCast<Float32Array>()(&inputDataArray))
   {
-    return CheckValuesFloatDouble<float32>(value, Constants::k_Float32);
+    return ConvertResult(StringInterpretationUtilities::Convert<float32>(value));;
   }
   if(TemplateHelpers::CanDynamicCast<Float64Array>()(&inputDataArray))
   {
-    return CheckValuesFloatDouble<float64>(value, Constants::k_Float64);
+    return ConvertResult(StringInterpretationUtilities::Convert<float64>(value));
   }
   if(TemplateHelpers::CanDynamicCast<Int8Array>()(&inputDataArray))
   {
-    return CheckValuesSignedInt<int8>(value, Constants::k_Int8);
+    return ConvertResult(StringInterpretationUtilities::Convert<int8>(value));
   }
   if(TemplateHelpers::CanDynamicCast<UInt8Array>()(&inputDataArray))
   {
-    return CheckValuesUnsignedInt<uint8>(value, Constants::k_UInt8);
+    return ConvertResult(StringInterpretationUtilities::Convert<uint8>(value));
   }
   if(TemplateHelpers::CanDynamicCast<Int16Array>()(&inputDataArray))
   {
-    return CheckValuesSignedInt<int16>(value, Constants::k_Int16);
+    return ConvertResult(StringInterpretationUtilities::Convert<int16>(value));
   }
   if(TemplateHelpers::CanDynamicCast<UInt16Array>()(&inputDataArray))
   {
-    return CheckValuesUnsignedInt<uint16>(value, Constants::k_UInt16);
+    return ConvertResult(StringInterpretationUtilities::Convert<uint16>(value));
   }
   if(TemplateHelpers::CanDynamicCast<Int32Array>()(&inputDataArray))
   {
-    return CheckValuesSignedInt<int32>(value, Constants::k_Int32);
+    return ConvertResult(StringInterpretationUtilities::Convert<int32>(value));
   }
   if(TemplateHelpers::CanDynamicCast<UInt32Array>()(&inputDataArray))
   {
-    return CheckValuesUnsignedInt<uint32>(value, Constants::k_UInt32);
+    return ConvertResult(StringInterpretationUtilities::Convert<uint32>(value));
   }
   if(TemplateHelpers::CanDynamicCast<Int64Array>()(&inputDataArray))
   {
-    return CheckValuesSignedInt<int64>(value, Constants::k_Int64);
+    return ConvertResult(StringInterpretationUtilities::Convert<int64>(value));
   }
   if(TemplateHelpers::CanDynamicCast<UInt64Array>()(&inputDataArray))
   {
-    return CheckValuesUnsignedInt<uint64>(value, Constants::k_UInt64);
+    return ConvertResult(StringInterpretationUtilities::Convert<uint64>(value));
   }
 
   return {MakeErrorResult(-259, fmt::format("Input DataObject could not be cast to any primitive type."))};
@@ -157,37 +142,6 @@ bool CheckArraysHaveSameTupleCount(const DataStructure& dataStructure, const std
     types.insert(iArrayPtr->getNumberOfTuples());
   }
   return types.size() == 1;
-}
-
-//-----------------------------------------------------------------------------
-bool CheckMemoryRequirement(DataStructure& dataStructure, uint64 requiredMemory, std::string& format)
-{
-  static const uint64 k_AvailableMemory = Memory::GetTotalMemory();
-
-  // Only check if format is set to in-memory
-  if(!format.empty())
-  {
-    return true;
-  }
-
-  Preferences* preferencesPtr = Application::GetOrCreateInstance()->getPreferences();
-
-  const uint64 memoryUsage = dataStructure.memoryUsage() + requiredMemory;
-  const uint64 largeDataStructureSize = preferencesPtr->largeDataStructureSize();
-  std::string largeDataFormat = preferencesPtr->largeDataFormat();
-
-  if(memoryUsage >= largeDataStructureSize)
-  {
-    // Check if out-of-core is available / enabled
-    if(largeDataFormat.empty() && memoryUsage >= k_AvailableMemory)
-    {
-      return false;
-    }
-    // Use out-of-core
-    format = largeDataFormat;
-  }
-
-  return true;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/simplnx/Utilities/DataArrayUtilities.hpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.hpp
@@ -1,26 +1,19 @@
 #pragma once
 
+#include "simplnx/simplnx_export.hpp"
+
 #include "simplnx/Common/Array.hpp"
 #include "simplnx/Common/Result.hpp"
 #include "simplnx/DataStructure/AbstractListStore.hpp"
 #include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
-#include "simplnx/DataStructure/DataStore.hpp"
-#include "simplnx/DataStructure/EmptyDataStore.hpp"
-#include "simplnx/DataStructure/IDataStore.hpp"
 #include "simplnx/DataStructure/NeighborList.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
-#include "simplnx/Filter/Actions/CreateArrayAction.hpp"
 #include "simplnx/Filter/IFilter.hpp"
-#include "simplnx/Filter/Output.hpp"
 #include "simplnx/Parameters/MultiArraySelectionParameter.hpp"
 #include "simplnx/Utilities/DataStoreUtilities.hpp"
-#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
-#include "simplnx/Utilities/MemoryUtilities.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
-#include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
-#include "simplnx/Utilities/TemplateHelpers.hpp"
-#include "simplnx/simplnx_export.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 
 #include <fmt/core.h>
 #include <fmt/ranges.h>
@@ -198,30 +191,6 @@ Result<> CreateNeighbors(DataStructure& dataStructure, usize numTuples, const Da
 }
 
 /**
- * @brief Attempts to retrieve a DataArray at a given DataPath in the DataStructure. Throws runtime_error on error
- * @tparam T
- * @param data
- * @param path
- * @return
- */
-template <class T>
-DataArray<T>* ArrayFromPath(DataStructure& dataStructure, const DataPath& path)
-{
-  using DataArrayType = DataArray<T>;
-  DataObject* objectPtr = dataStructure.getData(path);
-  if(objectPtr == nullptr)
-  {
-    throw std::runtime_error(fmt::format("DataArray does not exist at DataPath: '{}'", path.toString()));
-  }
-  auto* dataArray = dynamic_cast<DataArrayType*>(objectPtr);
-  if(dataArray == nullptr)
-  {
-    throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", path.toString()));
-  }
-  return dataArray;
-}
-
-/**
  * @brief
  * @tparam T
  * @param data
@@ -376,15 +345,6 @@ Result<> DeepCopy(DataStructure& dataStructure, const DataPath& sourceDataPath, 
 SIMPLNX_EXPORT Result<> ResizeAndReplaceDataArray(DataStructure& dataStructure, const DataPath& dataPath, std::vector<usize>& tupleShape, IDataAction::Mode mode);
 
 /**
- * @brief This function will ensure that a user entered numeric value can correctly be parsed into the selected NumericType
- *
- * @param value The string value that is to be parsed
- * @param numericType The NumericType to parse the value into.
- * @return
- */
-SIMPLNX_EXPORT Result<> CheckValueConverts(const std::string& value, NumericType numericType);
-
-/**
  * @brief This method will ensure that all the arrays are of the same type
  * @param dataStructure DataStructure that contains the data arrays
  * @param dataArrayPaths  The Paths to check
@@ -418,163 +378,6 @@ SIMPLNX_EXPORT Result<> ValidateFeatureIdsToFeatureAttributeMatrixIndexing(const
  * @param neighborListPath The path to the NeighborList to be initialized.
  */
 SIMPLNX_EXPORT void InitializeNeighborList(DataStructure& dataStructure, const DataPath& neighborListPath);
-
-/**
- * @brief These structs and functions are meant to make using a "mask array" or "Good Voxels Array" easier
- * for the developer. There is virtual function call overhead with using these structs and functions.
- *
- * An example use of these functions would be the following:
- * @code
- *  std::unique_ptr<MaskCompare> maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->goodVoxelsArrayPath);
- *  if(!maskCompare->bothTrue(arrayIndex, anotherArrayIndex))
- *  {
- *    // Do something based on the if statement...
- *  }
- * @endcode
- */
-struct MaskCompare
-{
-  virtual ~MaskCompare() noexcept = default;
-
-  /**
-   * @brief Both of the values pointed to by the index *must* be `true` or non-zero. If either of the values or
-   * *both* of the values are false, this will return false.
-   * @param indexA First index
-   * @param indexB Second index
-   * @return
-   */
-  virtual bool bothTrue(usize indexA, usize indexB) const = 0;
-
-  /**
-   * @brief Both of the values pointed to by the index *must* be `false` or non-zero. If either of the values or
-   * *both* of the values are `true`, this will return `false`.
-   * @param indexA
-   * @param indexB
-   * @return
-   */
-  virtual bool bothFalse(usize indexA, usize indexB) const = 0;
-
-  /**
-   * @brief Returns `true` or `false` based on the value at the index
-   * @param index index to check
-   * @return
-   */
-  virtual bool isTrue(usize index) const = 0;
-
-  virtual void setValue(usize index, bool val) = 0;
-
-  virtual usize getNumberOfTuples() const = 0;
-
-  virtual usize getNumberOfComponents() const = 0;
-
-  virtual usize countTrueValues() const = 0;
-};
-
-struct BoolMaskCompare : public MaskCompare
-{
-  BoolMaskCompare(AbstractDataStore<bool>& dataStore)
-  : m_DataStore(dataStore)
-  {
-  }
-  ~BoolMaskCompare() noexcept override = default;
-
-  AbstractDataStore<bool>& m_DataStore;
-  bool bothTrue(usize indexA, usize indexB) const override
-  {
-    return m_DataStore.at(indexA) && m_DataStore.at(indexB);
-  }
-  bool bothFalse(usize indexA, usize indexB) const override
-  {
-    return !m_DataStore.at(indexA) && !m_DataStore.at(indexB);
-  }
-  bool isTrue(usize index) const override
-  {
-    return m_DataStore.at(index);
-  }
-  void setValue(usize index, bool val) override
-  {
-    m_DataStore[index] = val;
-  }
-  usize getNumberOfTuples() const override
-  {
-    return m_DataStore.getNumberOfTuples();
-  }
-  usize getNumberOfComponents() const override
-  {
-    return m_DataStore.getNumberOfComponents();
-  }
-
-  usize countTrueValues() const override
-  {
-    return std::count(m_DataStore.begin(), m_DataStore.end(), true);
-  }
-};
-
-struct UInt8MaskCompare : public MaskCompare
-{
-  UInt8MaskCompare(AbstractDataStore<uint8>& dataStore)
-  : m_DataStore(dataStore)
-  {
-  }
-  ~UInt8MaskCompare() noexcept override = default;
-
-  AbstractDataStore<uint8>& m_DataStore;
-  bool bothTrue(usize indexA, usize indexB) const override
-  {
-    return m_DataStore.at(indexA) != 0 && m_DataStore.at(indexB) != 0;
-  }
-  bool bothFalse(usize indexA, usize indexB) const override
-  {
-    return m_DataStore.at(indexA) == 0 && m_DataStore.at(indexB) == 0;
-  }
-  bool isTrue(usize index) const override
-  {
-    return m_DataStore.at(index) != 0;
-  }
-  void setValue(usize index, bool val) override
-  {
-    m_DataStore[index] = static_cast<uint8>(val);
-  }
-  usize getNumberOfTuples() const override
-  {
-    return m_DataStore.getNumberOfTuples();
-  }
-  usize getNumberOfComponents() const override
-  {
-    return m_DataStore.getNumberOfComponents();
-  }
-
-  usize countTrueValues() const override
-  {
-    const usize falseCount = std::count(m_DataStore.begin(), m_DataStore.end(), 0);
-    return getNumberOfTuples() - falseCount;
-  }
-};
-
-/**
- * @brief Convenience method to create an instance of the MaskCompare subclass.
- *
- * An example use of these functions would be the following:
- * @code
- *  std::unique_ptr<MaskCompare> maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->goodVoxelsArrayPath);
- *  if(!maskCompare->bothTrue(arrayIndex, anotherArrayIndex))
- *  {
- *    // Do something based on the if statement...
- *  }
- * @endcode
- *
- * @param dataStructure The DataStructure object to pull the DataArray from
- * @param maskArrayPath The DataPath of the mask array.
- * @return
- */
-SIMPLNX_EXPORT std::unique_ptr<MaskCompare> InstantiateMaskCompare(DataStructure& dataStructure, const DataPath& maskArrayPath);
-
-/**
- * @brief Convenience method to create an instance of the MaskCompare subclass
- * @param maskArrayPtr A Pointer to the mask array which can be of either `bool` or `uint8` type.
- * @return
- */
-SIMPLNX_EXPORT std::unique_ptr<MaskCompare> InstantiateMaskCompare(IDataArray& maskArrayPtr);
 
 template <typename T>
 class CopyTupleUsingIndexList

--- a/src/simplnx/Utilities/DataArrayUtilities.hpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.hpp
@@ -8,13 +8,14 @@
 #include "simplnx/DataStructure/DataStore.hpp"
 #include "simplnx/DataStructure/EmptyDataStore.hpp"
 #include "simplnx/DataStructure/IDataStore.hpp"
-#include "simplnx/DataStructure/IO/Generic/DataIOCollection.hpp"
 #include "simplnx/DataStructure/NeighborList.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
 #include "simplnx/Filter/Actions/CreateArrayAction.hpp"
 #include "simplnx/Filter/IFilter.hpp"
 #include "simplnx/Filter/Output.hpp"
 #include "simplnx/Parameters/MultiArraySelectionParameter.hpp"
+#include "simplnx/Utilities/DataStoreUtilities.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 #include "simplnx/Utilities/MemoryUtilities.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
@@ -34,222 +35,8 @@
 #define FSEEK64 std::fseek
 #endif
 
-#define SIMPLNX_DEF_STRING_CONVERTOR_INT(CONTAINER_TYPE, TYPE, FUNCTION)                                                                                                                               \
-  CONTAINER_TYPE value;                                                                                                                                                                                \
-  try                                                                                                                                                                                                  \
-  {                                                                                                                                                                                                    \
-    value = FUNCTION(input);                                                                                                                                                                           \
-  } catch(const std::invalid_argument& e)                                                                                                                                                              \
-  {                                                                                                                                                                                                    \
-    return nx::core::MakeErrorResult<TYPE>(-10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, #TYPE, #FUNCTION));                                             \
-  } catch(const std::out_of_range& e)                                                                                                                                                                  \
-  {                                                                                                                                                                                                    \
-    return nx::core::MakeErrorResult<TYPE>(-10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, #TYPE, #FUNCTION));                                    \
-  }                                                                                                                                                                                                    \
-                                                                                                                                                                                                       \
-  if(value > std::numeric_limits<TYPE>::max() || value < std::numeric_limits<TYPE>::min())                                                                                                             \
-  {                                                                                                                                                                                                    \
-    return nx::core::MakeErrorResult<TYPE>(-10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, #TYPE, #FUNCTION));                                    \
-  }                                                                                                                                                                                                    \
-                                                                                                                                                                                                       \
-  return {static_cast<TYPE>(value)};
-
-#define SIMPLNX_DEF_STRING_CONVERTOR_SIGNED_INT(CONTAINER_TYPE, TYPE, FUNCTION)                                                                                                                        \
-  template <>                                                                                                                                                                                          \
-  struct ConvertTo<TYPE>                                                                                                                                                                               \
-  {                                                                                                                                                                                                    \
-    static Result<TYPE> convert(const std::string& input)                                                                                                                                              \
-    {                                                                                                                                                                                                  \
-      SIMPLNX_DEF_STRING_CONVERTOR_INT(CONTAINER_TYPE, TYPE, FUNCTION)                                                                                                                                 \
-    }                                                                                                                                                                                                  \
-  };
-
-#define SIMPLNX_DEF_STRING_CONVERTOR_UNSIGNED_INT(CONTAINER_TYPE, TYPE, FUNCTION)                                                                                                                      \
-  template <>                                                                                                                                                                                          \
-  struct ConvertTo<TYPE>                                                                                                                                                                               \
-  {                                                                                                                                                                                                    \
-    static Result<TYPE> convert(const std::string& input)                                                                                                                                              \
-    {                                                                                                                                                                                                  \
-      if(!input.empty() && input.at(0) == '-')                                                                                                                                                         \
-      {                                                                                                                                                                                                \
-        return nx::core::MakeErrorResult<TYPE>(-10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, #TYPE, #FUNCTION));                                \
-      }                                                                                                                                                                                                \
-                                                                                                                                                                                                       \
-      SIMPLNX_DEF_STRING_CONVERTOR_INT(CONTAINER_TYPE, TYPE, FUNCTION)                                                                                                                                 \
-    }                                                                                                                                                                                                  \
-  };
-
-#define SIMPLNX_DEF_STRING_CONVERTOR_FLOATING_POINT(TYPE, FUNCTION)                                                                                                                                    \
-  template <>                                                                                                                                                                                          \
-  struct ConvertTo<TYPE>                                                                                                                                                                               \
-  {                                                                                                                                                                                                    \
-    static Result<TYPE> convert(const std::string& input)                                                                                                                                              \
-    {                                                                                                                                                                                                  \
-      TYPE value;                                                                                                                                                                                      \
-      try                                                                                                                                                                                              \
-      {                                                                                                                                                                                                \
-        value = static_cast<TYPE>(FUNCTION(input));                                                                                                                                                    \
-      } catch(const std::invalid_argument& e)                                                                                                                                                          \
-      {                                                                                                                                                                                                \
-        return nx::core::MakeErrorResult<TYPE>(-10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, #TYPE, #FUNCTION));                                         \
-      } catch(const std::out_of_range& e)                                                                                                                                                              \
-      {                                                                                                                                                                                                \
-        return nx::core::MakeErrorResult<TYPE>(-10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, #TYPE, #FUNCTION));                                \
-      }                                                                                                                                                                                                \
-      return {value};                                                                                                                                                                                  \
-    }                                                                                                                                                                                                  \
-  };
-
 namespace nx::core
 {
-template <class T>
-struct ConvertTo
-{
-};
-
-/**
- * These macros will create convertor objects that convert from a string to a numeric type
- */
-
-SIMPLNX_DEF_STRING_CONVERTOR_UNSIGNED_INT(uint64, uint8, std::stoull)
-SIMPLNX_DEF_STRING_CONVERTOR_SIGNED_INT(int64, int8, std::stoll)
-SIMPLNX_DEF_STRING_CONVERTOR_UNSIGNED_INT(uint64, uint16, std::stoull)
-SIMPLNX_DEF_STRING_CONVERTOR_SIGNED_INT(int64, int16, std::stoll)
-SIMPLNX_DEF_STRING_CONVERTOR_UNSIGNED_INT(uint64, uint32, std::stoull)
-SIMPLNX_DEF_STRING_CONVERTOR_SIGNED_INT(int64, int32, std::stoll)
-SIMPLNX_DEF_STRING_CONVERTOR_UNSIGNED_INT(uint64, uint64, std::stoull)
-SIMPLNX_DEF_STRING_CONVERTOR_SIGNED_INT(int64, int64, std::stoll)
-#ifdef __APPLE__
-SIMPLNX_DEF_STRING_CONVERTOR_UNSIGNED_INT(usize, usize, std::stoull)
-#endif
-SIMPLNX_DEF_STRING_CONVERTOR_FLOATING_POINT(float32, std::stof)
-SIMPLNX_DEF_STRING_CONVERTOR_FLOATING_POINT(float64, std::stod)
-
-template <>
-struct ConvertTo<bool>
-{
-  static Result<bool> convert(const std::string& input)
-  {
-    if(input == "TRUE" || input == "true" || input == "True")
-    {
-      return {true};
-    }
-
-    if(input == "FALSE" || input == "false" || input == "False")
-    {
-      return {false};
-    }
-
-    Result<int64> intResult = ConvertTo<int64>::convert(input);
-    if(intResult.valid())
-    {
-      return {intResult.value() != 0};
-    }
-
-    Result<float64> floatResult = ConvertTo<float64>::convert(input);
-    if(floatResult.valid())
-    {
-      return {floatResult.value() != 0.0};
-    }
-
-    return {true};
-  }
-};
-
-/**
- * @brief Sets the dataFormat string to the large data format from the prefs
- * if forceOocData is true.
- * @param dataFormat
- */
-SIMPLNX_EXPORT void TryForceLargeDataFormatFromPrefs(std::string& dataFormat);
-
-/**
- * @brief Returns the application's DataIOCollection.
- * @return
- */
-SIMPLNX_EXPORT std::shared_ptr<DataIOCollection> GetIOCollection();
-
-/**
- * @brief Checks if the given string can be correctly converted into the given type
- * @tparam T The primitive type to convert the string into
- * @param valueAsStr The value to convert
- * @param strType The primitive type. The valid values can be found in a constants file
- * @return Result<> object that is either valid or has an error message/code
- */
-template <class T>
-Result<> CheckValuesUnsignedInt(const std::string& valueAsStr, const std::string& strType)
-{
-  static_assert(std::is_unsigned_v<T>);
-
-  if(valueAsStr[0] == '-')
-  {
-    return MakeErrorResult(-255, fmt::format("The value '{}' could not be converted to {} due to the value being outside of the range for {} to {}", valueAsStr, strType, std::numeric_limits<T>::min(),
-                                             std::numeric_limits<T>::max()));
-  }
-  Result<uint64> conversionResult = ConvertTo<uint64>::convert(valueAsStr);
-  if(conversionResult.valid()) // If the string was converted to a double, then lets check the range is valid
-  {
-    uint64 replaceValue = conversionResult.value();
-    if(!((replaceValue >= std::numeric_limits<T>::min()) && (replaceValue <= std::numeric_limits<T>::max())))
-    {
-      return MakeErrorResult(-256, fmt::format("The value '{}' could not be converted to {} due to the value being outside of the range for {} to {}", valueAsStr, strType,
-                                               std::numeric_limits<T>::min(), std::numeric_limits<T>::max()));
-    }
-  }
-  return ConvertResult(std::move(conversionResult));
-}
-
-/**
- * @brief
- * @tparam T
- * @param valueAsStr
- * @param strType
- * @return
- */
-template <class T>
-Result<> CheckValuesSignedInt(const std::string& valueAsStr, const std::string& strType)
-{
-  static_assert(std::is_signed_v<T>);
-
-  Result<int64> conversionResult = ConvertTo<int64>::convert(valueAsStr);
-  if(conversionResult.valid()) // If the string was converted to a double, then lets check the range is valid
-  {
-    int64 replaceValue = conversionResult.value();
-    if(!((replaceValue >= std::numeric_limits<T>::min()) && (replaceValue <= std::numeric_limits<T>::max())))
-    {
-      return MakeErrorResult(-257, fmt::format("The value '{}' could not be converted to {} due to the value being outside of the range for {} to {}", valueAsStr, strType,
-                                               std::numeric_limits<T>::min(), std::numeric_limits<T>::max()));
-    }
-  }
-  return ConvertResult(std::move(conversionResult));
-}
-
-/**
- * @brief
- * @tparam T
- * @param valueAsStr
- * @param strType
- * @return
- */
-template <class T>
-Result<> CheckValuesFloatDouble(const std::string& valueAsStr, const std::string& strType)
-{
-  static_assert(std::is_floating_point_v<T>);
-
-  Result<float64> conversionResult = ConvertTo<float64>::convert(valueAsStr);
-  if(conversionResult.valid()) // If the string was converted to a double, then lets check the range is valid
-  {
-    float64 replaceValue = conversionResult.value();
-    if(!(((replaceValue >= static_cast<T>(-1) * std::numeric_limits<T>::max()) && (replaceValue <= static_cast<T>(-1) * std::numeric_limits<T>::min())) || (replaceValue == 0) ||
-         ((replaceValue >= std::numeric_limits<T>::min()) && (replaceValue <= std::numeric_limits<T>::max()))))
-    {
-      return MakeErrorResult<>(-258, fmt::format("The {} replace value was invalid. The valid ranges are -{} to -{}, 0, %{} to %{}", std::numeric_limits<T>::max(), strType,
-                                                 std::numeric_limits<T>::min(), std::numeric_limits<T>::min(), std::numeric_limits<T>::max()));
-    }
-  }
-  return ConvertResult(std::move(conversionResult));
-}
-
 /**
  * @brief Validates whether the string can be converted to the primitive type used in the DataObject.
  *
@@ -312,7 +99,7 @@ struct ConditionalReplaceValueInArrayFromString
     using DataArrayType = DataArray<T>;
 
     auto& inputDataArray = dynamic_cast<DataArrayType&>(inputDataObject);
-    Result<T> conversionResult = ConvertTo<T>::convert(valueAsStr);
+    Result<T> conversionResult = StringInterpretationUtilities::Convert<T>(valueAsStr);
     if(conversionResult.invalid())
     {
       return MakeErrorResult<>(-4000, "Input String Value could not be converted to the appropriate numeric type.");
@@ -349,156 +136,6 @@ struct ConditionalReplaceValueInArrayFromString
  */
 SIMPLNX_EXPORT Result<> ConditionalReplaceValueInArray(const std::string& valueAsStr, DataObject& inputDataObject, const IDataArray& conditionalDataArray, bool invertmask = false);
 
-template <class T>
-uint64 CalculateDataSize(const IDataStore::ShapeType& tupleShape, const IDataStore::ShapeType& componentShape)
-{
-  uint64 numValues = std::accumulate(tupleShape.begin(), tupleShape.end(), 1ULL, std::multiplies<>());
-  uint64 numComponents = std::accumulate(componentShape.begin(), componentShape.end(), 1ULL, std::multiplies<>());
-  return numValues * numComponents * sizeof(T);
-}
-
-/**
- * @brief Creates a DataStore with the given properties
- * @tparam T Primitive Type (int, float, ...)
- * @param tupleShape The Tuple Dimensions
- * @param componentShape The component dimensions
- * @param mode The mode to assume: PREFLIGHT or EXECUTE. Preflight will NOT allocate any storage. EXECUTE will allocate the memory/storage
- * @return
- */
-template <class T>
-std::shared_ptr<AbstractDataStore<T>> CreateDataStore(const typename IDataStore::ShapeType& tupleShape, const typename IDataStore::ShapeType& componentShape, IDataAction::Mode mode,
-                                                      std::string dataFormat = "")
-{
-  switch(mode)
-  {
-  case IDataAction::Mode::Preflight: {
-    return std::make_unique<EmptyDataStore<T>>(tupleShape, componentShape, dataFormat);
-  }
-  case IDataAction::Mode::Execute: {
-    uint64 dataSize = CalculateDataSize<T>(tupleShape, componentShape);
-    TryForceLargeDataFormatFromPrefs(dataFormat);
-    auto ioCollection = GetIOCollection();
-    ioCollection->checkStoreDataFormat(dataSize, dataFormat);
-    return ioCollection->createDataStoreWithType<T>(dataFormat, tupleShape, componentShape);
-  }
-  default: {
-    throw std::runtime_error("Invalid mode");
-  }
-  }
-}
-
-SIMPLNX_EXPORT bool CheckMemoryRequirement(DataStructure& dataStructure, uint64 requiredMemory, std::string& format);
-
-/**
- * @brief Creates a DataArray with the given properties
- * @tparam T Primitive Type (int, float, ...)
- * @param dataStructure The DataStructure to use
- * @param tupleShape The Tuple Dimensions
- * @param nComp The number of components in the DataArray
- * @param path The DataPath to where the data will be stored.
- * @param mode The mode to assume: PREFLIGHT or EXECUTE. Preflight will NOT allocate any storage. EXECUTE will allocate the memory/storage
- * @return
- */
-template <class T>
-Result<> CreateArray(DataStructure& dataStructure, const std::vector<usize>& tupleShape, const std::vector<usize>& compShape, const DataPath& path, IDataAction::Mode mode, std::string dataFormat = "")
-{
-  auto parentPath = path.getParent();
-
-  std::optional<DataObject::IdType> dataObjectId;
-
-  DataObject* parentObjectPtr = nullptr;
-  if(parentPath.getLength() != 0)
-  {
-    parentObjectPtr = dataStructure.getData(parentPath);
-    if(parentObjectPtr == nullptr)
-    {
-      return MakeErrorResult(-260, fmt::format("CreateArray: Parent object '{}' does not exist", parentPath.toString()));
-    }
-
-    dataObjectId = parentObjectPtr->getId();
-  }
-
-  if(tupleShape.empty())
-  {
-    return MakeErrorResult(-261, fmt::format("CreateArray: Tuple Shape was empty. Please set the number of tuples."));
-  }
-
-  // Validate Number of Components
-  if(compShape.empty())
-  {
-    return MakeErrorResult(-262, fmt::format("CreateArray: Component Shape was empty. Please set the number of components."));
-  }
-  const usize numComponents = std::accumulate(compShape.cbegin(), compShape.cend(), static_cast<usize>(1), std::multiplies<>());
-  if(numComponents == 0 && mode == IDataAction::Mode::Execute)
-  {
-    return MakeErrorResult(-263, fmt::format("CreateArray: Number of components is ZERO. Please set the number of components."));
-  }
-
-  const usize last = path.getLength() - 1;
-
-  std::string name = path[last];
-
-  const usize numTuples = std::accumulate(tupleShape.cbegin(), tupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
-  uint64 requiredMemory = numTuples * numComponents * sizeof(T);
-  if(!CheckMemoryRequirement(dataStructure, requiredMemory, dataFormat))
-  {
-    uint64 totalMemory = requiredMemory + dataStructure.memoryUsage();
-    uint64 availableMemory = Memory::GetTotalMemory();
-    return MakeErrorResult(-267, fmt::format("CreateArray: Cannot create DataArray '{}'.\n\tTotal memory required for DataStructure: '{}' Bytes.\n\tTotal reported memory: '{}' Bytes", name,
-                                             totalMemory, availableMemory));
-  }
-
-  auto store = CreateDataStore<T>(tupleShape, compShape, mode, dataFormat);
-  if(nullptr == store)
-  {
-    return MakeErrorResult(-267, fmt::format("CreateArray: Unable to create DataStore<T> at '{}' of DataStore format '{}'", path.toString(), dataFormat));
-  }
-  auto dataArray = DataArray<T>::Create(dataStructure, name, store, dataObjectId);
-  if(dataArray == nullptr)
-  {
-    if(dataStructure.getId(path).has_value())
-    {
-      return MakeErrorResult(-264, fmt::format("CreateArray: Cannot create Data Array at path '{}' because it already exists. Choose a different name.", path.toString()));
-    }
-
-    if(parentObjectPtr->getDataObjectType() == DataObject::Type::AttributeMatrix)
-    {
-      auto* attrMatrixPtr = dynamic_cast<AttributeMatrix*>(parentObjectPtr);
-      std::string amShape = fmt::format("Attribute Matrix Tuple Dims: {}", fmt::join(attrMatrixPtr->getShape(), " x "));
-      std::string arrayShape = fmt::format("Data Array Tuple Shape: {}", fmt::join(store->getTupleShape(), " x "));
-      return MakeErrorResult(-265,
-                             fmt::format("CreateArray: Unable to create Data Array '{}' inside Attribute matrix '{}'. Mismatch of tuple dimensions. The created Data Array must have the same tuple "
-                                         "dimensions or the same total number of tuples.\n{}\n{}",
-                                         name, dataStructure.getDataPathsForId(parentObjectPtr->getId()).front().toString(), amShape, arrayShape));
-    }
-    else
-    {
-      return MakeErrorResult(-266, fmt::format("CreateArray: Unable to create DataArray at '{}'", path.toString()));
-    }
-  }
-
-  return {};
-}
-
-template <typename T>
-std::shared_ptr<AbstractDataStore<T>> ConvertDataStore(const AbstractDataStore<T>& dataStore, const std::string& dataFormat)
-{
-  if(dataStore.getDataFormat() == dataFormat)
-  {
-    return nullptr;
-  }
-
-  auto ioCollection = GetIOCollection();
-  std::shared_ptr<AbstractDataStore<T>> newStore = ioCollection->createDataStoreWithType<T>(dataFormat, dataStore.getTupleShape(), dataStore.getComponentShape());
-  if(newStore == nullptr)
-  {
-    return nullptr;
-  }
-
-  newStore->copy(dataStore);
-  return newStore;
-}
-
 template <typename T>
 bool ConvertDataArrayDataStore(const std::shared_ptr<DataArray<T>> dataArray, const std::string& dataFormat)
 {
@@ -507,7 +144,7 @@ bool ConvertDataArrayDataStore(const std::shared_ptr<DataArray<T>> dataArray, co
     return false;
   }
   const AbstractDataStore<T>& dataStore = dataArray->getDataStoreRef();
-  auto convertedDataStore = ConvertDataStore<T>(dataStore, dataFormat);
+  auto convertedDataStore = DataStoreUtilities::ConvertDataStore<T>(dataStore, dataFormat);
   if(convertedDataStore == nullptr)
   {
     return false;

--- a/src/simplnx/Utilities/DataArrayUtilities.hpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.hpp
@@ -31,16 +31,6 @@
 namespace nx::core
 {
 /**
- * @brief Validates whether the string can be converted to the primitive type used in the DataObject.
- *
- * The validate will check overflow and underflow and that the string represents some sort of numeric value
- * @param value
- * @param inputDataArray
- * @return
- */
-SIMPLNX_EXPORT Result<> CheckValueConvertsToArrayType(const std::string& value, const DataObject& inputDataArray);
-
-/**
  * @brief Replaces every value in an array based on a `mask` array.
  * @tparam T The primitive type used in the data array
  * @param inputArrayPtr InputArray that will have values replaced

--- a/src/simplnx/Utilities/DataStoreUtilities.cpp
+++ b/src/simplnx/Utilities/DataStoreUtilities.cpp
@@ -1,0 +1,21 @@
+#include "DataStoreUtilities.hpp"
+
+#include "simplnx/Core/Application.hpp"
+
+using namespace nx::core;
+
+//-----------------------------------------------------------------------------
+void DataStoreUtilities::TryForceLargeDataFormatFromPrefs(std::string& dataFormat)
+{
+  auto* preferencesPtr = Application::GetOrCreateInstance()->getPreferences();
+  if(preferencesPtr->forceOocData())
+  {
+    dataFormat = preferencesPtr->largeDataFormat();
+  }
+}
+
+//-----------------------------------------------------------------------------
+std::shared_ptr<DataIOCollection> DataStoreUtilities::GetIOCollection()
+{
+  return Application::GetOrCreateInstance()->getIOCollection();
+}

--- a/src/simplnx/Utilities/DataStoreUtilities.hpp
+++ b/src/simplnx/Utilities/DataStoreUtilities.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "simplnx/simplnx_export.hpp"
+
+#include "simplnx/DataStructure/AbstractDataStore.hpp"
+#include "simplnx/DataStructure/EmptyDataStore.hpp"
+#include "simplnx/DataStructure/IO/Generic/DataIOCollection.hpp"
+#include "simplnx/Filter/Output.hpp"
+
+#include <fmt/format.h>
+
+namespace nx::core::DataStoreUtilities
+{
+/**
+ * @brief Sets the dataFormat string to the large data format from the prefs
+ * if forceOocData is true.
+ * @param dataFormat
+ */
+SIMPLNX_EXPORT void TryForceLargeDataFormatFromPrefs(std::string& dataFormat);
+
+/**
+ * @brief Returns the application's DataIOCollection.
+ * @return
+ */
+SIMPLNX_EXPORT std::shared_ptr<DataIOCollection> GetIOCollection();
+
+template <class T>
+uint64 CalculateDataSize(const IDataStore::ShapeType& tupleShape, const IDataStore::ShapeType& componentShape)
+{
+  uint64 numValues = std::accumulate(tupleShape.begin(), tupleShape.end(), 1ULL, std::multiplies<>());
+  uint64 numComponents = std::accumulate(componentShape.begin(), componentShape.end(), 1ULL, std::multiplies<>());
+  return numValues * numComponents * sizeof(T);
+}
+
+/**
+ * @brief Creates a DataStore with the given properties
+ * @tparam T Primitive Type (int, float, ...)
+ * @param tupleShape The Tuple Dimensions
+ * @param componentShape The component dimensions
+ * @param mode The mode to assume: PREFLIGHT or EXECUTE. Preflight will NOT allocate any storage. EXECUTE will allocate the memory/storage
+ * @return
+ */
+template <class T>
+std::shared_ptr<AbstractDataStore<T>> CreateDataStore(const typename IDataStore::ShapeType& tupleShape, const typename IDataStore::ShapeType& componentShape, IDataAction::Mode mode,
+                                                      std::string dataFormat = "")
+{
+  switch(mode)
+  {
+  case IDataAction::Mode::Preflight: {
+    return std::make_unique<EmptyDataStore<T>>(tupleShape, componentShape, dataFormat);
+  }
+  case IDataAction::Mode::Execute: {
+    uint64 dataSize = CalculateDataSize<T>(tupleShape, componentShape);
+    TryForceLargeDataFormatFromPrefs(dataFormat);
+    auto ioCollection = GetIOCollection();
+    ioCollection->checkStoreDataFormat(dataSize, dataFormat);
+    return ioCollection->createDataStoreWithType<T>(dataFormat, tupleShape, componentShape);
+  }
+  default: {
+    throw std::runtime_error("Invalid mode");
+  }
+  }
+}
+
+template <typename T>
+std::shared_ptr<AbstractDataStore<T>> ConvertDataStore(const AbstractDataStore<T>& dataStore, const std::string& dataFormat)
+{
+  if(dataStore.getDataFormat() == dataFormat)
+  {
+    return nullptr;
+  }
+
+  auto ioCollection = GetIOCollection();
+  std::shared_ptr<AbstractDataStore<T>> newStore = ioCollection->createDataStoreWithType<T>(dataFormat, dataStore.getTupleShape(), dataStore.getComponentShape());
+  if(newStore == nullptr)
+  {
+    return nullptr;
+  }
+
+  newStore->copy(dataStore);
+  return newStore;
+}
+} // namespace nx::core::DataStoreUtilities

--- a/src/simplnx/Utilities/FileUtilities.hpp
+++ b/src/simplnx/Utilities/FileUtilities.hpp
@@ -32,8 +32,8 @@
 #pragma once
 
 #include "simplnx/Common/Result.hpp"
-#include "simplnx/DataStructure/IDataArray.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 
 #include <filesystem>
 #include <string>
@@ -123,7 +123,7 @@ public:
 
   Result<> parse(const std::string& token, size_t index) override
   {
-    Result<T> parseResult = ConvertTo<T>::convert(token);
+    Result<T> parseResult = StringInterpretationUtilities::Convert<T>(token);
     if(parseResult.valid())
     {
       m_Array[index] = parseResult.value();

--- a/src/simplnx/Utilities/MaskCompareUtilities.cpp
+++ b/src/simplnx/Utilities/MaskCompareUtilities.cpp
@@ -1,0 +1,29 @@
+#include "MaskCompareUtilities.hpp"
+
+#include "simplnx/DataStructure/DataArray.hpp"
+
+using namespace nx::core;
+
+//-----------------------------------------------------------------------------
+std::unique_ptr<MaskCompareUtilities::MaskCompare> MaskCompareUtilities::InstantiateMaskCompare(DataStructure& dataStructure, const DataPath& maskArrayPath)
+{
+  auto& maskArray = dataStructure.getDataRefAs<IDataArray>(maskArrayPath);
+
+  return MaskCompareUtilities::InstantiateMaskCompare(maskArray);
+}
+
+//-----------------------------------------------------------------------------
+std::unique_ptr<MaskCompareUtilities::MaskCompare> MaskCompareUtilities::InstantiateMaskCompare(IDataArray& maskArray)
+{
+  switch(maskArray.getDataType())
+  {
+  case DataType::boolean: {
+    return std::make_unique<MaskCompareUtilities::BoolMaskCompare>(dynamic_cast<BoolArray&>(maskArray).getDataStoreRef());
+  }
+  case DataType::uint8: {
+    return std::make_unique<MaskCompareUtilities::UInt8MaskCompare>(dynamic_cast<UInt8Array&>(maskArray).getDataStoreRef());
+  }
+  default:
+    throw std::runtime_error("InstantiateMaskCompare: The Mask Array being used is NOT of type bool or uint8.");
+  }
+}

--- a/src/simplnx/Utilities/MaskCompareUtilities.hpp
+++ b/src/simplnx/Utilities/MaskCompareUtilities.hpp
@@ -1,0 +1,167 @@
+#pragma once
+
+#include "simplnx/simplnx_export.hpp"
+
+#include "simplnx/Common/Types.hpp"
+#include "simplnx/DataStructure/AbstractDataStore.hpp"
+#include "simplnx/DataStructure/IDataArray.hpp"
+
+namespace nx::core::MaskCompareUtilities
+{
+/**
+ * @brief These structs and functions are meant to make using a "mask array" or "Good Voxels Array" easier
+ * for the developer. There is virtual function call overhead with using these structs and functions.
+ *
+ * An example use of these functions would be the following:
+ * @code
+ *  std::unique_ptr<MaskCompare> maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->goodVoxelsArrayPath);
+ *  if(!maskCompare->bothTrue(arrayIndex, anotherArrayIndex))
+ *  {
+ *    // Do something based on the if statement...
+ *  }
+ * @endcode
+ */
+struct MaskCompare
+{
+  virtual ~MaskCompare() noexcept = default;
+
+  /**
+   * @brief Both of the values pointed to by the index *must* be `true` or non-zero. If either of the values or
+   * *both* of the values are false, this will return false.
+   * @param indexA First index
+   * @param indexB Second index
+   * @return
+   */
+  virtual bool bothTrue(usize indexA, usize indexB) const = 0;
+
+  /**
+   * @brief Both of the values pointed to by the index *must* be `false` or non-zero. If either of the values or
+   * *both* of the values are `true`, this will return `false`.
+   * @param indexA
+   * @param indexB
+   * @return
+   */
+  virtual bool bothFalse(usize indexA, usize indexB) const = 0;
+
+  /**
+   * @brief Returns `true` or `false` based on the value at the index
+   * @param index index to check
+   * @return
+   */
+  virtual bool isTrue(usize index) const = 0;
+
+  virtual void setValue(usize index, bool val) = 0;
+
+  virtual usize getNumberOfTuples() const = 0;
+
+  virtual usize getNumberOfComponents() const = 0;
+
+  virtual usize countTrueValues() const = 0;
+};
+
+struct BoolMaskCompare : public MaskCompare
+{
+  BoolMaskCompare(AbstractDataStore<bool>& dataStore)
+  : m_DataStore(dataStore)
+  {
+  }
+  ~BoolMaskCompare() noexcept override = default;
+
+  AbstractDataStore<bool>& m_DataStore;
+  bool bothTrue(usize indexA, usize indexB) const override
+  {
+    return m_DataStore.at(indexA) && m_DataStore.at(indexB);
+  }
+  bool bothFalse(usize indexA, usize indexB) const override
+  {
+    return !m_DataStore.at(indexA) && !m_DataStore.at(indexB);
+  }
+  bool isTrue(usize index) const override
+  {
+    return m_DataStore.at(index);
+  }
+  void setValue(usize index, bool val) override
+  {
+    m_DataStore[index] = val;
+  }
+  usize getNumberOfTuples() const override
+  {
+    return m_DataStore.getNumberOfTuples();
+  }
+  usize getNumberOfComponents() const override
+  {
+    return m_DataStore.getNumberOfComponents();
+  }
+
+  usize countTrueValues() const override
+  {
+    return std::count(m_DataStore.begin(), m_DataStore.end(), true);
+  }
+};
+
+struct UInt8MaskCompare : public MaskCompare
+{
+  UInt8MaskCompare(AbstractDataStore<uint8>& dataStore)
+  : m_DataStore(dataStore)
+  {
+  }
+  ~UInt8MaskCompare() noexcept override = default;
+
+  AbstractDataStore<uint8>& m_DataStore;
+  bool bothTrue(usize indexA, usize indexB) const override
+  {
+    return m_DataStore.at(indexA) != 0 && m_DataStore.at(indexB) != 0;
+  }
+  bool bothFalse(usize indexA, usize indexB) const override
+  {
+    return m_DataStore.at(indexA) == 0 && m_DataStore.at(indexB) == 0;
+  }
+  bool isTrue(usize index) const override
+  {
+    return m_DataStore.at(index) != 0;
+  }
+  void setValue(usize index, bool val) override
+  {
+    m_DataStore[index] = static_cast<uint8>(val);
+  }
+  usize getNumberOfTuples() const override
+  {
+    return m_DataStore.getNumberOfTuples();
+  }
+  usize getNumberOfComponents() const override
+  {
+    return m_DataStore.getNumberOfComponents();
+  }
+
+  usize countTrueValues() const override
+  {
+    const usize falseCount = std::count(m_DataStore.begin(), m_DataStore.end(), 0);
+    return getNumberOfTuples() - falseCount;
+  }
+};
+
+/**
+ * @brief Convenience method to create an instance of the MaskCompare subclass.
+ *
+ * An example use of these functions would be the following:
+ * @code
+ *  std::unique_ptr<MaskCompare> maskCompare = InstantiateMaskCompare(m_DataStructure, m_InputValues->goodVoxelsArrayPath);
+ *  if(!maskCompare->bothTrue(arrayIndex, anotherArrayIndex))
+ *  {
+ *    // Do something based on the if statement...
+ *  }
+ * @endcode
+ *
+ * @param dataStructure The DataStructure object to pull the DataArray from
+ * @param maskArrayPath The DataPath of the mask array.
+ * @return
+ */
+SIMPLNX_EXPORT std::unique_ptr<MaskCompare> InstantiateMaskCompare(DataStructure& dataStructure, const DataPath& maskArrayPath);
+
+/**
+ * @brief Convenience method to create an instance of the MaskCompare subclass
+ * @param maskArrayPtr A Pointer to the mask array which can be of either `bool` or `uint8` type.
+ * @return
+ */
+SIMPLNX_EXPORT std::unique_ptr<MaskCompare> InstantiateMaskCompare(IDataArray& maskArrayPtr);
+} // namespace nx::core::MaskCompareUtilities

--- a/src/simplnx/Utilities/Parsing/Text/CsvParser.hpp
+++ b/src/simplnx/Utilities/Parsing/Text/CsvParser.hpp
@@ -3,7 +3,7 @@
 #include "simplnx/Common/Result.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataStructure.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 #include "simplnx/simplnx_export.hpp"
 
@@ -218,7 +218,7 @@ Result<> ReadFile(const std::filesystem::path& filename, AbstractDataStore<T>& d
   for(size_t i = 0; i < totalSize; ++i)
   {
     in >> value;
-    Result<T> parseResult = ConvertTo<T>::convert(value);
+    Result<T> parseResult = StringInterpretationUtilities::Convert<T>(value);
     if(parseResult.invalid())
     {
       return ConvertResult(std::move(parseResult));

--- a/src/simplnx/Utilities/StringInterpretationUtilities.cpp
+++ b/src/simplnx/Utilities/StringInterpretationUtilities.cpp
@@ -1,0 +1,22 @@
+#include "StringInterpretationUtilities.hpp"
+
+#include "simplnx/Utilities/FilterUtilities.hpp"
+
+using namespace nx::core;
+
+namespace
+{
+struct ConvertFunctor
+{
+  template <typename T>
+  Result<> operator()(const std::string& value)
+  {
+    return ConvertResult(StringInterpretationUtilities::Convert<T>(value));
+  }
+};
+} // namespace
+
+Result<> StringInterpretationUtilities::CheckValueConverts(DataType type, const std::string& value)
+{
+  return ExecuteDataFunction(ConvertFunctor{}, type, value);
+}

--- a/src/simplnx/Utilities/StringInterpretationUtilities.hpp
+++ b/src/simplnx/Utilities/StringInterpretationUtilities.hpp
@@ -40,6 +40,18 @@ template <typename T>
 Result<T> StringInterpreterFromType(const std::string& input)
 {
   T outputValue;
+
+  // This is segmented out to contain the need for apple specific macros in the case of error
+  std::string typeName = "usize";
+#ifdef __APPLE__
+  if constexpr(!std::is_same_v<T, usize>)
+  {
+    typeName = DataTypeToString(GetDataType<T>());
+  }
+#else
+  typeName = DataTypeToString(GetDataType<T>());
+#endif
+
   try
   {
     if constexpr(std::is_floating_point_v<T>)
@@ -61,27 +73,15 @@ Result<T> StringInterpreterFromType(const std::string& input)
       {
         if(!input.empty() && input.at(0) == '-')
         {
-#ifdef __APPLE__
-          if(std::is_same_v<T, usize>)
-          {
-            return nx::core::MakeErrorResult<T>(-10350, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, "usize", detail::TypeToFuncName<T>()));
-          }
-#endif
           return nx::core::MakeErrorResult<T>(
-              -10350, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), detail::TypeToFuncName<T>()));
+              -10350, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
         }
 
         uint64 value = std::stoull(input);
         if(value > std::numeric_limits<T>::max() || value < std::numeric_limits<T>::min())
         {
-#ifdef __APPLE__
-          if(std::is_same_v<T, usize>)
-          {
-            return nx::core::MakeErrorResult<T>(-10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, "usize", detail::TypeToFuncName<T>()));
-          }
-#endif
           return nx::core::MakeErrorResult<T>(
-              -10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), detail::TypeToFuncName<T>()));
+              -10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
         }
         outputValue = static_cast<T>(value);
       }
@@ -92,30 +92,18 @@ Result<T> StringInterpreterFromType(const std::string& input)
         if(value > std::numeric_limits<T>::max() || value < std::numeric_limits<T>::min())
         {
           return nx::core::MakeErrorResult<T>(
-              -10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), detail::TypeToFuncName<T>()));
+              -10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
         }
         outputValue = static_cast<T>(value);
       }
     }
   } catch(const std::invalid_argument& e)
   {
-#ifdef __APPLE__
-    if(std::is_same_v<T, usize>)
-    {
-      return nx::core::MakeErrorResult<T>(-10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, "usize", detail::TypeToFuncName<T>()));
-    }
-#endif
-    return nx::core::MakeErrorResult<T>(-10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), detail::TypeToFuncName<T>()));
+    return nx::core::MakeErrorResult<T>(-10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
   } catch(const std::out_of_range& e)
   {
-#ifdef __APPLE__
-    if(std::is_same_v<T, usize>)
-    {
-      return nx::core::MakeErrorResult<T>(-10352, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, "usize", detail::TypeToFuncName<T>()));
-    }
-#endif
     return nx::core::MakeErrorResult<T>(-10352,
-                                        fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), detail::TypeToFuncName<T>()));
+                                        fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
   }
   return {outputValue};
 }

--- a/src/simplnx/Utilities/StringInterpretationUtilities.hpp
+++ b/src/simplnx/Utilities/StringInterpretationUtilities.hpp
@@ -61,6 +61,12 @@ Result<T> StringInterpreterFromType(const std::string& input)
       {
         if(!input.empty() && input.at(0) == '-')
         {
+#ifdef __APPLE__
+          if(std::is_same_v<T, usize>)
+          {
+            return nx::core::MakeErrorResult<T>(-10350, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, "usize", detail::TypeToFuncName<T>()));
+          }
+#endif
           return nx::core::MakeErrorResult<T>(
               -10350, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), detail::TypeToFuncName<T>()));
         }
@@ -68,6 +74,12 @@ Result<T> StringInterpreterFromType(const std::string& input)
         uint64 value = std::stoull(input);
         if(value > std::numeric_limits<T>::max() || value < std::numeric_limits<T>::min())
         {
+#ifdef __APPLE__
+          if(std::is_same_v<T, usize>)
+          {
+            return nx::core::MakeErrorResult<T>(-10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, "usize", detail::TypeToFuncName<T>()));
+          }
+#endif
           return nx::core::MakeErrorResult<T>(
               -10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), detail::TypeToFuncName<T>()));
         }
@@ -87,9 +99,21 @@ Result<T> StringInterpreterFromType(const std::string& input)
     }
   } catch(const std::invalid_argument& e)
   {
+#ifdef __APPLE__
+    if(std::is_same_v<T, usize>)
+    {
+      return nx::core::MakeErrorResult<T>(-10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, "usize", detail::TypeToFuncName<T>()));
+    }
+#endif
     return nx::core::MakeErrorResult<T>(-10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), detail::TypeToFuncName<T>()));
   } catch(const std::out_of_range& e)
   {
+#ifdef __APPLE__
+    if(std::is_same_v<T, usize>)
+    {
+      return nx::core::MakeErrorResult<T>(-10352, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, "usize", detail::TypeToFuncName<T>()));
+    }
+#endif
     return nx::core::MakeErrorResult<T>(-10352,
                                         fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), detail::TypeToFuncName<T>()));
   }

--- a/src/simplnx/Utilities/StringInterpretationUtilities.hpp
+++ b/src/simplnx/Utilities/StringInterpretationUtilities.hpp
@@ -56,24 +56,6 @@ Result<T> StringInterpreterFromType(const std::string& input)
   {
     if constexpr(std::is_floating_point_v<T>)
     {
-#if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER)
-      std::size_t index = 0;
-      if constexpr(std::is_same_v<T, float32>)
-      {
-        float32 value = std::stof(input, &index);
-        outputValue = static_cast<T>(value);
-      }
-      else if constexpr(std::is_same_v<T, float64>)
-      {
-        float64 value = std::stod(input, &index);
-        outputValue = static_cast<T>(value);
-      }
-      if(index != input.size())
-      {
-        return nx::core::MakeErrorResult<T>(
-            -10354, fmt::format("Error: unable to parse to end of floating-point string trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
-      }
-#else
       if constexpr(std::is_same_v<T, float32>)
       {
         float32 value = std::stof(input);
@@ -84,7 +66,6 @@ Result<T> StringInterpreterFromType(const std::string& input)
         float64 value = std::stod(input);
         outputValue = static_cast<T>(value);
       }
-#endif
     }
     else
     {

--- a/src/simplnx/Utilities/StringInterpretationUtilities.hpp
+++ b/src/simplnx/Utilities/StringInterpretationUtilities.hpp
@@ -1,0 +1,174 @@
+#pragma once
+
+#include "simplnx/simplnx_export.hpp"
+
+#include "simplnx/Common/Result.hpp"
+#include "simplnx/Common/TypesUtility.hpp"
+
+#include <fmt/format.h>
+
+#include <string>
+
+namespace nx::core::StringInterpretationUtilities
+{
+namespace detail
+{
+template <typename T>
+std::function<Result<T>(const std::string&)> StringInterpreterFromType()
+{
+  if constexpr(std::is_floating_point_v<T>)
+  {
+    if constexpr(std::is_same_v<T, float32>)
+    {
+      return [](const std::string& input) -> Result<T> {
+        try
+        {
+          float32 value = std::stof(input);
+          return {static_cast<T>(value)};
+        } catch(const std::invalid_argument& e)
+        {
+          return nx::core::MakeErrorResult<T>(
+              -10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), typeid(detail::StringInterpreterFromType<T>()).name()));
+        } catch(const std::out_of_range& e)
+        {
+          return nx::core::MakeErrorResult<T>(-10352, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()),
+                                                                  typeid(detail::StringInterpreterFromType<T>()).name()));
+        }
+      };
+    }
+    if constexpr(std::is_same_v<T, float64>)
+    {
+      return [](const std::string& input) -> Result<T> {
+        try
+        {
+          float64 value = std::stod(input);
+          return {static_cast<T>(value)};
+        } catch(const std::invalid_argument& e)
+        {
+          return nx::core::MakeErrorResult<T>(
+              -10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), typeid(detail::StringInterpreterFromType<T>()).name()));
+        } catch(const std::out_of_range& e)
+        {
+          return nx::core::MakeErrorResult<T>(-10352, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()),
+                                                                  typeid(detail::StringInterpreterFromType<T>()).name()));
+        }
+      };
+    }
+  }
+  if constexpr(std::is_unsigned_v<T>)
+  {
+    return [](const std::string& input) -> Result<T> {
+      try
+      {
+        uint64 value = std::stoull(input);
+        return {static_cast<T>(value)};
+      } catch(const std::invalid_argument& e)
+      {
+        return nx::core::MakeErrorResult<T>(
+            -10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), typeid(detail::StringInterpreterFromType<T>()).name()));
+      } catch(const std::out_of_range& e)
+      {
+        return nx::core::MakeErrorResult<T>(-10352, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()),
+                                                                typeid(detail::StringInterpreterFromType<T>()).name()));
+      }
+    };
+  }
+
+  // is signed and not float
+  return [](const std::string& input) -> Result<T> {
+    try
+    {
+      int64 value = std::stoll(input);
+      return {static_cast<T>(value)};
+    } catch(const std::invalid_argument& e)
+    {
+      return nx::core::MakeErrorResult<T>(
+          -10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), typeid(detail::StringInterpreterFromType<T>()).name()));
+    } catch(const std::out_of_range& e)
+    {
+      return nx::core::MakeErrorResult<T>(-10352, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()),
+                                                              typeid(detail::StringInterpreterFromType<T>()).name()));
+    }
+  };
+}
+} // namespace detail
+
+template <typename T>
+Result<T> Convert(const std::string& input)
+{
+  if constexpr(std::is_same_v<T, bool>)
+  {
+    if(input == "TRUE" || input == "true" || input == "True")
+    {
+      return {true};
+    }
+
+    if(input == "FALSE" || input == "false" || input == "False")
+    {
+      return {false};
+    }
+
+    // We are about to run the gauntlet of std::sto functions, if all of them err out true will be returned
+    {
+      Result<int64> result = detail::StringInterpreterFromType<int64>()(input);
+      if(result.valid())
+      {
+        return {result.value() != 0};
+      }
+    }
+
+    {
+      Result<uint64> result = detail::StringInterpreterFromType<uint64>()(input);
+      if(result.valid())
+      {
+        return {result.value() != 0};
+      }
+    }
+
+    {
+      Result<float64> result = detail::StringInterpreterFromType<float64>()(input);
+      if(result.valid())
+      {
+        return {result.value() != 0.0};
+      }
+    }
+
+    {
+      Result<float32> result = detail::StringInterpreterFromType<float32>()(input);
+      if(result.valid())
+      {
+        return {result.value() != 0.0};
+      }
+    }
+
+    return {true};
+  }
+
+  if constexpr(!std::is_floating_point_v<T> && std::is_unsigned_v<T>)
+  {
+    if(!input.empty() && input.at(0) == '-')
+    {
+      return nx::core::MakeErrorResult<T>(-10350, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()),
+                                                              typeid(detail::StringInterpreterFromType<T>()).name()));
+    }
+  }
+
+  Result<T> result = detail::StringInterpreterFromType<T>()(input);
+  if(result.invalid())
+  {
+    return result;
+  }
+
+  if constexpr(std::is_floating_point_v<T>)
+  {
+    if(result.value() > std::numeric_limits<T>::max() || result.value() < std::numeric_limits<T>::min())
+    {
+      return nx::core::MakeErrorResult<T>(-10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()),
+                                                              typeid(detail::StringInterpreterFromType<T>()).name()));
+    }
+  }
+
+  return result;
+}
+
+} // namespace nx::core::StringInterpretationUtilities

--- a/src/simplnx/Utilities/StringInterpretationUtilities.hpp
+++ b/src/simplnx/Utilities/StringInterpretationUtilities.hpp
@@ -14,82 +14,86 @@ namespace nx::core::StringInterpretationUtilities
 namespace detail
 {
 template <typename T>
-std::function<Result<T>(const std::string&)> StringInterpreterFromType()
+std::string TypeToFuncName()
 {
   if constexpr(std::is_floating_point_v<T>)
   {
     if constexpr(std::is_same_v<T, float32>)
     {
-      return [](const std::string& input) -> Result<T> {
-        try
-        {
-          float32 value = std::stof(input);
-          return {static_cast<T>(value)};
-        } catch(const std::invalid_argument& e)
-        {
-          return nx::core::MakeErrorResult<T>(
-              -10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), typeid(detail::StringInterpreterFromType<T>()).name()));
-        } catch(const std::out_of_range& e)
-        {
-          return nx::core::MakeErrorResult<T>(-10352, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()),
-                                                                  typeid(detail::StringInterpreterFromType<T>()).name()));
-        }
-      };
+      return "std::stof";
     }
     if constexpr(std::is_same_v<T, float64>)
     {
-      return [](const std::string& input) -> Result<T> {
-        try
-        {
-          float64 value = std::stod(input);
-          return {static_cast<T>(value)};
-        } catch(const std::invalid_argument& e)
-        {
-          return nx::core::MakeErrorResult<T>(
-              -10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), typeid(detail::StringInterpreterFromType<T>()).name()));
-        } catch(const std::out_of_range& e)
-        {
-          return nx::core::MakeErrorResult<T>(-10352, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()),
-                                                                  typeid(detail::StringInterpreterFromType<T>()).name()));
-        }
-      };
+      return "std::stod";
     }
   }
   if constexpr(std::is_unsigned_v<T>)
   {
-    return [](const std::string& input) -> Result<T> {
-      try
-      {
-        uint64 value = std::stoull(input);
-        return {static_cast<T>(value)};
-      } catch(const std::invalid_argument& e)
-      {
-        return nx::core::MakeErrorResult<T>(
-            -10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), typeid(detail::StringInterpreterFromType<T>()).name()));
-      } catch(const std::out_of_range& e)
-      {
-        return nx::core::MakeErrorResult<T>(-10352, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()),
-                                                                typeid(detail::StringInterpreterFromType<T>()).name()));
-      }
-    };
+    return "std::stoull";
   }
 
   // is signed and not float
-  return [](const std::string& input) -> Result<T> {
-    try
+  return "std::stoll";
+}
+
+template <typename T>
+Result<T> StringInterpreterFromType(const std::string& input)
+{
+  T outputValue;
+  try
+  {
+    if constexpr(std::is_floating_point_v<T>)
     {
-      int64 value = std::stoll(input);
-      return {static_cast<T>(value)};
-    } catch(const std::invalid_argument& e)
-    {
-      return nx::core::MakeErrorResult<T>(
-          -10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), typeid(detail::StringInterpreterFromType<T>()).name()));
-    } catch(const std::out_of_range& e)
-    {
-      return nx::core::MakeErrorResult<T>(-10352, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()),
-                                                              typeid(detail::StringInterpreterFromType<T>()).name()));
+      if constexpr(std::is_same_v<T, float32>)
+      {
+        float32 value = std::stof(input);
+        outputValue = static_cast<T>(value);
+      }
+      else if constexpr(std::is_same_v<T, float64>)
+      {
+        float64 value = std::stod(input);
+        outputValue = static_cast<T>(value);
+      }
     }
-  };
+    else
+    {
+      if constexpr(std::is_unsigned_v<T>)
+      {
+        if(!input.empty() && input.at(0) == '-')
+        {
+          return nx::core::MakeErrorResult<T>(
+              -10350, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), detail::TypeToFuncName<T>()));
+        }
+
+        uint64 value = std::stoull(input);
+        if(value > std::numeric_limits<T>::max() || value < std::numeric_limits<T>::min())
+        {
+          return nx::core::MakeErrorResult<T>(
+              -10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), detail::TypeToFuncName<T>()));
+        }
+        outputValue = static_cast<T>(value);
+      }
+      else
+      {
+        // Default: is signed and not float
+        int64 value = std::stoll(input);
+        if(value > std::numeric_limits<T>::max() || value < std::numeric_limits<T>::min())
+        {
+          return nx::core::MakeErrorResult<T>(
+              -10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), detail::TypeToFuncName<T>()));
+        }
+        outputValue = static_cast<T>(value);
+      }
+    }
+  } catch(const std::invalid_argument& e)
+  {
+    return nx::core::MakeErrorResult<T>(-10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), detail::TypeToFuncName<T>()));
+  } catch(const std::out_of_range& e)
+  {
+    return nx::core::MakeErrorResult<T>(-10352,
+                                        fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()), detail::TypeToFuncName<T>()));
+  }
+  return {outputValue};
 }
 } // namespace detail
 
@@ -110,7 +114,7 @@ Result<T> Convert(const std::string& input)
 
     // We are about to run the gauntlet of std::sto functions, if all of them err out true will be returned
     {
-      Result<int64> result = detail::StringInterpreterFromType<int64>()(input);
+      Result<int64> result = detail::StringInterpreterFromType<int64>(input);
       if(result.valid())
       {
         return {result.value() != 0};
@@ -118,7 +122,7 @@ Result<T> Convert(const std::string& input)
     }
 
     {
-      Result<uint64> result = detail::StringInterpreterFromType<uint64>()(input);
+      Result<uint64> result = detail::StringInterpreterFromType<uint64>(input);
       if(result.valid())
       {
         return {result.value() != 0};
@@ -126,7 +130,7 @@ Result<T> Convert(const std::string& input)
     }
 
     {
-      Result<float64> result = detail::StringInterpreterFromType<float64>()(input);
+      Result<float64> result = detail::StringInterpreterFromType<float64>(input);
       if(result.valid())
       {
         return {result.value() != 0.0};
@@ -134,7 +138,7 @@ Result<T> Convert(const std::string& input)
     }
 
     {
-      Result<float32> result = detail::StringInterpreterFromType<float32>()(input);
+      Result<float32> result = detail::StringInterpreterFromType<float32>(input);
       if(result.valid())
       {
         return {result.value() != 0.0};
@@ -144,31 +148,7 @@ Result<T> Convert(const std::string& input)
     return {true};
   }
 
-  if constexpr(!std::is_floating_point_v<T> && std::is_unsigned_v<T>)
-  {
-    if(!input.empty() && input.at(0) == '-')
-    {
-      return nx::core::MakeErrorResult<T>(-10350, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()),
-                                                              typeid(detail::StringInterpreterFromType<T>()).name()));
-    }
-  }
-
-  Result<T> result = detail::StringInterpreterFromType<T>()(input);
-  if(result.invalid())
-  {
-    return result;
-  }
-
-  if constexpr(std::is_floating_point_v<T>)
-  {
-    if(result.value() > std::numeric_limits<T>::max() || result.value() < std::numeric_limits<T>::min())
-    {
-      return nx::core::MakeErrorResult<T>(-10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, DataTypeToString(GetDataType<T>()),
-                                                              typeid(detail::StringInterpreterFromType<T>()).name()));
-    }
-  }
-
-  return result;
+  return detail::StringInterpreterFromType<T>(input);
 }
 
 Result<> CheckValueConverts(DataType type, const std::string& value);

--- a/src/simplnx/Utilities/StringInterpretationUtilities.hpp
+++ b/src/simplnx/Utilities/StringInterpretationUtilities.hpp
@@ -73,15 +73,13 @@ Result<T> StringInterpreterFromType(const std::string& input)
       {
         if(!input.empty() && input.at(0) == '-')
         {
-          return nx::core::MakeErrorResult<T>(
-              -10350, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
+          return nx::core::MakeErrorResult<T>(-10350, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
         }
 
         uint64 value = std::stoull(input);
         if(value > std::numeric_limits<T>::max() || value < std::numeric_limits<T>::min())
         {
-          return nx::core::MakeErrorResult<T>(
-              -10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
+          return nx::core::MakeErrorResult<T>(-10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
         }
         outputValue = static_cast<T>(value);
       }
@@ -91,8 +89,7 @@ Result<T> StringInterpreterFromType(const std::string& input)
         int64 value = std::stoll(input);
         if(value > std::numeric_limits<T>::max() || value < std::numeric_limits<T>::min())
         {
-          return nx::core::MakeErrorResult<T>(
-              -10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
+          return nx::core::MakeErrorResult<T>(-10353, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
         }
         outputValue = static_cast<T>(value);
       }
@@ -102,8 +99,7 @@ Result<T> StringInterpreterFromType(const std::string& input)
     return nx::core::MakeErrorResult<T>(-10351, fmt::format("Error trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
   } catch(const std::out_of_range& e)
   {
-    return nx::core::MakeErrorResult<T>(-10352,
-                                        fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
+    return nx::core::MakeErrorResult<T>(-10352, fmt::format("Overflow error trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
   }
   return {outputValue};
 }

--- a/src/simplnx/Utilities/StringInterpretationUtilities.hpp
+++ b/src/simplnx/Utilities/StringInterpretationUtilities.hpp
@@ -159,5 +159,5 @@ Result<T> Convert(const std::string& input)
   return detail::StringInterpreterFromType<T>(input);
 }
 
-Result<> CheckValueConverts(DataType type, const std::string& value);
+SIMPLNX_EXPORT Result<> CheckValueConverts(DataType type, const std::string& value);
 } // namespace nx::core::StringInterpretationUtilities

--- a/src/simplnx/Utilities/StringInterpretationUtilities.hpp
+++ b/src/simplnx/Utilities/StringInterpretationUtilities.hpp
@@ -155,8 +155,10 @@ Result<T> Convert(const std::string& input)
 
     return {true};
   }
-
-  return detail::StringInterpreterFromType<T>(input);
+  else
+  {
+    return detail::StringInterpreterFromType<T>(input);
+  }
 }
 
 SIMPLNX_EXPORT Result<> CheckValueConverts(DataType type, const std::string& value);

--- a/src/simplnx/Utilities/StringInterpretationUtilities.hpp
+++ b/src/simplnx/Utilities/StringInterpretationUtilities.hpp
@@ -56,6 +56,24 @@ Result<T> StringInterpreterFromType(const std::string& input)
   {
     if constexpr(std::is_floating_point_v<T>)
     {
+#if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER)
+      std::size_t index = 0;
+      if constexpr(std::is_same_v<T, float32>)
+      {
+        float32 value = std::stof(input, &index);
+        outputValue = static_cast<T>(value);
+      }
+      else if constexpr(std::is_same_v<T, float64>)
+      {
+        float64 value = std::stod(input, &index);
+        outputValue = static_cast<T>(value);
+      }
+      if(index != input.size())
+      {
+        return nx::core::MakeErrorResult<T>(
+            -10354, fmt::format("Error: unable to parse to end of floating-point string trying to convert '{}' to type '{}' using function '{}'", input, typeName, detail::TypeToFuncName<T>()));
+      }
+#else
       if constexpr(std::is_same_v<T, float32>)
       {
         float32 value = std::stof(input);
@@ -66,6 +84,7 @@ Result<T> StringInterpreterFromType(const std::string& input)
         float64 value = std::stod(input);
         outputValue = static_cast<T>(value);
       }
+#endif
     }
     else
     {

--- a/src/simplnx/Utilities/StringInterpretationUtilities.hpp
+++ b/src/simplnx/Utilities/StringInterpretationUtilities.hpp
@@ -171,4 +171,5 @@ Result<T> Convert(const std::string& input)
   return result;
 }
 
+Result<> CheckValueConverts(DataType type, const std::string& value);
 } // namespace nx::core::StringInterpretationUtilities

--- a/test/DataArrayTest.cpp
+++ b/test/DataArrayTest.cpp
@@ -4,7 +4,7 @@
 #include "simplnx/DataStructure/DataStore.hpp"
 #include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 
 #include <catch2/catch.hpp>
 
@@ -67,7 +67,7 @@ TEST_CASE("nx::core::DataArray Copy TupleTest", "[simplnx][DataArray]")
   DataStructure dataStructure;
   IDataStore::ShapeType tupleShape{k_NumTuples};
   IDataStore::ShapeType componentShape{k_NumComponents};
-  Result<> result = CreateArray<int32>(dataStructure, tupleShape, componentShape, k_DataPath, IDataAction::Mode::Execute);
+  Result<> result = ArrayCreationUtilities::CreateArray<int32>(dataStructure, tupleShape, componentShape, k_DataPath, IDataAction::Mode::Execute);
   REQUIRE(result.valid() == true);
 
   auto& dataArray = dataStructure.getDataRefAs<DataArray<int32>>(k_DataPath);

--- a/test/H5Test.cpp
+++ b/test/H5Test.cpp
@@ -17,7 +17,8 @@
 #include "simplnx/DataStructure/ScalarData.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
 #include "simplnx/Filter/Actions/CreateImageGeometryAction.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/UnitTest/UnitTestCommon.hpp"
+#include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 #include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp"
 #include "simplnx/Utilities/Parsing/Text/CsvParser.hpp"
@@ -180,9 +181,13 @@ void CreateVertexGeometry(DataStructure& dataStructure)
   std::string inputFile = fmt::format("{}/test/Data/VertexCoordinates.csv", unit_test::k_SourceDir.view());
   uint64 vertexCount = CsvParser::LineCount(inputFile) - skipLines;
   REQUIRE(vertexCount == 144);
-  nx::core::Result result = nx::core::CreateArray<float>(dataStructure, {vertexCount}, {3}, path, IDataAction::Mode::Execute);
+  nx::core::Result result = ArrayCreationUtilities::CreateArray<float>(dataStructure, {vertexCount}, {3}, path, IDataAction::Mode::Execute);
   REQUIRE(result.valid());
-  auto vertexArray = nx::core::ArrayFromPath<float>(dataStructure, path);
+  auto* vertexArray = dataStructure.getDataAs<Float32Array>(path);
+  if(vertexArray == nullptr)
+  {
+    throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", path.toString()));
+  }
   CsvParser::ReadFile<float, float>(inputFile, vertexArray->getDataStoreRef(), skipLines, delimiter);
   vertexGeometry->setVertices(*vertexArray);
   REQUIRE(vertexGeometry->getNumberOfVertices() == 144);
@@ -217,9 +222,13 @@ void CreateTriangleGeometry(DataStructure& dataStructure)
   REQUIRE(faceCount == 242);
   // Create the default DataArray that will hold the FaceList and Vertices. We
   // size these to 1 because the Csv parser will resize them to the appropriate number of typles
-  nx::core::Result result = nx::core::CreateArray<MeshIndexType>(dataStructure, {faceCount}, {3}, path, IDataAction::Mode::Execute);
+  nx::core::Result result = ArrayCreationUtilities::CreateArray<MeshIndexType>(dataStructure, {faceCount}, {3}, path, IDataAction::Mode::Execute);
   REQUIRE(result.valid());
-  auto dataArray = nx::core::ArrayFromPath<MeshIndexType>(dataStructure, path);
+  auto* dataArray = dataStructure.getDataAs<IGeometry::SharedFaceList>(path);
+  if(dataArray == nullptr)
+  {
+    throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", path.toString()));
+  }
   CsvParser::ReadFile<MeshIndexType, MeshIndexType>(inputFile, dataArray->getDataStoreRef(), skipLines, delimiter);
   triangleGeom->setFaceList(*dataArray);
 
@@ -228,9 +237,13 @@ void CreateTriangleGeometry(DataStructure& dataStructure)
   inputFile = fmt::format("{}/test/Data/VertexCoordinates.csv", unit_test::k_SourceDir.view());
   uint64 vertexCount = CsvParser::LineCount(inputFile) - skipLines;
   REQUIRE(vertexCount == 144);
-  result = nx::core::CreateArray<float>(dataStructure, {vertexCount}, {3}, path, IDataAction::Mode::Execute);
+  result = ArrayCreationUtilities::CreateArray<float>(dataStructure, {vertexCount}, {3}, path, IDataAction::Mode::Execute);
   REQUIRE(result.valid());
-  auto vertexArray = nx::core::ArrayFromPath<float>(dataStructure, path);
+  auto* vertexArray = dataStructure.getDataAs<Float32Array>(path);
+  if(vertexArray == nullptr)
+  {
+    throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", path.toString()));
+  }
   CsvParser::ReadFile<float, float>(inputFile, vertexArray->getDataStoreRef(), skipLines, delimiter);
   triangleGeom->setVertices(*vertexArray);
 }
@@ -251,9 +264,13 @@ void CreateQuadGeometry(DataStructure& dataStructure)
   REQUIRE(faceCount == 121);
   // Create the default DataArray that will hold the FaceList and Vertices. We
   // size these to 1 because the Csv parser will resize them to the appropriate number of typles
-  nx::core::Result result = nx::core::CreateArray<MeshIndexType>(dataStructure, {faceCount}, {4}, path, IDataAction::Mode::Execute);
+  nx::core::Result result = ArrayCreationUtilities::CreateArray<MeshIndexType>(dataStructure, {faceCount}, {4}, path, IDataAction::Mode::Execute);
   REQUIRE(result.valid());
-  auto dataArray = nx::core::ArrayFromPath<MeshIndexType>(dataStructure, path);
+  auto* dataArray = dataStructure.getDataAs<IGeometry::SharedFaceList>(path);
+  if(dataArray == nullptr)
+  {
+    throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", path.toString()));
+  }
   CsvParser::ReadFile<MeshIndexType, MeshIndexType>(inputFile, dataArray->getDataStoreRef(), skipLines, delimiter);
   geometry->setFaceList(*dataArray);
 
@@ -262,9 +279,13 @@ void CreateQuadGeometry(DataStructure& dataStructure)
   inputFile = fmt::format("{}/test/Data/VertexCoordinates.csv", unit_test::k_SourceDir.view());
   uint64 vertexCount = CsvParser::LineCount(inputFile) - skipLines;
   REQUIRE(vertexCount == 144);
-  result = nx::core::CreateArray<float>(dataStructure, {vertexCount}, {3}, path, IDataAction::Mode::Execute);
+  result = ArrayCreationUtilities::CreateArray<float32>(dataStructure, {vertexCount}, {3}, path, IDataAction::Mode::Execute);
   REQUIRE(result.valid());
-  auto vertexArray = nx::core::ArrayFromPath<float>(dataStructure, path);
+  auto* vertexArray = dataStructure.getDataAs<Float32Array>(path);
+  if(vertexArray == nullptr)
+  {
+    throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", path.toString()));
+  }
   CsvParser::ReadFile<float, float>(inputFile, vertexArray->getDataStoreRef(), skipLines, delimiter);
   geometry->setVertices(*vertexArray);
 }
@@ -285,9 +306,13 @@ void CreateEdgeGeometry(DataStructure& dataStructure)
   REQUIRE(faceCount == 264);
   // Create the default DataArray that will hold the FaceList and Vertices. We
   // size these to 1 because the Csv parser will resize them to the appropriate number of typles
-  nx::core::Result result = nx::core::CreateArray<MeshIndexType>(dataStructure, {faceCount}, {2}, path, IDataAction::Mode::Execute);
+  nx::core::Result result = ArrayCreationUtilities::CreateArray<MeshIndexType>(dataStructure, {faceCount}, {2}, path, IDataAction::Mode::Execute);
   REQUIRE(result.valid());
-  auto dataArray = nx::core::ArrayFromPath<MeshIndexType>(dataStructure, path);
+  auto* dataArray = dataStructure.getDataAs<IGeometry::SharedEdgeList>(path);
+  if(dataArray == nullptr)
+  {
+    throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", path.toString()));
+  }
   CsvParser::ReadFile<MeshIndexType, MeshIndexType>(inputFile, dataArray->getDataStoreRef(), skipLines, delimiter);
   geometry->setEdgeList(*dataArray);
 
@@ -296,9 +321,13 @@ void CreateEdgeGeometry(DataStructure& dataStructure)
   inputFile = fmt::format("{}/test/Data/VertexCoordinates.csv", unit_test::k_SourceDir.view());
   uint64 vertexCount = CsvParser::LineCount(inputFile) - skipLines;
   REQUIRE(vertexCount == 144);
-  result = nx::core::CreateArray<float>(dataStructure, {vertexCount}, {3}, path, IDataAction::Mode::Execute);
+  result = ArrayCreationUtilities::CreateArray<float32>(dataStructure, {vertexCount}, {3}, path, IDataAction::Mode::Execute);
   REQUIRE(result.valid());
-  auto vertexArray = nx::core::ArrayFromPath<float>(dataStructure, path);
+  auto* vertexArray = dataStructure.getDataAs<Float32Array>(path);
+  if(vertexArray == nullptr)
+  {
+    throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", path.toString()));
+  }
   CsvParser::ReadFile<float, float>(inputFile, vertexArray->getDataStoreRef(), skipLines, delimiter);
   geometry->setVertices(*vertexArray);
 }
@@ -319,9 +348,13 @@ void CreateTetrahedralGeometry(DataStructure& dataStructure)
   REQUIRE(faceCount == 3);
   // Create the default DataArray that will hold the FaceList and Vertices. We
   // size these to 1 because the Csv parser will resize them to the appropriate number of typles
-  nx::core::Result result = nx::core::CreateArray<MeshIndexType>(dataStructure, {faceCount}, {4}, path, IDataAction::Mode::Execute);
+  nx::core::Result result = ArrayCreationUtilities::CreateArray<MeshIndexType>(dataStructure, {faceCount}, {4}, path, IDataAction::Mode::Execute);
   REQUIRE(result.valid());
-  auto dataArray = nx::core::ArrayFromPath<MeshIndexType>(dataStructure, path);
+  auto* dataArray = dataStructure.getDataAs<IGeometry::SharedTetList>(path);
+  if(dataArray == nullptr)
+  {
+    throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", path.toString()));
+  }
   CsvParser::ReadFile<MeshIndexType, MeshIndexType>(inputFile, dataArray->getDataStoreRef(), skipLines, delimiter);
   geometry->setPolyhedraList(*dataArray);
 
@@ -330,9 +363,13 @@ void CreateTetrahedralGeometry(DataStructure& dataStructure)
   inputFile = fmt::format("{}/test/Data/TetraVertexCoordinates.csv", unit_test::k_SourceDir.view());
   uint64 vertexCount = CsvParser::LineCount(inputFile) - skipLines;
   REQUIRE(vertexCount == 9);
-  result = nx::core::CreateArray<float>(dataStructure, {vertexCount}, {3}, path, IDataAction::Mode::Execute);
+  result = ArrayCreationUtilities::CreateArray<float32>(dataStructure, {vertexCount}, {3}, path, IDataAction::Mode::Execute);
   REQUIRE(result.valid());
-  auto vertexArray = nx::core::ArrayFromPath<float>(dataStructure, path);
+  auto* vertexArray = dataStructure.getDataAs<Float32Array>(path);
+  if(vertexArray == nullptr)
+  {
+    throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", path.toString()));
+  }
   CsvParser::ReadFile<float, float>(inputFile, vertexArray->getDataStoreRef(), skipLines, delimiter);
   geometry->setVertices(*vertexArray);
 }
@@ -353,9 +390,13 @@ void CreateHexahedralGeometry(DataStructure& dataStructure)
   REQUIRE(faceCount == 3);
   // Create the default DataArray that will hold the FaceList and Vertices. We
   // size these to 1 because the Csv parser will resize them to the appropriate number of typles
-  nx::core::Result result = nx::core::CreateArray<MeshIndexType>(dataStructure, {faceCount}, {8}, path, IDataAction::Mode::Execute);
+  nx::core::Result result = ArrayCreationUtilities::CreateArray<MeshIndexType>(dataStructure, {faceCount}, {8}, path, IDataAction::Mode::Execute);
   REQUIRE(result.valid());
-  auto dataArray = nx::core::ArrayFromPath<MeshIndexType>(dataStructure, path);
+  auto* dataArray = dataStructure.getDataAs<IGeometry::SharedHexList>(path);
+  if(dataArray == nullptr)
+  {
+    throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", path.toString()));
+  }
   CsvParser::ReadFile<MeshIndexType, MeshIndexType>(inputFile, dataArray->getDataStoreRef(), skipLines, delimiter);
   geometry->setPolyhedraList(*dataArray);
 
@@ -364,9 +405,13 @@ void CreateHexahedralGeometry(DataStructure& dataStructure)
   inputFile = fmt::format("{}/test/Data/HexaVertexCoordinates.csv", unit_test::k_SourceDir.view());
   uint64 vertexCount = CsvParser::LineCount(inputFile) - skipLines;
   REQUIRE(vertexCount == 20);
-  result = nx::core::CreateArray<float>(dataStructure, {vertexCount}, {3}, path, IDataAction::Mode::Execute);
+  result = ArrayCreationUtilities::CreateArray<float32>(dataStructure, {vertexCount}, {3}, path, IDataAction::Mode::Execute);
   REQUIRE(result.valid());
-  auto vertexArray = nx::core::ArrayFromPath<float>(dataStructure, path);
+  auto* vertexArray = dataStructure.getDataAs<Float32Array>(path);
+  if(vertexArray == nullptr)
+  {
+    throw std::runtime_error(fmt::format("DataPath does not point to a DataArray. DataPath: '{}'", path.toString()));
+  }
   CsvParser::ReadFile<float, float>(inputFile, vertexArray->getDataStoreRef(), skipLines, delimiter);
   geometry->setVertices(*vertexArray);
 }

--- a/test/H5Test.cpp
+++ b/test/H5Test.cpp
@@ -1014,7 +1014,7 @@ TEST_CASE("DataStructureAppend")
 
   DataStructure baseDataStructure;
 
-  auto createArrayResult = CreateArray<int32>(baseDataStructure, {10, 10, 10}, {3}, originalArrayPath, IDataAction::Mode::Execute);
+  auto createArrayResult = ArrayCreationUtilities::CreateArray<int32>(baseDataStructure, {10, 10, 10}, {3}, originalArrayPath, IDataAction::Mode::Execute);
   SIMPLNX_RESULT_REQUIRE_VALID(createArrayResult);
 
   const auto& originalArray = baseDataStructure.getDataRefAs<Int32Array>(originalArrayPath);


### PR DESCRIPTION
Fixes: #1274

Added Functionality:
- Create Array Action now accepts a string that will be transformed into a fill value
- Smaller executable size
- Smaller utility files
- Smaller headers nearly project wide
- DataArrayUtilities segmented into applicable utility files
- Easier debugging by removing various common macros (now templates)
- Simplified string to number conversions
- Integrated sanity check for intialization string in `CreateArray` for both preflight and execute
- Backported new fill functionality

Changes:
- Moved `MaskCompare` functionality from `DataArrayUtilities` to `MaskCompareUtilities`
- Moved `Convert` (string conversion) functionality from `DataArrayUtilities` to `StringInterpretationUtilities`
- Moved `CreateArray` functionality from `DataArrayUtilities` to `ArrayCreationUtilities` (therein removing the biggest utility file from being included in most Action headers)
- Moved `CreateDataStore` functionality from `DataArrayUtilities` to `DataStoreUtilities` (therein removing the biggest utility file from being included deep in the datastructure factory functions that are included in nearly everything by proxy)
- Reworked dependencies for aformentioned utility files to make them standalone (except `ArrayCreationUtilities` which includes `StringInterpretationUtilities` and `DataStoreUtilities`)
- Added a method to `DataStore` for setting initialization value (this was done to meet the request of issue (#1274)). The request was originally to pass it to the ctor (This would require reworking `AbstractDataStore`, and every factory function and mapping for all of OoC functionality, hard to over emphasize how much of a downstream effect this would have) `DataStore` is the only one that has an initialization value.
- Scoped all moved functionality to respective namespaces
- Removed Macros for string to number convert functions (created simplifed templates instead)
- Removed ArrayFromPath functionality (this cut an extra unnecessary dynamic cast) and made code conform to modern access patterns. This also removed the need to include `DataArrayUtilities` in various headers.
- Removed various extraneous string to number convert functions in favor of new simple, unified convert call system
- Lots of include cleanup to help cut down executable size and downstream header bloat

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the simplnx repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start simplnx commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## Naming Conventions

Naming of variables should descriptive where needed. Loop Control Variables can use `i` if warranted. Most of these conventions are enforced through the clang-tidy and clang-format configuration files. See the file `simplnx/docs/Code_Style_Guide.md` for a more in depth explanation.


## Filter Checklist

The help file `simplnx/docs/Porting_Filters.md` has documentation to help you port or write new filters. At the top is a nice checklist of items that should be noted when porting a filter.


## Unit Testing

The idea of unit testing is to test the filter for proper execution and error handling. How many variations on a unit test each filter needs is entirely dependent on what the filter is doing. Generally, the variations can fall into a few categories:

- [ ] 1 Unit test to test output from the filter against known exemplar set of data
- [ ] 1 Unit test to test invalid input code paths that are specific to a filter. Don't test that a DataPath does not exist since that test is already performed as part of the SelectDataArrayAction.

## Code Cleanup
- [ ] No commented out code (rare exceptions to this is allowed..)
- [ ] No API changes were made (or the changes have been approved)
- [ ] No major design changes were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added license to new files (if any)
- [ ] Added example pipelines that use the filter
- [ ] Classes and methods are properly documented


<!-- **Thanks for contributing to simplnx!** -->
