### PR TITLE
ENH: Add RandomizeFeatureIds utility and filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,7 +532,7 @@ set(SIMPLNX_HDRS
   ${SIMPLNX_SOURCE_DIR}/Utilities/DataArrayUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/DataGroupUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/DataObjectUtilities.hpp
-  ${SIMPLNX_SOURCE_DIR}/Utilities/DataStoreUtilities.cpp
+  ${SIMPLNX_SOURCE_DIR}/Utilities/DataStoreUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/FilePathGenerator.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/ColorTableUtilities.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/FileUtilities.hpp
@@ -734,6 +734,7 @@ set(SIMPLNX_SRCS
 
   ${SIMPLNX_SOURCE_DIR}/Utilities/ArrayCreationUtilities.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/ArrayThreshold.cpp
+  ${SIMPLNX_SOURCE_DIR}/Utilities/ClusteringUtilities.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/FilePathGenerator.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/FilterUtilities.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/FileUtilities.cpp

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/Common/Constants.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/ClusteringUtilities.hpp"
 #include "simplnx/Utilities/Math/MatrixMath.hpp"
 
 #include "EbsdLib/LaueOps/LaueOps.h"
@@ -86,7 +87,7 @@ Result<> CAxisSegmentFeatures::operator()()
   // would look like a smooth gradient. This is a user input parameter
   if(m_InputValues->RandomizeFeatureIds)
   {
-    randomizeFeatureIds(m_FeatureIdsArray, this->m_FoundFeatures + 1);
+    ClusterUtilities::RandomizeFeatureIds(m_FeatureIdsArray->getDataStoreRef(), this->m_FoundFeatures + 1);
   }
 
   return {};

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/MergeTwins.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/MergeTwins.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Common/Numbers.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/Utilities/ClusteringUtilities.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 
 #include "EbsdLib/Core/EbsdLibConstants.h"
@@ -189,32 +190,7 @@ Result<> MergeTwins::operator()()
   // would look like a smooth gradient. This is a user input parameter
   { // Randomize Parent IDs
     m_MessageHandler({IFilter::Message::Type::Info, "Randomizing Parent Ids...."});
-
-    std::mt19937_64 gen(std::mt19937_64::default_seed); // Standard mersenne_twister_engine seeded with milliseconds
-    std::uniform_real_distribution<float64> dist(0, 1);
-
-    auto nParents = static_cast<usize>(numParents);
-
-    std::vector<int32> parentIds(numParents);
-    std::iota(parentIds.begin(), parentIds.end(), 0);
-
-    m_MessageHandler({IFilter::Message::Type::Info, "Shuffling elements ...."});
-    //--- Shuffle elements by randomly exchanging each with one other.
-    for(usize i = 1; i < nParents; i++)
-    {
-      auto r = static_cast<usize>(std::floor(dist(gen) * static_cast<float64>(numParents - 1))); // Random remaining position.
-      int32 pid_i = parentIds[i];
-      parentIds[i] = parentIds[r];
-      parentIds[r] = pid_i;
-    }
-
-    m_MessageHandler({IFilter::Message::Type::Info, "Adjusting Feature Ids Array...."});
-    // Now adjust all the Feature ID values for each Voxel
-    for(usize i = 0; i < totalPoints; ++i)
-    {
-      cellParentIds[i] = parentIds[cellParentIds[i]];
-      featureParentIds[featureIds[i]] = cellParentIds[i];
-    }
+    ClusterUtilities::RandomizeFeatureIds(featureParentIds, numParents);
   }
 
   return result;

--- a/src/Plugins/SimplnxCore/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/CMakeLists.txt
@@ -101,6 +101,7 @@ set(FilterList
   PointSampleEdgeGeometryFilter
   PointSampleTriangleGeometryFilter
   QuickSurfaceMeshFilter
+  RandomizeFeatureIdsFilter
   ReadBinaryCTNorthstarFilter
   ReadCSVFileFilter
   ReadDeformKeyFileV12Filter

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.cpp
@@ -73,14 +73,6 @@ IFilter::UniquePointer RandomizeFeatureIdsFilter::clone() const
 IFilter::PreflightResult RandomizeFeatureIdsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                                   const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
-  auto featureIdsPath = filterArgs.value<DataPath>(k_FeatureIds_Key);
-
-  const Int32Array* featureIdsArray = dataStructure.getDataAs<Int32Array>(featureIdsPath);
-  if(featureIdsArray == nullptr)
-  {
-    return MakePreflightErrorResult(-72601, fmt::format("The Feature IDs array was not found at path '{}'", featureIdsPath.toString()));
-  }
-
   return {};
 }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.cpp
@@ -90,8 +90,8 @@ Result<> RandomizeFeatureIdsFilter::executeImpl(DataStructure& dataStructure, co
 {
   auto featureIdsPath = args.value<DataPath>(k_FeatureIds_Key);
 
-  Int32Array* featureIdsArray = dataStructure.getDataAs<Int32Array>(featureIdsPath);
-  auto& featureIdsStore = featureIdsArray->getDataStoreRef();
+  Int32Array& featureIdsArray = dataStructure.getDataRefAs<Int32Array>(featureIdsPath);
+  auto& featureIdsStore = featureIdsArray.getDataStoreRef();
   usize totalFeatures = *std::max_element(featureIdsStore.begin(), featureIdsStore.end());
 
   ClusterUtilities::RandomizeFeatureIds(featureIdsStore, totalFeatures);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.cpp
@@ -1,0 +1,102 @@
+#include "RandomizeFeatureIdsFilter.hpp"
+
+#include "simplnx/Common/TypesUtility.hpp"
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/Parameters/ArraySelectionParameter.hpp"
+#include "simplnx/Utilities/ClusteringUtilities.hpp"
+
+#include <stdexcept>
+
+using namespace nx::core;
+
+namespace
+{
+constexpr int32 k_EmptyParameterError = -123;
+}
+
+namespace nx::core
+{
+//------------------------------------------------------------------------------
+std::string RandomizeFeatureIdsFilter::name() const
+{
+  return FilterTraits<RandomizeFeatureIdsFilter>::name;
+}
+
+//------------------------------------------------------------------------------
+std::string RandomizeFeatureIdsFilter::className() const
+{
+  return FilterTraits<RandomizeFeatureIdsFilter>::className;
+}
+
+//------------------------------------------------------------------------------
+Uuid RandomizeFeatureIdsFilter::uuid() const
+{
+  return FilterTraits<RandomizeFeatureIdsFilter>::uuid;
+}
+
+//------------------------------------------------------------------------------
+std::string RandomizeFeatureIdsFilter::humanName() const
+{
+  return "Randomize Feature IDs";
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> RandomizeFeatureIdsFilter::defaultTags() const
+{
+  return {className(), "Randomize", "Feature IDs"};
+}
+
+//------------------------------------------------------------------------------
+Parameters RandomizeFeatureIdsFilter::parameters() const
+{
+  Parameters params;
+
+  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIds_Key, "Feature IDs Array", "Array storing the Feature IDs", DataPath(),
+                                                          ArraySelectionParameter::AllowedTypes{nx::core::DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
+
+  return params;
+}
+
+//------------------------------------------------------------------------------
+IFilter::VersionType RandomizeFeatureIdsFilter::parametersVersion() const
+{
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+IFilter::UniquePointer RandomizeFeatureIdsFilter::clone() const
+{
+  return std::make_unique<RandomizeFeatureIdsFilter>();
+}
+
+//------------------------------------------------------------------------------
+IFilter::PreflightResult RandomizeFeatureIdsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
+                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+{
+  auto featureIdsPath = filterArgs.value<DataPath>(k_FeatureIds_Key);
+  
+  const Int32Array* featureIdsArray = dataStructure.getDataAs<Int32Array>(featureIdsPath);
+  if(featureIdsArray == nullptr)
+  {
+      return MakePreflightErrorResult(
+          -72601, fmt::format("The Feature IDs array was not found at path '{}'", featureIdsPath.toString()));
+  }
+
+  return {};
+}
+
+//------------------------------------------------------------------------------
+Result<> RandomizeFeatureIdsFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+{
+  auto featureIdsPath = args.value<DataPath>(k_FeatureIds_Key);
+
+  Int32Array* featureIdsArray = dataStructure.getDataAs<Int32Array>(featureIdsPath);
+  auto& featureIdsStore = featureIdsArray->getDataStoreRef();
+  usize totalFeatures = *std::max_element(featureIdsStore.begin(), featureIdsStore.end());
+
+  ClusterUtilities::RandomizeFeatureIds(featureIdsStore, totalFeatures);
+
+  return {};
+}
+} // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.cpp
@@ -71,15 +71,14 @@ IFilter::UniquePointer RandomizeFeatureIdsFilter::clone() const
 
 //------------------------------------------------------------------------------
 IFilter::PreflightResult RandomizeFeatureIdsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
-                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto featureIdsPath = filterArgs.value<DataPath>(k_FeatureIds_Key);
-  
+
   const Int32Array* featureIdsArray = dataStructure.getDataAs<Int32Array>(featureIdsPath);
   if(featureIdsArray == nullptr)
   {
-      return MakePreflightErrorResult(
-          -72601, fmt::format("The Feature IDs array was not found at path '{}'", featureIdsPath.toString()));
+    return MakePreflightErrorResult(-72601, fmt::format("The Feature IDs array was not found at path '{}'", featureIdsPath.toString()));
   }
 
   return {};
@@ -87,7 +86,7 @@ IFilter::PreflightResult RandomizeFeatureIdsFilter::preflightImpl(const DataStru
 
 //------------------------------------------------------------------------------
 Result<> RandomizeFeatureIdsFilter::executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
-                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+                                                const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto featureIdsPath = args.value<DataPath>(k_FeatureIds_Key);
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "SimplnxCore/SimplnxCore_export.hpp"
+
+#include "simplnx/Common/StringLiteral.hpp"
+#include "simplnx/Filter/FilterTraits.hpp"
+#include "simplnx/Filter/IFilter.hpp"
+
+namespace nx::core
+{
+class SIMPLNXCORE_EXPORT RandomizeFeatureIdsFilter : public IFilter
+{
+public:
+  RandomizeFeatureIdsFilter() = default;
+  ~RandomizeFeatureIdsFilter() noexcept override = default;
+
+  RandomizeFeatureIdsFilter(const RandomizeFeatureIdsFilter&) = delete;
+  RandomizeFeatureIdsFilter(RandomizeFeatureIdsFilter&&) noexcept = delete;
+
+  RandomizeFeatureIdsFilter& operator=(const RandomizeFeatureIdsFilter&) = delete;
+  RandomizeFeatureIdsFilter& operator=(RandomizeFeatureIdsFilter&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_FeatureIds_Key = "feature_ids";
+
+  /**
+   * @brief Reads SIMPL json and converts it simplnx Arguments.
+   * @param json
+   * @return Result<Arguments>
+   */
+  //static Result<Arguments> FromSIMPLJson(const nlohmann::json& json);
+
+  /**
+   * @brief Returns the filter's name.
+   * @return std::string
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the C++ classname of this filter.
+   * @return std::string
+   */
+  std::string className() const override;
+
+  /**
+   * @brief Returns the filter's UUID.
+   * @return Uuid
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief Returns the filter name as a human-readable string.
+   * @return std::string
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
+   * @brief Returns a collection of parameters required to execute the filter.
+   * @return Parameters
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief Returns parameters version integer.
+   * Initial version should always be 1.
+   * Should be incremented everytime the parameters change.
+   * @return VersionType
+   */
+  VersionType parametersVersion() const override;
+
+  /**
+   * @brief Creates and returns a copy of the filter.
+   * @return UniquePointer
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief
+   * @param data
+   * @param filterArgs
+   * @param messageHandler
+   * @return Result<OutputActions>
+   */
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
+
+  /**
+   * @brief
+   * @param dataStructure
+   * @param args
+   * @param pipelineNode
+   * @param messageHandler
+   * @return Result<>
+   */
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& args, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
+};
+} // namespace nx::core
+
+SIMPLNX_DEF_FILTER_TRAITS(nx::core, RandomizeFeatureIdsFilter, "1766d576-9c03-4152-82b1-e72c4eb43630");

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.hpp
@@ -21,14 +21,7 @@ public:
   RandomizeFeatureIdsFilter& operator=(RandomizeFeatureIdsFilter&&) noexcept = delete;
 
   // Parameter Keys
-  static inline constexpr StringLiteral k_FeatureIds_Key = "feature_ids";
-
-  /**
-   * @brief Reads SIMPL json and converts it simplnx Arguments.
-   * @param json
-   * @return Result<Arguments>
-   */
-  //static Result<Arguments> FromSIMPLJson(const nlohmann::json& json);
+  static inline constexpr StringLiteral k_FeatureIds_Key = "feature_ids_path";
 
   /**
    * @brief Returns the filter's name.

--- a/src/simplnx/Utilities/ClusteringUtilities.cpp
+++ b/src/simplnx/Utilities/ClusteringUtilities.cpp
@@ -1,0 +1,44 @@
+#include "ClusteringUtilities.hpp"
+
+#include "simplnx/Utilities/DataStoreUtilities.hpp"
+
+#include <random>
+
+namespace nx::core::ClusterUtilities
+{
+void RandomizeFeatureIds(Int32AbstractDataStore& featureIdsStore, usize totalFeatures)
+{
+  const usize rangeMin = 1;
+  const usize rangeMax = totalFeatures - 1;
+  auto gen = std::mt19937_64(std::mt19937_64::default_seed);
+  std::uniform_real_distribution<float64> dist(0, 1);
+
+  IDataStore::ShapeType tupleShape{totalFeatures};
+  IDataStore::ShapeType componentShape{1};
+  std::shared_ptr<AbstractDataStore<int32>> randomIdsPtr = nx::core::DataStoreUtilities::CreateDataStore<int32>(tupleShape, componentShape, IDataAction::Mode::Execute);
+  Int32AbstractDataStore& randomIds = *randomIdsPtr.get();
+  std::iota(randomIds.begin(), randomIds.end(), 0);
+
+  //--- Shuffle elements by randomly exchanging each with one other.
+  for(usize i = 1; i < totalFeatures; i++)
+  {
+    auto r = static_cast<usize>(std::floor(dist(gen) * static_cast<float64>(rangeMax))); // Random remaining position.
+    if(r < rangeMin)
+    {
+      continue;
+    }
+
+    int32 randId_i = randomIds[i];
+    randomIds[i] = randomIds[r];
+    randomIds[r] = randId_i;
+  }
+
+  // Now adjust all the Grain ID values for each Voxel
+  // instead of taking total points as an input just extract the size, so we don't walk of
+  usize totalPoints = featureIdsStore.getSize();
+  for(int64 i = 0; i < totalPoints; ++i)
+  {
+    featureIdsStore[i] = randomIds[featureIdsStore[i]];
+  }
+}
+} // namespace nx::core::ClusterUtilities

--- a/src/simplnx/Utilities/ClusteringUtilities.cpp
+++ b/src/simplnx/Utilities/ClusteringUtilities.cpp
@@ -34,7 +34,7 @@ void RandomizeFeatureIds(Int32AbstractDataStore& featureIdsStore, usize totalFea
   }
 
   // Now adjust all the Grain ID values for each Voxel
-  // instead of taking total points as an input just extract the size, so we don't walk of
+  // instead of taking total points as an input just extract the size, so we don't walk off
   usize totalPoints = featureIdsStore.getSize();
   for(int64 i = 0; i < totalPoints; ++i)
   {

--- a/src/simplnx/Utilities/ClusteringUtilities.hpp
+++ b/src/simplnx/Utilities/ClusteringUtilities.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "simplnx/Common/Types.hpp"
+#include "simplnx/DataStructure/AbstractDataStore.hpp"
 #include "simplnx/simplnx_export.hpp"
 
 #include <cmath>
@@ -134,4 +135,11 @@ float64 GetDistance(const leftDataType& leftVector, usize leftOffset, const righ
   // Return the correct primitive type for distance
   return dist;
 }
+
+/**
+ * @brief Randomize the provided Feature IDs.
+ * @param featureIds
+ * @param totalFeatures
+ */
+SIMPLNX_EXPORT void RandomizeFeatureIds(Int32AbstractDataStore& featureIds, usize totalFeatures);
 } // namespace nx::core::ClusterUtilities

--- a/src/simplnx/Utilities/SegmentFeatures.cpp
+++ b/src/simplnx/Utilities/SegmentFeatures.cpp
@@ -1,6 +1,7 @@
 #include "SegmentFeatures.hpp"
 
 #include "simplnx/DataStructure/Geometry/IGridGeometry.hpp"
+#include "simplnx/Utilities/ClusteringUtilities.hpp"
 
 using namespace nx::core;
 
@@ -184,36 +185,5 @@ SegmentFeatures::SeedGenerator SegmentFeatures::initializeStaticVoxelSeedGenerat
 void SegmentFeatures::randomizeFeatureIds(nx::core::Int32Array* featureIds, uint64 totalFeatures) const
 {
   m_MessageHandler(IFilter::Message::Type::Info, "Randomizing Feature Ids");
-  // Generate an even distribution of numbers between the min and max range
-  const usize rangeMin = 1;
-  const usize rangeMax = totalFeatures - 1;
-  auto gen = initializeStaticVoxelSeedGenerator();
-  std::uniform_real_distribution<float64> dist(0, 1);
-
-  std::vector<int32> randomIds(totalFeatures);
-  std::iota(randomIds.begin(), randomIds.end(), 0);
-
-  //--- Shuffle elements by randomly exchanging each with one other.
-  for(usize i = 1; i < totalFeatures; i++)
-  {
-    auto r = static_cast<usize>(std::floor(dist(gen) * static_cast<float64>(rangeMax))); // Random remaining position.
-    if(r < rangeMin)
-    {
-      continue;
-    }
-
-    int32 randId_i = randomIds[i];
-    randomIds[i] = randomIds[r];
-    randomIds[r] = randId_i;
-  }
-
-  // Now adjust all the Grain ID values for each Voxel
-  auto& featureIdsStore = featureIds->getDataStoreRef();
-
-  // instead of taking total points as an input just extract the size, so we don't walk of
-  usize totalPoints = featureIdsStore.getSize();
-  for(int64 i = 0; i < totalPoints; ++i)
-  {
-    featureIdsStore[i] = randomIds[featureIdsStore[i]];
-  }
+  ClusterUtilities::RandomizeFeatureIds(featureIds->getDataStoreRef(), totalFeatures);
 }


### PR DESCRIPTION
* Fix DataStoreUtilities.hpp not included in CmakeLists.txt
* Add RandomizeFeatureIds utility function to nx::core.
* Updated existing randomize feature IDs calls to use the utility function.
* Add RandomizeFeatureIdsFilter to SimplnxCore

fixes #1179