### PR TITLE
ENH: Update ValidateFeatureIdsToFeatureAttributeMatrixIndexing API

### DIFF
--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeAvgOrientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeAvgOrientations.cpp
@@ -37,7 +37,7 @@ Result<> ComputeAvgOrientations::operator()()
 
   const size_t totalPoints = featureIds.getNumberOfTuples();
 
-  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, m_InputValues->avgQuatsArrayPath, featureIds, m_MessageHandler);
+  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, m_InputValues->avgQuatsArrayPath, featureIds, false, m_MessageHandler);
   if(validateNumFeatResult.invalid())
   {
     return validateNumFeatResult;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureReferenceMisorientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureReferenceMisorientations.cpp
@@ -45,7 +45,7 @@ Result<> ComputeFeatureReferenceMisorientations::operator()()
   auto& featureReferenceMisorientations = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->FeatureReferenceMisorientationsArrayName);
   auto& avgReferenceMisorientation = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->FeatureAvgMisorientationsArrayName);
 
-  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, m_InputValues->FeatureAvgMisorientationsArrayName, featureIds, m_MessageHandler);
+  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, m_InputValues->FeatureAvgMisorientationsArrayName, featureIds, false, m_MessageHandler);
   if(validateNumFeatResult.invalid())
   {
     return validateNumFeatResult;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeShapes.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeShapes.cpp
@@ -116,7 +116,7 @@ const std::atomic_bool& ComputeShapes::getCancel()
 Result<> ComputeShapes::operator()()
 {
   const auto& featureIds = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->FeatureIdsArrayPath);
-  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, m_InputValues->FeatureAttributeMatrixPath, featureIds, m_MessageHandler);
+  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, m_InputValues->FeatureAttributeMatrixPath, featureIds, false, m_MessageHandler);
   if(validateNumFeatResult.invalid())
   {
     return validateNumFeatResult;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureCentroids.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureCentroids.cpp
@@ -114,7 +114,7 @@ Result<> ComputeFeatureCentroids::operator()()
   // Output Feature Data
   auto& centroids = m_DataStructure.getDataAs<Float32Array>(m_InputValues->CentroidsArrayPath)->getDataStoreRef();
 
-  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, m_InputValues->CentroidsArrayPath, *featureIdsPtr, m_MessageHandler);
+  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, m_InputValues->CentroidsArrayPath, *featureIdsPtr, false, m_MessageHandler);
   if(validateNumFeatResult.invalid())
   {
     return validateNumFeatResult;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeLargestCrossSections.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeLargestCrossSections.cpp
@@ -35,7 +35,7 @@ Result<> ComputeLargestCrossSections::operator()()
   const usize numFeatures = largestCrossSectStore.getNumberOfTuples();
 
   // Validate the largestCrossSectStore array is the proper size
-  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, m_InputValues->LargestCrossSectionsArrayPath, featureIds, m_MessageHandler);
+  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, m_InputValues->LargestCrossSectionsArrayPath, featureIds, false, m_MessageHandler);
   if(validateNumFeatResult.invalid())
   {
     return validateNumFeatResult;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeSurfaceAreaToVolume.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeSurfaceAreaToVolume.cpp
@@ -43,7 +43,7 @@ Result<> ComputeSurfaceAreaToVolume::operator()()
   // Required Geometry
   const auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->InputImageGeometry);
 
