### PR TITLE
FILTER: Compute Coordinate Threshold

### DIFF
--- a/src/Plugins/SimplnxCore/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/CMakeLists.txt
@@ -26,6 +26,7 @@ set(FilterList
   ComputeBoundaryCellsFilter
   ComputeBoundaryElementFractionsFilter
   ComputeCoordinatesImageGeomFilter
+  ComputeCoordinateThresholdFilter
   ComputeDifferencesMapFilter
   ComputeEuclideanDistMapFilter
   ComputeFeatureBoundsFilter
@@ -174,6 +175,7 @@ set(AlgorithmList
   ComputeBiasedFeatures
   ComputeBoundaryCells
   ComputeCoordinatesImageGeom
+  ComputeCoordinateThreshold
   ComputeEuclideanDistMap
   ComputeFeatureBounds
   ComputeFeatureCentroids

--- a/src/Plugins/SimplnxCore/docs/ComputeCoordinateThresholdFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeCoordinateThresholdFilter.md
@@ -6,13 +6,19 @@ Geometry
 
 ## Description
 
-This filter produces a mask that marks cells that fall inside or outside a given bounding shape within a supplied geometry. The filter outputs a mask to provide the greatest flexibilty, while leveraging exisitng algorithms. This filter doesn't modify the input geometry in any way, if you wish to modify the data within the bounds consider using one of the cleanup filters on the marked values. See _Remove Flagged Vertices/Edges/Triangles_ for an example of a potential followup filter. There are several caveats to be aware of with this filter, detailed thouroghly in the following sections.
+This filter produces a mask that marks cells that fall inside or outside a given bounding shape within a supplied geometry. The filter outputs a mask to provide the greatest flexibility, while leveraging existing algorithms. This filter doesn't modify the input geometry in any way if you wish to modify the data within the bounding box, consider using one of the cleanup filters on the marked values. See _Remove Flagged Vertices/Edges/Triangles_ for an example of a potential followup filter.
+
+This filter has a check at runtime (during the execute phase, before individual mask value determination begins) that will return a warning (not error) if the bounds don't intersect any cells in the geometry. The intention of this is to alert the user that the mask will contain the same value throughout to allow the user to adapt the pipeline/parameters accordingly. When this check causes early bailout and warning, the mask will still be filled with outside bounds flag at every value. `ImageGeom` is the exception to this as it has checks done at preflight to prevent this from occurring.
+
+There are several issues to be aware of with this filter, detailed thoroughly in the following sections.
 
 ### Input Geometry Types
 
-This filter is meant to be as widely applicable as possible, so **cells will only be included in bounding box if all points fall within the bounds**.
+This filter is meant to be as widely applicable as possible, so **cells will only be included in the bounding box if all points fall within the bounds**.
 
-Starting with the simple case, a `VertexGeom`, if a vertex/point (cell-level) falls inside the bounds it will be flagged as within the bounds in the mask. The same is true for `ImageGeom`. For `EdgeGeom`, the edges (cell-level) must have both points fall inside the bounds to be considered inside. For `TriangleGeom`, the faces (cell-level) must have all 3 points fall inside the bounds to be considered inside. For `QuadGeom`, the faces (cell-level) must have all 4 points fall inside the bounds to be considered inside.
+Starting with the simple case, a `VertexGeom`, if a vertex/point (cell-level) falls inside the bounding box, it will be flagged as within the bounds in the mask. For `EdgeGeom`, the edges (cell-level) must have both points fall inside the bounds to be considered inside. For `TriangleGeom`, the faces (cell-level) must have all 3 points fall inside the bounds to be considered inside. For `QuadGeom`, the faces (cell-level) must have all 4 points fall inside the bounds to be considered inside.
+
+`ImageGeom` is a nuanced case. For it to be considered inside, all eight of the vertices making up the cell/voxel must fall within the bounds. This differs from various other places in the code where the centroids of the voxel are used to make determinations.
 
 ### Sphere Bounding Type
 
@@ -22,7 +28,7 @@ The way a point is determined to be in the sphere uses the following calculation
 
 ### Inverting the Mask
 
-This is primarily a convience option provided to the user. If toggled on the values will be true (`1`) by default and values withing the bounds will be marked false (`0`). This doesn't modify anything other than switching what value is set for bounds that fall inside or outside respectively.
+This is primarily a convenience option provided to the user. If toggled on the values will be true (`1`) by default and values withing the bounds will be marked false (`0`). This doesn't modify anything other than switching what value is set for bounds that fall inside or outside respectively.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/ComputeCoordinateThresholdFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeCoordinateThresholdFilter.md
@@ -1,0 +1,37 @@
+# Compute Coordinate Threshold
+
+## Group (Subgroup)
+
+Geometry
+
+## Description
+
+This filter produces a mask that marks cells that fall inside or outside a given bounding shape within a supplied geometry. The filter outputs a mask to provide the greatest flexibilty, while leveraging exisitng algorithms. This filter doesn't modify the input geometry in any way, if you wish to modify the data within the bounds consider using one of the cleanup filters on the marked values. See _Remove Flagged Vertices/Edges/Triangles_ for an example of a potential followup filter. There are several caveats to be aware of with this filter, detailed thouroghly in the following sections.
+
+### Input Geometry Types
+
+This filter is meant to be as widely applicable as possible, so **cells will only be included in bounding box if all points fall within the bounds**.
+
+Starting with the simple case, a `VertexGeom`, if a vertex/point (cell-level) falls inside the bounds it will be flagged as within the bounds in the mask. The same is true for `ImageGeom`. For `EdgeGeom`, the edges (cell-level) must have both points fall inside the bounds to be considered inside. For `TriangleGeom`, the faces (cell-level) must have all 3 points fall inside the bounds to be considered inside. For `QuadGeom`, the faces (cell-level) must have all 4 points fall inside the bounds to be considered inside.
+
+### Sphere Bounding Type
+
+The way a point is determined to be in the sphere uses the following calculation where `p` is the query point, `c` is the centroid of the sphere (provided from the first 3 values in "Sphere Info" parameter), and `r` is the radius of the sphere (provided from the 4th value in "Sphere Info" parameter):
+
+`(p_x - c_x)^2 + (p_y - c_y)^2 + (p_z - c_z)^2 <= r^2`
+
+### Inverting the Mask
+
+This is primarily a convience option provided to the user. If toggled on the values will be true (`1`) by default and values withing the bounds will be marked false (`0`). This doesn't modify anything other than switching what value is set for bounds that fall inside or outside respectively.
+
+% Auto generated parameter table will be inserted here
+
+## Example Pipelines
+
+## License & Copyright
+
+Please see the description file distributed with this **Plugin**
+
+## DREAM3D-NX Help
+
+If you need help, need to file a bug report or want to request a new feature, please head over to the [DREAM3DNX-Issues](https://github.com/BlueQuartzSoftware/DREAM3DNX-Issues/discussions) GitHub site where the community of DREAM3D-NX users can help answer your questions.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeCoordinateThreshold.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeCoordinateThreshold.cpp
@@ -248,20 +248,14 @@ Result<> ComputeCoordinateThreshold::operator()()
   case BoundsType::Sphere: {
     VectorFloat32Parameter::ValueType sphereInfo = m_InputValues->SphereInfo;
     f_IsInBounds = [sphereInfo](float32 x, float32 y, float32 z) -> uint8 {
-      float32 xDiff = std::abs(sphereInfo[0] - std::abs(x));
-      if(xDiff > std::abs(sphereInfo[3]))
-      {
-        return 0;
-      }
+      float32 xDiff = x - sphereInfo[0];
+      float32 yDiff = y - sphereInfo[1];
+      float32 zDiff = z - sphereInfo[2];
 
-      float32 yDiff = std::abs(sphereInfo[1] - std::abs(x));
-      if(yDiff > std::abs(sphereInfo[3]))
-      {
-        return 0;
-      }
+      // Do not switch to pow() inlined is faster for square case for floating point num
+      float32 tDiff = (xDiff * xDiff) + (yDiff * yDiff) + (zDiff * zDiff);
 
-      float32 zDiff = std::abs(sphereInfo[2] - std::abs(x));
-      if(zDiff > std::abs(sphereInfo[3]))
+      if(tDiff > (std::abs(sphereInfo[3]) * std::abs(sphereInfo[3])))
       {
         return 0;
       }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeCoordinateThreshold.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeCoordinateThreshold.cpp
@@ -1,0 +1,279 @@
+#include "ComputeCoordinateThreshold.hpp"
+
+#include "simplnx/Common/Array.hpp"
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/DataStructure/Geometry/EdgeGeom.hpp"
+#include "simplnx/DataStructure/Geometry/IGeometry.hpp"
+#include "simplnx/DataStructure/Geometry/INodeGeometry0D.hpp"
+#include "simplnx/DataStructure/Geometry/INodeGeometry1D.hpp"
+#include "simplnx/DataStructure/Geometry/INodeGeometry2D.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/DataStructure/Geometry/QuadGeom.hpp"
+#include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
+#include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
+#include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
+
+using namespace nx::core;
+
+namespace
+{
+template <typename T>
+concept GeometryType = std::is_base_of_v<IGeometry, T>;
+
+template <GeometryType GeomT>
+class ComputeMaskImpl
+{
+public:
+  ComputeMaskImpl(const GeomT& geom, UInt8AbstractDataStore& mask, bool shouldInvert, const std::function<uint8(float32, float32, float32)>& isInBoundsFunct)
+  : m_Geom(geom)
+  , m_Mask(mask)
+  , m_Invert(shouldInvert)
+  , m_IsInBoundsFunct(isInBoundsFunct)
+  {
+  }
+  ~ComputeMaskImpl() = default;
+
+  // -----------------------------------------------------------------------------
+  void compute(usize start, usize end) const
+  {
+    static_assert(std::is_same_v<ImageGeom, GeomT> || std::is_base_of_v<INodeGeometry0D, GeomT> || std::is_base_of_v<INodeGeometry1D, GeomT> || std::is_base_of_v<INodeGeometry2D, GeomT>);
+
+    uint8 trueValue = (m_Invert) ? 0 : 1;
+    uint8 falseValue = (m_Invert) ? 1 : 0;
+
+    if constexpr(std::is_same_v<ImageGeom, GeomT>)
+    {
+      usize xPoints = m_Geom.getNumXCells();
+      usize yPoints = m_Geom.getNumYCells();
+      FloatVec3 spacing = m_Geom.getSpacing();
+      FloatVec3 origin = m_Geom.getOrigin();
+
+      usize zStride = 0, yStride = 0;
+      for(usize i = start; i < end; i++)
+      {
+        zStride = i * xPoints * yPoints;
+        for(usize j = 0; j < yPoints; j++)
+        {
+          yStride = j * xPoints;
+          for(usize k = 0; k < xPoints; k++)
+          {
+            // We are inlining the calculations here to leverage the speed of primitives (no Point object or vector from the API)
+            float32 xVal = k * spacing[0] + origin[0] + (0.5f * spacing[0]);
+            float32 yVal = j * spacing[1] + origin[1] + (0.5f * spacing[1]);
+            float32 zVal = i * spacing[2] + origin[2] + (0.5f * spacing[2]);
+
+            usize tup = zStride + yStride + k;
+            if(m_IsInBoundsFunct(xVal, yVal, zVal) == 1)
+            {
+              m_Mask.setValue(tup, trueValue);
+            }
+            else
+            {
+              m_Mask.setValue(tup, falseValue);
+            }
+          }
+        }
+      }
+    }
+    if constexpr(std::is_same_v<VertexGeom, GeomT>)
+    {
+      const IGeometry::SharedVertexList::store_type& verts = m_Geom.getVerticesRef().getDataStoreRef();
+      for(usize i = start; i < end; i++)
+      {
+        float32 xVal = verts[(i * 3) + 0];
+        float32 yVal = verts[(i * 3) + 1];
+        float32 zVal = verts[(i * 3) + 2];
+
+        if(m_IsInBoundsFunct(xVal, yVal, zVal) == 1)
+        {
+          m_Mask.setValue(i, trueValue);
+        }
+        else
+        {
+          m_Mask.setValue(i, falseValue);
+        }
+      }
+    }
+    if constexpr(std::is_same_v<EdgeGeom, GeomT>)
+    {
+      const IGeometry::SharedVertexList::store_type& verts = m_Geom.getVerticesRef().getDataStoreRef();
+      const IGeometry::SharedEdgeList::store_type& edges = m_Geom.getEdgesRef().getDataStoreRef();
+      usize numComp = edges.getNumberOfComponents();
+      for(usize i = start; i < end; i++)
+      {
+        uint8 hits = 0;
+        for(usize comp = 0; comp < numComp; comp++)
+        {
+          const IGeometry::SharedFaceList::value_type activeVertIndex = edges.getValue((i * numComp) + comp);
+          float32 xVal = verts.getValue((activeVertIndex * 3) + 0);
+          float32 yVal = verts.getValue((activeVertIndex * 3) + 1);
+          float32 zVal = verts.getValue((activeVertIndex * 3) + 2);
+
+          hits += m_IsInBoundsFunct(xVal, yVal, zVal);
+        }
+        if(hits == numComp)
+        {
+          m_Mask.setValue(i, trueValue);
+        }
+        else
+        {
+          m_Mask.setValue(i, falseValue);
+        }
+      }
+    }
+    if constexpr(std::is_same_v<TriangleGeom, GeomT> || std::is_same_v<QuadGeom, GeomT>)
+    {
+      const IGeometry::SharedVertexList::store_type& verts = m_Geom.getVerticesRef().getDataStoreRef();
+      const IGeometry::SharedFaceList::store_type& faces = m_Geom.getFacesRef().getDataStoreRef();
+      usize numComp = faces.getNumberOfComponents();
+      for(usize i = start; i < end; i++)
+      {
+        uint8 hits = 0;
+        for(usize comp = 0; comp < numComp; comp++)
+        {
+          const IGeometry::SharedFaceList::value_type activeVertIndex = faces.getValue((i * numComp) + comp);
+          float32 xVal = verts.getValue((activeVertIndex * 3) + 0);
+          float32 yVal = verts.getValue((activeVertIndex * 3) + 1);
+          float32 zVal = verts.getValue((activeVertIndex * 3) + 2);
+
+          hits += m_IsInBoundsFunct(xVal, yVal, zVal);
+        }
+        if(hits == numComp)
+        {
+          m_Mask.setValue(i, trueValue);
+        }
+        else
+        {
+          m_Mask.setValue(i, falseValue);
+        }
+      }
+    }
+  }
+
+  // -----------------------------------------------------------------------------
+  void operator()(const Range& range) const
+  {
+    compute(range.min(), range.max());
+  }
+
+private:
+  const GeomT& m_Geom;
+  UInt8AbstractDataStore& m_Mask;
+  bool m_Invert;
+  const std::function<uint8(float32, float32, float32)>& m_IsInBoundsFunct;
+};
+
+Result<> ExecuteComputeMask(const IGeometry& geom, UInt8AbstractDataStore& mask, bool shouldInvert, const std::function<uint8(float32, float32, float32)>& isInBoundsFunct)
+{
+  ParallelDataAlgorithm dataAlg;
+  switch(geom.getGeomType())
+  {
+  case IGeometry::Type::Image: {
+    const auto& image = dynamic_cast<const ImageGeom&>(geom);
+    dataAlg.setRange(0, image.getNumZCells());
+    dataAlg.execute(ComputeMaskImpl<ImageGeom>(image, mask, shouldInvert, isInBoundsFunct));
+    break;
+  }
+  case IGeometry::Type::Triangle: {
+    dataAlg.setRange(0, geom.getNumberOfCells());
+    dataAlg.execute(ComputeMaskImpl<TriangleGeom>(dynamic_cast<const TriangleGeom&>(geom), mask, shouldInvert, isInBoundsFunct));
+    break;
+  }
+  case IGeometry::Type::Vertex: {
+    dataAlg.setRange(0, geom.getNumberOfCells());
+    dataAlg.execute(ComputeMaskImpl<VertexGeom>(dynamic_cast<const VertexGeom&>(geom), mask, shouldInvert, isInBoundsFunct));
+    break;
+  }
+  case IGeometry::Type::Edge: {
+    dataAlg.setRange(0, geom.getNumberOfCells());
+    dataAlg.execute(ComputeMaskImpl<EdgeGeom>(dynamic_cast<const EdgeGeom&>(geom), mask, shouldInvert, isInBoundsFunct));
+    break;
+  }
+  case IGeometry::Type::Quad: {
+    dataAlg.setRange(0, geom.getNumberOfCells());
+    dataAlg.execute(ComputeMaskImpl<QuadGeom>(dynamic_cast<const QuadGeom&>(geom), mask, shouldInvert, isInBoundsFunct));
+    break;
+  }
+  default: {
+    return MakeErrorResult(-89472, fmt::format("Input geometry must be of type(s) [ Image, Triangle, Vertex, Edge, Quad ]. Supplied geometry name {}", geom.getName()));
+  }
+  }
+  return {};
+}
+} // namespace
+
+// -----------------------------------------------------------------------------
+ComputeCoordinateThreshold::ComputeCoordinateThreshold(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel,
+                                                       ComputeCoordinateThresholdInputValues* inputValues)
+: m_DataStructure(dataStructure)
+, m_InputValues(inputValues)
+, m_ShouldCancel(shouldCancel)
+, m_MessageHandler(mesgHandler)
+{
+}
+
+// -----------------------------------------------------------------------------
+ComputeCoordinateThreshold::~ComputeCoordinateThreshold() noexcept = default;
+
+// -----------------------------------------------------------------------------
+Result<> ComputeCoordinateThreshold::operator()()
+{
+  std::function<uint8(float32, float32, float32)> f_IsInBounds;
+  switch(static_cast<BoundsType>(m_InputValues->ShapeType))
+  {
+  case BoundsType::Rectangle: {
+    VectorFloat32Parameter::ValueType minPoint = m_InputValues->MinCoord;
+    VectorFloat32Parameter::ValueType maxPoint = m_InputValues->MaxCoord;
+    f_IsInBounds = [minPoint, maxPoint](float32 x, float32 y, float32 z) -> uint8 {
+      if(minPoint[0] > x || maxPoint[0] < x)
+      {
+        return 0;
+      }
+
+      if(minPoint[1] > y || maxPoint[1] < y)
+      {
+        return 0;
+      }
+
+      if(minPoint[2] > z || maxPoint[2] < z)
+      {
+        return 0;
+      }
+
+      return 1;
+    };
+  }
+  case BoundsType::Sphere: {
+    VectorFloat32Parameter::ValueType sphereInfo = m_InputValues->SphereInfo;
+    f_IsInBounds = [sphereInfo](float32 x, float32 y, float32 z) -> uint8 {
+      float32 xDiff = std::abs(sphereInfo[0] - std::abs(x));
+      if(xDiff > std::abs(sphereInfo[3]))
+      {
+        return 0;
+      }
+
+      float32 yDiff = std::abs(sphereInfo[1] - std::abs(x));
+      if(yDiff > std::abs(sphereInfo[3]))
+      {
+        return 0;
+      }
+
+      float32 zDiff = std::abs(sphereInfo[2] - std::abs(x));
+      if(zDiff > std::abs(sphereInfo[3]))
+      {
+        return 0;
+      }
+
+      return 1;
+    };
+  }
+  }
+
+  const auto& geom = m_DataStructure.getDataRefAs<IGeometry>(m_InputValues->GeometryPath);
+  auto& mask = m_DataStructure.getDataRefAs<UInt8Array>(m_InputValues->MaskArrayPath).getDataStoreRef();
+
+  ExecuteComputeMask(geom, mask, m_InputValues->Invert, f_IsInBounds);
+
+  return {};
+}

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeCoordinateThreshold.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeCoordinateThreshold.cpp
@@ -1,7 +1,6 @@
 #include "ComputeCoordinateThreshold.hpp"
 
 #include "simplnx/Common/Array.hpp"
-#include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/EdgeGeom.hpp"
 #include "simplnx/DataStructure/Geometry/IGeometry.hpp"
@@ -12,6 +11,7 @@
 #include "simplnx/DataStructure/Geometry/QuadGeom.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
+#include "simplnx/Utilities/IntersectionUtilities.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -59,12 +59,27 @@ public:
           for(usize k = 0; k < xPoints; k++)
           {
             // We are inlining the calculations here to leverage the speed of primitives (no Point object or vector from the API)
-            float32 xVal = k * spacing[0] + origin[0] + (0.5f * spacing[0]);
-            float32 yVal = j * spacing[1] + origin[1] + (0.5f * spacing[1]);
-            float32 zVal = i * spacing[2] + origin[2] + (0.5f * spacing[2]);
+            float32 minXVal = k * spacing[0] + origin[0];
+            float32 minYVal = j * spacing[1] + origin[1];
+            float32 minZVal = i * spacing[2] + origin[2];
+
+            float32 maxXVal = k * spacing[0] + origin[0] + spacing[0];
+            float32 maxYVal = j * spacing[1] + origin[1] + spacing[1];
+            float32 maxZVal = i * spacing[2] + origin[2] + spacing[2];
+
+            // Check every vertex for spherical and other potential thresholds
+            uint8 inBoundsVertexCount = 0;
+            inBoundsVertexCount += m_IsInBoundsFunct(minXVal, minYVal, minZVal);
+            inBoundsVertexCount += m_IsInBoundsFunct(maxXVal, minYVal, minZVal);
+            inBoundsVertexCount += m_IsInBoundsFunct(minXVal, maxYVal, minZVal);
+            inBoundsVertexCount += m_IsInBoundsFunct(minXVal, minYVal, maxZVal);
+            inBoundsVertexCount += m_IsInBoundsFunct(maxXVal, maxYVal, maxZVal);
+            inBoundsVertexCount += m_IsInBoundsFunct(minXVal, maxYVal, maxZVal);
+            inBoundsVertexCount += m_IsInBoundsFunct(maxXVal, minYVal, maxZVal);
+            inBoundsVertexCount += m_IsInBoundsFunct(maxXVal, maxYVal, minZVal);
 
             usize tup = zStride + yStride + k;
-            if(m_IsInBoundsFunct(xVal, yVal, zVal) == 1)
+            if(inBoundsVertexCount == 8)
             {
               m_Mask.setValue(tup, trueValue);
             }
@@ -167,6 +182,7 @@ private:
 Result<> ExecuteComputeMask(const IGeometry& geom, UInt8AbstractDataStore& mask, bool shouldInvert, const std::function<uint8(float32, float32, float32)>& isInBoundsFunct)
 {
   ParallelDataAlgorithm dataAlg;
+  dataAlg.setParallelizationEnabled(false);
   switch(geom.getGeomType())
   {
   case IGeometry::Type::Image: {
@@ -200,6 +216,46 @@ Result<> ExecuteComputeMask(const IGeometry& geom, UInt8AbstractDataStore& mask,
   }
   }
   return {};
+}
+
+bool PrecheckRuntimeGeom(const IGeometry& geom, const ComputeCoordinateThresholdInputValues* inputValues)
+{
+  if(geom.getGeomType() == IGeometry::Type::Image)
+  {
+    return true;
+  }
+
+  const auto& iNodeGeom = dynamic_cast<const INodeGeometry0D&>(geom);
+
+  BoundingBox3Df bounds = iNodeGeom.getBoundingBox();
+  std::array<float32, 3> minPoint = bounds.getMinPoint().toArray();
+  std::array<float32, 3> maxPoint = bounds.getMaxPoint().toArray();
+
+  switch(static_cast<ComputeCoordinateThreshold::BoundsType>(inputValues->ShapeType))
+  {
+  case ComputeCoordinateThreshold::BoundsType::Rectangle: {
+    VectorFloat32Parameter::ValueType minBound = inputValues->MinCoord;
+    VectorFloat32Parameter::ValueType maxBound = inputValues->MaxCoord;
+
+    if(maxPoint[0] < minBound[0] || maxPoint[1] < minBound[1] || maxPoint[2] < minBound[2])
+    {
+      return false;
+    }
+
+    if(minPoint[0] > maxBound[0] || minPoint[1] > maxBound[1] || minPoint[2] > maxBound[2])
+    {
+      return false;
+    }
+
+    return true;
+  }
+  case ComputeCoordinateThreshold::BoundsType::Sphere: {
+    VectorFloat32Parameter::ValueType sphereInfo = inputValues->SphereInfo;
+    return IntersectionUtilities::SphereIntersectsRectangularPrism({sphereInfo[0], sphereInfo[1], sphereInfo[2]}, sphereInfo[3], minPoint, maxPoint);
+  }
+  }
+
+  return true;
 }
 } // namespace
 
@@ -255,7 +311,7 @@ Result<> ComputeCoordinateThreshold::operator()()
       // Do not switch to pow() inlined is faster for square case for floating point num
       float32 tDiff = (xDiff * xDiff) + (yDiff * yDiff) + (zDiff * zDiff);
 
-      if(tDiff > (std::abs(sphereInfo[3]) * std::abs(sphereInfo[3])))
+      if(tDiff > (sphereInfo[3] * sphereInfo[3]))
       {
         return 0;
       }
@@ -267,6 +323,20 @@ Result<> ComputeCoordinateThreshold::operator()()
 
   const auto& geom = m_DataStructure.getDataRefAs<IGeometry>(m_InputValues->GeometryPath);
   auto& mask = m_DataStructure.getDataRefAs<UInt8Array>(m_InputValues->MaskArrayPath).getDataStoreRef();
+
+  if(!PrecheckRuntimeGeom(geom, m_InputValues))
+  {
+    if(m_InputValues->Invert)
+    {
+      mask.fill(1);
+    }
+    else
+    {
+      mask.fill(0);
+    }
+
+    return MakeWarningVoidResult(-24715, "The input geometry did not contain any points within the supplied coordinate bounds, all values in the mask are the same.");
+  }
 
   ExecuteComputeMask(geom, mask, m_InputValues->Invert, f_IsInBounds);
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeCoordinateThreshold.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeCoordinateThreshold.cpp
@@ -243,6 +243,7 @@ Result<> ComputeCoordinateThreshold::operator()()
 
       return 1;
     };
+    break;
   }
   case BoundsType::Sphere: {
     VectorFloat32Parameter::ValueType sphereInfo = m_InputValues->SphereInfo;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeCoordinateThreshold.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeCoordinateThreshold.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "SimplnxCore/SimplnxCore_export.hpp"
+
+#include "simplnx/DataStructure/DataPath.hpp"
+#include "simplnx/DataStructure/DataStructure.hpp"
+#include "simplnx/Filter/IFilter.hpp"
+#include "simplnx/Parameters/ChoicesParameter.hpp"
+#include "simplnx/Parameters/VectorParameter.hpp"
+
+namespace nx::core
+{
+struct SIMPLNXCORE_EXPORT ComputeCoordinateThresholdInputValues
+{
+  ChoicesParameter::ValueType ShapeType;
+  bool Invert;
+  VectorFloat32Parameter::ValueType MinCoord;
+  VectorFloat32Parameter::ValueType MaxCoord;
+  VectorFloat32Parameter::ValueType SphereInfo;
+  DataPath GeometryPath;
+  DataPath MaskArrayPath;
+};
+
+/**
+ * @class
+ */
+class SIMPLNXCORE_EXPORT ComputeCoordinateThreshold
+{
+public:
+  ComputeCoordinateThreshold(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ComputeCoordinateThresholdInputValues* inputValues);
+  ~ComputeCoordinateThreshold() noexcept;
+
+  ComputeCoordinateThreshold(const ComputeCoordinateThreshold&) = delete;
+  ComputeCoordinateThreshold(ComputeCoordinateThreshold&&) noexcept = delete;
+  ComputeCoordinateThreshold& operator=(const ComputeCoordinateThreshold&) = delete;
+  ComputeCoordinateThreshold& operator=(ComputeCoordinateThreshold&&) noexcept = delete;
+
+  enum BoundsType : uint8
+  {
+    Rectangle = 0,
+    Sphere = 1
+  };
+
+  Result<> operator()();
+
+private:
+  DataStructure& m_DataStructure;
+  const ComputeCoordinateThresholdInputValues* m_InputValues = nullptr;
+  const std::atomic_bool& m_ShouldCancel;
+  const IFilter::MessageHandler& m_MessageHandler;
+};
+} // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeCoordinateThresholdFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeCoordinateThresholdFilter.cpp
@@ -4,12 +4,8 @@
 
 #include "simplnx/Common/TypeTraits.hpp"
 #include "simplnx/DataStructure/DataPath.hpp"
-#include "simplnx/DataStructure/Geometry/EdgeGeom.hpp"
 #include "simplnx/DataStructure/Geometry/IGeometry.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
-#include "simplnx/DataStructure/Geometry/QuadGeom.hpp"
-#include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
-#include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/DataStructure/IDataArray.hpp"
 #include "simplnx/Filter/Actions/CreateArrayAction.hpp"
 #include "simplnx/Parameters/ArrayCreationParameter.hpp"
@@ -17,6 +13,7 @@
 #include "simplnx/Parameters/ChoicesParameter.hpp"
 #include "simplnx/Parameters/GeometrySelectionParameter.hpp"
 #include "simplnx/Parameters/VectorParameter.hpp"
+#include "simplnx/Utilities/IntersectionUtilities.hpp"
 
 using namespace nx::core;
 
@@ -112,6 +109,72 @@ IFilter::PreflightResult ComputeCoordinateThresholdFilter::preflightImpl(const D
   const auto& geom = dataStructure.getDataRefAs<IGeometry>(pSelectedGeomPathValue);
 
   usize numCells = geom.getNumberOfCells();
+
+  switch(static_cast<ComputeCoordinateThreshold::BoundsType>(pContainerShapeTypeValue))
+  {
+  case ComputeCoordinateThreshold::Rectangle: {
+    auto pMinPoint = filterArgs.value<VectorFloat32Parameter::ValueType>(k_MinCoord_Key);
+    auto pMaxPoint = filterArgs.value<VectorFloat32Parameter::ValueType>(k_MaxCoord_Key);
+
+    if(pMaxPoint[0] < pMinPoint[0] || pMaxPoint[1] < pMinPoint[1] || pMaxPoint[2] < pMinPoint[2])
+    {
+      return MakePreflightErrorResult(-24710,
+                                      fmt::format("The maximum coordinate has one or more values less than those in the minimum coordinate.\nMin Coord(XYZ): {}, {}, {}\nMax Coord(XYZ): {}, {}, {}",
+                                                  pMinPoint[0], pMinPoint[1], pMinPoint[2], pMaxPoint[0], pMaxPoint[1], pMaxPoint[2]));
+    }
+
+    if(geom.getGeomType() == IGeometry::Type::Image)
+    {
+      const auto& imageGeom = dynamic_cast<const ImageGeom&>(geom);
+
+      BoundingBox3Df bounds = imageGeom.getBoundingBoxf();
+      const Point3Df& minBound = bounds.getMinPoint();
+      const Point3Df& maxBound = bounds.getMaxPoint();
+
+      if(pMaxPoint[0] < minBound[0] || pMaxPoint[1] < minBound[1] || pMaxPoint[2] < minBound[2])
+      {
+        return MakePreflightErrorResult(-24711, fmt::format("The supplied bounding box falls outside the geometries minimum point, filter will do nothing. Minimum Point in Geometry(XYZ): {}, {}, {}",
+                                                            minBound[0], minBound[1], minBound[2]));
+      }
+
+      if(pMinPoint[0] > maxBound[0] || pMinPoint[1] > maxBound[1] || pMinPoint[2] > maxBound[2])
+      {
+        return MakePreflightErrorResult(-24712, fmt::format("The supplied bounding box falls outside the geometries maximum point, filter will do nothing. Maximum Point in Geometry(XYZ): {}, {}, {}",
+                                                            maxBound[0], maxBound[1], maxBound[2]));
+      }
+    }
+
+    break;
+  }
+  case ComputeCoordinateThreshold::Sphere: {
+    auto pSphereInfo = filterArgs.value<VectorFloat32Parameter::ValueType>(k_SphereInfo_Key);
+
+    if(pSphereInfo[3] <= 0)
+    {
+      return MakePreflightErrorResult(-24713, fmt::format("The spheres radius must be greater than 0. Supplied radius: {}", pSphereInfo[3]));
+    }
+
+    if(geom.getGeomType() == IGeometry::Type::Image)
+    {
+      const auto& imageGeom = dynamic_cast<const ImageGeom&>(geom);
+
+      BoundingBox3Df bounds = imageGeom.getBoundingBoxf();
+      const Point3Df& minBound = bounds.getMinPoint();
+      const Point3Df& maxBound = bounds.getMaxPoint();
+
+      bool doesIntersect = IntersectionUtilities::SphereIntersectsRectangularPrism({pSphereInfo[0], pSphereInfo[1], pSphereInfo[2]}, pSphereInfo[3], minBound.toArray(), maxBound.toArray());
+
+      if(!doesIntersect)
+      {
+        return MakePreflightErrorResult(
+            -24714,
+            fmt::format("The supplied sphere falls outside the geometries bounds, filter will do nothing.\nMinimum Point in Geometry(XYZ): {}, {}, {}\nMaximum Point in Geometry(XYZ): {}, {}, {}",
+                        minBound[0], minBound[1], minBound[2], maxBound[0], maxBound[1], maxBound[2]));
+      }
+    }
+    break;
+  }
+  }
 
   nx::core::Result<OutputActions> resultOutputActions;
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeCoordinateThresholdFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeCoordinateThresholdFilter.cpp
@@ -1,0 +1,144 @@
+#include "ComputeCoordinateThresholdFilter.hpp"
+
+#include "SimplnxCore/Filters/Algorithms/ComputeCoordinateThreshold.hpp"
+
+#include "simplnx/Common/TypeTraits.hpp"
+#include "simplnx/DataStructure/DataPath.hpp"
+#include "simplnx/DataStructure/Geometry/EdgeGeom.hpp"
+#include "simplnx/DataStructure/Geometry/IGeometry.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/DataStructure/Geometry/QuadGeom.hpp"
+#include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
+#include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
+#include "simplnx/DataStructure/IDataArray.hpp"
+#include "simplnx/Filter/Actions/CreateArrayAction.hpp"
+#include "simplnx/Parameters/ArrayCreationParameter.hpp"
+#include "simplnx/Parameters/BoolParameter.hpp"
+#include "simplnx/Parameters/ChoicesParameter.hpp"
+#include "simplnx/Parameters/GeometrySelectionParameter.hpp"
+#include "simplnx/Parameters/VectorParameter.hpp"
+
+using namespace nx::core;
+
+namespace nx::core
+{
+//------------------------------------------------------------------------------
+std::string ComputeCoordinateThresholdFilter::name() const
+{
+  return FilterTraits<ComputeCoordinateThresholdFilter>::name.str();
+}
+
+//------------------------------------------------------------------------------
+std::string ComputeCoordinateThresholdFilter::className() const
+{
+  return FilterTraits<ComputeCoordinateThresholdFilter>::className;
+}
+
+//------------------------------------------------------------------------------
+Uuid ComputeCoordinateThresholdFilter::uuid() const
+{
+  return FilterTraits<ComputeCoordinateThresholdFilter>::uuid;
+}
+
+//------------------------------------------------------------------------------
+std::string ComputeCoordinateThresholdFilter::humanName() const
+{
+  return "Compute Coordinate Threshold";
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> ComputeCoordinateThresholdFilter::defaultTags() const
+{
+  return {className(), "Mask", "Statistics"};
+}
+
+//------------------------------------------------------------------------------
+Parameters ComputeCoordinateThresholdFilter::parameters() const
+{
+  Parameters params;
+
+  params.insertSeparator(Parameters::Separator{"Input Parameter(s)"});
+  params.insertLinkableParameter(
+      std::make_unique<ChoicesParameter>(k_ContainerShapeType_Key, "Coordinate Container Shape", "This will determine how the bounding box for determining included points is defined",
+                                         to_underlying(ComputeCoordinateThreshold::BoundsType::Rectangle), ChoicesParameter::Choices{"Rectangle", "Sphere"})); // sequence dependent DO NOT REORDER
+  params.insert(std::make_unique<BoolParameter>(k_InvertContainer_Key, "Invert Bounding Container",
+                                                "If selected, only points/edges/faces outside the container will be marked `true`, else only values in the container will be marked `true`", false));
+
+  params.insertSeparator(Parameters::Separator{"Coordinate Bounds"});
+  params.insert(std::make_unique<VectorFloat32Parameter>(k_MinCoord_Key, "Lower Bound (Physical Units)", "Specifies the lower corner of the rectangular prism (bounding box)",
+                                                         std::vector<float32>{0.0f, 0.0f, 0.0f}, std::vector<std::string>{"Min X", "Min Y", "Min Z"}));
+  params.insert(std::make_unique<VectorFloat32Parameter>(k_MaxCoord_Key, "Upper Bound (Physical Units)", "Specifies the upper corner of the rectangular prism (bounding box)",
+                                                         std::vector<float32>{1.0f, 1.0f, 1.0f}, std::vector<std::string>{"Max X", "Max Y", "Max Z"}));
+  params.insert(std::make_unique<VectorFloat32Parameter>(k_SphereInfo_Key, "Sphere centroid and Radius (Physical Units)",
+                                                         "Specifies the centroid of the bounding sphere in the first 3 values (XYZ) and radius in the 4th",
+                                                         std::vector<float32>{0.0f, 0.0f, 0.0f, 1.0f}, std::vector<std::string>{"X", "Y", "Z", "Radius"}));
+
+  params.insertSeparator(Parameters::Separator{"Input Data"});
+  params.insert(std::make_unique<GeometrySelectionParameter>(
+      k_SelectedGeometryPath_Key, "Selected Geometry", "The DataPath to the Geometry that contains the points/edges/faces for the geometry", DataPath{},
+      GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Vertex, IGeometry::Type::Edge, IGeometry::Type::Image, IGeometry::Type::Triangle, IGeometry::Type::Quad}));
+
+  params.insertSeparator(Parameters::Separator{"Output Cell Data"});
+  params.insert(std::make_unique<ArrayCreationParameter>(k_CreatedMaskPath_Key, "Created Mask Path/Name", "The path/name of the created mask", DataPath({"Geometric Coordinate Mask"})));
+
+  // Associate the Linkable Parameter(s) to the children parameters that they control
+  params.linkParameters(k_ContainerShapeType_Key, k_MinCoord_Key, static_cast<ChoicesParameter::ValueType>(to_underlying(ComputeCoordinateThreshold::BoundsType::Rectangle)));
+  params.linkParameters(k_ContainerShapeType_Key, k_MaxCoord_Key, static_cast<ChoicesParameter::ValueType>(to_underlying(ComputeCoordinateThreshold::BoundsType::Rectangle)));
+  params.linkParameters(k_ContainerShapeType_Key, k_SphereInfo_Key, static_cast<ChoicesParameter::ValueType>(to_underlying(ComputeCoordinateThreshold::BoundsType::Sphere)));
+
+  return params;
+}
+
+//------------------------------------------------------------------------------
+IFilter::VersionType ComputeCoordinateThresholdFilter::parametersVersion() const
+{
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+IFilter::UniquePointer ComputeCoordinateThresholdFilter::clone() const
+{
+  return std::make_unique<ComputeCoordinateThresholdFilter>();
+}
+
+//------------------------------------------------------------------------------
+IFilter::PreflightResult ComputeCoordinateThresholdFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
+                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+{
+  auto pContainerShapeTypeValue = filterArgs.value<ChoicesParameter::ValueType>(k_ContainerShapeType_Key);
+  auto pSelectedGeomPathValue = filterArgs.value<GeometrySelectionParameter::ValueType>(k_SelectedGeometryPath_Key);
+  auto pCreatedMaskPathValue = filterArgs.value<ArrayCreationParameter::ValueType>(k_CreatedMaskPath_Key);
+
+  const auto& geom = dataStructure.getDataRefAs<IGeometry>(pSelectedGeomPathValue);
+
+  usize numCells = geom.getNumberOfCells();
+
+  nx::core::Result<OutputActions> resultOutputActions;
+  {
+    auto createAction = std::make_unique<CreateArrayAction>(DataType::uint8, std::vector<usize>{numCells}, std::vector<usize>{1}, pCreatedMaskPathValue);
+    resultOutputActions.value().appendAction(std::move(createAction));
+  }
+
+  // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
+  return {std::move(resultOutputActions)};
+}
+
+//------------------------------------------------------------------------------
+Result<> ComputeCoordinateThresholdFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+{
+  ComputeCoordinateThresholdInputValues inputValues;
+
+  inputValues.ShapeType = filterArgs.value<ChoicesParameter::ValueType>(k_ContainerShapeType_Key);
+  inputValues.Invert = filterArgs.value<bool>(k_InvertContainer_Key);
+
+  inputValues.MinCoord = filterArgs.value<VectorFloat32Parameter::ValueType>(k_MinCoord_Key);
+  inputValues.MaxCoord = filterArgs.value<VectorFloat32Parameter::ValueType>(k_MaxCoord_Key);
+  inputValues.SphereInfo = filterArgs.value<VectorFloat32Parameter::ValueType>(k_SphereInfo_Key);
+
+  inputValues.GeometryPath = filterArgs.value<GeometrySelectionParameter::ValueType>(k_SelectedGeometryPath_Key);
+  inputValues.MaskArrayPath = filterArgs.value<ArrayCreationParameter::ValueType>(k_CreatedMaskPath_Key);
+
+  return ComputeCoordinateThreshold(dataStructure, messageHandler, shouldCancel, &inputValues)();
+}
+} // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeCoordinateThresholdFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeCoordinateThresholdFilter.hpp
@@ -1,0 +1,123 @@
+#pragma once
+
+#include "SimplnxCore/SimplnxCore_export.hpp"
+
+#include "simplnx/Filter/FilterTraits.hpp"
+#include "simplnx/Filter/IFilter.hpp"
+
+namespace nx::core
+{
+/**
+ * @class ComputeCoordinateThresholdFilter
+ * @brief This filter will ....
+ */
+class SIMPLNXCORE_EXPORT ComputeCoordinateThresholdFilter : public IFilter
+{
+public:
+  ComputeCoordinateThresholdFilter() = default;
+  ~ComputeCoordinateThresholdFilter() noexcept override = default;
+
+  ComputeCoordinateThresholdFilter(const ComputeCoordinateThresholdFilter&) = delete;
+  ComputeCoordinateThresholdFilter(ComputeCoordinateThresholdFilter&&) noexcept = delete;
+
+  ComputeCoordinateThresholdFilter& operator=(const ComputeCoordinateThresholdFilter&) = delete;
+  ComputeCoordinateThresholdFilter& operator=(ComputeCoordinateThresholdFilter&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_ContainerShapeType_Key = "container_shape_type_index";
+  static inline constexpr StringLiteral k_InvertContainer_Key = "invert_container";
+  static inline constexpr StringLiteral k_MinCoord_Key = "min_coord";
+  static inline constexpr StringLiteral k_MaxCoord_Key = "max_coord";
+  static inline constexpr StringLiteral k_SphereInfo_Key = "sphere_info";
+  static inline constexpr StringLiteral k_SelectedGeometryPath_Key = "selected_geometry_path";
+  static inline constexpr StringLiteral k_CreatedMaskPath_Key = "created_mask_path";
+
+  /**
+   * @brief Reads SIMPL json and converts it simplnx Arguments.
+   * @param json
+   * @return Result<Arguments>
+   */
+  static Result<Arguments> FromSIMPLJson(const nlohmann::json& json);
+
+  /**
+   * @brief Returns the name of the filter.
+   * @return
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the C++ classname of this filter.
+   * @return
+   */
+  std::string className() const override;
+
+  /**
+   * @brief Returns the uuid of the filter.
+   * @return
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief Returns the human-readable name of the filter.
+   * @return
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
+   * @brief Returns the parameters of the filter (i.e. its inputs)
+   * @return
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief Returns parameters version integer.
+   * Initial version should always be 1.
+   * Should be incremented everytime the parameters change.
+   * @return VersionType
+   */
+  VersionType parametersVersion() const override;
+
+  /**
+   * @brief Returns a copy of the filter.
+   * @return
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @param executionContext The ExecutionContext that can be used to determine the correct absolute path from a relative path
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
+
+  /**
+   * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
+   * On failure, there is no guarantee that the DataStructure is in a correct state.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @param executionContext The ExecutionContext that can be used to determine the correct absolute path from a relative path
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
+};
+} // namespace nx::core
+
+SIMPLNX_DEF_FILTER_TRAITS(nx::core, ComputeCoordinateThresholdFilter, "04986173-dcfa-4d27-85ed-85af8b947a69");

--- a/src/Plugins/SimplnxCore/test/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/test/CMakeLists.txt
@@ -26,6 +26,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   ComputeBoundaryCellsTest.cpp
   ComputeBoundaryElementFractionsTest.cpp
   ComputeCoordinatesImageGeomTest.cpp
+  ComputeCoordinateThresholdTest.cpp
   ComputeDifferencesMapTest.cpp
   ComputeEuclideanDistMapTest.cpp
   ComputeFeatureBoundsTest.cpp

--- a/src/Plugins/SimplnxCore/test/ComputeCoordinateThresholdTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeCoordinateThresholdTest.cpp
@@ -85,19 +85,53 @@ TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Image Geom Test - Rect
   imageGeom->setDimensions(dimsIn);
   imageGeom->setOrigin({0, 0, 0});
   imageGeom->setSpacing({1, 1, 1});
-  std::vector<size_t> dims(3, 0);
-  dims[0] = 1;
-  dims[1] = 5;
-  dims[2] = 5;
+
+#if 0
+      0, 0, 0, 0, 0,
+      0, 1, 1, 1, 0,
+      0, 1, 1, 1, 0,
+      0, 1, 1, 1, 0,
+      0, 0, 0, 0, 0;
+#endif
 
   VectorFloat32Parameter::ValueType minCoord = {1.0f, 1.0f, 0.0f};
-  VectorFloat32Parameter::ValueType maxCoord = {4.0f, 4.0f, 0.0f};
+  VectorFloat32Parameter::ValueType maxCoord = {4.0f, 4.0f, 1.0f};
 
   SECTION("Baseline")
   {
     RectangleExecuteFilter(dataStructure, false, minCoord, maxCoord);
 
     const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 0);
+    REQUIRE(mask[1] == 0);
+    REQUIRE(mask[2] == 0);
+    REQUIRE(mask[3] == 0);
+    REQUIRE(mask[4] == 0);
+
+    REQUIRE(mask[5] == 0);
+    REQUIRE(mask[6] == 1);
+    REQUIRE(mask[7] == 1);
+    REQUIRE(mask[8] == 1);
+    REQUIRE(mask[9] == 0);
+
+    REQUIRE(mask[10] == 0);
+    REQUIRE(mask[11] == 1);
+    REQUIRE(mask[12] == 1);
+    REQUIRE(mask[13] == 1);
+    REQUIRE(mask[14] == 0);
+
+    REQUIRE(mask[15] == 0);
+    REQUIRE(mask[16] == 1);
+    REQUIRE(mask[17] == 1);
+    REQUIRE(mask[18] == 1);
+    REQUIRE(mask[19] == 0);
+
+    REQUIRE(mask[20] == 0);
+    REQUIRE(mask[21] == 0);
+    REQUIRE(mask[22] == 0);
+    REQUIRE(mask[23] == 0);
+    REQUIRE(mask[24] == 0);
   }
 
   SECTION("Inverted")
@@ -105,6 +139,36 @@ TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Image Geom Test - Rect
     RectangleExecuteFilter(dataStructure, true, minCoord, maxCoord);
 
     const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 1);
+    REQUIRE(mask[1] == 1);
+    REQUIRE(mask[2] == 1);
+    REQUIRE(mask[3] == 1);
+    REQUIRE(mask[4] == 1);
+
+    REQUIRE(mask[5] == 1);
+    REQUIRE(mask[6] == 0);
+    REQUIRE(mask[7] == 0);
+    REQUIRE(mask[8] == 0);
+    REQUIRE(mask[9] == 1);
+
+    REQUIRE(mask[10] == 1);
+    REQUIRE(mask[11] == 0);
+    REQUIRE(mask[12] == 0);
+    REQUIRE(mask[13] == 0);
+    REQUIRE(mask[14] == 1);
+
+    REQUIRE(mask[15] == 1);
+    REQUIRE(mask[16] == 0);
+    REQUIRE(mask[17] == 0);
+    REQUIRE(mask[18] == 0);
+    REQUIRE(mask[19] == 1);
+
+    REQUIRE(mask[20] == 1);
+    REQUIRE(mask[21] == 1);
+    REQUIRE(mask[22] == 1);
+    REQUIRE(mask[23] == 1);
+    REQUIRE(mask[24] == 1);
   }
 }
 
@@ -117,18 +181,52 @@ TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Image Geom Test - Sphe
   imageGeom->setDimensions(dimsIn);
   imageGeom->setOrigin({0, 0, 0});
   imageGeom->setSpacing({1, 1, 1});
-  std::vector<size_t> dims(3, 0);
-  dims[0] = 1;
-  dims[1] = 5;
-  dims[2] = 5;
 
-  VectorFloat32Parameter::ValueType sphereInfo = {0.0f, 0.0f, 0.0f, 0.0f};
+#if 0
+      0, 0, 0, 0, 0,
+      0, 0, 1, 0, 0,
+      0, 1, 1, 1, 0,
+      0, 0, 1, 0, 0,
+      0, 0, 0, 0, 0;
+#endif
+
+  VectorFloat32Parameter::ValueType sphereInfo = {2.5f, 2.5f, 0.5f, 1.0f};
 
   SECTION("Baseline")
   {
     SphereExecuteFilter(dataStructure, false, sphereInfo);
 
     const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 0);
+    REQUIRE(mask[1] == 0);
+    REQUIRE(mask[2] == 0);
+    REQUIRE(mask[3] == 0);
+    REQUIRE(mask[4] == 0);
+
+    REQUIRE(mask[5] == 0);
+    REQUIRE(mask[6] == 0);
+    REQUIRE(mask[7] == 1);
+    REQUIRE(mask[8] == 0);
+    REQUIRE(mask[9] == 0);
+
+    REQUIRE(mask[10] == 0);
+    REQUIRE(mask[11] == 1);
+    REQUIRE(mask[12] == 1);
+    REQUIRE(mask[13] == 1);
+    REQUIRE(mask[14] == 0);
+
+    REQUIRE(mask[15] == 0);
+    REQUIRE(mask[16] == 0);
+    REQUIRE(mask[17] == 1);
+    REQUIRE(mask[18] == 0);
+    REQUIRE(mask[19] == 0);
+
+    REQUIRE(mask[20] == 0);
+    REQUIRE(mask[21] == 0);
+    REQUIRE(mask[22] == 0);
+    REQUIRE(mask[23] == 0);
+    REQUIRE(mask[24] == 0);
   }
 
   SECTION("Inverted")
@@ -136,6 +234,36 @@ TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Image Geom Test - Sphe
     SphereExecuteFilter(dataStructure, true, sphereInfo);
 
     const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 1);
+    REQUIRE(mask[1] == 1);
+    REQUIRE(mask[2] == 1);
+    REQUIRE(mask[3] == 1);
+    REQUIRE(mask[4] == 1);
+
+    REQUIRE(mask[5] == 1);
+    REQUIRE(mask[6] == 1);
+    REQUIRE(mask[7] == 0);
+    REQUIRE(mask[8] == 1);
+    REQUIRE(mask[9] == 1);
+
+    REQUIRE(mask[10] == 1);
+    REQUIRE(mask[11] == 0);
+    REQUIRE(mask[12] == 0);
+    REQUIRE(mask[13] == 0);
+    REQUIRE(mask[14] == 1);
+
+    REQUIRE(mask[15] == 1);
+    REQUIRE(mask[16] == 1);
+    REQUIRE(mask[17] == 0);
+    REQUIRE(mask[18] == 1);
+    REQUIRE(mask[19] == 1);
+
+    REQUIRE(mask[20] == 1);
+    REQUIRE(mask[21] == 1);
+    REQUIRE(mask[22] == 1);
+    REQUIRE(mask[23] == 1);
+    REQUIRE(mask[24] == 1);
   }
 }
 
@@ -207,7 +335,7 @@ TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Vertex Geom Test - Sph
     vertices[i * 3 + 2] = i;
   }
 
-  VectorFloat32Parameter::ValueType sphereInfo = {2.5f, 2.5f, 2.5f, 1.5f};
+  VectorFloat32Parameter::ValueType sphereInfo = {2.5f, 2.5f, 2.5f, 2.6f};
 
   SECTION("Baseline")
   {
@@ -424,7 +552,7 @@ TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Triangle Geom Test - S
     vertices[(i * 3) + 2] = i;
   }
 
-  VectorFloat32Parameter::ValueType sphereInfo = {1.5f, 1.5f, 1.5f, 2.0f};
+  VectorFloat32Parameter::ValueType sphereInfo = {1.0f, 1.0f, 1.0f, 1.75f};
 
   SECTION("Baseline")
   {
@@ -513,7 +641,7 @@ TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Quad Geom Test - Spher
     vertices[(i * 3) + 2] = i;
   }
 
-  VectorFloat32Parameter::ValueType sphereInfo = {5.0f, 5.0f, 5.0f, 2.0f};
+  VectorFloat32Parameter::ValueType sphereInfo = {5.5f, 5.5f, 5.5f, 2.6f};
 
   SECTION("Baseline")
   {

--- a/src/Plugins/SimplnxCore/test/ComputeCoordinateThresholdTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeCoordinateThresholdTest.cpp
@@ -1,0 +1,537 @@
+#include <catch2/catch.hpp>
+
+#include "SimplnxCore/Filters/Algorithms/ComputeCoordinateThreshold.hpp"
+#include "SimplnxCore/Filters/ComputeCoordinateThresholdFilter.hpp"
+
+#include "simplnx/DataStructure/Geometry/EdgeGeom.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/DataStructure/Geometry/QuadGeom.hpp"
+#include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
+#include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
+#include "simplnx/Parameters/ChoicesParameter.hpp"
+#include "simplnx/Parameters/VectorParameter.hpp"
+#include "simplnx/UnitTest/UnitTestCommon.hpp"
+
+#include "SimplnxCore/SimplnxCore_test_dirs.hpp"
+
+using namespace nx::core;
+
+namespace
+{
+constexpr uint64 k_TupleCount = 8;
+
+constexpr StringLiteral k_GeomName = "TestGeom";
+const DataPath k_GeomPath({k_GeomName});
+
+constexpr StringLiteral k_MaskName = "mask_array";
+const DataPath k_MaskPath({k_MaskName});
+
+void SphereExecuteFilter(DataStructure& dataStructure, bool shouldInvert, const VectorFloat32Parameter::ValueType& sphereInfo)
+{
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  ComputeCoordinateThresholdFilter filter;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_ContainerShapeType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(ComputeCoordinateThreshold::BoundsType::Sphere)));
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_SelectedGeometryPath_Key, std::make_any<DataPath>(k_GeomPath));
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_InvertContainer_Key, std::make_any<bool>(shouldInvert));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_SphereInfo_Key, std::make_any<VectorFloat32Parameter::ValueType>(sphereInfo));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_CreatedMaskPath_Key, std::make_any<DataPath>(k_MaskPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+}
+
+void RectangleExecuteFilter(DataStructure& dataStructure, bool shouldInvert, const VectorFloat32Parameter::ValueType& minPoint, const VectorFloat32Parameter::ValueType& maxPoint)
+{
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  ComputeCoordinateThresholdFilter filter;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_ContainerShapeType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(ComputeCoordinateThreshold::BoundsType::Rectangle)));
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_SelectedGeometryPath_Key, std::make_any<DataPath>(k_GeomPath));
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_InvertContainer_Key, std::make_any<bool>(shouldInvert));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_MinCoord_Key, std::make_any<VectorFloat32Parameter::ValueType>(minPoint));
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_MaxCoord_Key, std::make_any<VectorFloat32Parameter::ValueType>(maxPoint));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_CreatedMaskPath_Key, std::make_any<DataPath>(k_MaskPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+}
+} // namespace
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Image Geom Test - Rectangle", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  ImageGeom* imageGeom = ImageGeom::Create(dataStructure, k_GeomName);
+  constexpr size_t dimsIn[3] = {5, 5, 1};
+  imageGeom->setDimensions(dimsIn);
+  imageGeom->setOrigin({0, 0, 0});
+  imageGeom->setSpacing({1, 1, 1});
+  std::vector<size_t> dims(3, 0);
+  dims[0] = 1;
+  dims[1] = 5;
+  dims[2] = 5;
+
+  VectorFloat32Parameter::ValueType minCoord = {1.0f, 1.0f, 0.0f};
+  VectorFloat32Parameter::ValueType maxCoord = {4.0f, 4.0f, 0.0f};
+
+  SECTION("Baseline")
+  {
+    RectangleExecuteFilter(dataStructure, false, minCoord, maxCoord);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+  }
+
+  SECTION("Inverted")
+  {
+    RectangleExecuteFilter(dataStructure, true, minCoord, maxCoord);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+  }
+}
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Image Geom Test - Sphere", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  ImageGeom* imageGeom = ImageGeom::Create(dataStructure, k_GeomName);
+  constexpr size_t dimsIn[3] = {5, 5, 1};
+  imageGeom->setDimensions(dimsIn);
+  imageGeom->setOrigin({0, 0, 0});
+  imageGeom->setSpacing({1, 1, 1});
+  std::vector<size_t> dims(3, 0);
+  dims[0] = 1;
+  dims[1] = 5;
+  dims[2] = 5;
+
+  VectorFloat32Parameter::ValueType sphereInfo = {0.0f, 0.0f, 0.0f, 0.0f};
+
+  SECTION("Baseline")
+  {
+    SphereExecuteFilter(dataStructure, false, sphereInfo);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+  }
+
+  SECTION("Inverted")
+  {
+    SphereExecuteFilter(dataStructure, true, sphereInfo);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+  }
+}
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Vertex Geom Test - Rectangle", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  auto* vertexGeom = VertexGeom::Create(dataStructure, k_GeomName);
+  auto* vertexArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "Vertices", {k_TupleCount}, {3}, vertexGeom->getId());
+  vertexGeom->setVertices(*vertexArray);
+
+  auto& vertices = vertexArray->getDataStoreRef();
+  for(usize i = 0; i < k_TupleCount; ++i)
+  {
+    vertices[i * 3 + 0] = i;
+    vertices[i * 3 + 1] = i;
+    vertices[i * 3 + 2] = i;
+  }
+
+  VectorFloat32Parameter::ValueType minCoord = {3.0f, 3.0f, 3.0f};
+  VectorFloat32Parameter::ValueType maxCoord = {5.0f, 5.0f, 5.0f};
+
+  SECTION("Baseline")
+  {
+    RectangleExecuteFilter(dataStructure, false, minCoord, maxCoord);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 0);
+    REQUIRE(mask[1] == 0);
+    REQUIRE(mask[2] == 0);
+    REQUIRE(mask[3] == 1);
+    REQUIRE(mask[4] == 1);
+    REQUIRE(mask[5] == 1);
+    REQUIRE(mask[6] == 0);
+    REQUIRE(mask[7] == 0);
+  }
+
+  SECTION("Inverted")
+  {
+    RectangleExecuteFilter(dataStructure, true, minCoord, maxCoord);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 1);
+    REQUIRE(mask[1] == 1);
+    REQUIRE(mask[2] == 1);
+    REQUIRE(mask[3] == 0);
+    REQUIRE(mask[4] == 0);
+    REQUIRE(mask[5] == 0);
+    REQUIRE(mask[6] == 1);
+    REQUIRE(mask[7] == 1);
+  }
+}
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Vertex Geom Test - Sphere", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  auto* vertexGeom = VertexGeom::Create(dataStructure, k_GeomName);
+  auto* vertexArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "Vertices", {k_TupleCount}, {3}, vertexGeom->getId());
+  vertexGeom->setVertices(*vertexArray);
+
+  auto& vertices = vertexArray->getDataStoreRef();
+  for(usize i = 0; i < k_TupleCount; ++i)
+  {
+    vertices[i * 3 + 0] = i;
+    vertices[i * 3 + 1] = i;
+    vertices[i * 3 + 2] = i;
+  }
+
+  VectorFloat32Parameter::ValueType sphereInfo = {2.5f, 2.5f, 2.5f, 1.5f};
+
+  SECTION("Baseline")
+  {
+    SphereExecuteFilter(dataStructure, false, sphereInfo);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+    REQUIRE(mask[0] == 0);
+    REQUIRE(mask[1] == 1);
+    REQUIRE(mask[2] == 1);
+    REQUIRE(mask[3] == 1);
+    REQUIRE(mask[4] == 1);
+    REQUIRE(mask[5] == 0);
+    REQUIRE(mask[6] == 0);
+    REQUIRE(mask[7] == 0);
+  }
+
+  SECTION("Inverted")
+  {
+    SphereExecuteFilter(dataStructure, true, sphereInfo);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 1);
+    REQUIRE(mask[1] == 0);
+    REQUIRE(mask[2] == 0);
+    REQUIRE(mask[3] == 0);
+    REQUIRE(mask[4] == 0);
+    REQUIRE(mask[5] == 1);
+    REQUIRE(mask[6] == 1);
+    REQUIRE(mask[7] == 1);
+  }
+}
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Edge Geom Test - Rectangle", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  auto* geom = EdgeGeom::Create(dataStructure, k_GeomName);
+  auto* vertexArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "Vertices", {k_TupleCount}, {3}, geom->getId());
+  geom->setVertices(*vertexArray);
+
+  auto* edgesArray = IGeometry::MeshIndexArrayType::CreateWithStore<DataStore<IGeometry::MeshIndexType>>(dataStructure, "edges", {k_TupleCount}, {2}, geom->getId());
+  geom->setEdgeList(*edgesArray);
+
+  auto& vertices = vertexArray->getDataStoreRef();
+  auto& edges = edgesArray->getDataStoreRef();
+  for(usize i = 0; i < k_TupleCount; ++i)
+  {
+    edges[(i * 2) + 0] = i;
+    edges[(i * 2) + 1] = i + 1;
+    vertices[(i * 3) + 0] = i;
+    vertices[(i * 3) + 1] = i;
+    vertices[(i * 3) + 2] = i;
+  }
+  edges[((k_TupleCount - 1) * 2) + 1] = 0;
+
+  VectorFloat32Parameter::ValueType minCoord = {3.0f, 3.0f, 3.0f};
+  VectorFloat32Parameter::ValueType maxCoord = {5.0f, 5.0f, 5.0f};
+
+  SECTION("Baseline")
+  {
+    RectangleExecuteFilter(dataStructure, false, minCoord, maxCoord);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 0);
+    REQUIRE(mask[1] == 0);
+    REQUIRE(mask[2] == 0);
+    REQUIRE(mask[3] == 1);
+    REQUIRE(mask[4] == 1);
+    REQUIRE(mask[5] == 0);
+    REQUIRE(mask[6] == 0);
+    REQUIRE(mask[7] == 0);
+  }
+
+  SECTION("Inverted")
+  {
+    RectangleExecuteFilter(dataStructure, true, minCoord, maxCoord);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 1);
+    REQUIRE(mask[1] == 1);
+    REQUIRE(mask[2] == 1);
+    REQUIRE(mask[3] == 0);
+    REQUIRE(mask[4] == 0);
+    REQUIRE(mask[5] == 1);
+    REQUIRE(mask[6] == 1);
+    REQUIRE(mask[7] == 1);
+  }
+}
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Edge Geom Test - Sphere", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  auto* geom = EdgeGeom::Create(dataStructure, k_GeomName);
+  auto* vertexArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "Vertices", {k_TupleCount}, {3}, geom->getId());
+  geom->setVertices(*vertexArray);
+
+  auto* edgesArray = IGeometry::MeshIndexArrayType::CreateWithStore<DataStore<IGeometry::MeshIndexType>>(dataStructure, "edges", {k_TupleCount}, {2}, geom->getId());
+  geom->setEdgeList(*edgesArray);
+
+  auto& vertices = vertexArray->getDataStoreRef();
+  auto& edges = edgesArray->getDataStoreRef();
+  for(usize i = 0; i < k_TupleCount; ++i)
+  {
+    edges[(i * 2) + 0] = i;
+    edges[(i * 2) + 1] = i + 1;
+    vertices[(i * 3) + 0] = i;
+    vertices[(i * 3) + 1] = i;
+    vertices[(i * 3) + 2] = i;
+  }
+  edges[((k_TupleCount - 1) * 2) + 1] = 0;
+
+  VectorFloat32Parameter::ValueType sphereInfo = {2.5f, 2.5f, 2.5f, 1.0f};
+
+  SECTION("Baseline")
+  {
+    SphereExecuteFilter(dataStructure, false, sphereInfo);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 0);
+    REQUIRE(mask[1] == 0);
+    REQUIRE(mask[2] == 1);
+    REQUIRE(mask[3] == 0);
+    REQUIRE(mask[4] == 0);
+    REQUIRE(mask[5] == 0);
+    REQUIRE(mask[6] == 0);
+    REQUIRE(mask[7] == 0);
+  }
+
+  SECTION("Inverted")
+  {
+    SphereExecuteFilter(dataStructure, true, sphereInfo);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 1);
+    REQUIRE(mask[1] == 1);
+    REQUIRE(mask[2] == 0);
+    REQUIRE(mask[3] == 1);
+    REQUIRE(mask[4] == 1);
+    REQUIRE(mask[5] == 1);
+    REQUIRE(mask[6] == 1);
+    REQUIRE(mask[7] == 1);
+  }
+}
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Triangle Geom Test - Rectangle", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  auto* geom = TriangleGeom::Create(dataStructure, k_GeomName);
+  auto* vertexArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "Vertices", {6}, {3}, geom->getId());
+  geom->setVertices(*vertexArray);
+
+  auto* facesArray = IGeometry::MeshIndexArrayType::CreateWithStore<DataStore<IGeometry::MeshIndexType>>(dataStructure, "faces", {2}, {3}, geom->getId());
+  geom->setFaceList(*facesArray);
+
+  auto& vertices = vertexArray->getDataStoreRef();
+  auto& faces = facesArray->getDataStoreRef();
+  for(usize i = 0; i < 6; ++i)
+  {
+    faces[i] = i;
+    vertices[(i * 3) + 0] = i;
+    vertices[(i * 3) + 1] = i;
+    vertices[(i * 3) + 2] = i;
+  }
+
+  VectorFloat32Parameter::ValueType minCoord = {-1.0f, -1.0f, -1.0f};
+  VectorFloat32Parameter::ValueType maxCoord = {3.5f, 3.5f, 3.5f};
+
+  SECTION("Baseline")
+  {
+    RectangleExecuteFilter(dataStructure, false, minCoord, maxCoord);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 1);
+    REQUIRE(mask[1] == 0);
+  }
+
+  SECTION("Inverted")
+  {
+    RectangleExecuteFilter(dataStructure, true, minCoord, maxCoord);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 0);
+    REQUIRE(mask[1] == 1);
+  }
+}
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Triangle Geom Test - Sphere", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  auto* geom = TriangleGeom::Create(dataStructure, k_GeomName);
+  auto* vertexArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "Vertices", {6}, {3}, geom->getId());
+  geom->setVertices(*vertexArray);
+
+  auto* facesArray = IGeometry::MeshIndexArrayType::CreateWithStore<DataStore<IGeometry::MeshIndexType>>(dataStructure, "faces", {2}, {3}, geom->getId());
+  geom->setFaceList(*facesArray);
+
+  auto& vertices = vertexArray->getDataStoreRef();
+  auto& faces = facesArray->getDataStoreRef();
+  for(usize i = 0; i < 6; ++i)
+  {
+    faces[i] = i;
+    vertices[(i * 3) + 0] = i;
+    vertices[(i * 3) + 1] = i;
+    vertices[(i * 3) + 2] = i;
+  }
+
+  VectorFloat32Parameter::ValueType sphereInfo = {1.5f, 1.5f, 1.5f, 2.0f};
+
+  SECTION("Baseline")
+  {
+    SphereExecuteFilter(dataStructure, false, sphereInfo);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 1);
+    REQUIRE(mask[1] == 0);
+  }
+
+  SECTION("Inverted")
+  {
+    SphereExecuteFilter(dataStructure, true, sphereInfo);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 0);
+    REQUIRE(mask[1] == 1);
+  }
+}
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Quad Geom Test - Rectangle", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  auto* geom = QuadGeom::Create(dataStructure, k_GeomName);
+  auto* vertexArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "Vertices", {k_TupleCount}, {3}, geom->getId());
+  geom->setVertices(*vertexArray);
+
+  auto* facesArray = IGeometry::MeshIndexArrayType::CreateWithStore<DataStore<IGeometry::MeshIndexType>>(dataStructure, "faces", {2}, {4}, geom->getId());
+  geom->setFaceList(*facesArray);
+
+  auto& vertices = vertexArray->getDataStoreRef();
+  auto& faces = facesArray->getDataStoreRef();
+  for(usize i = 0; i < k_TupleCount; ++i)
+  {
+    faces[i] = i;
+    vertices[(i * 3) + 0] = i;
+    vertices[(i * 3) + 1] = i;
+    vertices[(i * 3) + 2] = i;
+  }
+
+  VectorFloat32Parameter::ValueType minCoord = {0.0f, 0.0f, 0.0f};
+  VectorFloat32Parameter::ValueType maxCoord = {3.0f, 3.0f, 3.0f};
+
+  SECTION("Baseline")
+  {
+    RectangleExecuteFilter(dataStructure, false, minCoord, maxCoord);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 1);
+    REQUIRE(mask[1] == 0);
+  }
+
+  SECTION("Inverted")
+  {
+    RectangleExecuteFilter(dataStructure, true, minCoord, maxCoord);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 0);
+    REQUIRE(mask[1] == 1);
+  }
+}
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Quad Geom Test - Sphere", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  auto* geom = QuadGeom::Create(dataStructure, k_GeomName);
+  auto* vertexArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "Vertices", {k_TupleCount}, {3}, geom->getId());
+  geom->setVertices(*vertexArray);
+
+  auto* facesArray = IGeometry::MeshIndexArrayType::CreateWithStore<DataStore<IGeometry::MeshIndexType>>(dataStructure, "faces", {2}, {4}, geom->getId());
+  geom->setFaceList(*facesArray);
+
+  auto& vertices = vertexArray->getDataStoreRef();
+  auto& faces = facesArray->getDataStoreRef();
+  for(usize i = 0; i < k_TupleCount; ++i)
+  {
+    faces[i] = i;
+    vertices[(i * 3) + 0] = i;
+    vertices[(i * 3) + 1] = i;
+    vertices[(i * 3) + 2] = i;
+  }
+
+  VectorFloat32Parameter::ValueType sphereInfo = {5.0f, 5.0f, 5.0f, 2.0f};
+
+  SECTION("Baseline")
+  {
+    SphereExecuteFilter(dataStructure, false, sphereInfo);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 0);
+    REQUIRE(mask[1] == 1);
+  }
+
+  SECTION("Inverted")
+  {
+    SphereExecuteFilter(dataStructure, true, sphereInfo);
+
+    const auto& mask = dataStructure.getDataRefAs<UInt8Array>(k_MaskPath);
+
+    REQUIRE(mask[0] == 1);
+    REQUIRE(mask[1] == 0);
+  }
+}

--- a/src/Plugins/SimplnxCore/test/ComputeCoordinateThresholdTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeCoordinateThresholdTest.cpp
@@ -76,6 +76,270 @@ void RectangleExecuteFilter(DataStructure& dataStructure, bool shouldInvert, con
 }
 } // namespace
 
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Rectangle Preflight Error - Triangle Geom", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  auto* geom = TriangleGeom::Create(dataStructure, k_GeomName);
+  auto* vertexArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "Vertices", {6}, {3}, geom->getId());
+  geom->setVertices(*vertexArray);
+
+  auto* facesArray = IGeometry::MeshIndexArrayType::CreateWithStore<DataStore<IGeometry::MeshIndexType>>(dataStructure, "faces", {2}, {3}, geom->getId());
+  geom->setFaceList(*facesArray);
+
+  auto& vertices = vertexArray->getDataStoreRef();
+  auto& faces = facesArray->getDataStoreRef();
+  for(usize i = 0; i < 6; ++i)
+  {
+    faces[i] = i;
+    vertices[(i * 3) + 0] = i;
+    vertices[(i * 3) + 1] = i;
+    vertices[(i * 3) + 2] = i;
+  }
+
+  VectorFloat32Parameter::ValueType minCoord = {3.5f, 3.5f, 3.5f};
+  VectorFloat32Parameter::ValueType maxCoord = {-1.0f, -1.0f, -1.0f};
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  ComputeCoordinateThresholdFilter filter;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_ContainerShapeType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(ComputeCoordinateThreshold::BoundsType::Rectangle)));
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_SelectedGeometryPath_Key, std::make_any<DataPath>(k_GeomPath));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_MinCoord_Key, std::make_any<VectorFloat32Parameter::ValueType>(minCoord));
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_MaxCoord_Key, std::make_any<VectorFloat32Parameter::ValueType>(maxCoord));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_CreatedMaskPath_Key, std::make_any<DataPath>(k_MaskPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+}
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Sphere Preflight Error - Triangle Geom", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  auto* geom = TriangleGeom::Create(dataStructure, k_GeomName);
+  auto* vertexArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "Vertices", {6}, {3}, geom->getId());
+  geom->setVertices(*vertexArray);
+
+  auto* facesArray = IGeometry::MeshIndexArrayType::CreateWithStore<DataStore<IGeometry::MeshIndexType>>(dataStructure, "faces", {2}, {3}, geom->getId());
+  geom->setFaceList(*facesArray);
+
+  auto& vertices = vertexArray->getDataStoreRef();
+  auto& faces = facesArray->getDataStoreRef();
+  for(usize i = 0; i < 6; ++i)
+  {
+    faces[i] = i;
+    vertices[(i * 3) + 0] = i;
+    vertices[(i * 3) + 1] = i;
+    vertices[(i * 3) + 2] = i;
+  }
+
+  VectorFloat32Parameter::ValueType sphereInfo = {1.0f, 1.0f, 1.0f, -1.75f};
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  ComputeCoordinateThresholdFilter filter;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_ContainerShapeType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(ComputeCoordinateThreshold::BoundsType::Sphere)));
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_SelectedGeometryPath_Key, std::make_any<DataPath>(k_GeomPath));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_SphereInfo_Key, std::make_any<VectorFloat32Parameter::ValueType>(sphereInfo));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_CreatedMaskPath_Key, std::make_any<DataPath>(k_MaskPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+}
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Rectangle Preflight Bounds Error - Image Geom", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  ImageGeom* imageGeom = ImageGeom::Create(dataStructure, k_GeomName);
+  constexpr size_t dimsIn[3] = {5, 5, 1};
+  imageGeom->setDimensions(dimsIn);
+  imageGeom->setOrigin({0, 0, 0});
+  imageGeom->setSpacing({1, 1, 1});
+
+#if 0
+      0, 0, 0, 0, 0,
+      0, 1, 1, 1, 0,
+      0, 1, 1, 1, 0,
+      0, 1, 1, 1, 0,
+      0, 0, 0, 0, 0;
+#endif
+
+  VectorFloat32Parameter::ValueType minCoord = {5.5f, 5.5f, 1.5f};
+  VectorFloat32Parameter::ValueType maxCoord = {6.5f, 6.5f, 1.5f};
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  ComputeCoordinateThresholdFilter filter;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_ContainerShapeType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(ComputeCoordinateThreshold::BoundsType::Rectangle)));
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_SelectedGeometryPath_Key, std::make_any<DataPath>(k_GeomPath));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_MinCoord_Key, std::make_any<VectorFloat32Parameter::ValueType>(minCoord));
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_MaxCoord_Key, std::make_any<VectorFloat32Parameter::ValueType>(maxCoord));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_CreatedMaskPath_Key, std::make_any<DataPath>(k_MaskPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+}
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Sphere Preflight Bounds Error - Image Geom", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  ImageGeom* imageGeom = ImageGeom::Create(dataStructure, k_GeomName);
+  constexpr size_t dimsIn[3] = {5, 5, 1};
+  imageGeom->setDimensions(dimsIn);
+  imageGeom->setOrigin({0, 0, 0});
+  imageGeom->setSpacing({1, 1, 1});
+
+#if 0
+      0, 0, 0, 0, 0,
+      0, 0, 1, 0, 0,
+      0, 1, 1, 1, 0,
+      0, 0, 1, 0, 0,
+      0, 0, 0, 0, 0;
+#endif
+
+  VectorFloat32Parameter::ValueType sphereInfo = {5.5f, 5.5f, 1.5f, 0.5f};
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  ComputeCoordinateThresholdFilter filter;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_ContainerShapeType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(ComputeCoordinateThreshold::BoundsType::Sphere)));
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_SelectedGeometryPath_Key, std::make_any<DataPath>(k_GeomPath));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_SphereInfo_Key, std::make_any<VectorFloat32Parameter::ValueType>(sphereInfo));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_CreatedMaskPath_Key, std::make_any<DataPath>(k_MaskPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+}
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Rectangle Runtime Warning - Triangle Geom", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  auto* geom = TriangleGeom::Create(dataStructure, k_GeomName);
+  auto* vertexArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "Vertices", {6}, {3}, geom->getId());
+  geom->setVertices(*vertexArray);
+
+  auto* facesArray = IGeometry::MeshIndexArrayType::CreateWithStore<DataStore<IGeometry::MeshIndexType>>(dataStructure, "faces", {2}, {3}, geom->getId());
+  geom->setFaceList(*facesArray);
+
+  auto& vertices = vertexArray->getDataStoreRef();
+  auto& faces = facesArray->getDataStoreRef();
+  for(usize i = 0; i < 6; ++i)
+  {
+    faces[i] = i;
+    vertices[(i * 3) + 0] = i;
+    vertices[(i * 3) + 1] = i;
+    vertices[(i * 3) + 2] = i;
+  }
+
+  VectorFloat32Parameter::ValueType minCoord;
+  VectorFloat32Parameter::ValueType maxCoord;
+
+  SECTION("Positive Case")
+  {
+    minCoord = {6.0f, 6.0f, 6.0f};
+    maxCoord = {9.0f, 9.0f, 9.0f};
+  }
+
+  SECTION("Negative Case")
+  {
+    minCoord = {-2.0f, -2.0f, -2.0f};
+    maxCoord = {-1.0f, -1.0f, -1.0f};
+  }
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  ComputeCoordinateThresholdFilter filter;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_ContainerShapeType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(ComputeCoordinateThreshold::BoundsType::Rectangle)));
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_SelectedGeometryPath_Key, std::make_any<DataPath>(k_GeomPath));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_MinCoord_Key, std::make_any<VectorFloat32Parameter::ValueType>(minCoord));
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_MaxCoord_Key, std::make_any<VectorFloat32Parameter::ValueType>(maxCoord));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_CreatedMaskPath_Key, std::make_any<DataPath>(k_MaskPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+  REQUIRE(!executeResult.result.warnings().empty());
+}
+
+TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Sphere Runtime Warning - Triangle Geom", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
+{
+  DataStructure dataStructure;
+
+  auto* geom = TriangleGeom::Create(dataStructure, k_GeomName);
+  auto* vertexArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "Vertices", {6}, {3}, geom->getId());
+  geom->setVertices(*vertexArray);
+
+  auto* facesArray = IGeometry::MeshIndexArrayType::CreateWithStore<DataStore<IGeometry::MeshIndexType>>(dataStructure, "faces", {2}, {3}, geom->getId());
+  geom->setFaceList(*facesArray);
+
+  auto& vertices = vertexArray->getDataStoreRef();
+  auto& faces = facesArray->getDataStoreRef();
+  for(usize i = 0; i < 6; ++i)
+  {
+    faces[i] = i;
+    vertices[(i * 3) + 0] = i;
+    vertices[(i * 3) + 1] = i;
+    vertices[(i * 3) + 2] = i;
+  }
+
+  VectorFloat32Parameter::ValueType sphereInfo = {6.0f, 6.0f, 6.0f, 0.75f};
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  ComputeCoordinateThresholdFilter filter;
+  Arguments args;
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_ContainerShapeType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(ComputeCoordinateThreshold::BoundsType::Sphere)));
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_SelectedGeometryPath_Key, std::make_any<DataPath>(k_GeomPath));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_SphereInfo_Key, std::make_any<VectorFloat32Parameter::ValueType>(sphereInfo));
+
+  args.insertOrAssign(ComputeCoordinateThresholdFilter::k_CreatedMaskPath_Key, std::make_any<DataPath>(k_MaskPath));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+  REQUIRE(!executeResult.result.warnings().empty());
+}
+
 TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Image Geom Test - Rectangle", "[SimplnxCore][ComputeCoordinateThresholdFilter]")
 {
   DataStructure dataStructure;
@@ -190,7 +454,7 @@ TEST_CASE("SimplnxCore::ComputeCoordinateThresholdFilter: Image Geom Test - Sphe
       0, 0, 0, 0, 0;
 #endif
 
-  VectorFloat32Parameter::ValueType sphereInfo = {2.5f, 2.5f, 0.5f, 1.0f};
+  VectorFloat32Parameter::ValueType sphereInfo = {2.5f, 2.5f, 0.5f, 1.66f};
 
   SECTION("Baseline")
   {

--- a/src/simplnx/Utilities/IntersectionUtilities.hpp
+++ b/src/simplnx/Utilities/IntersectionUtilities.hpp
@@ -350,6 +350,178 @@ std::optional<Eigen::Vector3<T>> MTIntersection(const Eigen::Vector3<T>& origin,
   return {};
 }
 
+/**
+ * @brief This function determines whether any point in a given rectangular prism falls within a sphere
+ * @tparam T floating point number (algorithm is capable of working with other primitives, but restricted until use case arises)
+ * @param sphereCenter The center of the sphere (XYZ)
+ * @param radius The radius of the sphere
+ * @param minBound The minimum point of the rectangular prism (XYZ)
+ * @param maxBound The maximum point of the rectangular prism (XYZ)
+ * @return bool returns true if sphere intersects rectangular prism
+ */
+template <std::floating_point T>
+bool SphereIntersectsRectangularPrism(const std::array<T, 3>& sphereCenter, T radius, const std::array<T, 3>& minBound, const std::array<T, 3>& maxBound)
+{
+  /**
+   * For this we are first going to determine the region the center falls in. Where
+   * X is in the bounding box of the rectangle
+   * E is somewhere outside the rectangle but falls within the unbounded planes of the parallel sides
+   * C is somewhere outside the rectangle but falls within the unbounded planes of the adjacent sides
+   *
+   * This solution for 2D space is being expanded to 3D
+   *
+   * C | E | C
+   * E | X | E
+   * C | E | C
+   *
+   * Next we validate overlap with the radius. If
+   * The center was in X we are done
+   * The center was in C find if vertex/edge point falls within the sphere
+   * The center was in E verify distance to face is less than the radius
+   */
+
+  // Check if center is outside lower bound
+  bool outMinX = sphereCenter[0] < minBound[0];
+  bool outMinY = sphereCenter[1] < minBound[1];
+  bool outMinZ = sphereCenter[2] < minBound[2];
+
+  // Check if center is outside upper bound
+  bool outMaxX = sphereCenter[0] > maxBound[0];
+  bool outMaxY = sphereCenter[1] > maxBound[1];
+  bool outMaxZ = sphereCenter[2] > maxBound[2];
+
+  if(outMinX || outMinY || outMinZ || outMaxX || outMaxY || outMaxZ)
+  {
+    float32 xPoint;
+    float32 yPoint;
+    float32 zPoint;
+    if(outMinX && outMinY && outMinZ)
+    {
+      // Center is in C; Checking if point falls in sphere
+      xPoint = minBound[0];
+      yPoint = minBound[1];
+      zPoint = minBound[2];
+    }
+    else if(outMaxX && outMinY && outMinZ)
+    {
+      // Center is in C; Checking if point falls in sphere
+      xPoint = maxBound[0];
+      yPoint = minBound[1];
+      zPoint = minBound[2];
+    }
+    else if(outMinX && outMaxY && outMinZ)
+    {
+      // Center is in C; Checking if point falls in sphere
+      xPoint = minBound[0];
+      yPoint = maxBound[1];
+      zPoint = minBound[2];
+    }
+    else if(outMinX && outMinY && outMaxZ)
+    {
+      // Center is in C; Checking if point falls in sphere
+      xPoint = minBound[0];
+      yPoint = minBound[1];
+      zPoint = maxBound[2];
+    }
+    else if(outMaxX && outMaxY && outMaxZ)
+    {
+      // Center is in C; Checking if point falls in sphere
+      xPoint = maxBound[0];
+      yPoint = maxBound[1];
+      zPoint = maxBound[2];
+    }
+    else if(outMinX && outMaxY && outMaxZ)
+    {
+      // Center is in C; Checking if point falls in sphere
+      xPoint = minBound[0];
+      yPoint = maxBound[1];
+      zPoint = maxBound[2];
+    }
+    else if(outMaxX && outMinY && outMaxZ)
+    {
+      // Center is in C; Checking if point falls in sphere
+      xPoint = maxBound[0];
+      yPoint = minBound[1];
+      zPoint = maxBound[2];
+    }
+    else if(outMaxX && outMaxY && outMinZ)
+    {
+      // Center is in C; Checking if point falls in sphere
+      xPoint = maxBound[0];
+      yPoint = maxBound[1];
+      zPoint = minBound[2];
+    }
+    else
+    {
+      // Center is in E or F (Face); Checking if point falls in sphere via distance to nearest point in rect bounds
+      bool inXBound = !outMinX && !outMaxX;
+      bool inYBound = !outMinY && !outMaxY;
+      bool inZBound = !outMinZ && !outMaxZ;
+
+      if(inXBound)
+      {
+        xPoint = sphereCenter[0];
+      }
+      else
+      {
+        if(outMinX)
+        {
+          xPoint = minBound[0];
+        }
+        if(outMaxX)
+        {
+          xPoint = maxBound[0];
+        }
+      }
+      if(inYBound)
+      {
+        yPoint = sphereCenter[1];
+      }
+      else
+      {
+        if(outMinY)
+        {
+          yPoint = minBound[1];
+        }
+        if(outMaxY)
+        {
+          yPoint = maxBound[1];
+        }
+      }
+      if(inZBound)
+      {
+        zPoint = sphereCenter[2];
+      }
+      else
+      {
+        if(outMinZ)
+        {
+          zPoint = minBound[2];
+        }
+        if(outMaxZ)
+        {
+          zPoint = maxBound[2];
+        }
+      }
+    }
+
+    float32 xDiff = xPoint - sphereCenter[0];
+    float32 yDiff = yPoint - sphereCenter[1];
+    float32 zDiff = zPoint - sphereCenter[2];
+
+    // Do not switch to pow() inlined is faster for square case for floating point num
+    float32 tDiff = (xDiff * xDiff) + (yDiff * yDiff) + (zDiff * zDiff);
+
+    if(tDiff > (radius * radius))
+    {
+      return false;
+    }
+  }
+  // Center is in X or point is within the radius; Valid
+
+  return true;
+}
+
 } // namespace IntersectionUtilities
 
 } // namespace nx::core


### PR DESCRIPTION
Fixes: #1208

This filter offers the ability to produce a mask for cells that fall within a given bounding geometric shape for most geometries. See documentation provided for further details.

Discussion was had to expand the bounding definitions down the line, so the filter was designed around executing lambdas that determine whether a point is in or out of bounds. These lambdas are run by a parallel wrapper class that handles parsing the different geometry types to pass an xyz point to the lambda. The idea being all that would be necessary to add new functionality would be:

- [ ] Updating input parameters/args/preflight for the filter
- [ ] Updating the `BoundsType` enum in the algorithm header
- [ ] Defining a new lambda to be passed to the parallel algorithm in the switch inside the `operator()` function of the algorithm class
- [ ] Adding 5 new test cases; one for each supported geometry (with 2 sections; one regular one inverted)

This PR adds the following functionality:
- New filter providing a way to mask off cells with supplied bounds in a variety of geometries
- Extensive supporting documentation
- 20 new test cases testing every algorithm code path (10 unique, 2 sections in each)