### PR TITLE
ENH: Clarify Kernel Average Misorientation algorithm with proper casting.

### DIFF
--- a/src/Plugins/OrientationAnalysis/docs/ComputeKernelAvgMisorientationsFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ComputeKernelAvgMisorientationsFilter.md
@@ -11,6 +11,8 @@ This **Filter** determines the Kernel Average Misorientation (KAM) for each **Ce
 1. Calculate the misorientation angle between each **Cell** in a kernel and the central **Cell** of the kernel
 2. Average all of the misorientations for the kernel and store at the central **Cell**
 
+The calculation will **not** consider cells that belong to different 'feature Ids', ie.e, different grains.
+
 *Note:* All **Cells** in the kernel are weighted equally during the averaging, though they are not equidistant from the central **Cell**.
 
 % Auto generated parameter table will be inserted here

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeKernelAvgMisorientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeKernelAvgMisorientations.cpp
@@ -96,26 +96,27 @@ public:
             uint32_t phase1 = crystalStructures[cellPhases[point]];
             for(int32_t j = -kernelSize[2]; j < kernelSize[2] + 1; j++)
             {
-              size_t jStride = j * xPoints * yPoints;
+
               if(plane + j < 0 || plane + j > zPoints - 1)
               {
                 continue;
               }
+              const int64_t jStride = j * xPoints * yPoints;
               for(int32_t k = -kernelSize[1]; k < kernelSize[1] + 1; k++)
               {
-                size_t kStride = k * xPoints;
                 if(row + k < 0 || row + k > yPoints - 1)
                 {
                   continue;
                 }
+                const int64_t kStride = k * xPoints;
                 for(int32_t l = -kernelSize[0]; l < kernelSize[0] + 1; l++)
                 {
                   if(col + l < 0 || col + l > xPoints - 1)
                   {
                     continue;
                   }
-                  const size_t neighbor = point + (jStride) + (kStride) + (l);
-                  if(featureIds[point] == featureIds[neighbor])
+                  const int64_t neighbor = static_cast<int64_t>(point) + jStride + kStride + l;
+                  if(neighbor >= 0 && featureIds[point] == featureIds[static_cast<size_t>(neighbor)])
                   {
                     quatIndex = neighbor * 4;
                     q2[0] = quats[quatIndex];
@@ -123,7 +124,7 @@ public:
                     q2[2] = quats[quatIndex + 2];
                     q2[3] = quats[quatIndex + 3];
                     OrientationF axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
-                    totalMisorientation = totalMisorientation + (axisAngle[3] * nx::core::Constants::k_180OverPiD);
+                    totalMisorientation = totalMisorientation + (axisAngle[3] * nx::core::Constants::k_180OverPiF);
                     numVoxel++;
                   }
                 }


### PR DESCRIPTION
Added proper casting as the previous code was relying on the compiler to do the proper casting at the proper time. This explicitly sets the types and adds defensive checks to ensure the calculated index is >= 0.

Updated the documentation to state that the KAM is only calculated within a grain.
