### PR TITLE
ENH: Replace C style 2D arrays with Eigen::Matrix

### DIFF
--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeSchmids.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeSchmids.cpp
@@ -1,7 +1,8 @@
 #include "ComputeSchmids.hpp"
 
+#include "OrientationAnalysis/utilities/OrientationUtilities.hpp"
+
 #include "simplnx/DataStructure/DataArray.hpp"
-#include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/Utilities/Math/MatrixMath.hpp"
 
 #include "EbsdLib/LaueOps/LaueOps.h"
@@ -55,30 +56,21 @@ Result<> ComputeSchmids::operator()()
 
   int32_t slipSystem = 0;
 
-  double g[3][3] = {{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}};
-  double sampleLoading[3] = {0.0f, 0.0f, 0.0f};
-  double crystalLoading[3] = {0.0f, 0.0f, 0.0f};
+  Eigen::Vector3d sampleLoading = {m_InputValues->LoadingDirection[0], m_InputValues->LoadingDirection[1], m_InputValues->LoadingDirection[2]};
+  sampleLoading.normalize();
+
   double angleComps[2] = {0.0f, 0.0f};
   double schmid = 0.0f;
 
-  sampleLoading[0] = m_InputValues->LoadingDirection[0];
-  sampleLoading[1] = m_InputValues->LoadingDirection[1];
-  sampleLoading[2] = m_InputValues->LoadingDirection[2];
-  MatrixMath::Normalize3x1(sampleLoading);
-  double plane[3] = {0.0f, 0.0f};
-  double direction[3] = {0.0f, 0.0f};
-
+  Eigen::Vector3d plane;
+  Eigen::Vector3d direction;
   if(m_InputValues->OverrideSystem)
   {
-    plane[0] = m_InputValues->SlipPlane[0];
-    plane[1] = m_InputValues->SlipPlane[1];
-    plane[2] = m_InputValues->SlipPlane[2];
-    MatrixMath::Normalize3x1(plane);
+    plane = {m_InputValues->SlipPlane[0], m_InputValues->SlipPlane[1], m_InputValues->SlipPlane[2]};
+    plane.normalize();
 
-    direction[0] = m_InputValues->SlipDirection[0];
-    direction[1] = m_InputValues->SlipDirection[1];
-    direction[2] = m_InputValues->SlipDirection[2];
-    MatrixMath::Normalize3x1(direction);
+    direction = {m_InputValues->SlipDirection[0], m_InputValues->SlipDirection[1], m_InputValues->SlipDirection[2]};
+    direction.normalize();
   }
 
   for(size_t i = 1; i < totalFeatures; i++)
@@ -88,17 +80,17 @@ Result<> ComputeSchmids::operator()()
     {
       continue;
     }
-    OrientationTransformation::qu2om<QuatF, OrientationD>({avgQuatPtr[i * 4 + 0], avgQuatPtr[i * 4 + 1], avgQuatPtr[i * 4 + 2], avgQuatPtr[i * 4 + 3]}).toGMatrix(g);
-
-    MatrixMath::Multiply3x3with3x1(g, sampleLoading, crystalLoading);
+    auto om = OrientationTransformation::qu2om<QuatF, OrientationD>({avgQuatPtr[i * 4 + 0], avgQuatPtr[i * 4 + 1], avgQuatPtr[i * 4 + 2], avgQuatPtr[i * 4 + 3]});
+    auto g = OrientationUtilities::OrientationMatrixToGMatrix(om);
+    Eigen::Vector3d crystalLoading = g * sampleLoading;
 
     if(!m_InputValues->OverrideSystem)
     {
-      orientationOps[xtal]->getSchmidFactorAndSS(crystalLoading, schmid, angleComps, slipSystem);
+      orientationOps[xtal]->getSchmidFactorAndSS(crystalLoading.data(), schmid, angleComps, slipSystem);
     }
     else
     {
-      orientationOps[xtal]->getSchmidFactorAndSS(crystalLoading, plane, direction, schmid, angleComps, slipSystem);
+      orientationOps[xtal]->getSchmidFactorAndSS(crystalLoading.data(), plane.data(), direction.data(), schmid, angleComps, slipSystem);
     }
 
     schmidArray[i] = static_cast<float>(schmid);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeShapes.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeShapes.cpp
