### PR TITLE
ENH: Creates an edge geometry that visualizes the bounding boxes

### DIFF
--- a/src/Plugins/SimplnxCore/docs/ComputeFeatureBoundsFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeFeatureBoundsFilter.md
@@ -8,7 +8,7 @@ Geometry
 
 **Warning**: _Potential Runtime Error_ - It is expected that the max feature id plus one (`max_feature_id_value` + 1) is equal to or less than the number of tuples in the supplied feature Attribute Matrix. This cannot be checked in preflight and will terminate the pipeline if encountered.
 
-This filter calculates the bounding boxes for each feature given Feature Ids and Geometry (refer to table below for supported geometry types and their corresponding feature id sizing). The bounding boxes are defined and stored as two points in space, a lower and upper point. The optimal storage solution is use case defined, and as such there are two options provided `split` and `unified`.
+This filter calculates the bounding boxes for each feature given Feature Ids and Geometry (refer to table below for supported geometry types and their corresponding feature id sizing). _**This filter does output `NaN`s for empty features**_, cases where a point can not be associated to a feature. The bounding boxes are defined and stored as two points in space, a lower and upper point. The optimal storage solution is use case defined, and as such there are two options provided `split` and `unified`.
 
 | Geometry Type | Expected Feature ID Length|
 |---------------|---------------------------|
@@ -33,6 +33,51 @@ The intended use case for `split` is primarily for output compatibility. By logi
 One 6-component `float32` **DataArray**. Bounds array in the format of min-x, min-y, min-z, max-x, max-y, max-z.
 
 The intended use case for `unified` is primarily for simplicity of internal calculations. Essentially, this format is the result of appending the max array onto the min array. It is easier to pass around and parse one array within `simplnx` API's. For mainline `simplnx` filters this will be the expected/preferred input format.