-  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, m_InputValues->NumCellsArrayPath.getParent(), *featureIdsArrayPtr, m_MessageHandler);
+  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, m_InputValues->NumCellsArrayPath.getParent(), *featureIdsArrayPtr, false, m_MessageHandler);
   if(validateNumFeatResult.invalid())
   {
     return validateNumFeatResult;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.cpp
@@ -156,7 +156,7 @@ Result<> ResampleImageGeom::operator()()
   if(m_InputValues->RenumberFeatures)
   {
     const auto& featureIds = m_DataStructure.getDataRefAs<Int32Array>(featureIdsArrayPath);
-    auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, cellFeatureAMPath, featureIds, m_MessageHandler);
+    auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, cellFeatureAMPath, featureIds, false, m_MessageHandler);
     if(validateNumFeatResult.invalid())
     {
       return validateNumFeatResult;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesFilter.cpp
@@ -126,7 +126,7 @@ Result<> ComputeFeaturePhasesFilter::executeImpl(DataStructure& dataStructure, c
   auto& featurePhases = dataStructure.getDataAs<Int32Array>(pFeaturePhasesArrayPathValue)->getDataStoreRef();
 
   // Validate the featurePhases array is the proper size
-  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(dataStructure, pCellFeatureAMPathValue, featureIdsArray, messageHandler);
+  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(dataStructure, pCellFeatureAMPathValue, featureIdsArray, false, messageHandler);
   if(validateNumFeatResult.invalid())
   {
     return validateNumFeatResult;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
@@ -151,7 +151,7 @@ Result<> ComputeFeatureSizesFilter::executeImpl(DataStructure& dataStructure, co
   const auto& featureIdsStoreRef = featureIdsArrayPtr->getDataStoreRef();
   {
     auto featureAttributeMatrixPath = args.value<DataPath>(k_CellFeatureAttributeMatrixPath_Key);
-    auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(dataStructure, featureAttributeMatrixPath, *featureIdsArrayPtr, messageHandler);
+    auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(dataStructure, featureAttributeMatrixPath, *featureIdsArrayPtr, false, messageHandler);
     if(validateNumFeatResult.invalid())
     {
       return validateNumFeatResult;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceFeaturesFilter.cpp
@@ -304,7 +304,7 @@ Result<> ComputeSurfaceFeaturesFilter::executeImpl(DataStructure& dataStructure,
   // Resize the surface features array to the proper size
   const auto& featureIdsArray = dataStructure.getDataRefAs<Int32Array>(pFeatureIdsArrayPathValue);
 
-  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(dataStructure, pFeaturesAttributeMatrixPathValue, featureIdsArray, messageHandler);
+  auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(dataStructure, pFeaturesAttributeMatrixPathValue, featureIdsArray, false, messageHandler);
   if(validateNumFeatResult.invalid())
   {
     return validateNumFeatResult;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CopyFeatureArrayToElementArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CopyFeatureArrayToElementArrayFilter.cpp
@@ -176,7 +176,7 @@ Result<> CopyFeatureArrayToElementArrayFilter::executeImpl(DataStructure& dataSt
     DataPath createdArrayPath = pFeatureIdsArrayPathValue.replaceName(selectedFeatureArrayPath.getTargetName() + createdArraySuffix);
     const auto* selectedFeatureArray = dataStructure.getDataAs<IDataArray>(selectedFeatureArrayPath);
 
-    auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(dataStructure, selectedFeatureArrayPath, featureIds, messageHandler);
+    auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(dataStructure, selectedFeatureArrayPath, featureIds, false, messageHandler);
     if(validateNumFeatResult.invalid())
     {
       return validateNumFeatResult;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropImageGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropImageGeometryFilter.cpp
@@ -670,7 +670,7 @@ Result<> CropImageGeometryFilter::executeImpl(DataStructure& dataStructure, cons
   if(shouldRenumberFeatures)
   {
     const auto& featureIds = dataStructure.getDataRefAs<Int32Array>(featureIdsArrayPath);
-    auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(dataStructure, cellFeatureAMPath, featureIds, messageHandler);
+    auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(dataStructure, cellFeatureAMPath, featureIds, false, messageHandler);
     if(validateNumFeatResult.invalid())
     {
       return validateNumFeatResult;

--- a/src/simplnx/Utilities/DataArrayUtilities.cpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.cpp
@@ -122,7 +122,7 @@ Result<> ResizeAndReplaceDataArray(DataStructure& dataStructure, const DataPath&
 }
 
 //-----------------------------------------------------------------------------
-Result<> ValidateFeatureIdsToFeatureAttributeMatrixIndexing(const DataStructure& dataStructure, const DataPath& sourceDataPath, const Int32Array& featureIds,
+Result<> ValidateFeatureIdsToFeatureAttributeMatrixIndexing(const DataStructure& dataStructure, const DataPath& sourceDataPath, const Int32Array& featureIds, bool ignoreNegativeValues,
                                                             const IFilter::MessageHandler& messageHandler)
 {
   messageHandler(IFilter::ProgressMessage{IFilter::ProgressMessage::Type::Info, fmt::format("Validating range of values within input array '{}'...", featureIds.getName())});
@@ -146,7 +146,7 @@ Result<> ValidateFeatureIdsToFeatureAttributeMatrixIndexing(const DataStructure&
   auto& featureIdsStore = featureIds.getDataStoreRef();
   auto [minFeatureId, maxFeatureId] = std::minmax_element(featureIdsStore.begin(), featureIdsStore.end());
 
-  if(*minFeatureId < 0)
+  if(!ignoreNegativeValues && *minFeatureId < 0)
   {
     return MakeErrorResult(
         -5355, fmt::format("Feature Ids array with name '{}' has negative values within the array. The most negative value encountered was '{}'. All values must be positive within the array",

--- a/src/simplnx/Utilities/DataArrayUtilities.hpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.hpp
@@ -355,14 +355,15 @@ SIMPLNX_EXPORT bool CheckArraysHaveSameTupleCount(const DataStructure& dataStruc
  * @param dataStructure the DataStructure containing the array
  * @param sourceDataPath The DataPath to the AttributeMatrix or DataArray that the featureIds array indexes into
  * @param featureIds the ids for the array
+ * @param ignoreNegativeValues Ignore negative values in the feature Ids array. This should be used carefully.
  * @return void
  */
-SIMPLNX_EXPORT Result<> ValidateFeatureIdsToFeatureAttributeMatrixIndexing(const DataStructure& dataStructure, const DataPath& sourceDataPath, const Int32Array& featureIds,
+SIMPLNX_EXPORT Result<> ValidateFeatureIdsToFeatureAttributeMatrixIndexing(const DataStructure& dataStructure, const DataPath& sourceDataPath, const Int32Array& featureIds, bool ignoreNegativeValues,
                                                                            const IFilter::MessageHandler& messageHandler);
 
 /**
  * @brief This function resize the outermost vector of the NeighborList's underlying data to the NeighborList's set
- * number of tuples and initializes each item in the vector to a (non null) pointer to an empty vector
+ * number of tuples and initializes each item in the vector to a (non-null) pointer to an empty vector
  *
  * @param dataStructure
  * @param neighborListPath The path to the NeighborList to be initialized.

--- a/src/simplnx/Utilities/Meshing/TriangleUtilities.hpp
+++ b/src/simplnx/Utilities/Meshing/TriangleUtilities.hpp
@@ -75,6 +75,7 @@ template <class ContainerT>
 Result<> CalculateFeatureVolumes(const INodeGeometry2D::SharedFaceList::store_type& triangles, const INodeGeometry2D::SharedVertexList::store_type& verts, const Int32AbstractDataStore& idsStore,
                                  ContainerT& volumes, const std::atomic_bool& shouldCancel)
 {
+  usize volumeSize = volumes.size();
   std::array<usize, 3> faceVertexIndices = {0, 0, 0};
   if(idsStore.getNumberOfComponents() == 2)
   {
@@ -93,16 +94,19 @@ Result<> CalculateFeatureVolumes(const INodeGeometry2D::SharedFaceList::store_ty
       int32 faceLabel0 = idsStore[2 * i + 0];
       int32 faceLabel1 = idsStore[2 * i + 1];
 
-      if(faceLabel0 < 0 && faceLabel1 >= 0)
+      bool faceLabel0InRange = faceLabel0 >= 0 && faceLabel0 < static_cast<int64_t>(volumeSize);
+      bool faceLabel1InRange = faceLabel1 >= 0 && faceLabel1 < static_cast<int64_t>(volumeSize);
+
+      if(faceLabel0 < 0 && faceLabel1InRange)
       {
         std::swap(faceVertexIndices[2], faceVertexIndices[1]);
         volumes[faceLabel1] += detail::FindTriangleVolume(faceVertexIndices, verts);
       }
-      else if(faceLabel1 < 0 && faceLabel0 >= 0)
+      else if(faceLabel1 < 0 && faceLabel0InRange)
       {
         volumes[faceLabel0] += detail::FindTriangleVolume(faceVertexIndices, verts);
       }
-      else
+      else if(faceLabel0InRange && faceLabel1InRange)
       {
         volumes[faceLabel0] += detail::FindTriangleVolume(faceVertexIndices, verts);
         std::swap(faceVertexIndices[2], faceVertexIndices[1]);
@@ -124,7 +128,12 @@ Result<> CalculateFeatureVolumes(const INodeGeometry2D::SharedFaceList::store_ty
       faceVertexIndices[1] = triangles[triangleIndex + 2];
       faceVertexIndices[2] = triangles[triangleIndex + 1];
 
-      volumes[idsStore[i]] += detail::FindTriangleVolume(faceVertexIndices, verts);
+      int32 featureId = idsStore[i];
+      if(featureId < 0)
+      {
+        continue;
+      }
+      volumes[featureId] += detail::FindTriangleVolume(faceVertexIndices, verts);
     }
   }
   else


### PR DESCRIPTION
Adds boolean to ignore values that are less than zero. This can be used if the developer is already checking for that condition in the algorithm.