@@ -568,24 +568,24 @@ void ComputeShapes::findAxisEulers()
   for(size_t featureId = 1; featureId < numfeatures; featureId++)
   {
     // insert principal unit vectors into rotation matrix representing Feature reference frame within the sample reference frame
-    //(Note that the 3 direction is actually the long axis and the 1 direction is actually the short axis)
+    // (Note that the 3 directions are actually the long axis and the 1 direction is actually the short axis)
     // clang-format off
     size_t idx = featureId*9;
-    float g[3][3] = {{m_EFVec[idx + 0], m_EFVec[idx + 3], m_EFVec[idx + 6]},
-                     {m_EFVec[idx + 1], m_EFVec[idx + 4], m_EFVec[idx + 7]},
-                     {m_EFVec[idx + 2], m_EFVec[idx + 5], m_EFVec[idx + 8]}};
+    OrientationF g = {m_EFVec[idx + 0], m_EFVec[idx + 3], m_EFVec[idx + 6],
+                     m_EFVec[idx + 1], m_EFVec[idx + 4], m_EFVec[idx + 7],
+                     m_EFVec[idx + 2], m_EFVec[idx + 5], m_EFVec[idx + 8]};
     // clang-format on
 
     // check for right-handedness
-    OrientationTransformation::ResultType result = OrientationTransformation::om_check(OrientationF(g));
+    OrientationTransformation::ResultType result = OrientationTransformation::om_check(g);
     if(result.result == 0)
     {
-      g[2][0] *= -1.0f;
-      g[2][1] *= -1.0f;
-      g[2][2] *= -1.0f;
+      g[6] *= -1.0f;
+      g[7] *= -1.0f;
+      g[8] *= -1.0f;
     }
 
-    OrientationF eu = OrientationTransformation::om2eu<OrientationF, OrientationF>(OrientationF(g));
+    OrientationF eu = OrientationTransformation::om2eu<OrientationF, OrientationF>(g);
 
     axisEulerAngles[3 * featureId] = eu[0];
     axisEulerAngles[3 * featureId + 1] = eu[1];

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/RotateEulerRefFrame.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/RotateEulerRefFrame.cpp
@@ -1,5 +1,7 @@
 #include "RotateEulerRefFrame.hpp"
 
+#include "OrientationAnalysis/utilities/OrientationUtilities.hpp"
+
 #include "simplnx/Common/Numbers.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/Math/MatrixMath.hpp"
@@ -32,12 +34,11 @@ public:
 
   void convert(size_t start, size_t end) const
   {
-    float rotMat[3][3] = {{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}};
-    OrientationTransformation::ax2om<OrientationF, OrientationF>(OrientationF(m_AxisAngle[0], m_AxisAngle[1], m_AxisAngle[2], m_Angle * nx::core::numbers::pi / 180.0F)).toGMatrix(rotMat);
+    auto om = OrientationTransformation::ax2om<OrientationF, OrientationF>(OrientationF(m_AxisAngle[0], m_AxisAngle[1], m_AxisAngle[2], m_Angle * nx::core::numbers::pi / 180.0F));
+
+    OrientationUtilities::Matrix3fR rotMat = OrientationUtilities::OrientationMatrixToGMatrix(om);
 
     float ea1 = 0, ea2 = 0, ea3 = 0;
-    float g[3][3] = {{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}};
-    float gNew[3][3] = {{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}};
     for(size_t i = start; i < end; i++)
     {
       if(m_ShouldCancel)
@@ -47,12 +48,11 @@ public:
       ea1 = m_CellEulerAngles[3 * i + 0];
       ea2 = m_CellEulerAngles[3 * i + 1];
       ea3 = m_CellEulerAngles[3 * i + 2];
-      OrientationTransformation::eu2om<OrientationF, OrientationF>(OrientationF(ea1, ea2, ea3)).toGMatrix(g);
+      om = OrientationTransformation::eu2om<OrientationF, OrientationF>(OrientationF(ea1, ea2, ea3));
+      OrientationUtilities::Matrix3fR g = OrientationUtilities::OrientationMatrixToGMatrix(om);
+      OrientationUtilities::Matrix3fR gNew = (g * rotMat).colwise().normalized();
 
-      nx::core::MatrixMath::Multiply3x3with3x3(g, rotMat, gNew);
-      nx::core::MatrixMath::Normalize3x3(gNew);
-
-      OrientationF eu = OrientationTransformation::om2eu<OrientationF, OrientationF>(OrientationF(gNew));
+      auto eu = OrientationTransformation::om2eu<OrientationF, OrientationF>(OrientationF(gNew.data(), 9));
       m_CellEulerAngles[3 * i] = eu[0];
       m_CellEulerAngles[3 * i + 1] = eu[1];
       m_CellEulerAngles[3 * i + 2] = eu[2];

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteGBCDGMTFile.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteGBCDGMTFile.cpp
@@ -185,7 +185,6 @@ Result<> WriteGBCDGMTFile::operator()()
       for(int32 i = 0; i < nSym; i++)
       {
         // get symmetry operator1
-        // double tempSymOperator[3][3];
         EbsdLib::Matrix3X3D tSymOp = orientOps->getMatSymOpD(i);
         const Matrix3X3Type sym1 = (Matrix3X3Type() << tSymOp[0], tSymOp[1], tSymOp[2], tSymOp[3], tSymOp[4], tSymOp[5], tSymOp[6], tSymOp[7], tSymOp[8]).finished();
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/utilities/OrientationUtilities.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/utilities/OrientationUtilities.hpp
@@ -13,7 +13,7 @@ using Matrix3fR = Eigen::Matrix<float, 3, 3, Eigen::RowMajor>;
 using Matrix3dR = Eigen::Matrix<double, 3, 3, Eigen::RowMajor>;
 
 using Matrix1dR = Eigen::Matrix<double, 3, 1, Eigen::RowMajor>;
-using Matrix1FR = Eigen::Matrix<float, 3, 1, Eigen::RowMajor>;
+using Matrix1fR = Eigen::Matrix<float, 3, 1, Eigen::RowMajor>;
 
 template <typename T>
 Eigen::Matrix<T, 3, 3, Eigen::RowMajor> OrientationMatrixToGMatrix(const Orientation<T>& oMatrix)
@@ -90,7 +90,7 @@ Eigen::Matrix<T, 3, 3, Eigen::RowMajor> GMatrixToEigenMatrix(const T g[3][3])
 }
 
 template <typename T>
-Eigen::Matrix<T, 3, 3, Eigen::RowMajor> GMatrixToEigenMatrixTranspose(T oMatrix[3][3])
+Eigen::Matrix<T, 3, 3, Eigen::RowMajor> GMatrixToEigenMatrixTranspose(const T oMatrix[3][3])
 {
   Eigen::Matrix<T, 3, 3, Eigen::RowMajor> g1t;
   g1t(0, 0) = oMatrix[0];

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/utilities/OrientationUtilities.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/utilities/OrientationUtilities.hpp
@@ -12,6 +12,9 @@ namespace OrientationUtilities
 using Matrix3fR = Eigen::Matrix<float, 3, 3, Eigen::RowMajor>;
 using Matrix3dR = Eigen::Matrix<double, 3, 3, Eigen::RowMajor>;
 
+using Matrix1dR = Eigen::Matrix<double, 3, 1, Eigen::RowMajor>;
+using Matrix1FR = Eigen::Matrix<float, 3, 1, Eigen::RowMajor>;
+
 template <typename T>
 Eigen::Matrix<T, 3, 3, Eigen::RowMajor> OrientationMatrixToGMatrix(const Orientation<T>& oMatrix)
 {
@@ -69,6 +72,38 @@ Eigen::Matrix<T, 3, 3, Eigen::RowMajor> EbsdLibMatrixToEigenMatrix(const EbsdLib
 }
 
 std::string CrystalStructureEnumToString(uint32_t crystalStructureType);
+
+template <typename T>
+Eigen::Matrix<T, 3, 3, Eigen::RowMajor> GMatrixToEigenMatrix(T g[3][3])
+{
+  Eigen::Matrix<T, 3, 3, Eigen::RowMajor> eigenMatrix;
+  eigenMatrix(0, 0) = g[0][0];
+  eigenMatrix(0, 1) = g[0][1];
+  eigenMatrix(0, 2) = g[0][2];
+  eigenMatrix(1, 0) = g[1][0];
+  eigenMatrix(1, 1) = g[1][1];
+  eigenMatrix(1, 2) = g[1][2];
+  eigenMatrix(2, 0) = g[2][0];
+  eigenMatrix(2, 1) = g[2][1];
+  eigenMatrix(2, 2) = g[2][2];
+  return eigenMatrix;
+}
+
+template <typename T>
+Eigen::Matrix<T, 3, 3, Eigen::RowMajor> GMatrixToEigenMatrixTranspose(T oMatrix[3][3])
+{
+  Eigen::Matrix<T, 3, 3, Eigen::RowMajor> g1t;
+  g1t(0, 0) = oMatrix[0];
+  g1t(0, 1) = oMatrix[3];
+  g1t(0, 2) = oMatrix[6];
+  g1t(1, 0) = oMatrix[1];
+  g1t(1, 1) = oMatrix[4];
+  g1t(1, 2) = oMatrix[7];
+  g1t(2, 0) = oMatrix[2];
+  g1t(2, 1) = oMatrix[5];
+  g1t(2, 2) = oMatrix[8];
+  return g1t;
+}
 
 } // namespace OrientationUtilities
 } // namespace nx::core

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/utilities/OrientationUtilities.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/utilities/OrientationUtilities.hpp
@@ -74,7 +74,7 @@ Eigen::Matrix<T, 3, 3, Eigen::RowMajor> EbsdLibMatrixToEigenMatrix(const EbsdLib
 std::string CrystalStructureEnumToString(uint32_t crystalStructureType);
 
 template <typename T>
-Eigen::Matrix<T, 3, 3, Eigen::RowMajor> GMatrixToEigenMatrix(T g[3][3])
+Eigen::Matrix<T, 3, 3, Eigen::RowMajor> GMatrixToEigenMatrix(const T g[3][3])
 {
   Eigen::Matrix<T, 3, 3, Eigen::RowMajor> eigenMatrix;
   eigenMatrix(0, 0) = g[0][0];

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CalculateTriangleGroupCurvatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CalculateTriangleGroupCurvatures.cpp
@@ -272,7 +272,7 @@ void CalculateTriangleGroupCurvatures::operator()() const
     // this constitutes a rotation matrix to a local coordinate system
     double rot[3][3] = {{up[0], up[1], up[2]}, {vp[0], vp[1], vp[2]}, {np[0], np[1], np[2]}};
     double out[3] = {0.0, 0.0, 0.0};
-    // Transform all centroids and normals to new coordinate system
+    // Transform all centroids and normals to a new coordinate system
     for(size_t m = 0; m < patchCentroids->getNumberOfTuples(); ++m)
     {
       ::memcpy(out, &patchCentroids->data()[m * 3], 3 * sizeof(double));
@@ -287,7 +287,7 @@ void CalculateTriangleGroupCurvatures::operator()() const
       MatrixMath::Multiply3x3with3x1(rot, &patchNormals->data()[m * 3], out);
       ::memcpy(&patchNormals->data()[m * 3], out, 3 * sizeof(double));
 
-      // We rotate the normals now, but we don't use them yet. If we start using part 3 of Goldfeathers paper then we
+      // We rotate the normals now, but we don't use them yet. If we start using part 3 of Goldfeather's paper, then we
       // will need the normals.
     }
 

--- a/src/simplnx/Utilities/Math/GeometryMath.cpp
+++ b/src/simplnx/Utilities/Math/GeometryMath.cpp
@@ -170,8 +170,3 @@ BoundingBox3Df nx::core::GeometryMath::FindBoundingBoxOfFaces(const nx::core::Tr
 
   return {ll, ur};
 }
-
-BoundingBox3Df nx::core::GeometryMath::FindBoundingBoxOfRotatedFace(TriangleGeom& faces, int32 faceId, float32 g[3][3])
-{
-  throw std::runtime_error("nx::core::GeometryMath::FindBoundingBoxOfRotatedFace is not implemented");
-}

--- a/src/simplnx/Utilities/Math/GeometryMath.hpp
+++ b/src/simplnx/Utilities/Math/GeometryMath.hpp
@@ -403,16 +403,6 @@ T GetLengthOfRayInBox(const nx::core::Ray<T>& ray, const nx::core::BoundingBox3D
 nx::core::BoundingBox3Df SIMPLNX_EXPORT FindBoundingBoxOfVertices(nx::core::INodeGeometry0D& geom);
 
 /**
- * @brief Returns the BoundingBox around the specified face manipulated by the
- * provided rotation matrix.
- * @param faces
- * @param faceId
- * @param float[3][3]
- * @return nx::core::BoundingBox<float32>
- */
-nx::core::BoundingBox3Df SIMPLNX_EXPORT FindBoundingBoxOfRotatedFace(nx::core::TriangleGeom& faces, int32 faceId, float32 g[3][3]);
-
-/**
  * @brief Returns the BoundingBox around the specified face.
  * @param faces
  * @param faceId
@@ -426,19 +416,6 @@ nx::core::BoundingBox3Df FindBoundingBoxOfFace(const detail::GeometryStoreCache&
  * @return nx::core::BoundingBox<float32>
  */
 nx::core::BoundingBox3Df SIMPLNX_EXPORT FindBoundingBoxOfFaces(const nx::core::TriangleGeom& triangleGeom, const std::vector<int32>& faceIds);
-
-/**
- * @brief Returns the bounding box around the specified faces manipulated by the
- * provided rotation matrix.
- * @param faces
- * @param faceIds
- * @param float32 g[3][3]
- * @return nx::core::BoundingBox<float32>
- */
-// nx::core::BoundingBox<float32> FindBoundingBoxOfRotatedFaces(TriangleGeom* faces, const Int32Int32DynamicListArray.ElementList& faceIds, float32 g[3][3])
-//{
-//  throw std::runtime_error("");
-//}
 
 /**
  * @brief Returns true if the specified Ray crosses into or out of the triangle

--- a/src/simplnx/Utilities/Math/MatrixMath.hpp
+++ b/src/simplnx/Utilities/Math/MatrixMath.hpp
@@ -48,7 +48,13 @@ namespace nx::core
  */
 namespace MatrixMath
 {
-
+template <typename T>
+void Print3x3(std::ostream& o, T outMat[3][3])
+{
+  o << outMat[0][0] << " " << outMat[0][1] << " " << outMat[0][2] << "\n";
+  o << outMat[1][0] << " " << outMat[1][1] << " " << outMat[1][2] << "\n";
+  o << outMat[2][0] << " " << outMat[2][1] << " " << outMat[2][2] << "\n";
+}
 /**
  * @brief Performs the Matrix Multiplication of g1 and g2 and puts the result into outMat. (Single Precision version)
  * @param g1
@@ -350,7 +356,9 @@ void Identity3x3(T g[3][3])
 }
 
 /**
- * @brief Performs an "in place" normalization of the 3x1 vector.
+ * @brief Performs an "in place" normalization of the 3x3 vector down the columns.
+ *
+ * This is the same as Eigen::colwise().normalized() function.
  * @param g
  */
 template <typename T>


### PR DESCRIPTION
Effort to remote as many instances of double g[3][3] as possible and use Eigen instead. 

This could be cleaner if there were some more API added to EbsdLib in a few locations.