+
+### Edge Geometry Nuances
+
+Producing an edge geometry for the bounding boxes has a couple nuances that aren't very intuitive, these will be covered here. Firstly, the output edge geometry may **NOT** contain all features that are in the input geometry. For a feature to be included it must meet two conditions:
+
+- The bounding box must not contain any NANs
+- The feature id must be greater than or equal to 0
+
+This is most relevant if you have empty features in the input geometry or you have invalid feature ids (-1). This is remedied by the feature ids created at the edge (cell) data, these map the edges making up the bounding boxes to the feature they originate from. With empty features, this will cause gaps in the sequence (eg with 3 being an empty feature the edge feature ids would follow a 1,2,4,5 sequence). This is important to note because the user may wish to create a Feature Attribute Matrix by creating an Attribute Matrix equivalent to `number of edges / 12`, but this would only be true for the case in which the values in array are consecutive in order (ie there are no empty features).
+
+Lastly, we will peel back the covers on how the geometry is constructed in the case that the user needs to parse or manipulate the data within it. Each bound box in the geometry is extrapolated from a maximum and minimum point. The points are constructed from every combination in the following order:
+
+```console
+| Index |     Vertex Point      |
+|-------|-----------------------|
+|   0   | {min-X, min-Y, min-Z} |
+|   1   | {max-X, min-Y, min-Z} |
+|   2   | {max-X, max-Y, min-Z} |
+|   3   | {min-X, max-Y, min-Z} |
+|   4   | {min-X, min-Y, max-Z} |
+|   5   | {max-X, min-Y, max-Z} |
+|   6   | {max-X, max-Y, max-Z} |
+|   7   | {min-X, max-Y, max-Z} |
+```
+
+The edges for each bounding box are 12 in number and constructed in following order:
+
+```console
+| Index | Vertex Indices |
+|-------|----------------|
+|   0   |     {0, 1}     |
+|   1   |     {1, 2}     |
+|   2   |     {2, 3}     |
+|   3   |     {3, 4}     |
+|   4   |     {4, 5}     |
+|   5   |     {5, 6}     |
+|   6   |     {6, 7}     |
+|   7   |     {7, 4}     |
+|   8   |     {0, 4}     |
+|   9   |     {1, 5}     |
+|  10   |     {2, 6}     |
+|  11   |     {3, 7}     |
+```
+
+Since edges are the cell level data in edge geometries, the feature ids map to the edges. This means that the feature ids array will always contain 11 more consecutive instances of the same feature from when it first appears (12 total). To know the number of features in the edge geom, just divide the number of edges by 12.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureBounds.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureBounds.cpp
@@ -29,20 +29,20 @@ std::vector<float32> ComputeBounds(const GeomT& geom, const Int32AbstractDataSto
   std::vector<float32> bounds(numFeatures * 6, std::numeric_limits<float32>::quiet_NaN());
   if constexpr(std::is_same_v<ImageGeom, GeomT>)
   {
-    size_t xPoints = geom.getNumXCells();
-    size_t yPoints = geom.getNumYCells();
-    size_t zPoints = geom.getNumZCells();
+    usize xPoints = geom.getNumXCells();
+    usize yPoints = geom.getNumYCells();
+    usize zPoints = geom.getNumZCells();
     FloatVec3 spacing = geom.getSpacing();
     FloatVec3 origin = geom.getOrigin();
 
-    size_t zStride = 0, yStride = 0;
-    for(size_t i = 0; i < zPoints; i++)
+    usize zStride = 0, yStride = 0;
+    for(usize i = 0; i < zPoints; i++)
     {
       zStride = i * xPoints * yPoints;
-      for(size_t j = 0; j < yPoints; j++)
+      for(usize j = 0; j < yPoints; j++)
       {
         yStride = j * xPoints;
-        for(size_t k = 0; k < xPoints; k++)
+        for(usize k = 0; k < xPoints; k++)
         {
           const int32 currentFeatureId = featureIds[zStride + yStride + k];
           if(currentFeatureId < 0)
@@ -280,8 +280,8 @@ Result<> ComputeFeatureBounds::operator()()
     std::array<usize, 2> vertPair = {0, 0};
 
     // Compute the number of features which will tell use the number of vertices and edges
-    size_t numVerts = numFeatures * 8;
-    size_t numEdges = numFeatures * 12;
+    usize numVerts = numFeatures * 8;
+    usize numEdges = numFeatures * 12;
 
     auto& edgeGeom = m_DataStructure.getDataRefAs<EdgeGeom>(m_InputValues->EdgeGeometryDataPath);
     edgeGeom.resizeVertexList(numVerts);
@@ -292,8 +292,8 @@ Result<> ComputeFeatureBounds::operator()()
     DataPath edgeAmPath = m_InputValues->EdgeGeometryDataPath.createChildPath(m_InputValues->EdgeAttributeMatrixName);
     auto& edgeFeatureIds = m_DataStructure.getDataRefAs<Int32Array>(edgeAmPath.createChildPath(m_InputValues->FeatureIdsArrayName)).getDataStoreRef();
     edgeFeatureIds.fill(-1);
-    size_t currentOffset = 0;
-    for(size_t idx = 0; idx < numFeatures; ++idx)
+    usize currentOffset = 0;
+    for(usize idx = 0; idx < numFeatures; ++idx)
     {
       usize activeIndex = idx * 6;
       // NaN values mean that there was something wrong with the bounding min/max points.
@@ -322,7 +322,7 @@ Result<> ComputeFeatureBounds::operator()()
       edgeGeom.setVertexCoordinate(currentOffset * 8 + 7, {bounds[activeIndex + 0], bounds[activeIndex + 4], bounds[activeIndex + 5]});
 
       // Create the 12 Edges
-      for(size_t edgeIdx = 0; edgeIdx < cubeEdges.size(); ++edgeIdx)
+      for(usize edgeIdx = 0; edgeIdx < cubeEdges.size(); ++edgeIdx)
       {
         vertPair[0] = currentOffset * 8 + (cubeEdges[edgeIdx].first);
         vertPair[1] = currentOffset * 8 + (cubeEdges[edgeIdx].second);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureBounds.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureBounds.cpp
@@ -18,59 +18,38 @@ using namespace nx::core;
 
 namespace
 {
+template <typename T>
+concept GeometryType = std::is_base_of_v<IGeometry, T>;
 
-std::array<float, 6> copyBoundsForFeature(const ComputeFeatureBoundsInputValues* inputValues, const DataStructure& datatStructure, size_t featureIndex)
+template <GeometryType GeomT>
+std::vector<float32> ComputeBounds(const GeomT& geom, const Int32AbstractDataStore& featureIds, usize numFeatures)
 {
+  static_assert(std::is_same_v<ImageGeom, GeomT> || std::is_base_of_v<INodeGeometry0D, GeomT> || std::is_base_of_v<INodeGeometry1D, GeomT> || std::is_base_of_v<INodeGeometry2D, GeomT>);
 
-  switch(auto outputType = static_cast<ComputeFeatureBounds::OutputDataType>(inputValues->OutputType))
+  std::vector<float32> bounds(numFeatures * 6, std::numeric_limits<float32>::quiet_NaN());
+  if constexpr(std::is_same_v<ImageGeom, GeomT>)
   {
-  case ComputeFeatureBounds::OutputDataType::Split: {
-    auto& minArray = datatStructure.getDataRefAs<Float32Array>(inputValues->MinArrayPath).getDataStoreRef();
-    auto& maxArray = datatStructure.getDataRefAs<Float32Array>(inputValues->MaxArrayPath).getDataStoreRef();
+    size_t xPoints = geom.getNumXCells();
+    size_t yPoints = geom.getNumYCells();
+    size_t zPoints = geom.getNumZCells();
+    FloatVec3 spacing = geom.getSpacing();
+    FloatVec3 origin = geom.getOrigin();
 
-    return {minArray[featureIndex * 3], minArray[featureIndex * 3 + 1], minArray[featureIndex * 3 + 2], maxArray[featureIndex * 3], maxArray[featureIndex * 3 + 1], maxArray[featureIndex * 3 + 2]};
-  }
-  case ComputeFeatureBounds::OutputDataType::Unified: {
-    auto& unifiedArray = datatStructure.getDataRefAs<Float32Array>(inputValues->UnifiedArrayPath).getDataStoreRef();
-    return {unifiedArray[featureIndex * 3],     unifiedArray[featureIndex * 3 + 1], unifiedArray[featureIndex * 3 + 2],
-            unifiedArray[featureIndex * 3 + 3], unifiedArray[featureIndex * 3 + 4], unifiedArray[featureIndex * 3 + 5]};
-  }
-  }
-  return {};
-}
-
-namespace GeometryGrid
-{
-
-std::pair<Point3Df, Point3Df> CalculateFeatureBounds(int32 activeFeature, const ImageGeom& imageGeom, const Int32AbstractDataStore& featureIds)
-{
-
-  float32 maxX = std::numeric_limits<float32>::quiet_NaN();
-  float32 maxY = std::numeric_limits<float32>::quiet_NaN();
-  float32 maxZ = std::numeric_limits<float32>::quiet_NaN();
-
-  float32 minX = std::numeric_limits<float32>::quiet_NaN();
-  float32 minY = std::numeric_limits<float32>::quiet_NaN();
-  float32 minZ = std::numeric_limits<float32>::quiet_NaN();
-
-  size_t xPoints = imageGeom.getNumXCells();
-  size_t yPoints = imageGeom.getNumYCells();
-  size_t zPoints = imageGeom.getNumZCells();
-  FloatVec3 spacing = imageGeom.getSpacing();
-  FloatVec3 origin = imageGeom.getOrigin();
-
-  size_t zStride = 0, yStride = 0;
-  for(size_t i = 0; i < zPoints; i++)
-  {
-    zStride = i * xPoints * yPoints;
-    for(size_t j = 0; j < yPoints; j++)
+    size_t zStride = 0, yStride = 0;
+    for(size_t i = 0; i < zPoints; i++)
     {
-      yStride = j * xPoints;
-      for(size_t k = 0; k < xPoints; k++)
+      zStride = i * xPoints * yPoints;
+      for(size_t j = 0; j < yPoints; j++)
       {
-        if(featureIds[zStride + yStride + k] == activeFeature)
+        yStride = j * xPoints;
+        for(size_t k = 0; k < xPoints; k++)
         {
-          // We are inlining the calculations here to leverage the speed of primitives (no Point object or vector from the API)
+          const int32 currentFeatureId = featureIds[zStride + yStride + k];
+          if(currentFeatureId < 0)
+          {
+            continue;
+          }
+
           float32 xValMin = k * spacing[0] + origin[0];
           float32 yValMin = j * spacing[1] + origin[1];
           float32 zValMin = i * spacing[2] + origin[2];
@@ -79,126 +58,58 @@ std::pair<Point3Df, Point3Df> CalculateFeatureBounds(int32 activeFeature, const 
           float32 yValMax = j * spacing[1] + origin[1] + spacing[1];
           float32 zValMax = i * spacing[2] + origin[2] + spacing[2];
 
-          minX = std::isnan(minX) ? xValMin : std::min(minX, xValMin);
-          minY = std::isnan(minY) ? yValMin : std::min(minY, yValMin);
-          minZ = std::isnan(minZ) ? zValMin : std::min(minZ, zValMin);
+          usize activeIndex = currentFeatureId * 6;
+          bounds[activeIndex + 0] = std::isnan(bounds[activeIndex + 0]) ? xValMin : std::min(bounds[activeIndex + 0], xValMin);
+          bounds[activeIndex + 1] = std::isnan(bounds[activeIndex + 1]) ? yValMin : std::min(bounds[activeIndex + 1], yValMin);
+          bounds[activeIndex + 2] = std::isnan(bounds[activeIndex + 2]) ? zValMin : std::min(bounds[activeIndex + 2], zValMin);
 
-          maxX = std::isnan(maxX) ? xValMax : std::max(maxX, xValMax);
-          maxY = std::isnan(maxY) ? yValMax : std::max(maxY, yValMax);
-          maxZ = std::isnan(maxZ) ? zValMax : std::max(maxZ, zValMax);
+          bounds[activeIndex + 3] = std::isnan(bounds[activeIndex + 3]) ? xValMax : std::max(bounds[activeIndex + 3], xValMax);
+          bounds[activeIndex + 4] = std::isnan(bounds[activeIndex + 4]) ? yValMax : std::max(bounds[activeIndex + 4], yValMax);
+          bounds[activeIndex + 5] = std::isnan(bounds[activeIndex + 5]) ? zValMax : std::max(bounds[activeIndex + 5], zValMax);
         }
       }
     }
   }
-
-  return std::make_pair(Point3Df(minX, minY, minZ), Point3Df(maxX, maxY, maxZ));
-}
-
-using MinMaxPairType = std::pair<Point3Df, Point3Df>;
-std::vector<MinMaxPairType> CalculateFeatureBounds2(int32 numFeatures, const ImageGeom& imageGeom, const Int32AbstractDataStore& featureIds)
-{
-  auto quietNan = std::numeric_limits<float32>::quiet_NaN();
-  std::vector<MinMaxPairType> features(numFeatures, MinMaxPairType{{quietNan, quietNan, quietNan}, {quietNan, quietNan, quietNan}});
-
-  size_t xPoints = imageGeom.getNumXCells();
-  size_t yPoints = imageGeom.getNumYCells();
-  size_t zPoints = imageGeom.getNumZCells();
-  FloatVec3 spacing = imageGeom.getSpacing();
-  FloatVec3 origin = imageGeom.getOrigin();
-
-  size_t zStride = 0, yStride = 0;
-  for(size_t i = 0; i < zPoints; i++)
+  if constexpr(std::is_same_v<VertexGeom, GeomT>)
   {
-    zStride = i * xPoints * yPoints;
-    for(size_t j = 0; j < yPoints; j++)
+    const IGeometry::SharedVertexList::store_type& verts = geom.getVerticesRef().getDataStoreRef();
+
+    for(usize i = 0; i < verts.getNumberOfTuples(); i++)
     {
-      yStride = j * xPoints;
-      for(size_t k = 0; k < xPoints; k++)
+      const int32 currentFeatureId = featureIds[i];
+      if(currentFeatureId < 0)
       {
-        const int32 currentFeatureId = featureIds[zStride + yStride + k];
-        if(currentFeatureId < 0)
-        {
-          continue;
-        }
-        auto& minPoint = features[currentFeatureId].first;
-        auto& maxPoint = features[currentFeatureId].second;
-
-        float32 xValMin = k * spacing[0] + origin[0];
-        float32 yValMin = j * spacing[1] + origin[1];
-        float32 zValMin = i * spacing[2] + origin[2];
-
-        float32 xValMax = k * spacing[0] + origin[0] + spacing[0];
-        float32 yValMax = j * spacing[1] + origin[1] + spacing[1];
-        float32 zValMax = i * spacing[2] + origin[2] + spacing[2];
-
-        float32 minX = std::isnan(minPoint[0]) ? xValMin : std::min(minPoint[0], xValMin);
-        float32 minY = std::isnan(minPoint[1]) ? yValMin : std::min(minPoint[1], yValMin);
-        float32 minZ = std::isnan(minPoint[2]) ? zValMin : std::min(minPoint[2], zValMin);
-
-        float32 maxX = std::isnan(maxPoint[0]) ? xValMax : std::max(maxPoint[0], xValMax);
-        float32 maxY = std::isnan(maxPoint[1]) ? yValMax : std::max(maxPoint[1], yValMax);
-        float32 maxZ = std::isnan(maxPoint[2]) ? zValMax : std::max(maxPoint[2], zValMax);
-
-        features[currentFeatureId] = {{minX, minY, minZ}, {maxX, maxY, maxZ}};
+        continue;
       }
-    }
-  }
 
-  return features;
-}
-
-} // namespace GeometryGrid
-namespace Geometry0D
-{
-std::pair<Point3Df, Point3Df> CalculateFeatureBounds(int32 activeFeature, const IGeometry::SharedVertexList::store_type& verts, const Int32AbstractDataStore& featureIds)
-{
-  float32 maxX = std::numeric_limits<float32>::lowest();
-  float32 maxY = std::numeric_limits<float32>::lowest();
-  float32 maxZ = std::numeric_limits<float32>::lowest();
-
-  float32 minX = std::numeric_limits<float32>::max();
-  float32 minY = std::numeric_limits<float32>::max();
-  float32 minZ = std::numeric_limits<float32>::max();
-
-  for(usize i = 0; i < verts.getNumberOfTuples(); i++)
-  {
-    if(featureIds[i] == activeFeature)
-    {
       float32 xVal = verts[(i * 3) + 0];
       float32 yVal = verts[(i * 3) + 1];
       float32 zVal = verts[(i * 3) + 2];
 
-      minX = std::min(minX, xVal);
-      minY = std::min(minY, yVal);
-      minZ = std::min(minZ, zVal);
+      usize activeIndex = currentFeatureId * 6;
+      bounds[activeIndex + 0] = std::isnan(bounds[activeIndex + 0]) ? xVal : std::min(bounds[activeIndex + 0], xVal);
+      bounds[activeIndex + 1] = std::isnan(bounds[activeIndex + 1]) ? yVal : std::min(bounds[activeIndex + 1], yVal);
+      bounds[activeIndex + 2] = std::isnan(bounds[activeIndex + 2]) ? zVal : std::min(bounds[activeIndex + 2], zVal);
 
-      maxX = std::max(maxX, xVal);
-      maxY = std::max(maxY, yVal);
-      maxZ = std::max(maxZ, zVal);
+      bounds[activeIndex + 3] = std::isnan(bounds[activeIndex + 3]) ? xVal : std::max(bounds[activeIndex + 3], xVal);
+      bounds[activeIndex + 4] = std::isnan(bounds[activeIndex + 4]) ? yVal : std::max(bounds[activeIndex + 4], yVal);
+      bounds[activeIndex + 5] = std::isnan(bounds[activeIndex + 5]) ? zVal : std::max(bounds[activeIndex + 5], zVal);
     }
   }
-
-  return std::make_pair(Point3Df(minX, minY, minZ), Point3Df(maxX, maxY, maxZ));
-}
-} // namespace Geometry0D
-namespace Geometry1D
-{
-std::pair<Point3Df, Point3Df> CalculateFeatureBounds(int32 activeFeature, const IGeometry::SharedVertexList::store_type& verts, const IGeometry::SharedEdgeList::store_type& edges,
-                                                     const Int32AbstractDataStore& featureIds)
-{
-  float32 maxX = std::numeric_limits<float32>::lowest();
-  float32 maxY = std::numeric_limits<float32>::lowest();
-  float32 maxZ = std::numeric_limits<float32>::lowest();
-
-  float32 minX = std::numeric_limits<float32>::max();
-  float32 minY = std::numeric_limits<float32>::max();
-  float32 minZ = std::numeric_limits<float32>::max();
-
-  usize numComp = edges.getNumberOfComponents();
-  for(usize i = 0; i < edges.getNumberOfTuples(); i++)
+  if constexpr(std::is_same_v<EdgeGeom, GeomT>)
   {
-    if(featureIds[i] == activeFeature)
+    const IGeometry::SharedVertexList::store_type& verts = geom.getVerticesRef().getDataStoreRef();
+    const IGeometry::SharedEdgeList::store_type& edges = geom.getEdgesRef().getDataStoreRef();
+
+    usize numComp = edges.getNumberOfComponents();
+    for(usize i = 0; i < edges.getNumberOfTuples(); i++)
     {
+      const int32 currentFeatureId = featureIds[i];
+      if(currentFeatureId < 0)
+      {
+        continue;
+      }
+
       for(usize comp = 0; comp < numComp; comp++)
       {
         const IGeometry::SharedFaceList::value_type activeVertIndex = edges[(i * numComp) + comp];
@@ -206,38 +117,31 @@ std::pair<Point3Df, Point3Df> CalculateFeatureBounds(int32 activeFeature, const 
         float32 yVal = verts[(activeVertIndex * 3) + 1];
         float32 zVal = verts[(activeVertIndex * 3) + 2];
 
-        minX = std::min(minX, xVal);
-        minY = std::min(minY, yVal);
-        minZ = std::min(minZ, zVal);
+        usize activeIndex = currentFeatureId * 6;
+        bounds[activeIndex + 0] = std::isnan(bounds[activeIndex + 0]) ? xVal : std::min(bounds[activeIndex + 0], xVal);
+        bounds[activeIndex + 1] = std::isnan(bounds[activeIndex + 1]) ? yVal : std::min(bounds[activeIndex + 1], yVal);
+        bounds[activeIndex + 2] = std::isnan(bounds[activeIndex + 2]) ? zVal : std::min(bounds[activeIndex + 2], zVal);
 
-        maxX = std::max(maxX, xVal);
-        maxY = std::max(maxY, yVal);
-        maxZ = std::max(maxZ, zVal);
+        bounds[activeIndex + 3] = std::isnan(bounds[activeIndex + 3]) ? xVal : std::max(bounds[activeIndex + 3], xVal);
+        bounds[activeIndex + 4] = std::isnan(bounds[activeIndex + 4]) ? yVal : std::max(bounds[activeIndex + 4], yVal);
+        bounds[activeIndex + 5] = std::isnan(bounds[activeIndex + 5]) ? zVal : std::max(bounds[activeIndex + 5], zVal);
       }
     }
   }
-
-  return std::make_pair(Point3Df(minX, minY, minZ), Point3Df(maxX, maxY, maxZ));
-}
-} // namespace Geometry1D
-namespace Geometry2D
-{
-std::pair<Point3Df, Point3Df> CalculateFeatureBounds(int32 activeFeature, const IGeometry::SharedVertexList::store_type& verts, const IGeometry::SharedFaceList::store_type& faces,
-                                                     const Int32AbstractDataStore& featureIds)
-{
-  float32 maxX = std::numeric_limits<float32>::lowest();
-  float32 maxY = std::numeric_limits<float32>::lowest();
-  float32 maxZ = std::numeric_limits<float32>::lowest();
-
-  float32 minX = std::numeric_limits<float32>::max();
-  float32 minY = std::numeric_limits<float32>::max();
-  float32 minZ = std::numeric_limits<float32>::max();
-
-  usize numComp = faces.getNumberOfComponents();
-  for(usize i = 0; i < faces.getNumberOfTuples(); i++)
+  if constexpr(std::is_same_v<TriangleGeom, GeomT> || std::is_same_v<QuadGeom, GeomT>)
   {
-    if(featureIds[i] == activeFeature)
+    const IGeometry::SharedVertexList::store_type& verts = geom.getVerticesRef().getDataStoreRef();
+    const IGeometry::SharedFaceList::store_type& faces = geom.getFacesRef().getDataStoreRef();
+
+    usize numComp = faces.getNumberOfComponents();
+    for(usize i = 0; i < faces.getNumberOfTuples(); i++)
     {
+      const int32 currentFeatureId = featureIds[i];
+      if(currentFeatureId < 0)
+      {
+        continue;
+      }
+
       for(usize comp = 0; comp < numComp; comp++)
       {
         const IGeometry::SharedFaceList::value_type activeVertIndex = faces[(i * numComp) + comp];
@@ -245,185 +149,45 @@ std::pair<Point3Df, Point3Df> CalculateFeatureBounds(int32 activeFeature, const 
         float32 yVal = verts[(activeVertIndex * 3) + 1];
         float32 zVal = verts[(activeVertIndex * 3) + 2];
 
-        minX = std::min(minX, xVal);
-        minY = std::min(minY, yVal);
-        minZ = std::min(minZ, zVal);
+        usize activeIndex = currentFeatureId * 6;
+        bounds[activeIndex + 0] = std::isnan(bounds[activeIndex + 0]) ? xVal : std::min(bounds[activeIndex + 0], xVal);
+        bounds[activeIndex + 1] = std::isnan(bounds[activeIndex + 1]) ? yVal : std::min(bounds[activeIndex + 1], yVal);
+        bounds[activeIndex + 2] = std::isnan(bounds[activeIndex + 2]) ? zVal : std::min(bounds[activeIndex + 2], zVal);
 
-        maxX = std::max(maxX, xVal);
-        maxY = std::max(maxY, yVal);
-        maxZ = std::max(maxZ, zVal);
+        bounds[activeIndex + 3] = std::isnan(bounds[activeIndex + 3]) ? xVal : std::max(bounds[activeIndex + 3], xVal);
+        bounds[activeIndex + 4] = std::isnan(bounds[activeIndex + 4]) ? yVal : std::max(bounds[activeIndex + 4], yVal);
+        bounds[activeIndex + 5] = std::isnan(bounds[activeIndex + 5]) ? zVal : std::max(bounds[activeIndex + 5], zVal);
       }
     }
   }
 
-  return std::make_pair(Point3Df(minX, minY, minZ), Point3Df(maxX, maxY, maxZ));
+  return bounds;
 }
-} // namespace Geometry2D
 
-template <typename T>
-concept GeometryType = std::is_base_of_v<IGeometry, T>;
-
-template <GeometryType GeomT>
-class ComputeSplitBoundsImpl
-{
-public:
-  ComputeSplitBoundsImpl(const GeomT& geom, const Int32AbstractDataStore& featureIds, Float32AbstractDataStore& minBounds, Float32AbstractDataStore& maxBounds)
-  : m_Geom(geom)
-  , m_FeatureIds(featureIds)
-  , m_MinBounds(minBounds)
-  , m_MaxBounds(maxBounds)
-  {
-  }
-  ~ComputeSplitBoundsImpl() = default;
-
-  // -----------------------------------------------------------------------------
-  void compute(usize start, usize end) const
-  {
-    std::pair<Point3Df, Point3Df> minMax;
-    for(usize feature = start; feature < end; feature++)
-    {
-      if constexpr(std::is_same_v<ImageGeom, GeomT>)
-      {
-        minMax = GeometryGrid::CalculateFeatureBounds(feature, m_Geom, m_FeatureIds);
-      }
-      if constexpr(std::is_same_v<VertexGeom, GeomT>)
-      {
-        const IGeometry::SharedVertexList::store_type& verts = m_Geom.getVerticesRef().getDataStoreRef();
-        minMax = Geometry0D::CalculateFeatureBounds(feature, verts, m_FeatureIds);
-      }
-      if constexpr(std::is_same_v<EdgeGeom, GeomT>)
-      {
-        const IGeometry::SharedVertexList::store_type& verts = m_Geom.getVerticesRef().getDataStoreRef();
-        const IGeometry::SharedEdgeList::store_type& edges = m_Geom.getEdgesRef().getDataStoreRef();
-        minMax = Geometry1D::CalculateFeatureBounds(feature, verts, edges, m_FeatureIds);
-      }
-      if constexpr(std::is_same_v<TriangleGeom, GeomT> || std::is_same_v<QuadGeom, GeomT>)
-      {
-        const IGeometry::SharedVertexList::store_type& verts = m_Geom.getVerticesRef().getDataStoreRef();
-        const IGeometry::SharedFaceList::store_type& faces = m_Geom.getFacesRef().getDataStoreRef();
-        minMax = Geometry2D::CalculateFeatureBounds(feature, verts, faces, m_FeatureIds);
-      }
-
-      // Set Min
-      m_MinBounds[(feature * 3) + 0] = minMax.first.getX();
-      m_MinBounds[(feature * 3) + 1] = minMax.first.getY();
-      m_MinBounds[(feature * 3) + 2] = minMax.first.getZ();
-
-      // Set Max
-      m_MaxBounds[(feature * 3) + 0] = minMax.second.getX();
-      m_MaxBounds[(feature * 3) + 1] = minMax.second.getY();
-      m_MaxBounds[(feature * 3) + 2] = minMax.second.getZ();
-    }
-  }
-
-  // -----------------------------------------------------------------------------
-  void operator()(const Range& range) const
-  {
-    compute(range.min(), range.max());
-  }
-
-private:
-  const GeomT& m_Geom;
-  const Int32AbstractDataStore& m_FeatureIds;
-  Float32AbstractDataStore& m_MinBounds;
-  Float32AbstractDataStore& m_MaxBounds;
-};
-
-template <GeometryType GeomT>
-class ComputeUnifiedBoundsImpl
-{
-public:
-  ComputeUnifiedBoundsImpl(const GeomT& geom, const Int32AbstractDataStore& featureIds, Float32AbstractDataStore& unifiedBounds)
-  : m_Geom(geom)
-  , m_FeatureIds(featureIds)
-  , m_UnifiedBounds(unifiedBounds)
-  {
-  }
-  ~ComputeUnifiedBoundsImpl() = default;
-
-  // -----------------------------------------------------------------------------
-  void compute(usize start, usize end) const
-  {
-    static_assert(std::is_same_v<ImageGeom, GeomT> || std::is_base_of_v<INodeGeometry0D, GeomT> || std::is_base_of_v<INodeGeometry1D, GeomT> || std::is_base_of_v<INodeGeometry2D, GeomT>);
-    std::pair<Point3Df, Point3Df> minMax;
-    for(usize feature = start; feature < end; feature++)
-    {
-      if constexpr(std::is_same_v<ImageGeom, GeomT>)
-      {
-        minMax = GeometryGrid::CalculateFeatureBounds(feature, m_Geom, m_FeatureIds);
-      }
-      if constexpr(std::is_same_v<VertexGeom, GeomT>)
-      {
-        const IGeometry::SharedVertexList::store_type& verts = m_Geom.getVerticesRef().getDataStoreRef();
-        minMax = Geometry0D::CalculateFeatureBounds(feature, verts, m_FeatureIds);
-      }
-      if constexpr(std::is_same_v<EdgeGeom, GeomT>)
-      {
-        const IGeometry::SharedVertexList::store_type& verts = m_Geom.getVerticesRef().getDataStoreRef();
-        const IGeometry::SharedEdgeList::store_type& edges = m_Geom.getEdgesRef().getDataStoreRef();
-        minMax = Geometry1D::CalculateFeatureBounds(feature, verts, edges, m_FeatureIds);
-      }
-      if constexpr(std::is_same_v<TriangleGeom, GeomT> || std::is_same_v<QuadGeom, GeomT>)
-      {
-        const IGeometry::SharedVertexList::store_type& verts = m_Geom.getVerticesRef().getDataStoreRef();
-        const IGeometry::SharedFaceList::store_type& faces = m_Geom.getFacesRef().getDataStoreRef();
-        minMax = Geometry2D::CalculateFeatureBounds(feature, verts, faces, m_FeatureIds);
-      }
-
-      // Set Min
-      m_UnifiedBounds[(feature * 6) + 0] = minMax.first.getX();
-      m_UnifiedBounds[(feature * 6) + 1] = minMax.first.getY();
-      m_UnifiedBounds[(feature * 6) + 2] = minMax.first.getZ();
-
-      // Set Max
-      m_UnifiedBounds[(feature * 6) + 3] = minMax.second.getX();
-      m_UnifiedBounds[(feature * 6) + 4] = minMax.second.getY();
-      m_UnifiedBounds[(feature * 6) + 5] = minMax.second.getZ();
-    }
-  }
-
-  // -----------------------------------------------------------------------------
-  void operator()(const Range& range) const
-  {
-    compute(range.min(), range.max());
-  }
-
-private:
-  const GeomT& m_Geom;
-  const Int32AbstractDataStore& m_FeatureIds;
-  Float32AbstractDataStore& m_UnifiedBounds;
-};
-
-template <template <class> class BodyT, class... ArgsT>
-Result<> ExecuteComputeBounds(const IGeometry& geom, ParallelDataAlgorithm&& dataAlg, ArgsT&&... args)
+template <class... ArgsT>
+std::vector<float32> ExecuteComputeBounds(const IGeometry& geom, ArgsT&&... args)
 {
   switch(geom.getGeomType())
   {
   case IGeometry::Type::Image: {
-    dataAlg.execute(BodyT<ImageGeom>(dynamic_cast<const ImageGeom&>(geom), std::forward<ArgsT>(args)...));
-    break;
+    return ComputeBounds(dynamic_cast<const ImageGeom&>(geom), std::forward<ArgsT>(args)...);
   }
   case IGeometry::Type::Triangle: {
-    dataAlg.execute(BodyT<TriangleGeom>(dynamic_cast<const TriangleGeom&>(geom), std::forward<ArgsT>(args)...));
-    break;
+    return ComputeBounds(dynamic_cast<const TriangleGeom&>(geom), std::forward<ArgsT>(args)...);
   }
   case IGeometry::Type::Vertex: {
-    dataAlg.execute(BodyT<VertexGeom>(dynamic_cast<const VertexGeom&>(geom), std::forward<ArgsT>(args)...));
-    break;
+    return ComputeBounds(dynamic_cast<const VertexGeom&>(geom), std::forward<ArgsT>(args)...);
   }
   case IGeometry::Type::Edge: {
-    dataAlg.execute(BodyT<EdgeGeom>(dynamic_cast<const EdgeGeom&>(geom), std::forward<ArgsT>(args)...));
-    break;
+    return ComputeBounds(dynamic_cast<const EdgeGeom&>(geom), std::forward<ArgsT>(args)...);
   }
   case IGeometry::Type::Quad: {
-    dataAlg.execute(BodyT<QuadGeom>(dynamic_cast<const QuadGeom&>(geom), std::forward<ArgsT>(args)...));
-    break;
+    return ComputeBounds(dynamic_cast<const QuadGeom&>(geom), std::forward<ArgsT>(args)...);
   }
   default: {
-    return MakeErrorResult(-89472, fmt::format("Input geometry must be of type(s) [ Image, Triangle, Vertex, Edge, Quad ]. Supplied geometry name {}", geom.getName()));
+    return {};
   }
   }
-  return {};
 }
 } // namespace
 
@@ -454,70 +218,45 @@ Result<> ComputeFeatureBounds::operator()()
 
   const auto& geom = m_DataStructure.getDataRefAs<IGeometry>(m_InputValues->GeometryPath);
 
-  // Specialize on the Image Geometry to flip the loops so we loop over the entire
-  // image geometry only once updating the min and max as we go. This equates to
-  // about a 10x speed up in release mode.
-  if(geom.getGeomType() == IGeometry::Type::Image)
+  std::vector<float32> bounds = ExecuteComputeBounds(geom, featureIds, numFeatures);
+  if(bounds.empty())
   {
-    auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->GeometryPath);
-    std::vector<GeometryGrid::MinMaxPairType> output = GeometryGrid::CalculateFeatureBounds2(numFeatures, imageGeom, featureIds);
-    switch(static_cast<OutputDataType>(m_InputValues->OutputType))
-    {
-    case OutputDataType::Split: {
-      auto& minArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->MinArrayPath).getDataStoreRef();
-      auto& maxArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->MaxArrayPath).getDataStoreRef();
-      for(size_t i = 0; i < numFeatures; i++)
-      {
-        minArray.setTuple(i, output[i].first.data());
-        maxArray.setTuple(i, output[i].second.data());
-      }
-      break;
-    }
-    case OutputDataType::Unified: {
-      auto& unifiedArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->UnifiedArrayPath).getDataStoreRef();
-      for(size_t i = 0; i < numFeatures; i++)
-      {
-        unifiedArray.setComponent(i, 0, output[i].first[0]);
-        unifiedArray.setComponent(i, 1, output[i].first[1]);
-        unifiedArray.setComponent(i, 2, output[i].first[2]);
-        unifiedArray.setComponent(i, 3, output[i].second[0]);
-        unifiedArray.setComponent(i, 4, output[i].second[1]);
-        unifiedArray.setComponent(i, 5, output[i].second[2]);
-      }
-      break;
-    }
-    }
+    return MakeErrorResult(-89472, fmt::format("Input geometry must be of type(s) [ Image, Triangle, Vertex, Edge, Quad ]. Supplied geometry name {}", geom.getName()));
   }
-  else
-  {
-    ParallelDataAlgorithm dataAlg;
-    dataAlg.setRange(0, numFeatures);
 
-    switch(static_cast<OutputDataType>(m_InputValues->OutputType))
+  switch(static_cast<OutputDataType>(m_InputValues->OutputType))
+  {
+  case OutputDataType::Split: {
+    auto& minBounds = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->MinArrayPath).getDataStoreRef();
+    auto& maxBounds = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->MaxArrayPath).getDataStoreRef();
+    for(usize i = 0; i < minBounds.getNumberOfTuples(); i++)
     {
-    case OutputDataType::Split: {
-      auto& minArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->MinArrayPath).getDataStoreRef();
-      minArray.fill(std::numeric_limits<float>::quiet_NaN());
-      auto& maxArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->MaxArrayPath).getDataStoreRef();
-      maxArray.fill(std::numeric_limits<float>::quiet_NaN());
-      auto result = ExecuteComputeBounds<::ComputeSplitBoundsImpl>(geom, std::move(dataAlg), featureIds, minArray, maxArray);
-      if(result.invalid())
-      {
-        return result;
-      }
-      break;
+      usize activeIndex = i * 6;
+      minBounds.setValue((i * 3) + 0, bounds[activeIndex + 0]);
+      minBounds.setValue((i * 3) + 1, bounds[activeIndex + 1]);
+      minBounds.setValue((i * 3) + 2, bounds[activeIndex + 2]);
+
+      maxBounds.setValue((i * 3) + 0, bounds[activeIndex + 3]);
+      maxBounds.setValue((i * 3) + 1, bounds[activeIndex + 4]);
+      maxBounds.setValue((i * 3) + 2, bounds[activeIndex + 5]);
     }
-    case OutputDataType::Unified: {
-      auto& unifiedArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->UnifiedArrayPath).getDataStoreRef();
-      unifiedArray.fill(std::numeric_limits<float>::quiet_NaN());
-      auto result = ExecuteComputeBounds<::ComputeUnifiedBoundsImpl>(geom, std::move(dataAlg), featureIds, unifiedArray);
-      if(result.invalid())
-      {
-        return result;
-      }
-      break;
+    break;
+  }
+  case OutputDataType::Unified: {
+    auto& unifiedBounds = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->UnifiedArrayPath).getDataStoreRef();
+    for(usize i = 0; i < unifiedBounds.getNumberOfTuples(); i++)
+    {
+      usize activeIndex = i * 6;
+      unifiedBounds.setValue(activeIndex + 0, bounds[activeIndex + 0]);
+      unifiedBounds.setValue(activeIndex + 1, bounds[activeIndex + 1]);
+      unifiedBounds.setValue(activeIndex + 2, bounds[activeIndex + 2]);
+
+      unifiedBounds.setValue(activeIndex + 3, bounds[activeIndex + 3]);
+      unifiedBounds.setValue(activeIndex + 4, bounds[activeIndex + 4]);
+      unifiedBounds.setValue(activeIndex + 5, bounds[activeIndex + 5]);
     }
-    }
+    break;
+  }
   }
 
   if(m_InputValues->CreateEdgeGeometry)
@@ -556,22 +295,31 @@ Result<> ComputeFeatureBounds::operator()()
     size_t currentOffset = 0;
     for(size_t idx = 0; idx < numFeatures; ++idx)
     {
-      std::array<float, 6> bounds = copyBoundsForFeature(m_InputValues, m_DataStructure, idx);
+      usize activeIndex = idx * 6;
       // NaN values mean that there was something wrong with the bounding min/max points.
-      if(std::any_of(bounds.begin(), bounds.end(), [](float v) { return std::isnan(v); }))
+      bool foundNAN = false;
+      for(usize i = 0; i < 6; i++)
+      {
+        if(std::isnan(bounds[activeIndex + i]))
+        {
+          foundNAN = true;
+          break;
+        }
+      }
+      if(foundNAN)
       {
         continue;
       }
 
       // Create the 8 Vertices
-      edgeGeom.setVertexCoordinate(currentOffset * 8 + 0, {bounds[0], bounds[1], bounds[2]});
-      edgeGeom.setVertexCoordinate(currentOffset * 8 + 1, {bounds[3], bounds[1], bounds[2]});
-      edgeGeom.setVertexCoordinate(currentOffset * 8 + 2, {bounds[3], bounds[4], bounds[2]});
-      edgeGeom.setVertexCoordinate(currentOffset * 8 + 3, {bounds[0], bounds[4], bounds[2]});
-      edgeGeom.setVertexCoordinate(currentOffset * 8 + 4, {bounds[0], bounds[1], bounds[5]});
-      edgeGeom.setVertexCoordinate(currentOffset * 8 + 5, {bounds[3], bounds[1], bounds[5]});
-      edgeGeom.setVertexCoordinate(currentOffset * 8 + 6, {bounds[3], bounds[4], bounds[5]});
-      edgeGeom.setVertexCoordinate(currentOffset * 8 + 7, {bounds[0], bounds[4], bounds[5]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 0, {bounds[activeIndex + 0], bounds[activeIndex + 1], bounds[activeIndex + 2]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 1, {bounds[activeIndex + 3], bounds[activeIndex + 1], bounds[activeIndex + 2]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 2, {bounds[activeIndex + 3], bounds[activeIndex + 4], bounds[activeIndex + 2]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 3, {bounds[activeIndex + 0], bounds[activeIndex + 4], bounds[activeIndex + 2]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 4, {bounds[activeIndex + 0], bounds[activeIndex + 1], bounds[activeIndex + 5]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 5, {bounds[activeIndex + 3], bounds[activeIndex + 1], bounds[activeIndex + 5]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 6, {bounds[activeIndex + 3], bounds[activeIndex + 4], bounds[activeIndex + 5]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 7, {bounds[activeIndex + 0], bounds[activeIndex + 4], bounds[activeIndex + 5]});
 
       // Create the 12 Edges
       for(size_t edgeIdx = 0; edgeIdx < cubeEdges.size(); ++edgeIdx)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureBounds.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureBounds.cpp
@@ -18,17 +18,40 @@ using namespace nx::core;
 
 namespace
 {
+
+std::array<float, 6> copyBoundsForFeature(const ComputeFeatureBoundsInputValues* inputValues, const DataStructure& datatStructure, size_t featureIndex)
+{
+
+  switch(auto outputType = static_cast<ComputeFeatureBounds::OutputDataType>(inputValues->OutputType))
+  {
+  case ComputeFeatureBounds::OutputDataType::Split: {
+    auto& minArray = datatStructure.getDataRefAs<Float32Array>(inputValues->MinArrayPath).getDataStoreRef();
+    auto& maxArray = datatStructure.getDataRefAs<Float32Array>(inputValues->MaxArrayPath).getDataStoreRef();
+
+    return {minArray[featureIndex * 3], minArray[featureIndex * 3 + 1], minArray[featureIndex * 3 + 2], maxArray[featureIndex * 3], maxArray[featureIndex * 3 + 1], maxArray[featureIndex * 3 + 2]};
+  }
+  case ComputeFeatureBounds::OutputDataType::Unified: {
+    auto& unifiedArray = datatStructure.getDataRefAs<Float32Array>(inputValues->UnifiedArrayPath).getDataStoreRef();
+    return {unifiedArray[featureIndex * 3],     unifiedArray[featureIndex * 3 + 1], unifiedArray[featureIndex * 3 + 2],
+            unifiedArray[featureIndex * 3 + 3], unifiedArray[featureIndex * 3 + 4], unifiedArray[featureIndex * 3 + 5]};
+  }
+  }
+  return {};
+}
+
 namespace GeometryGrid
 {
+
 std::pair<Point3Df, Point3Df> CalculateFeatureBounds(int32 activeFeature, const ImageGeom& imageGeom, const Int32AbstractDataStore& featureIds)
 {
-  float32 maxX = std::numeric_limits<float32>::lowest();
-  float32 maxY = std::numeric_limits<float32>::lowest();
-  float32 maxZ = std::numeric_limits<float32>::lowest();
 
-  float32 minX = std::numeric_limits<float32>::max();
-  float32 minY = std::numeric_limits<float32>::max();
-  float32 minZ = std::numeric_limits<float32>::max();
+  float32 maxX = std::numeric_limits<float32>::quiet_NaN();
+  float32 maxY = std::numeric_limits<float32>::quiet_NaN();
+  float32 maxZ = std::numeric_limits<float32>::quiet_NaN();
+
+  float32 minX = std::numeric_limits<float32>::quiet_NaN();
+  float32 minY = std::numeric_limits<float32>::quiet_NaN();
+  float32 minZ = std::numeric_limits<float32>::quiet_NaN();
 
   size_t xPoints = imageGeom.getNumXCells();
   size_t yPoints = imageGeom.getNumYCells();
@@ -48,17 +71,21 @@ std::pair<Point3Df, Point3Df> CalculateFeatureBounds(int32 activeFeature, const 
         if(featureIds[zStride + yStride + k] == activeFeature)
         {
           // We are inlining the calculations here to leverage the speed of primitives (no Point object or vector from the API)
-          float32 xVal = k * spacing[0] + origin[0] + (0.5f * spacing[0]);
-          float32 yVal = j * spacing[1] + origin[1] + (0.5f * spacing[1]);
-          float32 zVal = i * spacing[2] + origin[2] + (0.5f * spacing[2]);
+          float32 xValMin = k * spacing[0] + origin[0];
+          float32 yValMin = j * spacing[1] + origin[1];
+          float32 zValMin = i * spacing[2] + origin[2];
 
-          minX = std::min(minX, xVal);
-          minY = std::min(minY, yVal);
-          minZ = std::min(minZ, zVal);
+          float32 xValMax = k * spacing[0] + origin[0] + spacing[0];
+          float32 yValMax = j * spacing[1] + origin[1] + spacing[1];
+          float32 zValMax = i * spacing[2] + origin[2] + spacing[2];
 
-          maxX = std::max(maxX, xVal);
-          maxY = std::max(maxY, yVal);
-          maxZ = std::max(maxZ, zVal);
+          minX = std::isnan(minX) ? xValMin : std::min(minX, xValMin);
+          minY = std::isnan(minY) ? yValMin : std::min(minY, yValMin);
+          minZ = std::isnan(minZ) ? zValMin : std::min(minZ, zValMin);
+
+          maxX = std::isnan(maxX) ? xValMax : std::max(maxX, xValMax);
+          maxY = std::isnan(maxY) ? yValMax : std::max(maxY, yValMax);
+          maxZ = std::isnan(maxZ) ? zValMax : std::max(maxZ, zValMax);
         }
       }
     }
@@ -66,6 +93,60 @@ std::pair<Point3Df, Point3Df> CalculateFeatureBounds(int32 activeFeature, const 
 
   return std::make_pair(Point3Df(minX, minY, minZ), Point3Df(maxX, maxY, maxZ));
 }
+
+using MinMaxPairType = std::pair<Point3Df, Point3Df>;
+std::vector<MinMaxPairType> CalculateFeatureBounds2(int32 numFeatures, const ImageGeom& imageGeom, const Int32AbstractDataStore& featureIds)
+{
+  auto quietNan = std::numeric_limits<float32>::quiet_NaN();
+  std::vector<MinMaxPairType> features(numFeatures, MinMaxPairType{{quietNan, quietNan, quietNan}, {quietNan, quietNan, quietNan}});
+
+  size_t xPoints = imageGeom.getNumXCells();
+  size_t yPoints = imageGeom.getNumYCells();
+  size_t zPoints = imageGeom.getNumZCells();
+  FloatVec3 spacing = imageGeom.getSpacing();
+  FloatVec3 origin = imageGeom.getOrigin();
+
+  size_t zStride = 0, yStride = 0;
+  for(size_t i = 0; i < zPoints; i++)
+  {
+    zStride = i * xPoints * yPoints;
+    for(size_t j = 0; j < yPoints; j++)
+    {
+      yStride = j * xPoints;
+      for(size_t k = 0; k < xPoints; k++)
+      {
+        const int32 currentFeatureId = featureIds[zStride + yStride + k];
+        if(currentFeatureId < 0)
+        {
+          continue;
+        }
+        auto& minPoint = features[currentFeatureId].first;
+        auto& maxPoint = features[currentFeatureId].second;
+
+        float32 xValMin = k * spacing[0] + origin[0];
+        float32 yValMin = j * spacing[1] + origin[1];
+        float32 zValMin = i * spacing[2] + origin[2];
+
+        float32 xValMax = k * spacing[0] + origin[0] + spacing[0];
+        float32 yValMax = j * spacing[1] + origin[1] + spacing[1];
+        float32 zValMax = i * spacing[2] + origin[2] + spacing[2];
+
+        float32 minX = std::isnan(minPoint[0]) ? xValMin : std::min(minPoint[0], xValMin);
+        float32 minY = std::isnan(minPoint[1]) ? yValMin : std::min(minPoint[1], yValMin);
+        float32 minZ = std::isnan(minPoint[2]) ? zValMin : std::min(minPoint[2], zValMin);
+
+        float32 maxX = std::isnan(maxPoint[0]) ? xValMax : std::max(maxPoint[0], xValMax);
+        float32 maxY = std::isnan(maxPoint[1]) ? yValMax : std::max(maxPoint[1], yValMax);
+        float32 maxZ = std::isnan(maxPoint[2]) ? zValMax : std::max(maxPoint[2], zValMax);
+
+        features[currentFeatureId] = {{minX, minY, minZ}, {maxX, maxY, maxZ}};
+      }
+    }
+  }
+
+  return features;
+}
+
 } // namespace GeometryGrid
 namespace Geometry0D
 {
@@ -371,21 +452,145 @@ Result<> ComputeFeatureBounds::operator()()
                                                featureAM.getNumTuples(), numFeatures, m_InputValues->FeatureIdsArrayPath.getTargetName()));
   }
 
-  ParallelDataAlgorithm dataAlg;
-  dataAlg.setRange(0, numFeatures);
-
   const auto& geom = m_DataStructure.getDataRefAs<IGeometry>(m_InputValues->GeometryPath);
-  switch(static_cast<OutputDataType>(m_InputValues->OutputType))
+
+  // Specialize on the Image Geometry to flip the loops so we loop over the entire
+  // image geometry only once updating the min and max as we go. This equates to
+  // about a 10x speed up in release mode.
+  if(geom.getGeomType() == IGeometry::Type::Image)
   {
-  case OutputDataType::Split: {
-    auto& minArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->MinArrayPath).getDataStoreRef();
-    auto& maxArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->MaxArrayPath).getDataStoreRef();
-    return ExecuteComputeBounds<::ComputeSplitBoundsImpl>(geom, std::move(dataAlg), featureIds, minArray, maxArray);
+    auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->GeometryPath);
+    std::vector<GeometryGrid::MinMaxPairType> output = GeometryGrid::CalculateFeatureBounds2(numFeatures, imageGeom, featureIds);
+    switch(static_cast<OutputDataType>(m_InputValues->OutputType))
+    {
+    case OutputDataType::Split: {
+      auto& minArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->MinArrayPath).getDataStoreRef();
+      auto& maxArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->MaxArrayPath).getDataStoreRef();
+      for(size_t i = 0; i < numFeatures; i++)
+      {
+        minArray.setTuple(i, output[i].first.data());
+        maxArray.setTuple(i, output[i].second.data());
+      }
+      break;
+    }
+    case OutputDataType::Unified: {
+      auto& unifiedArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->UnifiedArrayPath).getDataStoreRef();
+      for(size_t i = 0; i < numFeatures; i++)
+      {
+        unifiedArray.setComponent(i, 0, output[i].first[0]);
+        unifiedArray.setComponent(i, 1, output[i].first[1]);
+        unifiedArray.setComponent(i, 2, output[i].first[2]);
+        unifiedArray.setComponent(i, 3, output[i].second[0]);
+        unifiedArray.setComponent(i, 4, output[i].second[1]);
+        unifiedArray.setComponent(i, 5, output[i].second[2]);
+      }
+      break;
+    }
+    }
   }
-  case OutputDataType::Unified: {
-    auto& unifiedArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->UnifiedArrayPath).getDataStoreRef();
-    return ExecuteComputeBounds<::ComputeUnifiedBoundsImpl>(geom, std::move(dataAlg), featureIds, unifiedArray);
+  else
+  {
+    ParallelDataAlgorithm dataAlg;
+    dataAlg.setRange(0, numFeatures);
+
+    switch(static_cast<OutputDataType>(m_InputValues->OutputType))
+    {
+    case OutputDataType::Split: {
+      auto& minArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->MinArrayPath).getDataStoreRef();
+      minArray.fill(std::numeric_limits<float>::quiet_NaN());
+      auto& maxArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->MaxArrayPath).getDataStoreRef();
+      maxArray.fill(std::numeric_limits<float>::quiet_NaN());
+      auto result = ExecuteComputeBounds<::ComputeSplitBoundsImpl>(geom, std::move(dataAlg), featureIds, minArray, maxArray);
+      if(result.invalid())
+      {
+        return result;
+      }
+      break;
+    }
+    case OutputDataType::Unified: {
+      auto& unifiedArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->UnifiedArrayPath).getDataStoreRef();
+      unifiedArray.fill(std::numeric_limits<float>::quiet_NaN());
+      auto result = ExecuteComputeBounds<::ComputeUnifiedBoundsImpl>(geom, std::move(dataAlg), featureIds, unifiedArray);
+      if(result.invalid())
+      {
+        return result;
+      }
+      break;
+    }
+    }
   }
+
+  if(m_InputValues->CreateEdgeGeometry)
+  {
+    // define all 12 cube edges as pairs of vertex indices
+    static constexpr std::array<std::pair<int, int>, 12> cubeEdges = {{// bottom face
+                                                                       {0, 1},
+                                                                       {1, 2},
+                                                                       {2, 3},
+                                                                       {3, 0},
+                                                                       // top face
+                                                                       {4, 5},
+                                                                       {5, 6},
+                                                                       {6, 7},
+                                                                       {7, 4},
+                                                                       // vertical sides
+                                                                       {0, 4},
+                                                                       {1, 5},
+                                                                       {2, 6},
+                                                                       {3, 7}}};
+    std::array<usize, 2> vertPair = {0, 0};
+
+    // Compute the number of features which will tell use the number of vertices and edges
+    size_t numVerts = numFeatures * 8;
+    size_t numEdges = numFeatures * 12;
+
+    auto& edgeGeom = m_DataStructure.getDataRefAs<EdgeGeom>(m_InputValues->EdgeGeometryDataPath);
+    edgeGeom.resizeVertexList(numVerts);
+    edgeGeom.resizeEdgeList(numEdges);
+    edgeGeom.getEdgeAttributeMatrix()->resizeTuples({numEdges});
+    edgeGeom.getVertexAttributeMatrix()->resizeTuples({numVerts});
+
+    DataPath edgeAmPath = m_InputValues->EdgeGeometryDataPath.createChildPath(m_InputValues->EdgeAttributeMatrixName);
+    auto& edgeFeatureIds = m_DataStructure.getDataRefAs<Int32Array>(edgeAmPath.createChildPath(m_InputValues->FeatureIdsArrayName)).getDataStoreRef();
+    edgeFeatureIds.fill(-1);
+    size_t currentOffset = 0;
+    for(size_t idx = 0; idx < numFeatures; ++idx)
+    {
+      std::array<float, 6> bounds = copyBoundsForFeature(m_InputValues, m_DataStructure, idx);
+      // NaN values mean that there was something wrong with the bounding min/max points.
+      if(std::any_of(bounds.begin(), bounds.end(), [](float v) { return std::isnan(v); }))
+      {
+        continue;
+      }
+
+      // Create the 8 Vertices
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 0, {bounds[0], bounds[1], bounds[2]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 1, {bounds[3], bounds[1], bounds[2]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 2, {bounds[3], bounds[4], bounds[2]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 3, {bounds[0], bounds[4], bounds[2]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 4, {bounds[0], bounds[1], bounds[5]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 5, {bounds[3], bounds[1], bounds[5]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 6, {bounds[3], bounds[4], bounds[5]});
+      edgeGeom.setVertexCoordinate(currentOffset * 8 + 7, {bounds[0], bounds[4], bounds[5]});
+
+      // Create the 12 Edges
+      for(size_t edgeIdx = 0; edgeIdx < cubeEdges.size(); ++edgeIdx)
+      {
+        vertPair[0] = currentOffset * 8 + (cubeEdges[edgeIdx].first);
+        vertPair[1] = currentOffset * 8 + (cubeEdges[edgeIdx].second);
+
+        edgeGeom.setEdgePointIds(currentOffset * 12 + edgeIdx, vertPair);
+        edgeFeatureIds[currentOffset * 12 + edgeIdx] = currentOffset;
+      }
+      currentOffset++;
+    }
+
+    currentOffset--;
+    // Update the Edge Geometry sizes
+    edgeGeom.resizeVertexList(currentOffset * 8);
+    edgeGeom.getVertexAttributeMatrix()->resizeTuples({currentOffset * 8});
+    edgeGeom.resizeEdgeList(currentOffset * 12);
+    edgeGeom.getEdgeAttributeMatrix()->resizeTuples({currentOffset * 12});
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureBounds.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureBounds.hpp
@@ -6,6 +6,9 @@
 #include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/Filter/IFilter.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
+#include "simplnx/Parameters/DataGroupCreationParameter.hpp"
+#include "simplnx/Parameters/DataGroupSelectionParameter.hpp"
+#include "simplnx/Parameters/DataObjectNameParameter.hpp"
 
 namespace nx::core
 {
@@ -18,6 +21,11 @@ struct SIMPLNXCORE_EXPORT ComputeFeatureBoundsInputValues
   DataPath MinArrayPath;
   DataPath MaxArrayPath;
   DataPath UnifiedArrayPath;
+
+  bool CreateEdgeGeometry;
+  DataGroupCreationParameter::ValueType EdgeGeometryDataPath;
+  DataObjectNameParameter::ValueType EdgeAttributeMatrixName;
+  DataObjectNameParameter::ValueType FeatureIdsArrayName;
 };
 
 /**

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureBoundsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureBoundsFilter.cpp
@@ -13,11 +13,16 @@
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/DataStructure/IDataArray.hpp"
 #include "simplnx/Filter/Actions/CreateArrayAction.hpp"
+#include "simplnx/Filter/Actions/CreateAttributeMatrixAction.hpp"
+#include "simplnx/Filter/Actions/CreateGeometry1DAction.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/AttributeMatrixSelectionParameter.hpp"
+#include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
+#include "simplnx/Parameters/DataGroupCreationParameter.hpp"
 #include "simplnx/Parameters/DataObjectNameParameter.hpp"
 #include "simplnx/Parameters/GeometrySelectionParameter.hpp"
+#include "simplnx/Parameters/NumberParameter.hpp"
 
 using namespace nx::core;
 
@@ -62,13 +67,16 @@ Parameters ComputeFeatureBoundsFilter::parameters() const
   params.insertLinkableParameter(std::make_unique<ChoicesParameter>(
       k_OutputType_Key, "Output Array(s) Type", "If split two three component arrays will be created (Max & Min). If unified one six component array will be created with the XYZXYZ MinMax scheme",
       to_underlying(ComputeFeatureBounds::OutputDataType::Split), ChoicesParameter::Choices{"Split", "Unified"})); // sequence dependent DO NOT REORDER
+  params.insertLinkableParameter(
+      std::make_unique<BoolParameter>(k_Generate_Geometry, "Create Bounding Box Geometries", "Whether or not to create an Edge geometry that are the bounding boxes", false));
 
   params.insertSeparator(Parameters::Separator{"Input Cell Data"});
-  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIdsArrayPath_Key, "Feature Ids", "The DataPath to the DataArray that specifies which feature each point belongs", DataPath{},
-                                                          ArraySelectionParameter::AllowedTypes{DataType::int32}));
   params.insert(std::make_unique<GeometrySelectionParameter>(
       k_SelectedGeometryPath_Key, "Selected Geometry", "The DataPath to the Geometry that contains the points/edges/faces for the geometry", DataPath{},
       GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Vertex, IGeometry::Type::Edge, IGeometry::Type::Image, IGeometry::Type::Triangle, IGeometry::Type::Quad}));
+
+  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIdsArrayPath_Key, "Feature Ids", "The DataPath to the DataArray that specifies which feature each point belongs", DataPath{},
+                                                          ArraySelectionParameter::AllowedTypes{DataType::int32}));
 
   params.insertSeparator(Parameters::Separator{"Input Feature Data"});
   params.insert(std::make_unique<AttributeMatrixSelectionParameter>(k_FeatureAMPath_Key, "Feature Data Attribute Matrix",
@@ -82,10 +90,19 @@ Parameters ComputeFeatureBoundsFilter::parameters() const
   params.insert(std::make_unique<DataObjectNameParameter>(k_UnifiedArrayName_Key, "Unified Bounds Array Name",
                                                           "The name of the array containing the min and max point of the bounding box for each feature", "Feature Bounds"));
 
+  params.insertSeparator(Parameters::Separator{"Output Edge Geometry"});
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_OutputEdgeGeometryPath_Key, "Created Edge Geometry", "The name of the created Edge Geometry", DataPath({"Edge Geometry"})));
+  params.insert(std::make_unique<DataObjectNameParameter>(k_EdgeAttributeMatrixName_Key, "Edge Attribute Matrix", "Attribute Matrix to store information about the created edges", "Edge Data"));
+  params.insert(std::make_unique<DataObjectNameParameter>(k_FeatureIdsArrayName_Key, "Edge Feature Ids", "Identifies the Feature Id to which each edge belongs", "Feature Ids"));
+
   // Associate the Linkable Parameter(s) to the children parameters that they control
   params.linkParameters(k_OutputType_Key, k_MinArrayName_Key, static_cast<ChoicesParameter::ValueType>(to_underlying(ComputeFeatureBounds::OutputDataType::Split)));
   params.linkParameters(k_OutputType_Key, k_MaxArrayName_Key, static_cast<ChoicesParameter::ValueType>(to_underlying(ComputeFeatureBounds::OutputDataType::Split)));
   params.linkParameters(k_OutputType_Key, k_UnifiedArrayName_Key, static_cast<ChoicesParameter::ValueType>(to_underlying(ComputeFeatureBounds::OutputDataType::Unified)));
+
+  params.linkParameters(k_Generate_Geometry, k_OutputEdgeGeometryPath_Key, static_cast<BoolParameter::ValueType>(true));
+  params.linkParameters(k_Generate_Geometry, k_EdgeAttributeMatrixName_Key, static_cast<BoolParameter::ValueType>(true));
+  params.linkParameters(k_Generate_Geometry, k_FeatureIdsArrayName_Key, static_cast<BoolParameter::ValueType>(true));
 
   return params;
 }
@@ -110,6 +127,11 @@ IFilter::PreflightResult ComputeFeatureBoundsFilter::preflightImpl(const DataStr
   auto pFeatureAMPathValue = filterArgs.value<AttributeMatrixSelectionParameter::ValueType>(k_FeatureAMPath_Key);
   auto pFeatureIdsArrayPathValue = filterArgs.value<ArraySelectionParameter::ValueType>(k_FeatureIdsArrayPath_Key);
   auto pSelectedGeomPathValue = filterArgs.value<GeometrySelectionParameter::ValueType>(k_SelectedGeometryPath_Key);
+
+  auto pCreateEdgeGeometry = filterArgs.value<bool>(k_Generate_Geometry);
+  auto pSliceDataContainerNameValue = filterArgs.value<DataGroupCreationParameter::ValueType>(k_OutputEdgeGeometryPath_Key);
+  auto pEdgeAttributeMatrixNameValue = filterArgs.value<DataObjectNameParameter::ValueType>(k_EdgeAttributeMatrixName_Key);
+  auto pFeatureIdsArrayName = filterArgs.value<DataObjectNameParameter::ValueType>(k_FeatureIdsArrayName_Key);
 
   const auto& geom = dataStructure.getDataRefAs<IGeometry>(pSelectedGeomPathValue);
 
@@ -150,6 +172,21 @@ IFilter::PreflightResult ComputeFeatureBoundsFilter::preflightImpl(const DataStr
   }
   }
 
+  // optionally create the edge geometry
+  if(pCreateEdgeGeometry)
+  {
+    auto createGeometryAction = std::make_unique<CreateEdgeGeometryAction>(pSliceDataContainerNameValue, 1, 2, INodeGeometry0D::k_VertexAttributeMatrixName, pEdgeAttributeMatrixNameValue,
+                                                                           EdgeGeom::k_SharedVertexListName, EdgeGeom::k_SharedEdgeListName);
+    resultOutputActions.value().appendAction(std::move(createGeometryAction));
+
+    std::vector<size_t> tDims = {1};
+    const std::vector<size_t> compDims = {1};
+
+    DataPath path = pSliceDataContainerNameValue.createChildPath(pEdgeAttributeMatrixNameValue).createChildPath(pFeatureIdsArrayName);
+    auto createArray = std::make_unique<CreateArrayAction>(DataType::int32, tDims, compDims, path);
+    resultOutputActions.value().appendAction(std::move(createArray));
+  }
+
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
   return {std::move(resultOutputActions)};
 }
@@ -167,6 +204,11 @@ Result<> ComputeFeatureBoundsFilter::executeImpl(DataStructure& dataStructure, c
   inputValues.MinArrayPath = inputValues.FeatureAMPath.createChildPath(filterArgs.value<DataObjectNameParameter::ValueType>(k_MinArrayName_Key));
   inputValues.MaxArrayPath = inputValues.FeatureAMPath.createChildPath(filterArgs.value<DataObjectNameParameter::ValueType>(k_MaxArrayName_Key));
   inputValues.UnifiedArrayPath = inputValues.FeatureAMPath.createChildPath(filterArgs.value<DataObjectNameParameter::ValueType>(k_UnifiedArrayName_Key));
+
+  inputValues.CreateEdgeGeometry = filterArgs.value<bool>(k_Generate_Geometry);
+  inputValues.EdgeGeometryDataPath = filterArgs.value<DataGroupCreationParameter::ValueType>(k_OutputEdgeGeometryPath_Key);
+  inputValues.EdgeAttributeMatrixName = filterArgs.value<DataObjectNameParameter::ValueType>(k_EdgeAttributeMatrixName_Key);
+  inputValues.FeatureIdsArrayName = filterArgs.value<DataObjectNameParameter::ValueType>(k_FeatureIdsArrayName_Key);
 
   return ComputeFeatureBounds(dataStructure, messageHandler, shouldCancel, &inputValues)();
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureBoundsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureBoundsFilter.cpp
@@ -68,7 +68,7 @@ Parameters ComputeFeatureBoundsFilter::parameters() const
       k_OutputType_Key, "Output Array(s) Type", "If split two three component arrays will be created (Max & Min). If unified one six component array will be created with the XYZXYZ MinMax scheme",
       to_underlying(ComputeFeatureBounds::OutputDataType::Split), ChoicesParameter::Choices{"Split", "Unified"})); // sequence dependent DO NOT REORDER
   params.insertLinkableParameter(
-      std::make_unique<BoolParameter>(k_Generate_Geometry, "Create Bounding Box Geometries", "Whether or not to create an Edge geometry that are the bounding boxes", false));
+      std::make_unique<BoolParameter>(k_CreateEdgeGeometry_Key, "Create Bounding Box Geometries", "Whether or not to create an Edge geometry that contains the bounding boxes", false));
 
   params.insertSeparator(Parameters::Separator{"Input Cell Data"});
   params.insert(std::make_unique<GeometrySelectionParameter>(
@@ -93,16 +93,16 @@ Parameters ComputeFeatureBoundsFilter::parameters() const
   params.insertSeparator(Parameters::Separator{"Output Edge Geometry"});
   params.insert(std::make_unique<DataGroupCreationParameter>(k_OutputEdgeGeometryPath_Key, "Created Edge Geometry", "The name of the created Edge Geometry", DataPath({"Edge Geometry"})));
   params.insert(std::make_unique<DataObjectNameParameter>(k_EdgeAttributeMatrixName_Key, "Edge Attribute Matrix", "Attribute Matrix to store information about the created edges", "Edge Data"));
-  params.insert(std::make_unique<DataObjectNameParameter>(k_FeatureIdsArrayName_Key, "Edge Feature Ids", "Identifies the Feature Id to which each edge belongs", "Feature Ids"));
+  params.insert(std::make_unique<DataObjectNameParameter>(k_CreatedFeatureIdsArrayName_Key, "Edge Feature Ids", "Identifies the Feature Id to which each edge belongs", "Feature Ids"));
 
   // Associate the Linkable Parameter(s) to the children parameters that they control
   params.linkParameters(k_OutputType_Key, k_MinArrayName_Key, static_cast<ChoicesParameter::ValueType>(to_underlying(ComputeFeatureBounds::OutputDataType::Split)));
   params.linkParameters(k_OutputType_Key, k_MaxArrayName_Key, static_cast<ChoicesParameter::ValueType>(to_underlying(ComputeFeatureBounds::OutputDataType::Split)));
   params.linkParameters(k_OutputType_Key, k_UnifiedArrayName_Key, static_cast<ChoicesParameter::ValueType>(to_underlying(ComputeFeatureBounds::OutputDataType::Unified)));
 
-  params.linkParameters(k_Generate_Geometry, k_OutputEdgeGeometryPath_Key, static_cast<BoolParameter::ValueType>(true));
-  params.linkParameters(k_Generate_Geometry, k_EdgeAttributeMatrixName_Key, static_cast<BoolParameter::ValueType>(true));
-  params.linkParameters(k_Generate_Geometry, k_FeatureIdsArrayName_Key, static_cast<BoolParameter::ValueType>(true));
+  params.linkParameters(k_CreateEdgeGeometry_Key, k_OutputEdgeGeometryPath_Key, static_cast<BoolParameter::ValueType>(true));
+  params.linkParameters(k_CreateEdgeGeometry_Key, k_EdgeAttributeMatrixName_Key, static_cast<BoolParameter::ValueType>(true));
+  params.linkParameters(k_CreateEdgeGeometry_Key, k_CreatedFeatureIdsArrayName_Key, static_cast<BoolParameter::ValueType>(true));
 
   return params;
 }
@@ -128,10 +128,10 @@ IFilter::PreflightResult ComputeFeatureBoundsFilter::preflightImpl(const DataStr
   auto pFeatureIdsArrayPathValue = filterArgs.value<ArraySelectionParameter::ValueType>(k_FeatureIdsArrayPath_Key);
   auto pSelectedGeomPathValue = filterArgs.value<GeometrySelectionParameter::ValueType>(k_SelectedGeometryPath_Key);
 
-  auto pCreateEdgeGeometry = filterArgs.value<bool>(k_Generate_Geometry);
+  auto pCreateEdgeGeometry = filterArgs.value<bool>(k_CreateEdgeGeometry_Key);
   auto pSliceDataContainerNameValue = filterArgs.value<DataGroupCreationParameter::ValueType>(k_OutputEdgeGeometryPath_Key);
   auto pEdgeAttributeMatrixNameValue = filterArgs.value<DataObjectNameParameter::ValueType>(k_EdgeAttributeMatrixName_Key);
-  auto pFeatureIdsArrayName = filterArgs.value<DataObjectNameParameter::ValueType>(k_FeatureIdsArrayName_Key);
+  auto pFeatureIdsArrayName = filterArgs.value<DataObjectNameParameter::ValueType>(k_CreatedFeatureIdsArrayName_Key);
 
   const auto& geom = dataStructure.getDataRefAs<IGeometry>(pSelectedGeomPathValue);
 
@@ -205,10 +205,10 @@ Result<> ComputeFeatureBoundsFilter::executeImpl(DataStructure& dataStructure, c
   inputValues.MaxArrayPath = inputValues.FeatureAMPath.createChildPath(filterArgs.value<DataObjectNameParameter::ValueType>(k_MaxArrayName_Key));
   inputValues.UnifiedArrayPath = inputValues.FeatureAMPath.createChildPath(filterArgs.value<DataObjectNameParameter::ValueType>(k_UnifiedArrayName_Key));
 
-  inputValues.CreateEdgeGeometry = filterArgs.value<bool>(k_Generate_Geometry);
+  inputValues.CreateEdgeGeometry = filterArgs.value<bool>(k_CreateEdgeGeometry_Key);
   inputValues.EdgeGeometryDataPath = filterArgs.value<DataGroupCreationParameter::ValueType>(k_OutputEdgeGeometryPath_Key);
   inputValues.EdgeAttributeMatrixName = filterArgs.value<DataObjectNameParameter::ValueType>(k_EdgeAttributeMatrixName_Key);
-  inputValues.FeatureIdsArrayName = filterArgs.value<DataObjectNameParameter::ValueType>(k_FeatureIdsArrayName_Key);
+  inputValues.FeatureIdsArrayName = filterArgs.value<DataObjectNameParameter::ValueType>(k_CreatedFeatureIdsArrayName_Key);
 
   return ComputeFeatureBounds(dataStructure, messageHandler, shouldCancel, &inputValues)();
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureBoundsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureBoundsFilter.hpp
@@ -32,10 +32,10 @@ public:
   static inline constexpr StringLiteral k_MaxArrayName_Key = "max_array_name";
   static inline constexpr StringLiteral k_UnifiedArrayName_Key = "unified_array_name";
 
-  static inline constexpr StringLiteral k_Generate_Geometry = "create_edge_geometry";
+  static inline constexpr StringLiteral k_CreateEdgeGeometry_Key = "create_edge_geometry";
   static inline constexpr StringLiteral k_OutputEdgeGeometryPath_Key = "output_edge_geometry_path";
   static inline constexpr StringLiteral k_EdgeAttributeMatrixName_Key = "edge_attribute_matrix_name";
-  static inline constexpr StringLiteral k_FeatureIdsArrayName_Key = "feature_ids_array_name";
+  static inline constexpr StringLiteral k_CreatedFeatureIdsArrayName_Key = "created_feature_ids_array_name";
 
   /**
    * @brief Reads SIMPL json and converts it simplnx Arguments.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureBoundsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureBoundsFilter.hpp
@@ -32,6 +32,11 @@ public:
   static inline constexpr StringLiteral k_MaxArrayName_Key = "max_array_name";
   static inline constexpr StringLiteral k_UnifiedArrayName_Key = "unified_array_name";
 
+  static inline constexpr StringLiteral k_Generate_Geometry = "create_edge_geometry";
+  static inline constexpr StringLiteral k_OutputEdgeGeometryPath_Key = "output_edge_geometry_path";
+  static inline constexpr StringLiteral k_EdgeAttributeMatrixName_Key = "edge_attribute_matrix_name";
+  static inline constexpr StringLiteral k_FeatureIdsArrayName_Key = "feature_ids_array_name";
+
   /**
    * @brief Reads SIMPL json and converts it simplnx Arguments.
    * @param json

--- a/src/Plugins/SimplnxCore/test/ComputeFeatureBoundsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeFeatureBoundsTest.cpp
@@ -89,7 +89,7 @@ TEST_CASE("SimplnxCore::ComputeFeatureBoundsFilter: Image Geom Test - Unified", 
     SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
 
-  const std::array<float32, 6> expectedValues = std::array<float32, 6>{1.5f, 1.5f, 0.5f, 3.5f, 3.5f, 0.5f};
+  const std::array<float32, 6> expectedValues = std::array<float32, 6>{1.0f, 1.0f, 0.0f, 4.0f, 4.0f, 1.0f};
 
   const auto& unified = dataStructure.getDataRefAs<Float32Array>(k_FeatureAMPath.createChildPath("unified"));
   // Start from 1 because feature 0 is junk
@@ -161,7 +161,7 @@ TEST_CASE("SimplnxCore::ComputeFeatureBoundsFilter: Image Geom Test - Split", "[
     SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
 
-  const std::array<float32, 6> expectedValues = std::array<float32, 6>{1.5f, 1.5f, 0.5f, 3.5f, 3.5f, 0.5f};
+  const std::array<float32, 6> expectedValues = std::array<float32, 6>{1.0f, 1.0f, 0.0f, 4.0f, 4.0f, 1.0f};
 
   const auto& min = dataStructure.getDataRefAs<Float32Array>(k_FeatureAMPath.createChildPath("min"));
   const auto& max = dataStructure.getDataRefAs<Float32Array>(k_FeatureAMPath.createChildPath("max"));

--- a/src/Plugins/SimplnxCore/test/ComputeFeatureBoundsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeFeatureBoundsTest.cpp
@@ -28,6 +28,115 @@ const DataPath k_CroppedGeomPath{std::vector<std::string>{"Cropped VertexGeom"}}
 const std::vector<DataPath> targetDataArrays{k_VertexDataPath.createChildPath("DataArray")};
 } // namespace
 
+TEST_CASE("SimplnxCore::ComputeFeatureBoundsFilter: Output Edge Geom Test - Image Geom/Split", "[SimplnxCore][ComputeFeatureBoundsFilter]")
+{
+  DataStructure dataStructure;
+
+  const std::string k_GeomName = "ImageGeom";
+  const DataPath k_GeomPath({k_GeomName});
+  const std::string k_FeatureAMName = "Feature Data";
+  const DataPath k_FeatureAMPath = k_GeomPath.createChildPath(k_FeatureAMName);
+
+  ImageGeom* imageGeom = ImageGeom::Create(dataStructure, k_GeomName);
+  constexpr size_t dimsIn[3] = {5, 5, 1};
+  imageGeom->setDimensions(dimsIn);
+  imageGeom->setOrigin({0, 0, 0});
+  imageGeom->setSpacing({1, 1, 1});
+  std::vector<size_t> dims(3, 0);
+  dims[0] = 1;
+  dims[1] = 5;
+  dims[2] = 5;
+
+  const std::string k_CellAMName = "Cell Data";
+  const DataPath k_CellAMPath = k_GeomPath.createChildPath(k_CellAMName);
+  AttributeMatrix* cellAm = AttributeMatrix::Create(dataStructure, k_CellAMName, dims, imageGeom->getId());
+
+  Int32Array* featureIds = Int32Array::CreateWithStore<DataStore<int32>>(dataStructure, "feature_ids", dims, std::vector<usize>{1}, cellAm->getId());
+  featureIds->fill(-1);
+  (*featureIds)[6] = 1;
+  (*featureIds)[7] = 1;
+  (*featureIds)[8] = 1;
+  (*featureIds)[11] = 1;
+  (*featureIds)[12] = 1;
+  (*featureIds)[13] = 1;
+  (*featureIds)[16] = 1;
+  (*featureIds)[17] = 1;
+  (*featureIds)[18] = 1;
+
+  dims.resize(1);
+  dims[0] = 2;
+  AttributeMatrix* featureAm = AttributeMatrix::Create(dataStructure, k_FeatureAMName, dims, imageGeom->getId());
+
+  {
+    // Instantiate the filter, a DataStructure object and an Arguments Object
+    ComputeFeatureBoundsFilter filter;
+    Arguments args;
+
+    // Create default Parameters for the filter.
+    args.insertOrAssign(ComputeFeatureBoundsFilter::k_OutputType_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(ComputeFeatureBounds::OutputDataType::Split)));
+    args.insertOrAssign(ComputeFeatureBoundsFilter::k_SelectedGeometryPath_Key, std::make_any<DataPath>(k_GeomPath));
+    args.insertOrAssign(ComputeFeatureBoundsFilter::k_FeatureIdsArrayPath_Key, std::make_any<DataPath>(k_CellAMPath.createChildPath("feature_ids")));
+    args.insertOrAssign(ComputeFeatureBoundsFilter::k_FeatureAMPath_Key, std::make_any<DataPath>(k_FeatureAMPath));
+    args.insertOrAssign(ComputeFeatureBoundsFilter::k_MinArrayName_Key, std::make_any<std::string>("min"));
+    args.insertOrAssign(ComputeFeatureBoundsFilter::k_MaxArrayName_Key, std::make_any<std::string>("max"));
+
+    args.insertOrAssign(ComputeFeatureBoundsFilter::k_CreateEdgeGeometry_Key, std::make_any<bool>(true));
+    args.insertOrAssign(ComputeFeatureBoundsFilter::k_OutputEdgeGeometryPath_Key, std::make_any<DataPath>(DataPath({"EdgeGeom"})));
+    args.insertOrAssign(ComputeFeatureBoundsFilter::k_EdgeAttributeMatrixName_Key, std::make_any<std::string>("EdgeAM"));
+    args.insertOrAssign(ComputeFeatureBoundsFilter::k_CreatedFeatureIdsArrayName_Key, std::make_any<std::string>("feature_ids"));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+  }
+
+  // const std::array<float32, 6> expectedValues = std::array<float32, 6>{1.0f, 1.0f, 0.0f, 4.0f, 4.0f, 1.0f};
+  static constexpr std::array<std::array<float32, 3>, 8> expectedVertices = {
+      {{1.0f, 1.0f, 0.0f}, {4.0f, 1.0f, 0.0f}, {4.0f, 4.0f, 0.0f}, {1.0f, 4.0f, 0.0f}, {1.0f, 1.0f, 1.0f}, {4.0f, 1.0f, 1.0f}, {4.0f, 4.0f, 1.0f}, {1.0f, 4.0f, 1.0f}}};
+
+  // define all 12 cube edges as pairs of vertex indices
+  static constexpr std::array<std::array<int32, 2>, 12> expectedEdges = {{// bottom face
+                                                                          {0, 1},
+                                                                          {1, 2},
+                                                                          {2, 3},
+                                                                          {3, 0},
+                                                                          // top face
+                                                                          {4, 5},
+                                                                          {5, 6},
+                                                                          {6, 7},
+                                                                          {7, 4},
+                                                                          // vertical sides
+                                                                          {0, 4},
+                                                                          {1, 5},
+                                                                          {2, 6},
+                                                                          {3, 7}}};
+
+  const auto& edgeGeom = dataStructure.getDataRefAs<EdgeGeom>(DataPath({"EdgeGeom"}));
+  const auto& sharedVertList = edgeGeom.getVerticesRef();
+  const auto& sharedEdgeList = edgeGeom.getEdgesRef();
+  const auto& edgeFeatureIds = dataStructure.getDataRefAs<Int32Array>(DataPath({"EdgeGeom", "EdgeAM", "feature_ids"}));
+
+  for(usize i = 0; i < sharedVertList.getNumberOfTuples(); i++)
+  {
+    REQUIRE(sharedVertList[(i * 3) + 0] == expectedVertices[i][0]);
+    REQUIRE(sharedVertList[(i * 3) + 1] == expectedVertices[i][1]);
+    REQUIRE(sharedVertList[(i * 3) + 2] == expectedVertices[i][2]);
+  }
+
+  for(usize i = 0; i < sharedEdgeList.getNumberOfTuples(); i++)
+  {
+    // Start from 1 because feature 0 is junk
+    REQUIRE(edgeFeatureIds[i] == 1);
+
+    REQUIRE(sharedEdgeList[(i * 2) + 0] == expectedEdges[i][0]);
+    REQUIRE(sharedEdgeList[(i * 2) + 1] == expectedEdges[i][1]);
+  }
+}
+
 TEST_CASE("SimplnxCore::ComputeFeatureBoundsFilter: Image Geom Test - Unified", "[SimplnxCore][ComputeFeatureBoundsFilter]")
 {
 


### PR DESCRIPTION
Enhance the current filter implementation with the ability to create the bounding boxes as an Edge Geometry.

- Optimizes the ImageGeometry section of the code to gather the min/max values within a single loop over the entire Image geometry resulting in a 10x speedup.


- [x] Needs a Unit Test for the generated edge geometry
- [x] Needs a new unit test data file created and verified.
- [x] Documentation needs updating
