### PR TITLE
BUG: Fix Import DREAM3D Memory Usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,9 +455,11 @@ set(SIMPLNX_HDRS
   ${SIMPLNX_SOURCE_DIR}/DataStructure/DataStructure.hpp
   ${SIMPLNX_SOURCE_DIR}/DataStructure/DynamicListArray.hpp
   ${SIMPLNX_SOURCE_DIR}/DataStructure/EmptyDataStore.hpp
+  ${SIMPLNX_SOURCE_DIR}/DataStructure/EmptyListStore.hpp
   ${SIMPLNX_SOURCE_DIR}/DataStructure/IArray.hpp
   ${SIMPLNX_SOURCE_DIR}/DataStructure/IDataArray.hpp
   ${SIMPLNX_SOURCE_DIR}/DataStructure/IDataStore.hpp
+  ${SIMPLNX_SOURCE_DIR}/DataStructure/IListStore.hpp
   ${SIMPLNX_SOURCE_DIR}/DataStructure/INeighborList.hpp
   ${SIMPLNX_SOURCE_DIR}/DataStructure/LinkedPath.hpp
   ${SIMPLNX_SOURCE_DIR}/DataStructure/Metadata.hpp

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LaplacianSmoothing.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LaplacianSmoothing.cpp
@@ -30,6 +30,11 @@ Result<> LaplacianSmoothing::edgeBasedSmoothing()
 {
   auto& surfaceMesh = m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues->pTriangleGeometryDataPath);
 
+  if(surfaceMesh.getVertices() == nullptr)
+  {
+    return MakeErrorResult(-559, "Error finding TriangleGeom vertices.");
+  }
+
   Float32AbstractDataStore& verts = surfaceMesh.getVertices()->getDataStoreRef();
 
   IGeometry::MeshIndexType nvert = surfaceMesh.getNumberOfVertices();

--- a/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
@@ -331,7 +331,7 @@ TEST_CASE("DREAM3DFileTest:Import/Export DREAM3D Filter Test")
     REQUIRE(importDataStructure.getData(DataPath({DataNames::k_Group1Name})) != nullptr);
     auto* dataArray = importDataStructure.getDataAs<DataArray<int8>>(DataPath({DataNames::k_ArrayName}));
     REQUIRE(dataArray != nullptr);
-    REQUIRE(dataArray->template getIDataStoreAs<EmptyDataStore<int8>>() == nullptr);
+    REQUIRE(dataArray->template getIDataStoreAs<EmptyDataStore<int8>>() != nullptr);
   }
 }
 

--- a/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
@@ -331,7 +331,7 @@ TEST_CASE("DREAM3DFileTest:Import/Export DREAM3D Filter Test")
     REQUIRE(importDataStructure.getData(DataPath({DataNames::k_Group1Name})) != nullptr);
     auto* dataArray = importDataStructure.getDataAs<DataArray<int8>>(DataPath({DataNames::k_ArrayName}));
     REQUIRE(dataArray != nullptr);
-    REQUIRE(dataArray->template getIDataStoreAs<EmptyDataStore<int8>>() != nullptr);
+    REQUIRE(dataArray->template getIDataStoreAs<EmptyDataStore<int8>>() == nullptr);
   }
 }
 

--- a/src/simplnx/DataStructure/AbstractDataStore.hpp
+++ b/src/simplnx/DataStructure/AbstractDataStore.hpp
@@ -6,7 +6,6 @@
 #include "simplnx/Common/TypesUtility.hpp"
 #include "simplnx/DataStructure/DataObject.hpp"
 #include "simplnx/DataStructure/IDataStore.hpp"
-#include "simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp"
 
 #include <nonstd/span.hpp>
 
@@ -18,6 +17,11 @@
 
 namespace nx::core
 {
+namespace HDF5
+{
+class DatasetIO;
+}
+
 /**
  * @class AbstractDataStore
  * @brief The AbstractDataStore class serves as an interface class for the

--- a/src/simplnx/DataStructure/AbstractListStore.hpp
+++ b/src/simplnx/DataStructure/AbstractListStore.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "simplnx/Common/Types.hpp"
+#include "simplnx/DataStructure/IListStore.hpp"
 
 #include <memory>
 #include <numeric>
@@ -11,7 +12,7 @@
 namespace nx::core
 {
 template <class T>
-class AbstractListStore
+class AbstractListStore : public IListStore
 {
 public:
   /////////////////////////////////
@@ -541,37 +542,11 @@ public:
   virtual std::unique_ptr<AbstractListStore> deepCopy() const = 0;
 
   /**
-   * @brief This method sets the shape of the dimensions to `tupleShape`.
-   *
-   * There are 3 possibilities when using this function:
-   * [1] The number of tuples of the new shape is *LESS* than the original. In this
-   * case a memory allocation will take place and the first 'N' elements of data
-   * will be copied into the new array. The remaining data is *LOST*
-   *
-   * [2] The number of tuples of the new shape is *EQUAL* to the original. In this
-   * case the shape is set and the function returns.
-   *
-   * [3] The number of tuples of the new shape is *GREATER* than the original. In
-   * this case a new array is allocated and all the data from the original array
-   * is copied into the new array and the remaining elements are initialized to
-   * the default initialization value.
-   *
-   * @param tupleShape The new shape of the data where the dimensions are "C" ordered
-   * from *slowest* to *fastest*.
-   */
-  virtual void resizeTuples(usize tupleCount) = 0;
-
-  /**
    * @brief addEntry
    * @param grainId
    * @param value
    */
   virtual void addEntry(int32 grainId, value_type value) = 0;
-
-  /**
-   * @brief Clear All Lists
-   */
-  virtual void clearAllLists() = 0;
 
   /**
    * @brief setList
@@ -594,8 +569,6 @@ public:
    */
   virtual vector_type getList(int32 grainId) const = 0;
 
-  virtual usize getListSize(usize grainId) const = 0;
-
   /**
    * @brief copyOfList
    * @param grainId
@@ -613,17 +586,6 @@ public:
   virtual T getValue(int32 grainId, int32 index, bool& ok) const = 0;
 
   virtual void setValue(int32 grainId, usize index, T value) = 0;
-
-  /**
-   * @brief getNumberOfLists
-   * @return int32
-   */
-  virtual uint64 getNumberOfLists() const = 0;
-
-  uint64 size() const
-  {
-    return getNumberOfLists();
-  }
 
   /**
    * @brief operator []
@@ -682,11 +644,6 @@ public:
   {
     return const_iterator(*this, size());
   }
-
-  /**
-   * @brief Clears the array.
-   */
-  virtual void clear() = 0;
 
   virtual void setData(const std::vector<shared_vector_type>& lists) = 0;
 

--- a/src/simplnx/DataStructure/AbstractListStore.hpp
+++ b/src/simplnx/DataStructure/AbstractListStore.hpp
@@ -537,7 +537,7 @@ public:
   using reference = value_type&;
   using const_reference = const value_type&;
 
-  virtual ~AbstractListStore() = default;
+  ~AbstractListStore() override = default;
 
   virtual std::unique_ptr<AbstractListStore> deepCopy() const = 0;
 

--- a/src/simplnx/DataStructure/DataStore.hpp
+++ b/src/simplnx/DataStructure/DataStore.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "simplnx/DataStructure/AbstractDataStore.hpp"
+#include "simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp"
 
 #include <fmt/core.h>
 #include <nonstd/span.hpp>

--- a/src/simplnx/DataStructure/EmptyListStore.hpp
+++ b/src/simplnx/DataStructure/EmptyListStore.hpp
@@ -1,0 +1,213 @@
+#pragma once
+
+#include "AbstractListStore.hpp"
+
+#include "simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp"
+
+namespace nx::core
+{
+template <class T>
+class EmptyListStore : public AbstractListStore<T>
+{
+public:
+  using shape_type = typename std::vector<usize>;
+  using value_type = T;
+  using parent_type = AbstractListStore<T>;
+  using vector_type = typename parent_type::vector_type;
+  using shared_vector_type = typename parent_type::shared_vector_type;
+
+  EmptyListStore() = default;
+  /**
+   * @brief Constructs a ListStore using the specified tuple shape and list size.
+   * @param tupleShape
+   * @param listSize
+   */
+  EmptyListStore(usize numTuples)
+  : AbstractListStore<T>()
+  , m_NumTuples(numTuples)
+  {
+  }
+
+  EmptyListStore(const EmptyListStore& rhs) = default;
+  EmptyListStore(EmptyListStore&& rhs) = default;
+
+  ~EmptyListStore() = default;
+
+  /**
+   * @brief Returns a copy of the current list store.
+   * @return std::unique<AbstractListStore<T>>
+   */
+  std::unique_ptr<parent_type> deepCopy() const override
+  {
+    return std::make_unique<EmptyListStore>(*this);
+  }
+
+  /**
+   * @brief addEntry
+   * @param grainId
+   * @param value
+   */
+  void addEntry(int32 grainId, value_type value) override
+  {
+    throw std::runtime_error("EmptyListStore cannot add values to list");
+  }
+
+  void resizeTuples(usize tupleCount) override
+  {
+    m_NumTuples = tupleCount;
+  }
+
+  void clear() override
+  {
+    m_NumTuples = 0;
+  }
+
+  /**
+   * @brief Clear All Lists
+   */
+  void clearAllLists() override
+  {
+    m_NumTuples = 0;
+  }
+
+  uint64 getNumberOfLists() const override
+  {
+    return m_NumTuples;
+  }
+
+  /**
+   * @brief getList
+   * @param grainId
+   * @return shared_vector_type
+   */
+  vector_type getList(int32 grainId) const override
+  {
+    return {};
+  }
+
+  /**
+   * @brief copyOfList
+   * @param grainId
+   * @return vector_type
+   */
+  vector_type copyOfList(int32 grainId) const override
+  {
+    return {};
+  }
+
+  /**
+   * @brief setList
+   * @param grainId
+   * @param neighborList
+   */
+  void setList(int32 grainId, const shared_vector_type& neighborList) override
+  {
+    throw std::runtime_error("EmptyListStore cannot set list values");
+  }
+
+  /**
+   * @brief setList
+   * @param grainId
+   * @param neighborList
+   */
+  void setList(int32 grainId, const vector_type& neighborList) override
+  {
+    throw std::runtime_error("EmptyListStore cannot set list values");
+  }
+
+  usize getListSize(usize grainId) const override
+  {
+    return 0;
+  }
+
+  /**
+   * @brief getValue
+   * @param grainId
+   * @param index
+   * @param ok
+   * @return T
+   */
+  T getValue(int32 grainId, int32 index, bool& ok) const override
+  {
+    throw std::runtime_error("EmptyListStore cannot get list value");
+  }
+
+  void setValue(int32 grainId, usize index, T value) override
+  {
+    throw std::runtime_error("EmptyListStore cannot set list value");
+  }
+
+  /**
+   * @brief operator []
+   * @param grainId
+   * @return vector_type&
+   */
+  vector_type operator[](int32 grainId) const override
+  {
+    throw std::runtime_error("EmptyListStore cannot get list");
+  }
+
+  /**
+   * @brief operator []
+   * @param grainId
+   * @return vector_type&
+   */
+  vector_type operator[](usize grainId) const override
+  {
+    throw std::runtime_error("EmptyListStore cannot get list");
+  }
+
+  /**
+   * @brief Returns a const reference to the vector_type value found at the specified index. This cannot be used to edit the vector_type value found at the specified index.
+   * @param grainId
+   * @return vector_type
+   */
+  vector_type at(int32 grainId) const override
+  {
+    throw std::runtime_error("EmptyListStore cannot get list");
+  }
+
+  /**
+   * @brief Returns a const reference to the vector_type value found at the specified index. This cannot be used to edit the vector_type value found at the specified index.
+   * @param grainId
+   * @return vector_type
+   */
+  vector_type at(usize grainId) const override
+  {
+    throw std::runtime_error("EmptyListStore cannot get list");
+  }
+
+  void setData(const std::vector<shared_vector_type>& lists) override
+  {
+    throw std::runtime_error("EmptyListStore cannot set lists");
+  }
+
+  void setData(const std::vector<vector_type>& lists) override
+  {
+    throw std::runtime_error("EmptyListStore cannot set lists");
+  }
+
+  void readHdf5(const HDF5::DatasetIO& datasetReader) override
+  {
+    auto tupleDimsResult = datasetReader.readVectorAttribute<uint64>("TupleDimensions");
+    if(tupleDimsResult.invalid())
+    {
+      clear();
+    }
+    else
+    {
+      std::vector<uint64> tupleDims = tupleDimsResult.value();
+      uint64 numTuples = std::accumulate(tupleDims.begin(), tupleDims.end(), static_cast<uint64>(1), std::multiplies<>());
+      resizeTuples(numTuples);
+    }
+  }
+
+  void writeHdf5(HDF5::DatasetIO& datasetReader) override
+  {
+    throw std::runtime_error("EmptyListStore cannot write to HDF5");
+  }
+
+private:
+  usize m_NumTuples = 0;
+};
+} // namespace nx::core

--- a/src/simplnx/DataStructure/EmptyListStore.hpp
+++ b/src/simplnx/DataStructure/EmptyListStore.hpp
@@ -31,7 +31,7 @@ public:
   EmptyListStore(const EmptyListStore& rhs) = default;
   EmptyListStore(EmptyListStore&& rhs) = default;
 
-  ~EmptyListStore() = default;
+  ~EmptyListStore() override = default;
 
   /**
    * @brief Returns a copy of the current list store.

--- a/src/simplnx/DataStructure/IListStore.hpp
+++ b/src/simplnx/DataStructure/IListStore.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "simplnx/Common/Types.hpp"
+
+namespace nx::core
+{
+namespace HDF5
+{
+class DatasetIO;
+}
+
+class IListStore
+{
+public:
+  ~IListStore() = default;
+
+  /**
+   * @brief This method sets the shape of the dimensions to `tupleShape`.
+   *
+   * There are 3 possibilities when using this function:
+   * [1] The number of tuples of the new shape is *LESS* than the original. In this
+   * case a memory allocation will take place and the first 'N' elements of data
+   * will be copied into the new array. The remaining data is *LOST*
+   *
+   * [2] The number of tuples of the new shape is *EQUAL* to the original. In this
+   * case the shape is set and the function returns.
+   *
+   * [3] The number of tuples of the new shape is *GREATER* than the original. In
+   * this case a new array is allocated and all the data from the original array
+   * is copied into the new array and the remaining elements are initialized to
+   * the default initialization value.
+   *
+   * @param tupleShape The new shape of the data where the dimensions are "C" ordered
+   * from *slowest* to *fastest*.
+   */
+  virtual void resizeTuples(usize tupleCount) = 0;
+
+  /**
+   * @brief Clear All Lists
+   */
+  virtual void clearAllLists() = 0;
+
+  virtual usize getListSize(usize grainId) const = 0;
+
+  /**
+   * @brief getNumberOfLists
+   * @return int32
+   */
+  virtual uint64 getNumberOfLists() const = 0;
+
+  uint64 size() const
+  {
+    return getNumberOfLists();
+  }
+
+  /**
+   * @brief Clears the array.
+   */
+  virtual void clear() = 0;
+
+  virtual void readHdf5(const HDF5::DatasetIO& datasetReader) = 0;
+  virtual void writeHdf5(HDF5::DatasetIO& datasetReader) = 0;
+
+protected:
+  IListStore() = default;
+  IListStore(const IListStore& rhs) = default;
+  IListStore(IListStore&& rhs) = default;
+};
+} // namespace nx::core

--- a/src/simplnx/DataStructure/IListStore.hpp
+++ b/src/simplnx/DataStructure/IListStore.hpp
@@ -12,7 +12,7 @@ class DatasetIO;
 class IListStore
 {
 public:
-  ~IListStore() = default;
+  virtual ~IListStore() = default;
 
   /**
    * @brief This method sets the shape of the dimensions to `tupleShape`.

--- a/src/simplnx/DataStructure/IO/Generic/CoreDataIOManager.cpp
+++ b/src/simplnx/DataStructure/IO/Generic/CoreDataIOManager.cpp
@@ -1,6 +1,7 @@
 #include "CoreDataIOManager.hpp"
 
 #include "simplnx/DataStructure/DataStore.hpp"
+#include "simplnx/DataStructure/ListStore.hpp"
 
 namespace nx::core::Generic
 {
@@ -9,6 +10,7 @@ CoreDataIOManager::CoreDataIOManager()
 {
   addCoreFactories();
   addDataStoreFnc();
+  addListStoreFnc();
 }
 
 CoreDataIOManager::~CoreDataIOManager() noexcept = default;
@@ -66,5 +68,50 @@ void CoreDataIOManager::addDataStoreFnc()
     return dataStore;
   };
   addDataStoreCreationFnc(formatName(), dataStoreFnc);
+}
+
+void CoreDataIOManager::addListStoreFnc()
+{
+  ListStoreCreateFnc listStoreFnc = [](nx::core::DataType numericType, usize tupleCount) {
+    std::unique_ptr<IListStore> listStore = nullptr;
+    switch(numericType)
+    {
+    case DataType::int8:
+      listStore = std::make_unique<Int8ListStore>(tupleCount);
+      break;
+    case DataType::int16:
+      listStore = std::make_unique<Int16ListStore>(tupleCount);
+      break;
+    case DataType::int32:
+      listStore = std::make_unique<Int32ListStore>(tupleCount);
+      break;
+    case DataType::int64:
+      listStore = std::make_unique<Int64ListStore>(tupleCount);
+      break;
+    case DataType::uint8:
+      listStore = std::make_unique<UInt8ListStore>(tupleCount);
+      break;
+    case DataType::uint16:
+      listStore = std::make_unique<UInt16ListStore>(tupleCount);
+      break;
+    case DataType::uint32:
+      listStore = std::make_unique<UInt32ListStore>(tupleCount);
+      break;
+    case DataType::uint64:
+      listStore = std::make_unique<UInt64ListStore>(tupleCount);
+      break;
+    case DataType::float32:
+      listStore = std::make_unique<Float32ListStore>(tupleCount);
+      break;
+    case DataType::float64:
+      listStore = std::make_unique<Float64ListStore>(tupleCount);
+      break;
+    case DataType::boolean:
+      listStore = nullptr;
+      break;
+    }
+    return listStore;
+  };
+  addListStoreCreationFnc(formatName(), listStoreFnc);
 }
 } // namespace nx::core::Generic

--- a/src/simplnx/DataStructure/IO/Generic/CoreDataIOManager.hpp
+++ b/src/simplnx/DataStructure/IO/Generic/CoreDataIOManager.hpp
@@ -31,6 +31,7 @@ private:
   void addCoreFactories();
 
   void addDataStoreFnc();
+  void addListStoreFnc();
 
   factory_collection m_FactoryCollection;
 };

--- a/src/simplnx/DataStructure/IO/Generic/DataIOCollection.cpp
+++ b/src/simplnx/DataStructure/IO/Generic/DataIOCollection.cpp
@@ -60,6 +60,20 @@ std::unique_ptr<IDataStore> DataIOCollection::createDataStore(const std::string&
   return coreManager.dataStoreCreationFnc(coreManager.formatName())(dataType, tupleShape, componentShape, {});
 }
 
+std::unique_ptr<IListStore> DataIOCollection::createListStore(const std::string& type, DataType dataType, usize tupleCount) const
+{
+  for(const auto& [ioType, ioManager] : m_ManagerMap)
+  {
+    if(ioManager->hasListStoreCreationFnc(type))
+    {
+      return ioManager->listStoreCreationFnc(type)(dataType, tupleCount);
+    }
+  }
+
+  nx::core::Generic::CoreDataIOManager coreManager;
+  return coreManager.listStoreCreationFnc(coreManager.formatName())(dataType, tupleCount);
+}
+
 void DataIOCollection::checkStoreDataFormat(uint64 dataSize, std::string& dataFormat) const
 {
   if(!dataFormat.empty())

--- a/src/simplnx/DataStructure/IO/Generic/DataIOCollection.hpp
+++ b/src/simplnx/DataStructure/IO/Generic/DataIOCollection.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "simplnx/DataStructure/AbstractDataStore.hpp"
+#include "simplnx/DataStructure/AbstractListStore.hpp"
 #include "simplnx/simplnx_export.hpp"
 
 #include "simplnx/Common/Types.hpp"
@@ -58,6 +59,15 @@ public:
     DataType numericType = GetDataType<T>();
     std::shared_ptr<IDataStore> dataStore = createDataStore(type, numericType, tupleShape, componentShape);
     return std::dynamic_pointer_cast<AbstractDataStore<T>>(dataStore);
+  }
+
+  std::unique_ptr<IListStore> createListStore(const std::string& type, DataType numericType, usize tupleCount) const;
+  template <typename T>
+  std::shared_ptr<AbstractListStore<T>> createListStoreWithType(const std::string& dataFormat, usize tupleCount) const
+  {
+    DataType numericType = GetDataType<T>();
+    std::shared_ptr<IListStore> listStore = createListStore(dataFormat, numericType, tupleCount);
+    return std::dynamic_pointer_cast<AbstractListStore<T>>(listStore);
   }
 
   /**

--- a/src/simplnx/DataStructure/IO/Generic/IDataIOManager.cpp
+++ b/src/simplnx/DataStructure/IO/Generic/IDataIOManager.cpp
@@ -38,4 +38,19 @@ void IDataIOManager::addDataStoreCreationFnc(const std::string& type, DataStoreC
 {
   m_DataStoreCreationMap[type] = creationFnc;
 }
+
+bool IDataIOManager::hasListStoreCreationFnc(const std::string& type) const
+{
+  return m_ListStoreCreationMap.find(type) != m_ListStoreCreationMap.end();
+}
+
+IDataIOManager::ListStoreCreateFnc IDataIOManager::listStoreCreationFnc(const std::string& type) const
+{
+  return m_ListStoreCreationMap.at(type);
+}
+
+void IDataIOManager::addListStoreCreationFnc(const std::string& type, ListStoreCreateFnc creationFnc)
+{
+  m_ListStoreCreationMap[type] = creationFnc;
+}
 } // namespace nx::core

--- a/src/simplnx/DataStructure/IO/Generic/IDataIOManager.hpp
+++ b/src/simplnx/DataStructure/IO/Generic/IDataIOManager.hpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataObject.hpp"
 #include "simplnx/DataStructure/IDataStore.hpp"
+#include "simplnx/DataStructure/IListStore.hpp"
 #include "simplnx/DataStructure/IO/Generic/IDataFactory.hpp"
 #include "simplnx/simplnx_export.hpp"
 
@@ -28,7 +29,9 @@ public:
   using factory_collection = std::map<factory_id_type, factory_ptr>;
   using DataStoreCreateFnc =
       std::function<std::unique_ptr<IDataStore>(DataType, const typename IDataStore::ShapeType&, const typename IDataStore::ShapeType&, const std::optional<IDataStore::ShapeType>&)>;
+  using ListStoreCreateFnc = std::function<std::unique_ptr<IListStore>(DataType, usize)>;
   using DataStoreCreationMap = std::map<std::string, DataStoreCreateFnc>;
+  using ListStoreCreationMap = std::map<std::string, ListStoreCreateFnc>;
 
   virtual ~IDataIOManager() noexcept;
 
@@ -75,14 +78,18 @@ public:
   bool hasDataStoreCreationFnc(const std::string& type) const;
 
   DataStoreCreateFnc dataStoreCreationFnc(const std::string& type) const;
+  bool hasListStoreCreationFnc(const std::string& type) const;
+  ListStoreCreateFnc listStoreCreationFnc(const std::string& type) const;
 
 protected:
   IDataIOManager();
 
   void addDataStoreCreationFnc(const std::string& type, DataStoreCreateFnc creationFnc);
+  void addListStoreCreationFnc(const std::string& type, ListStoreCreateFnc creationFnc);
 
 private:
   factory_collection m_FactoryCollection;
   DataStoreCreationMap m_DataStoreCreationMap;
+  ListStoreCreationMap m_ListStoreCreationMap;
 };
 } // namespace nx::core

--- a/src/simplnx/DataStructure/IO/HDF5/DataArrayIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataArrayIO.hpp
@@ -47,6 +47,82 @@ public:
     err = (data == nullptr) ? -400 : 0;
   }
 
+  template <typename K>
+  static Result<> importDataStore(data_type* dataArray, const DataPath& dataPath, const nx::core::HDF5::DatasetIO& datasetReader)
+  {
+    std::shared_ptr<AbstractDataStore<T>> dataStore = DataStoreIO::ReadDataStore<T>(datasetReader);
+    if(dataStore == nullptr)
+    {
+      return MakeErrorResult(-150202, fmt::format("Failed to import DataArray data at path '{}'.", dataPath.toString()));
+    }
+    dataArray->setDataStore(dataStore);
+    return {};
+  }
+
+  /**
+   * @brief Replaces the AbstractDataStore using data from the HDF5 dataset.
+   * @param dataStructure
+   * @param dataPath
+   * @param dataStructureReader
+   * @return Result<>
+   */
+  Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const override
+  {
+    if(!dataStructure.containsData(dataPath))
+    {
+      return MakeErrorResult(-150200, fmt::format("Imported DataStructure Object at path '{}' does not exist.", dataPath.toString()));
+    }
+
+    auto* dataArray = dataStructure.getDataAs<data_type>(dataPath);
+    if(dataArray == nullptr)
+    {
+      return MakeErrorResult(-150201, fmt::format("Imported DataStructure Object at path '{}' is not of the expected type.", dataPath.toString()));
+    }
+
+    auto datasetReader = dataStructureGroup.openDataset(dataPath.toString());
+    std::string dataTypeStr;
+    auto dataTypeStrResult = datasetReader.readStringAttribute(Constants::k_ObjectTypeTag);
+    dataTypeStr = std::move(dataTypeStrResult.value());
+    const bool isBoolArray = (dataTypeStr.compare("DataArray<bool>") == 0);
+
+    auto typeResult = datasetReader.getDataType();
+    const auto type = std::move(typeResult.value());
+    switch(type)
+    {
+    case DataType::float32:
+      return importDataStore<float32>(dataArray, dataPath, datasetReader);
+    case DataType::float64:
+      return importDataStore<float64>(dataArray, dataPath, datasetReader);
+    case DataType::int8:
+      return importDataStore<int8>(dataArray, dataPath, datasetReader);
+    case DataType::int16:
+      return importDataStore<int16>(dataArray, dataPath, datasetReader);
+    case DataType::int32:
+      return importDataStore<int32>(dataArray, dataPath, datasetReader);
+    case DataType::int64:
+      return importDataStore<int64>(dataArray, dataPath, datasetReader);
+    case DataType::uint8: {
+      if(isBoolArray)
+      {
+        return importDataStore<bool>(dataArray, dataPath, datasetReader);
+      }
+      else
+      {
+        return importDataStore<uint8>(dataArray, dataPath, datasetReader);
+      }
+    }
+    break;
+    case DataType::uint16:
+      return importDataStore<uint16>(dataArray, dataPath, datasetReader);
+    case DataType::uint32:
+      return importDataStore<uint32>(dataArray, dataPath, datasetReader);
+    case DataType::uint64:
+      return importDataStore<uint64>(dataArray, dataPath, datasetReader);
+    default:
+      return MakeErrorResult(-150209, fmt::format("Undetermined DataArray type: '{}'", dataTypeStr));
+    }
+  }
+
   /**
    * @brief Attempts to read the DataArray from HDF5.
    * Returns a Result<> with any errors or warnings encountered during the process.

--- a/src/simplnx/DataStructure/IO/HDF5/DataArrayIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataArrayIO.hpp
@@ -80,10 +80,9 @@ public:
     }
 
     auto datasetReader = parentGroupReader.openDataset(dataPath.getTargetName());
-    std::string dataTypeStr;
     auto dataTypeStrResult = datasetReader.readStringAttribute(Constants::k_ObjectTypeTag);
-    dataTypeStr = std::move(dataTypeStrResult.value());
-    const bool isBoolArray = (dataTypeStr.compare("DataArray<bool>") == 0);
+    std::string dataTypeStr = std::move(dataTypeStrResult.value());
+    const bool isBoolArray = dataTypeStr == "DataArray<bool>";
 
     auto typeResult = datasetReader.getDataType();
     const auto type = std::move(typeResult.value());

--- a/src/simplnx/DataStructure/IO/HDF5/DataArrayIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataArrayIO.hpp
@@ -66,7 +66,7 @@ public:
    * @param dataStructureReader
    * @return Result<>
    */
-  Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const override
+  Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& parentGroupReader) const override
   {
     if(!dataStructure.containsData(dataPath))
     {
@@ -79,7 +79,7 @@ public:
       return MakeErrorResult(-150201, fmt::format("Imported DataStructure Object at path '{}' is not of the expected type.", dataPath.toString()));
     }
 
-    auto datasetReader = dataStructureGroup.openDataset(dataPath.toString());
+    auto datasetReader = parentGroupReader.openDataset(dataPath.getTargetName());
     std::string dataTypeStr;
     auto dataTypeStrResult = datasetReader.readStringAttribute(Constants::k_ObjectTypeTag);
     dataTypeStr = std::move(dataTypeStrResult.value());

--- a/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.cpp
@@ -28,7 +28,13 @@ Result<DataStructure> DataStructureReader::ReadFile(const nx::core::HDF5::FileIO
 {
   DataStructureReader dataStructureReader;
   auto groupReader = fileReader.openGroup(Constants::k_DataStructureTag);
-  return dataStructureReader.readGroup(groupReader, useEmptyDataStores);
+  auto result = dataStructureReader.readGroup(groupReader, useEmptyDataStores);
+
+  if(result.valid())
+  {
+    dataStructureReader.loadRequiredData(fileReader);
+  }
+  return result;
 }
 
 Result<std::shared_ptr<DataObject>> DataStructureReader::ReadObject(const nx::core::HDF5::FileIO& fileReader, const DataPath& dataPath)
@@ -262,4 +268,38 @@ std::shared_ptr<IDataIO> DataStructureReader::getDataFactory(typename IDataIOMan
   return getDataReader()->getFactoryAs<IDataIO>(typeName);
 }
 
+void DataStructureReader::addRequiredPath(const DataPath& requiredDataPath)
+{
+  m_RequiredPaths.push_back(requiredDataPath);
+}
+
+void DataStructureReader::addRequiredId(DataObject::IdType requiredDataId)
+{
+  m_RequiredIds.push_back(requiredDataId);
+}
+
+void DataStructureReader::addRequiredId(DataObject::OptionalId requiredDataId)
+{
+  if(requiredDataId.has_value())
+  {
+    m_RequiredIds.push_back(requiredDataId.value());
+  }
+}
+
+void DataStructureReader::loadRequiredData(const nx::core::HDF5::FileIO& fileReader)
+{
+  for (auto& id : m_RequiredIds)
+  {
+    auto* requiredObject = m_CurrentStructure.getData(id);
+    if(requiredObject != nullptr)
+    {
+      addRequiredPath(requiredObject->getDataPaths()[0]);
+    }
+  }
+
+  for(const auto& dataPath : m_RequiredPaths)
+  {
+    FinishImportingObject(m_CurrentStructure, fileReader, dataPath);
+  }
+}
 } // namespace nx::core::HDF5

--- a/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.cpp
@@ -60,7 +60,7 @@ Result<> DataStructureReader::FinishImportingObject(DataStructure& dataStructure
   std::shared_ptr<IDataIO> factory = nullptr;
 
   std::string parentPathString = Constants::k_DataStructureTag;
-  parentPathString += dataPath.getParent().toString();
+  parentPathString += "/" + dataPath.getParent().toString();
 
   DataStructureReader dataStructureReader;
   auto parentGroupReader = fileReader.openGroup(parentPathString);

--- a/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.cpp
@@ -288,7 +288,7 @@ void DataStructureReader::addRequiredId(DataObject::OptionalId requiredDataId)
 
 void DataStructureReader::loadRequiredData(const nx::core::HDF5::FileIO& fileReader)
 {
-  for (auto& id : m_RequiredIds)
+  for(auto& id : m_RequiredIds)
   {
     auto* requiredObject = m_CurrentStructure.getData(id);
     if(requiredObject != nullptr)

--- a/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.cpp
@@ -31,6 +31,72 @@ Result<DataStructure> DataStructureReader::ReadFile(const nx::core::HDF5::FileIO
   return dataStructureReader.readGroup(groupReader, useEmptyDataStores);
 }
 
+Result<std::shared_ptr<DataObject>> DataStructureReader::ReadObject(const nx::core::HDF5::FileIO& fileReader, const DataPath& dataPath)
+{
+  std::string parentPathString = Constants::k_DataStructureTag;
+  parentPathString += dataPath.getParent().toString();
+
+  DataStructureReader dataStructureReader;
+  auto parentGroupReader = fileReader.openGroup(parentPathString);
+
+  if(Result<> importResult = dataStructureReader.readObjectFromGroup(parentGroupReader, dataPath.getTargetName()); importResult.invalid())
+  {
+    return ConvertInvalidResult<std::shared_ptr<DataObject>>(std::move(importResult));
+  }
+
+  const DataStructure& dataStructure = dataStructureReader.getDataStructure();
+  const DataMap& dataMap = dataStructure.getDataMap();
+  if(dataMap.getSize() == 0)
+  {
+    return MakeErrorResult<std::shared_ptr<DataObject>>(-69040, fmt::format("Failed to import DataObject at path '{}'", dataPath.toString()));
+  }
+
+  auto item = dataMap.begin();
+  return {(*item).second};
+}
+
+Result<> DataStructureReader::FinishImportingObject(DataStructure& dataStructure, const nx::core::HDF5::FileIO& fileReader, const DataPath& dataPath)
+{
+  std::shared_ptr<IDataIO> factory = nullptr;
+
+  std::string parentPathString = Constants::k_DataStructureTag;
+  parentPathString += dataPath.getParent().toString();
+
+  DataStructureReader dataStructureReader;
+  auto parentGroupReader = fileReader.openGroup(parentPathString);
+  bool isGroup = parentGroupReader.isGroup(dataPath.getTargetName());
+  if(isGroup)
+  {
+    auto childObj = parentGroupReader.openGroup(dataPath.getTargetName());
+    auto attrResult = childObj.readStringAttribute(Constants::k_ObjectTypeTag);
+    if(attrResult.invalid())
+    {
+      return ConvertResult(std::move(attrResult));
+    }
+    std::string typeName = std::move(attrResult.value());
+
+    factory = dataStructureReader.getDataFactory(typeName);
+  }
+  else
+  {
+    auto childObj = parentGroupReader.openDataset(dataPath.getTargetName());
+    auto typeNameResult = childObj.readStringAttribute(Constants::k_ObjectTypeTag);
+    if(typeNameResult.invalid())
+    {
+      return ConvertResult(std::move(typeNameResult));
+    }
+    std::string typeName = std::move(typeNameResult.value());
+
+    factory = dataStructureReader.getDataFactory(typeName);
+  }
+
+  if(factory == nullptr)
+  {
+    return MakeErrorResult(-23405, fmt::format("Failed to determine import factory type for path '{}'", dataPath.toString()));
+  }
+  return factory->finishImportingData(dataStructure, dataPath, parentGroupReader);
+}
+
 Result<DataStructure> DataStructureReader::readGroup(const nx::core::HDF5::GroupIO& groupReader, bool useEmptyDataStores)
 {
   clearDataStructure();

--- a/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.hpp
@@ -74,6 +74,10 @@ public:
    */
   void clearDataStructure();
 
+  void addRequiredPath(const DataPath& requiredDataPath);
+  void addRequiredId(DataObject::IdType requiredDataId);
+  void addRequiredId(DataObject::OptionalId requiredDataId);
+
 protected:
   /**
    * @brief Returns a pointer to the nx::core::HDF5::DataFactoryManager used for finding the
@@ -90,8 +94,12 @@ protected:
    */
   std::shared_ptr<IDataIO> getDataFactory(typename IDataIOManager::factory_id_type typeName) const;
 
+  void loadRequiredData(const nx::core::HDF5::FileIO& fileReader);
+
 private:
   std::shared_ptr<DataIOManager> m_IOManager = nullptr;
   DataStructure m_CurrentStructure;
+  std::vector<DataPath> m_RequiredPaths;
+  std::vector<DataObject::IdType> m_RequiredIds;
 };
 } // namespace nx::core::HDF5

--- a/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.hpp
@@ -37,6 +37,10 @@ public:
    */
   static Result<DataStructure> ReadFile(const nx::core::HDF5::FileIO& fileReader, bool useEmptyDataStores = false);
 
+  static Result<std::shared_ptr<DataObject>> ReadObject(const nx::core::HDF5::FileIO& fileReader, const DataPath& dataPath);
+
+  static Result<> FinishImportingObject(DataStructure& dataStructure, const nx::core::HDF5::FileIO& fileReader, const DataPath& dataPath);
+
   /**
    * @brief Imports and returns a DataStructure from a target nx::core::HDF5::GroupIO.
    * Returns any HDF5 error code that occur by reference. Otherwise, this value

--- a/src/simplnx/DataStructure/IO/HDF5/EdgeGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/EdgeGeomIO.cpp
@@ -39,7 +39,14 @@ Result<> EdgeGeomIO::readData(DataStructureReader& structureReader, const group_
   geometry->setElementCentroidsId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
   geometry->setElementSizesId(ReadDataId(groupReader, IOConstants::k_ElementSizesTag));
 
-  // return BaseGroup::readHdf5(dataStructureReader, groupReader, useEmptyDataStore);
+  // Add required data for preflight operations.
+  structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_VertexListTag));
+  structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_EdgeListTag));
+  structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementContainingVertTag));
+  structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementNeighborsTag));
+  structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
+  structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementSizesTag));
+
   return {};
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/EdgeGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/EdgeGeomIO.cpp
@@ -42,6 +42,25 @@ Result<> EdgeGeomIO::readData(DataStructureReader& structureReader, const group_
   // return BaseGroup::readHdf5(dataStructureReader, groupReader, useEmptyDataStore);
   return {};
 }
+
+Result<> EdgeGeomIO::finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const
+{
+  auto* geometry = dataStructure.getDataAs<EdgeGeom>(dataPath);
+  if (geometry == nullptr)
+  {
+    return MakeErrorResult(-25070, fmt::format("Failed to finish importing geometry at path '{}'. Geometry does not exist or is of wrong type.", dataPath.toString()));
+  }
+
+  auto groupReader = dataStructureGroup.openGroup(dataPath.toString());
+  geometry->setEdgeListId(ReadDataId(groupReader, IOConstants::k_EdgeListTag));
+  geometry->setEdgeDataId(ReadDataId(groupReader, IOConstants::k_EdgeDataTag));
+  geometry->setElementContainingVertId(ReadDataId(groupReader, IOConstants::k_ElementContainingVertTag));
+  geometry->setElementNeighborsId(ReadDataId(groupReader, IOConstants::k_ElementNeighborsTag));
+  geometry->setElementCentroidsId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
+
+  return {};
+}
+
 Result<> EdgeGeomIO::writeData(DataStructureWriter& dataStructureWriter, const EdgeGeom& geometry, group_writer_type& parentGroupWriter, bool importable) const
 {
   auto groupWriter = parentGroupWriter.createGroup(geometry.getName());

--- a/src/simplnx/DataStructure/IO/HDF5/EdgeGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/EdgeGeomIO.cpp
@@ -61,13 +61,6 @@ Result<> EdgeGeomIO::finishImportingData(DataStructure& dataStructure, const Dat
     return MakeErrorResult(-25070, fmt::format("Failed to finish importing geometry at path '{}'. Geometry does not exist or is of wrong type.", dataPath.toString()));
   }
 
-  auto groupReader = dataStructureGroup.openGroup(dataPath.toString());
-  geometry->setEdgeListId(ReadDataId(groupReader, IOConstants::k_EdgeListTag));
-  geometry->setEdgeDataId(ReadDataId(groupReader, IOConstants::k_EdgeDataTag));
-  geometry->setElementContainingVertId(ReadDataId(groupReader, IOConstants::k_ElementContainingVertTag));
-  geometry->setElementNeighborsId(ReadDataId(groupReader, IOConstants::k_ElementNeighborsTag));
-  geometry->setElementCentroidsId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
-
   return {};
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/EdgeGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/EdgeGeomIO.cpp
@@ -53,7 +53,7 @@ Result<> EdgeGeomIO::readData(DataStructureReader& structureReader, const group_
 Result<> EdgeGeomIO::finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const
 {
   auto* geometry = dataStructure.getDataAs<EdgeGeom>(dataPath);
-  if (geometry == nullptr)
+  if(geometry == nullptr)
   {
     return MakeErrorResult(-25070, fmt::format("Failed to finish importing geometry at path '{}'. Geometry does not exist or is of wrong type.", dataPath.toString()));
   }

--- a/src/simplnx/DataStructure/IO/HDF5/EdgeGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/EdgeGeomIO.cpp
@@ -39,13 +39,16 @@ Result<> EdgeGeomIO::readData(DataStructureReader& structureReader, const group_
   geometry->setElementCentroidsId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
   geometry->setElementSizesId(ReadDataId(groupReader, IOConstants::k_ElementSizesTag));
 
-  // Add required data for preflight operations.
-  structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_VertexListTag));
-  structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_EdgeListTag));
-  structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementContainingVertTag));
-  structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementNeighborsTag));
-  structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
-  structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementSizesTag));
+  if(useEmptyDataStore)
+  {
+    // Add required data for preflight operations.
+    structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_VertexListTag));
+    structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_EdgeListTag));
+    structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementContainingVertTag));
+    structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementNeighborsTag));
+    structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
+    structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementSizesTag));
+  }
 
   return {};
 }

--- a/src/simplnx/DataStructure/IO/HDF5/EdgeGeomIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/EdgeGeomIO.hpp
@@ -34,6 +34,8 @@ public:
   Result<> readData(DataStructureReader& dataStructureReader, const group_reader_type& parentGroup, const std::string& geomName, DataObject::IdType importId,
                     const std::optional<DataObject::IdType>& parentId, bool useEmptyDataStore = false) const override;
 
+  Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const override;
+
   /**
    * @brief Attempts to write an EdgeGeom to HDF5.
    * @param dataStructureWriter

--- a/src/simplnx/DataStructure/IO/HDF5/HexahedralGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/HexahedralGeomIO.cpp
@@ -26,6 +26,18 @@ Result<> HexahedralGeomIO::readData(DataStructureReader& structureReader, const 
   auto* geom = HexahedralGeom::Import(structureReader.getDataStructure(), objectName, importId, parentId);
   return INodeGeom3dIO::ReadNodeGeom3dData(structureReader, *geom, parentGroup, objectName, importId, parentId, useEmptyDataStore);
 }
+
+Result<> HexahedralGeomIO::finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const
+{
+  auto* geometry = dataStructure.getDataAs<HexahedralGeom>(dataPath);
+  if(geometry == nullptr)
+  {
+    return MakeErrorResult(-25070, fmt::format("Failed to finish importing geometry at path '{}'. Geometry does not exist or is of wrong type.", dataPath.toString()));
+  }
+
+  return INodeGeom3dIO::FinishImportingNodeGeom3dData(dataStructure, dataPath, dataStructureGroup);
+}
+
 Result<> HexahedralGeomIO::writeData(DataStructureWriter& structureReader, const HexahedralGeom& geom, group_writer_type& parentGroup, bool importable) const
 {
   auto groupWriter = parentGroup.createGroup(geom.getName());

--- a/src/simplnx/DataStructure/IO/HDF5/HexahedralGeomIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/HexahedralGeomIO.hpp
@@ -30,6 +30,8 @@ public:
   Result<> readData(DataStructureReader& dataStructureReader, const group_reader_type& parentGroup, const std::string& geomName, DataObject::IdType importId,
                     const std::optional<DataObject::IdType>& parentId, bool useEmptyDataStore = false) const override;
 
+  Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const override;
+
   /**
    * @brief Attempts to write an EdgeGeom to HDF5.
    * @param dataStructureWriter

--- a/src/simplnx/DataStructure/IO/HDF5/IDataIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/IDataIO.cpp
@@ -1,5 +1,6 @@
 #include "IDataIO.hpp"
 
+#include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/DataStructure/IO/HDF5/DataStructureWriter.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/GroupIO.hpp"
@@ -51,6 +52,11 @@ Result<> IDataIO::WriteObjectAttributes(DataStructureWriter& dataStructureWriter
   // Add to DataStructureWriter for use in linking
   dataStructureWriter.addWriter(objectWriter, dataObject.getId());
 
+  return {};
+}
+
+Result<> IDataIO::finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const
+{
   return {};
 }
 } // namespace nx::core::HDF5

--- a/src/simplnx/DataStructure/IO/HDF5/IDataIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/IDataIO.hpp
@@ -7,6 +7,8 @@
 
 namespace nx::core
 {
+class DataStructure;
+
 namespace HDF5
 {
 class DataStructureReader;
@@ -37,6 +39,8 @@ public:
    */
   virtual Result<> readData(DataStructureReader& dataStructureReader, const group_reader_type& parentGroup, const std::string& objectName, DataObject::IdType importId,
                             const std::optional<DataObject::IdType>& parentId, bool useEmptyDataStore = false) const = 0;
+
+  virtual Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const;
 
   /**
    * @brief Attempts to write a DataObject to HDF5.

--- a/src/simplnx/DataStructure/IO/HDF5/IGeometryIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/IGeometryIO.cpp
@@ -33,9 +33,6 @@ Result<> IGeometryIO::FinishImportingGeomData(DataStructure& dataStructure, cons
     return MakeErrorResult(-50590, fmt::format("Failed to finish importing IGeometry at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
   }
 
-  auto groupReader = dataStructureGroup.openGroup(dataPath.toString());
-  geom->setElementSizesId(ReadDataId(groupReader, IOConstants::k_ElementSizesTag));
-
   return {};
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/IGeometryIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/IGeometryIO.cpp
@@ -24,6 +24,21 @@ Result<> IGeometryIO::ReadGeometryData(DataStructureReader& dataStructureReader,
 
   return {};
 }
+
+Result<> IGeometryIO::FinishImportingGeomData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup)
+{
+  auto* geom = dataStructure.getDataAs<IGeometry>(dataPath);
+  if(geom == nullptr)
+  {
+    return MakeErrorResult(-50590, fmt::format("Failed to finish importing IGeometry at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
+  }
+
+  auto groupReader = dataStructureGroup.openGroup(dataPath.toString());
+  geom->setElementSizesId(ReadDataId(groupReader, IOConstants::k_ElementSizesTag));
+
+  return {};
+}
+
 Result<> IGeometryIO::WriteGeometryData(DataStructureWriter& dataStructureWriter, const IGeometry& geometry, group_writer_type& parentGroup, bool importable)
 {
   auto groupWriter = parentGroup.createGroup(geometry.getName());

--- a/src/simplnx/DataStructure/IO/HDF5/IGeometryIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/IGeometryIO.hpp
@@ -49,6 +49,8 @@ protected:
    * @return Result<>
    */
   static Result<> WriteGeometryData(DataStructureWriter& dataStructureWriter, const IGeometry& geometry, group_writer_type& parentGroup, bool importable);
+
+  static Result<> FinishImportingGeomData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup);
 };
 } // namespace HDF5
 } // namespace nx::core

--- a/src/simplnx/DataStructure/IO/HDF5/IGridGeometryIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/IGridGeometryIO.cpp
@@ -12,7 +12,7 @@ IGridGeometryIO::~IGridGeometryIO() noexcept = default;
 Result<> IGridGeometryIO::ReadGridGeometryData(DataStructureReader& dataStructureReader, IGridGeometry& geometry, const group_reader_type& parentGroup, const std::string& objectName,
                                                DataObject::IdType importId, const std::optional<DataObject::IdType>& parentId, bool useEmptyDataStore)
 {
-  Result<> result = IGeometryIO::ReadGeometryData(dataStructureReader, geometry, parentGroup, objectName, importId, parentId, false);
+  Result<> result = IGeometryIO::ReadGeometryData(dataStructureReader, geometry, parentGroup, objectName, importId, parentId, useEmptyDataStore);
   if(result.invalid())
   {
     return result;

--- a/src/simplnx/DataStructure/IO/HDF5/IGridGeometryIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/IGridGeometryIO.cpp
@@ -12,7 +12,7 @@ IGridGeometryIO::~IGridGeometryIO() noexcept = default;
 Result<> IGridGeometryIO::ReadGridGeometryData(DataStructureReader& dataStructureReader, IGridGeometry& geometry, const group_reader_type& parentGroup, const std::string& objectName,
                                                DataObject::IdType importId, const std::optional<DataObject::IdType>& parentId, bool useEmptyDataStore)
 {
-  Result<> result = IGeometryIO::ReadGeometryData(dataStructureReader, geometry, parentGroup, objectName, importId, parentId, useEmptyDataStore);
+  Result<> result = IGeometryIO::ReadGeometryData(dataStructureReader, geometry, parentGroup, objectName, importId, parentId, false);
   if(result.invalid())
   {
     return result;
@@ -25,6 +25,18 @@ Result<> IGridGeometryIO::ReadGridGeometryData(DataStructureReader& dataStructur
 
   return {};
 }
+
+Result<> IGridGeometryIO::FinishImportingGridGeometryData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup)
+{
+  auto* geom = dataStructure.getDataAs<IGridGeometry>(dataPath);
+  if(geom == nullptr)
+  {
+    return MakeErrorResult(-50594, fmt::format("Failed to finish importing IGridGeometry at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
+  }
+
+  return {};
+}
+
 Result<> IGridGeometryIO::WriteGridGeometryData(DataStructureWriter& dataStructureWriter, const IGridGeometry& geometry, group_writer_type& parentGroup, bool importable)
 {
   auto result = IGeometryIO::WriteGeometryData(dataStructureWriter, geometry, parentGroup, importable);

--- a/src/simplnx/DataStructure/IO/HDF5/IGridGeometryIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/IGridGeometryIO.hpp
@@ -45,6 +45,8 @@ protected:
    * @return Result<>
    */
   static Result<> WriteGridGeometryData(DataStructureWriter& dataStructureWriter, const IGridGeometry& geometry, group_writer_type& parentGroup, bool importable);
+
+  static Result<> FinishImportingGridGeometryData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup);
 };
 } // namespace HDF5
 } // namespace nx::core

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom0dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom0dIO.cpp
@@ -55,9 +55,6 @@ Result<> INodeGeom0dIO::FinishImportingNodeGeom0dData(DataStructure& dataStructu
       auto value = unitsAttr.value();
       geom->setUnits(static_cast<IGeometry::LengthUnit>(value));
     }
-
-    geom->setVertexListId(ReadDataId(groupReader, IOConstants::k_VertexListTag));
-    geom->setVertexDataId(ReadDataId(groupReader, IOConstants::k_VertexDataTag));
   }
 
   return IGeometryIO::FinishImportingGeomData(dataStructure, dataPath, dataStructureGroup);

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom0dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom0dIO.cpp
@@ -31,8 +31,11 @@ Result<> INodeGeom0dIO::ReadNodeGeom0dData(DataStructureReader& dataStructureRea
   geometry.setVertexDataId(ReadDataId(groupReader, IOConstants::k_VertexDataTag));
 
   // Required data
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_VertexListTag));
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_VertexDataTag));
+  if(useEmptyDataStore)
+  {
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_VertexListTag));
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_VertexDataTag));
+  }
 
   return {};
 }

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom0dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom0dIO.cpp
@@ -31,6 +31,30 @@ Result<> INodeGeom0dIO::ReadNodeGeom0dData(DataStructureReader& dataStructureRea
 
   return {};
 }
+
+Result<> INodeGeom0dIO::FinishImportingNodeGeom0dData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup)
+{
+  auto* geom = dataStructure.getDataAs<INodeGeometry0D>(dataPath);
+  if(geom == nullptr)
+  {
+    return MakeErrorResult(-50590, fmt::format("Failed to finish importing INodeGeometry0D at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
+  }
+
+  {
+    auto groupReader = dataStructureGroup.openGroup(dataPath.toString());
+    if(const auto unitsAttr = groupReader.readScalarAttribute<uint32>(IOConstants::k_H5_UNITS); unitsAttr.valid())
+    {
+      auto value = unitsAttr.value();
+      geom->setUnits(static_cast<IGeometry::LengthUnit>(value));
+    }
+
+    geom->setVertexListId(ReadDataId(groupReader, IOConstants::k_VertexListTag));
+    geom->setVertexDataId(ReadDataId(groupReader, IOConstants::k_VertexDataTag));
+  }
+
+  return IGeometryIO::FinishImportingGeomData(dataStructure, dataPath, dataStructureGroup);
+}
+
 Result<> INodeGeom0dIO::WriteNodeGeom0dData(DataStructureWriter& dataStructureWriter, const INodeGeometry0D& geometry, group_writer_type& parentGroupWriter, bool importable)
 {
   Result<> result = IGeometryIO::WriteGeometryData(dataStructureWriter, geometry, parentGroupWriter, importable);

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom0dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom0dIO.cpp
@@ -1,5 +1,6 @@
 #include "INodeGeom0dIO.hpp"
 
+#include "DataStructureReader.hpp"
 #include "DataStructureWriter.hpp"
 #include "simplnx/DataStructure/Geometry/INodeGeometry0D.hpp"
 #include "simplnx/DataStructure/IO/Generic/IOConstants.hpp"
@@ -28,6 +29,10 @@ Result<> INodeGeom0dIO::ReadNodeGeom0dData(DataStructureReader& dataStructureRea
 
   geometry.setVertexListId(ReadDataId(groupReader, IOConstants::k_VertexListTag));
   geometry.setVertexDataId(ReadDataId(groupReader, IOConstants::k_VertexDataTag));
+
+  // Required data
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_VertexListTag));
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_VertexDataTag));
 
   return {};
 }

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom0dIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom0dIO.hpp
@@ -45,6 +45,8 @@ protected:
    * @return Result<>
    */
   static Result<> WriteNodeGeom0dData(DataStructureWriter& dataStructureWriter, const INodeGeometry0D& geometry, group_writer_type& parentGroup, bool importable);
+
+  static Result<> FinishImportingNodeGeom0dData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup);
 };
 } // namespace HDF5
 } // namespace nx::core

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom1dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom1dIO.cpp
@@ -1,5 +1,6 @@
 #include "INodeGeom1dIO.hpp"
 
+#include "DataStructureReader.hpp"
 #include "DataStructureWriter.hpp"
 #include "simplnx/DataStructure/Geometry/INodeGeometry1D.hpp"
 #include "simplnx/DataStructure/IO/Generic/IOConstants.hpp"
@@ -25,6 +26,12 @@ Result<> INodeGeom1dIO::ReadNodeGeom1dData(DataStructureReader& dataStructureRea
   geometry.setElementNeighborsId(ReadDataId(groupReader, IOConstants::k_ElementNeighborsTag));
   geometry.setElementCentroidsId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
 
+  // Required data
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_EdgeListTag));
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_EdgeDataTag));
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementContainingVertTag));
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementNeighborsTag));
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
   return {};
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom1dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom1dIO.cpp
@@ -27,11 +27,15 @@ Result<> INodeGeom1dIO::ReadNodeGeom1dData(DataStructureReader& dataStructureRea
   geometry.setElementCentroidsId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
 
   // Required data
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_EdgeListTag));
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_EdgeDataTag));
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementContainingVertTag));
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementNeighborsTag));
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
+  if(useEmptyDataStore)
+  {
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_EdgeListTag));
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_EdgeDataTag));
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementContainingVertTag));
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementNeighborsTag));
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
+  }
+
   return {};
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom1dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom1dIO.cpp
@@ -27,6 +27,27 @@ Result<> INodeGeom1dIO::ReadNodeGeom1dData(DataStructureReader& dataStructureRea
 
   return {};
 }
+
+Result<> INodeGeom1dIO::FinishImportingNodeGeom1dData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup)
+{
+  auto* geom = dataStructure.getDataAs<INodeGeometry1D>(dataPath);
+  if(geom == nullptr)
+  {
+    return MakeErrorResult(-50590, fmt::format("Failed to finish importing INodeGeometry1D at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
+  }
+
+  {
+    auto groupReader = dataStructureGroup.openGroup(dataPath.toString());
+    geom->setEdgeListId(ReadDataId(groupReader, IOConstants::k_EdgeListTag));
+    geom->setEdgeDataId(ReadDataId(groupReader, IOConstants::k_EdgeDataTag));
+    geom->setElementContainingVertId(ReadDataId(groupReader, IOConstants::k_ElementContainingVertTag));
+    geom->setElementNeighborsId(ReadDataId(groupReader, IOConstants::k_ElementNeighborsTag));
+    geom->setElementCentroidsId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
+  }
+
+  return INodeGeom0dIO::FinishImportingNodeGeom0dData(dataStructure, dataPath, dataStructureGroup);
+}
+
 Result<> INodeGeom1dIO::WriteNodeGeom1dData(DataStructureWriter& dataStructureWriter, const INodeGeometry1D& geometry, group_writer_type& parentGroupWriter, bool importable)
 {
   Result<> result = INodeGeom0dIO::WriteNodeGeom0dData(dataStructureWriter, geometry, parentGroupWriter, importable);

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom1dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom1dIO.cpp
@@ -47,15 +47,6 @@ Result<> INodeGeom1dIO::FinishImportingNodeGeom1dData(DataStructure& dataStructu
     return MakeErrorResult(-50590, fmt::format("Failed to finish importing INodeGeometry1D at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
   }
 
-  {
-    auto groupReader = dataStructureGroup.openGroup(dataPath.toString());
-    geom->setEdgeListId(ReadDataId(groupReader, IOConstants::k_EdgeListTag));
-    geom->setEdgeDataId(ReadDataId(groupReader, IOConstants::k_EdgeDataTag));
-    geom->setElementContainingVertId(ReadDataId(groupReader, IOConstants::k_ElementContainingVertTag));
-    geom->setElementNeighborsId(ReadDataId(groupReader, IOConstants::k_ElementNeighborsTag));
-    geom->setElementCentroidsId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
-  }
-
   return INodeGeom0dIO::FinishImportingNodeGeom0dData(dataStructure, dataPath, dataStructureGroup);
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom1dIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom1dIO.hpp
@@ -45,6 +45,8 @@ protected:
    * @return Result<>
    */
   static Result<> WriteNodeGeom1dData(DataStructureWriter& dataStructureWriter, const INodeGeometry1D& geometry, group_writer_type& parentGroup, bool importable);
+
+  static Result<> FinishImportingNodeGeom1dData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup);
 };
 } // namespace HDF5
 } // namespace nx::core

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom2dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom2dIO.cpp
@@ -1,5 +1,6 @@
 #include "INodeGeom2dIO.hpp"
 
+#include "DataStructureReader.hpp"
 #include "DataStructureWriter.hpp"
 #include "simplnx/DataStructure/Geometry/INodeGeometry2D.hpp"
 #include "simplnx/DataStructure/IO/Generic/IOConstants.hpp"
@@ -23,6 +24,11 @@ Result<> INodeGeom2dIO::ReadNodeGeom2dData(DataStructureReader& dataStructureRea
   geometry.setFaceListId(ReadDataId(groupReader, IOConstants::k_FaceListTag));
   geometry.setFaceDataId(ReadDataId(groupReader, IOConstants::k_FaceDataTag));
   geometry.setUnsharedEdgesId(ReadDataId(groupReader, IOConstants::k_UnsharedEdgeListTag));
+
+  // Required data
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_FaceListTag));
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_FaceDataTag));
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_UnsharedEdgeListTag));
 
   return {};
 }

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom2dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom2dIO.cpp
@@ -26,9 +26,12 @@ Result<> INodeGeom2dIO::ReadNodeGeom2dData(DataStructureReader& dataStructureRea
   geometry.setUnsharedEdgesId(ReadDataId(groupReader, IOConstants::k_UnsharedEdgeListTag));
 
   // Required data
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_FaceListTag));
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_FaceDataTag));
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_UnsharedEdgeListTag));
+  if(useEmptyDataStore)
+  {
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_FaceListTag));
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_FaceDataTag));
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_UnsharedEdgeListTag));
+  }
 
   return {};
 }

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom2dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom2dIO.cpp
@@ -27,6 +27,24 @@ Result<> INodeGeom2dIO::ReadNodeGeom2dData(DataStructureReader& dataStructureRea
   return {};
 }
 
+Result<> INodeGeom2dIO::FinishImportingNodeGeom2dData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup)
+{
+  auto* geom = dataStructure.getDataAs<INodeGeometry2D>(dataPath);
+  if(geom == nullptr)
+  {
+    return MakeErrorResult(-50591, fmt::format("Failed to finish importing INodeGeometry2D at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
+  }
+
+  {
+    auto groupReader = dataStructureGroup.openGroup(dataPath.toString());
+    geom->setFaceListId(ReadDataId(groupReader, IOConstants::k_FaceListTag));
+    geom->setFaceDataId(ReadDataId(groupReader, IOConstants::k_FaceDataTag));
+    geom->setUnsharedEdgesId(ReadDataId(groupReader, IOConstants::k_UnsharedEdgeListTag));
+  }
+
+  return INodeGeom1dIO::FinishImportingNodeGeom1dData(dataStructure, dataPath, dataStructureGroup);
+}
+
 Result<> INodeGeom2dIO::WriteNodeGeom2dData(DataStructureWriter& dataStructureWriter, const INodeGeometry2D& geometry, group_writer_type& parentGroupWriter, bool importable)
 {
   Result<> result = INodeGeom1dIO::WriteNodeGeom1dData(dataStructureWriter, geometry, parentGroupWriter, importable);

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom2dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom2dIO.cpp
@@ -44,13 +44,6 @@ Result<> INodeGeom2dIO::FinishImportingNodeGeom2dData(DataStructure& dataStructu
     return MakeErrorResult(-50591, fmt::format("Failed to finish importing INodeGeometry2D at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
   }
 
-  {
-    auto groupReader = dataStructureGroup.openGroup(dataPath.toString());
-    geom->setFaceListId(ReadDataId(groupReader, IOConstants::k_FaceListTag));
-    geom->setFaceDataId(ReadDataId(groupReader, IOConstants::k_FaceDataTag));
-    geom->setUnsharedEdgesId(ReadDataId(groupReader, IOConstants::k_UnsharedEdgeListTag));
-  }
-
   return INodeGeom1dIO::FinishImportingNodeGeom1dData(dataStructure, dataPath, dataStructureGroup);
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom2dIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom2dIO.hpp
@@ -45,6 +45,8 @@ protected:
    * @return Result<>
    */
   static Result<> WriteNodeGeom2dData(DataStructureWriter& dataStructureWriter, const INodeGeometry2D& geometry, group_writer_type& parentGroup, bool importable);
+
+  static Result<> FinishImportingNodeGeom2dData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup);
 };
 } // namespace HDF5
 } // namespace nx::core

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom3dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom3dIO.cpp
@@ -36,7 +36,7 @@ Result<> INodeGeom3dIO::ReadNodeGeom3dData(DataStructureReader& dataStructureRea
 Result<> INodeGeom3dIO::FinishImportingNodeGeom3dData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup)
 {
   auto* geom = dataStructure.getDataAs<INodeGeometry3D>(dataPath);
-  if (geom == nullptr)
+  if(geom == nullptr)
   {
     return MakeErrorResult(-50592, fmt::format("Failed to finish importing INodeGeometry3D at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
   }
@@ -47,7 +47,7 @@ Result<> INodeGeom3dIO::FinishImportingNodeGeom3dData(DataStructure& dataStructu
     geom->setPolyhedraDataId(ReadDataId(groupReader, IOConstants::k_PolyhedronDataTag));
     geom->setUnsharedFacedId(ReadDataId(groupReader, IOConstants::k_UnsharedFaceListTag));
   }
-  
+
   return INodeGeom2dIO::FinishImportingNodeGeom2dData(dataStructure, dataPath, dataStructureGroup);
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom3dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom3dIO.cpp
@@ -1,5 +1,6 @@
 #include "INodeGeom3dIO.hpp"
 
+#include "DataStructureReader.hpp"
 #include "DataStructureWriter.hpp"
 #include "simplnx/DataStructure/Geometry/INodeGeometry3D.hpp"
 #include "simplnx/DataStructure/IO/Generic/IOConstants.hpp"
@@ -23,6 +24,11 @@ Result<> INodeGeom3dIO::ReadNodeGeom3dData(DataStructureReader& dataStructureRea
   geom.setPolyhedronListId(ReadDataId(groupReader, IOConstants::k_PolyhedronListTag));
   geom.setPolyhedraDataId(ReadDataId(groupReader, IOConstants::k_PolyhedronDataTag));
   geom.setUnsharedFacedId(ReadDataId(groupReader, IOConstants::k_UnsharedFaceListTag));
+
+  // Required data
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_PolyhedronListTag));
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_PolyhedronDataTag));
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_UnsharedFaceListTag));
 
   return {};
 }

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom3dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom3dIO.cpp
@@ -44,13 +44,6 @@ Result<> INodeGeom3dIO::FinishImportingNodeGeom3dData(DataStructure& dataStructu
     return MakeErrorResult(-50592, fmt::format("Failed to finish importing INodeGeometry3D at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
   }
 
-  {
-    auto groupReader = dataStructureGroup.openGroup(dataPath.toString());
-    geom->setPolyhedronListId(ReadDataId(groupReader, IOConstants::k_PolyhedronListTag));
-    geom->setPolyhedraDataId(ReadDataId(groupReader, IOConstants::k_PolyhedronDataTag));
-    geom->setUnsharedFacedId(ReadDataId(groupReader, IOConstants::k_UnsharedFaceListTag));
-  }
-
   return INodeGeom2dIO::FinishImportingNodeGeom2dData(dataStructure, dataPath, dataStructureGroup);
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom3dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom3dIO.cpp
@@ -26,6 +26,25 @@ Result<> INodeGeom3dIO::ReadNodeGeom3dData(DataStructureReader& dataStructureRea
 
   return {};
 }
+
+Result<> INodeGeom3dIO::FinishImportingNodeGeom3dData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup)
+{
+  auto* geom = dataStructure.getDataAs<INodeGeometry3D>(dataPath);
+  if (geom == nullptr)
+  {
+    return MakeErrorResult(-50592, fmt::format("Failed to finish importing INodeGeometry3D at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
+  }
+
+  {
+    auto groupReader = dataStructureGroup.openGroup(dataPath.toString());
+    geom->setPolyhedronListId(ReadDataId(groupReader, IOConstants::k_PolyhedronListTag));
+    geom->setPolyhedraDataId(ReadDataId(groupReader, IOConstants::k_PolyhedronDataTag));
+    geom->setUnsharedFacedId(ReadDataId(groupReader, IOConstants::k_UnsharedFaceListTag));
+  }
+  
+  return INodeGeom2dIO::FinishImportingNodeGeom2dData(dataStructure, dataPath, dataStructureGroup);
+}
+
 Result<> INodeGeom3dIO::WriteNodeGeom3dData(DataStructureWriter& dataStructureWriter, const INodeGeometry3D& geom, group_writer_type& parentGroup, bool importable)
 {
   Result<> result = INodeGeom2dIO::WriteNodeGeom2dData(dataStructureWriter, geom, parentGroup, importable);

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom3dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom3dIO.cpp
@@ -26,9 +26,12 @@ Result<> INodeGeom3dIO::ReadNodeGeom3dData(DataStructureReader& dataStructureRea
   geom.setUnsharedFacedId(ReadDataId(groupReader, IOConstants::k_UnsharedFaceListTag));
 
   // Required data
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_PolyhedronListTag));
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_PolyhedronDataTag));
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_UnsharedFaceListTag));
+  if(useEmptyDataStore)
+  {
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_PolyhedronListTag));
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_PolyhedronDataTag));
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_UnsharedFaceListTag));
+  }
 
   return {};
 }

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom3dIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom3dIO.hpp
@@ -45,6 +45,8 @@ protected:
    * @return Result<>
    */
   static Result<> WriteNodeGeom3dData(DataStructureWriter& dataStructureWriter, const INodeGeometry3D& geometry, group_writer_type& parentGroup, bool importable);
+
+  static Result<> FinishImportingNodeGeom3dData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup);
 };
 } // namespace HDF5
 } // namespace nx::core

--- a/src/simplnx/DataStructure/IO/HDF5/NeighborListIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/NeighborListIO.hpp
@@ -38,9 +38,18 @@ public:
   {
     try
     {
+      std::string numNeighborsName;
+      auto numNeighborsNameResult = dataReader.readStringAttribute("Linked NumNeighbors Dataset");
+      if(numNeighborsNameResult.invalid())
+      {
+        return {};
+      }
+      numNeighborsName = std::move(numNeighborsNameResult.value());
+      auto numNeighborsReader = parentGroup.openDataset(numNeighborsName);
+
       if(useEmptyDataStore)
       {
-        auto tupleDimsResult = dataReader.readVectorAttribute<uint64>("TupleDimensions");
+        auto tupleDimsResult = numNeighborsReader.readVectorAttribute<uint64>("TupleDimensions");
         if(tupleDimsResult.invalid())
         {
           return nullptr;
@@ -50,15 +59,6 @@ public:
         return std::make_shared<EmptyListStore<T>>(numTuples);
       }
 
-      std::string numNeighborsName;
-      auto numNeighborsNameResult = dataReader.readStringAttribute("Linked NumNeighbors Dataset");
-      if(numNeighborsNameResult.invalid())
-      {
-        return {};
-      }
-      numNeighborsName = std::move(numNeighborsNameResult.value());
-
-      auto numNeighborsReader = parentGroup.openDataset(numNeighborsName);
       auto numNeighborsPtr = DataStoreIO::ReadDataStore<int32>(numNeighborsReader);
       auto& numNeighborsStore = *numNeighborsPtr.get();
 
@@ -130,7 +130,7 @@ public:
    * @param dataStructureReader
    * @return Result<>
    */
-  Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const override
+  Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& parentGroup) const override
   {
     if(!dataStructure.containsData(dataPath))
     {
@@ -138,13 +138,6 @@ public:
     }
 
     NeighborList<T>& neighborList = dataStructure.getDataRefAs<NeighborList<T>>(dataPath);
-
-    auto parentGroup = dataStructureGroup.openGroup(dataPath.getParent().toString());
-    if(parentGroup.isValid())
-    {
-      return MakeErrorResult(-150201, fmt::format("Failed to open HDF5 parent group for path '{}'", dataPath.toString()));
-    }
-
     auto dataReader = parentGroup.openDataset(dataPath.getTargetName());
 
     std::string numNeighborsName;

--- a/src/simplnx/DataStructure/IO/HDF5/NeighborListIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/NeighborListIO.hpp
@@ -4,6 +4,7 @@
 #include "simplnx/Common/Result.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataStore.hpp"
+#include "simplnx/DataStructure/EmptyListStore.hpp"
 #include "simplnx/DataStructure/IO/HDF5/DataArrayIO.hpp"
 #include "simplnx/DataStructure/IO/HDF5/DataStoreIO.hpp"
 #include "simplnx/DataStructure/IO/HDF5/IDataIO.hpp"
@@ -20,6 +21,7 @@ class NeighborListIO : public IDataIO
 {
 public:
   using data_type = NeighborList<T>;
+  using store_type = typename data_type::store_type;
   using shared_vector_type = typename data_type::SharedVectorType;
 
   NeighborListIO() = default;
@@ -32,10 +34,22 @@ public:
    * @param dataReader
    * @return Result<>
    */
-  static std::vector<shared_vector_type> ReadHdf5Data(const nx::core::HDF5::GroupIO& parentGroup, const nx::core::HDF5::DatasetIO& dataReader)
+  static std::shared_ptr<store_type> ReadHdf5Data(const nx::core::HDF5::GroupIO& parentGroup, const nx::core::HDF5::DatasetIO& dataReader, bool useEmptyDataStore = false)
   {
     try
     {
+      if(useEmptyDataStore)
+      {
+        auto tupleDimsResult = dataReader.readVectorAttribute<uint64>("TupleDimensions");
+        if(tupleDimsResult.invalid())
+        {
+          return nullptr;
+        }
+        std::vector<uint64> tupleDims = tupleDimsResult.value();
+        uint64 numTuples = std::accumulate(tupleDims.begin(), tupleDims.end(), static_cast<uint64>(1), std::multiplies<>());
+        return std::make_shared<EmptyListStore<T>>(numTuples);
+      }
+
       std::string numNeighborsName;
       auto numNeighborsNameResult = dataReader.readStringAttribute("Linked NumNeighbors Dataset");
       if(numNeighborsNameResult.invalid())
@@ -48,33 +62,39 @@ public:
       auto numNeighborsPtr = DataStoreIO::ReadDataStore<int32>(numNeighborsReader);
       auto& numNeighborsStore = *numNeighborsPtr.get();
 
-      std::vector<T> flatDataStore = dataReader.template readAsVector<T>();
-      if(flatDataStore.empty())
+      auto flatDataStorePtr = dataReader.template readAsDataStore<T>();
+      if(flatDataStorePtr == nullptr)
       {
-        throw std::runtime_error(fmt::format("Error reading neighbor list from DataStore from HDF5 at {} called {}", dataReader.getFilePath().string(), dataReader.getName()));
+        throw std::runtime_error(fmt::format("Error reading neighbor list from DataStore from HDF5 at '{}' called '{}'", dataReader.getFilePath().string(), dataReader.getName()));
       }
 
-      std::vector<shared_vector_type> dataVector;
+      const AbstractDataStore<T>& flatDataStore = *flatDataStorePtr.get();
+      if(flatDataStore.empty())
+      {
+        throw std::runtime_error(fmt::format("Error reading neighbor list from DataStore from HDF5 at '{}' called '{}'", dataReader.getFilePath().string(), dataReader.getName()));
+      }
+
       usize offset = 0;
       const auto numTuples = numNeighborsStore.getNumberOfTuples();
+      auto listStorePtr = DataStoreUtilities::CreateListStore<T>(numTuples);
+      AbstractListStore<T>& listStore = *listStorePtr.get();
       for(usize i = 0; i < numTuples; i++)
       {
         const auto numNeighbors = numNeighborsStore[i];
-        auto sharedVector = std::make_shared<std::vector<T>>(numNeighbors);
-        std::vector<T>& vector = *sharedVector.get();
+        std::vector<T> vector(numNeighbors);
 
         size_t neighborListStart = offset;
         size_t neighborListEnd = offset + numNeighbors;
-        sharedVector->assign(flatDataStore.begin() + neighborListStart, flatDataStore.begin() + neighborListEnd);
+        vector.assign(flatDataStore.begin() + neighborListStart, flatDataStore.begin() + neighborListEnd);
         offset += numNeighbors;
-        dataVector.push_back(sharedVector);
+        listStore.setList(i, vector);
       }
 
-      return dataVector;
+      return listStorePtr;
     } catch(const std::exception& e)
     {
       std::cout << "Cannot Read Neighborlist Dataset at path '" << dataReader.getObjectPath() << "' with error '" << e.what() << "'" << std::endl;
-      return {};
+      return nullptr;
     }
   }
 
@@ -93,13 +113,80 @@ public:
                     const std::optional<DataObject::IdType>& parentId, bool useEmptyDataStore = false) const override
   {
     auto datasetReader = parentGroup.openDataset(objectName);
-    auto dataVector = ReadHdf5Data(parentGroup, datasetReader);
-    auto* dataObject = data_type::Import(dataStructureReader.getDataStructure(), objectName, importId, dataVector, parentId);
+    auto listStorePtr = ReadHdf5Data(parentGroup, datasetReader, useEmptyDataStore);
+    auto* dataObject = data_type::Import(dataStructureReader.getDataStructure(), objectName, importId, listStorePtr, parentId);
     if(dataObject == nullptr)
     {
       std::string ss = "Failed to import NeighborList from HDF5";
       return MakeErrorResult(-505, ss);
     }
+    return {};
+  }
+
+  /**
+   * @brief Replaces the AbstractListStore using data from the HDF5 dataset.
+   * @param dataStructure
+   * @param dataPath
+   * @param dataStructureReader
+   * @return Result<>
+   */
+  Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const override
+  {
+    if(!dataStructure.containsData(dataPath))
+    {
+      return MakeErrorResult(-150200, fmt::format("Imported DataStructure Object at path '{}' does not exist.", dataPath.toString()));
+    }
+
+    NeighborList<T>& neighborList = dataStructure.getDataRefAs<NeighborList<T>>(dataPath);
+
+    auto parentGroup = dataStructureGroup.openGroup(dataPath.getParent().toString());
+    if(parentGroup.isValid())
+    {
+      return MakeErrorResult(-150201, fmt::format("Failed to open HDF5 parent group for path '{}'", dataPath.toString()));
+    }
+
+    auto dataReader = parentGroup.openDataset(dataPath.getTargetName());
+
+    std::string numNeighborsName;
+    auto numNeighborsNameResult = dataReader.readStringAttribute("Linked NumNeighbors Dataset");
+    if(numNeighborsNameResult.invalid())
+    {
+      return {};
+    }
+    numNeighborsName = std::move(numNeighborsNameResult.value());
+
+    auto numNeighborsReader = parentGroup.openDataset(numNeighborsName);
+    auto numNeighborsPtr = DataStoreIO::ReadDataStore<int32>(numNeighborsReader);
+    auto& numNeighborsStore = *numNeighborsPtr.get();
+
+    auto flatDataStorePtr = dataReader.template readAsDataStore<T>();
+    if(flatDataStorePtr == nullptr)
+    {
+      return MakeErrorResult(-150201, fmt::format("Imported DataStructure Object at path '{}' is not of the expected type.", dataPath.toString()));
+    }
+    AbstractDataStore<T>& flatDataStore = *(flatDataStorePtr.get());
+    if(flatDataStore.empty())
+    {
+      throw std::runtime_error(fmt::format("Error reading neighbor list from DataStore from HDF5 at '{}' called '{}'", dataReader.getFilePath().string(), dataReader.getName()));
+    }
+
+    usize offset = 0;
+    const auto numTuples = numNeighborsStore.getNumberOfTuples();
+    auto listStorePtr = DataStoreUtilities::CreateListStore<T>(numTuples);
+    AbstractListStore<T>& listStore = *listStorePtr.get();
+    for(usize i = 0; i < numTuples; i++)
+    {
+      const auto numNeighbors = numNeighborsStore[i];
+      std::vector<T> vector(numNeighbors);
+
+      size_t neighborListStart = offset;
+      size_t neighborListEnd = offset + numNeighbors;
+      vector.assign(flatDataStore.begin() + neighborListStart, flatDataStore.begin() + neighborListEnd);
+      offset += numNeighbors;
+      listStore.setList(i, vector);
+    }
+
+    neighborList.setStore(listStorePtr);
     return {};
   }
 

--- a/src/simplnx/DataStructure/IO/HDF5/QuadGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/QuadGeomIO.cpp
@@ -26,6 +26,18 @@ Result<> QuadGeomIO::readData(DataStructureReader& structureReader, const group_
   auto* geometry = QuadGeom::Import(structureReader.getDataStructure(), objectName, importId, parentId);
   return INodeGeom2dIO::ReadNodeGeom2dData(structureReader, *geometry, parentGroup, objectName, importId, parentId, useEmptyDataStore);
 }
+
+Result<> QuadGeomIO::finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const
+{
+  auto* geom = dataStructure.getDataAs<QuadGeom>(dataPath);
+  if(geom == nullptr)
+  {
+    return MakeErrorResult(-50590, fmt::format("Failed to finish importing QuadGeom at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
+  }
+
+  return INodeGeom2dIO::FinishImportingNodeGeom2dData(dataStructure, dataPath, dataStructureGroup);
+}
+
 Result<> QuadGeomIO::writeData(DataStructureWriter& dataStructureWriter, const QuadGeom& geom, group_writer_type& parentGroup, bool importable) const
 {
   return INodeGeom2dIO::WriteNodeGeom2dData(dataStructureWriter, geom, parentGroup, importable);

--- a/src/simplnx/DataStructure/IO/HDF5/QuadGeomIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/QuadGeomIO.hpp
@@ -30,6 +30,8 @@ public:
   Result<> readData(DataStructureReader& dataStructureReader, const group_reader_type& parentGroup, const std::string& geomName, DataObject::IdType importId,
                     const std::optional<DataObject::IdType>& parentId, bool useEmptyDataStore = false) const override;
 
+  Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const override;
+
   /**
    * @brief Attempts to write an QuadGeom to HDF5.
    * @param dataStructureWriter

--- a/src/simplnx/DataStructure/IO/HDF5/RectGridGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/RectGridGeomIO.cpp
@@ -61,6 +61,42 @@ Result<> RectGridGeomIO::readData(DataStructureReader& dataStructureReader, cons
   return {};
 }
 
+Result<> RectGridGeomIO::finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const
+{
+  auto* geom = dataStructure.getDataAs<RectGridGeom>(dataPath);
+  if(geom == nullptr)
+  {
+    return MakeErrorResult(-50590, fmt::format("Failed to finish importing RectGridGeom at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
+  }
+
+  {
+    auto groupReader = dataStructureGroup.openGroup(dataPath.toString());
+
+    if(const auto unitsAttr = groupReader.readScalarAttribute<uint32>(IOConstants::k_H5_UNITS); unitsAttr.valid())
+    {
+      auto value = unitsAttr.value();
+      geom->setUnits(static_cast<IGeometry::LengthUnit>(value));
+    }
+
+    // Read Dimensions
+    auto volumeDimensionsResult = groupReader.readVectorAttribute<usize>("Dimensions");
+    if(volumeDimensionsResult.invalid())
+    {
+      return ConvertInvalidResult<void>(std::move(volumeDimensionsResult));
+    }
+    const std::vector<size_t> volumeDimensions = std::move(volumeDimensionsResult.value());
+
+    geom->setDimensions(volumeDimensions);
+
+    // Read DataObject IDs
+    geom->setXBoundsId(ReadDataId(groupReader, IOConstants::k_XBoundsTag));
+    geom->setYBoundsId(ReadDataId(groupReader, IOConstants::k_YBoundsTag));
+    geom->setZBoundsId(ReadDataId(groupReader, IOConstants::k_ZBoundsTag));
+  }
+
+  return IGridGeometryIO::FinishImportingGridGeometryData(dataStructure, dataPath, dataStructureGroup);
+}
+
 Result<> RectGridGeomIO::writeData(DataStructureWriter& dataStructureWriter, const RectGridGeom& geometry, group_writer_type& parentGroup, bool importable) const
 {
   Result<> result = IGridGeometryIO::WriteGridGeometryData(dataStructureWriter, geometry, parentGroup, importable);

--- a/src/simplnx/DataStructure/IO/HDF5/RectGridGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/RectGridGeomIO.cpp
@@ -59,9 +59,12 @@ Result<> RectGridGeomIO::readData(DataStructureReader& dataStructureReader, cons
   geometry->setZBoundsId(ReadDataId(groupReader, IOConstants::k_ZBoundsTag));
 
   // Required data
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_XBoundsTag));
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_YBoundsTag));
-  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ZBoundsTag));
+  if(useEmptyDataStore)
+  {
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_XBoundsTag));
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_YBoundsTag));
+    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ZBoundsTag));
+  }
 
   return {};
 }

--- a/src/simplnx/DataStructure/IO/HDF5/RectGridGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/RectGridGeomIO.cpp
@@ -95,11 +95,6 @@ Result<> RectGridGeomIO::finishImportingData(DataStructure& dataStructure, const
     const std::vector<size_t> volumeDimensions = std::move(volumeDimensionsResult.value());
 
     geom->setDimensions(volumeDimensions);
-
-    // Read DataObject IDs
-    geom->setXBoundsId(ReadDataId(groupReader, IOConstants::k_XBoundsTag));
-    geom->setYBoundsId(ReadDataId(groupReader, IOConstants::k_YBoundsTag));
-    geom->setZBoundsId(ReadDataId(groupReader, IOConstants::k_ZBoundsTag));
   }
 
   return IGridGeometryIO::FinishImportingGridGeometryData(dataStructure, dataPath, dataStructureGroup);

--- a/src/simplnx/DataStructure/IO/HDF5/RectGridGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/RectGridGeomIO.cpp
@@ -58,6 +58,11 @@ Result<> RectGridGeomIO::readData(DataStructureReader& dataStructureReader, cons
   geometry->setYBoundsId(ReadDataId(groupReader, IOConstants::k_YBoundsTag));
   geometry->setZBoundsId(ReadDataId(groupReader, IOConstants::k_ZBoundsTag));
 
+  // Required data
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_XBoundsTag));
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_YBoundsTag));
+  dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ZBoundsTag));
+
   return {};
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/RectGridGeomIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/RectGridGeomIO.hpp
@@ -30,6 +30,8 @@ public:
   Result<> readData(DataStructureReader& dataStructureReader, const group_reader_type& parentGroup, const std::string& geomName, DataObject::IdType importId,
                     const std::optional<DataObject::IdType>& parentId, bool useEmptyDataStore = false) const override;
 
+  Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const override;
+
   /**
    * @brief Attempts to write an RectGridGeom to HDF5.
    * @param dataStructureWriter

--- a/src/simplnx/DataStructure/IO/HDF5/TetrahedralGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/TetrahedralGeomIO.cpp
@@ -27,6 +27,17 @@ Result<> TetrahedralGeomIO::readData(DataStructureReader& structureReader, const
   auto* geometry = TetrahedralGeom::Import(structureReader.getDataStructure(), objectName, importId, parentId);
   return INodeGeom3dIO::ReadNodeGeom3dData(structureReader, *geometry, parentGroup, objectName, importId, parentId, useEmptyDataStore);
 }
+
+Result<> TetrahedralGeomIO::finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const
+{
+  auto* geom = dataStructure.getDataAs<TetrahedralGeom>(dataPath);
+  if(geom == nullptr)
+  {
+    return MakeErrorResult(-50595, fmt::format("Failed to finish importing TetrahedraldGeom at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
+  }
+  return INodeGeom3dIO::FinishImportingNodeGeom3dData(dataStructure, dataPath, dataStructureGroup);
+}
+
 Result<> TetrahedralGeomIO::writeData(DataStructureWriter& dataStructureWriter, const TetrahedralGeom& geometry, group_writer_type& parentGroup, bool importable) const
 {
   return INodeGeom3dIO::WriteNodeGeom3dData(dataStructureWriter, geometry, parentGroup, importable);

--- a/src/simplnx/DataStructure/IO/HDF5/TetrahedralGeomIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/TetrahedralGeomIO.hpp
@@ -30,6 +30,8 @@ public:
   Result<> readData(DataStructureReader& dataStructureReader, const group_reader_type& parentGroup, const std::string& geomName, DataObject::IdType importId,
                     const std::optional<DataObject::IdType>& parentId, bool useEmptyDataStore = false) const override;
 
+  Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const override;
+
   /**
    * @brief Attempts to write an TetrahedralGeom to HDF5.
    * @param dataStructureWriter

--- a/src/simplnx/DataStructure/IO/HDF5/TriangleGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/TriangleGeomIO.cpp
@@ -27,6 +27,17 @@ Result<> TriangleGeomIO::readData(DataStructureReader& structureReader, const gr
   auto* geometry = TriangleGeom::Import(structureReader.getDataStructure(), objectName, importId, parentId);
   return INodeGeom2dIO::ReadNodeGeom2dData(structureReader, *geometry, parentGroup, objectName, importId, parentId, useEmptyDataStore);
 }
+
+Result<> TriangleGeomIO::finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const
+{
+  auto* geom = dataStructure.getDataAs<TriangleGeom>(dataPath);
+  if(geom == nullptr)
+  {
+    return MakeErrorResult(-50595, fmt::format("Failed to finish importing TriangleGeom at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
+  }
+  return INodeGeom2dIO::FinishImportingNodeGeom2dData(dataStructure, dataPath, dataStructureGroup);
+}
+
 Result<> TriangleGeomIO::writeData(DataStructureWriter& dataStructureWriter, const TriangleGeom& geometry, group_writer_type& parentGroupWriter, bool importable) const
 {
   return INodeGeom2dIO::WriteNodeGeom2dData(dataStructureWriter, geometry, parentGroupWriter, importable);

--- a/src/simplnx/DataStructure/IO/HDF5/TriangleGeomIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/TriangleGeomIO.hpp
@@ -30,6 +30,8 @@ public:
   Result<> readData(DataStructureReader& dataStructureReader, const group_reader_type& parentGroup, const std::string& geomName, DataObject::IdType importId,
                     const std::optional<DataObject::IdType>& parentId, bool useEmptyDataStore = false) const override;
 
+  Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const override;
+
   /**
    * @brief Attempts to write an TriangleGeom to HDF5.
    * @param dataStructureWriter

--- a/src/simplnx/DataStructure/IO/HDF5/VertexGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/VertexGeomIO.cpp
@@ -26,6 +26,17 @@ Result<> VertexGeomIO::readData(DataStructureReader& dataStructureReader, const 
   auto* geometry = VertexGeom::Import(dataStructureReader.getDataStructure(), objectName, importId, parentId);
   return INodeGeom0dIO::ReadNodeGeom0dData(dataStructureReader, *geometry, parentGroup, objectName, importId, parentId, useEmptyDataStore);
 }
+
+Result<> VertexGeomIO::finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const
+{
+  auto* geom = dataStructure.getDataAs<VertexGeom>(dataPath);
+  if(geom == nullptr)
+  {
+    return MakeErrorResult(-50595, fmt::format("Failed to finish importing VertexGeom at path '{}'. Data not found or of incorrect type.", dataPath.toString()));
+  }
+  return INodeGeom0dIO::FinishImportingNodeGeom0dData(dataStructure, dataPath, dataStructureGroup);
+}
+
 Result<> VertexGeomIO::writeData(DataStructureWriter& structureReader, const VertexGeom& geometry, group_writer_type& parentGroupWriter, bool importable) const
 {
   return INodeGeom0dIO::WriteNodeGeom0dData(structureReader, geometry, parentGroupWriter, importable);

--- a/src/simplnx/DataStructure/IO/HDF5/VertexGeomIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/VertexGeomIO.hpp
@@ -30,6 +30,8 @@ public:
   Result<> readData(DataStructureReader& dataStructureReader, const group_reader_type& parentGroup, const std::string& geomName, DataObject::IdType importId,
                     const std::optional<DataObject::IdType>& parentId, bool useEmptyDataStore = false) const override;
 
+  Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& dataStructureGroup) const override;
+
   /**
    * @brief Attempts to write an VertexGeom to HDF5.
    * @param dataStructureWriter

--- a/src/simplnx/DataStructure/ListStore.hpp
+++ b/src/simplnx/DataStructure/ListStore.hpp
@@ -261,12 +261,12 @@ public:
 
   void readHdf5(const HDF5::DatasetIO& datasetReader) override
   {
-    throw std::runtime_error("EmptyListStore cannot read from HDF5");
+    throw std::runtime_error("ListStore cannot read from HDF5");
   }
 
   void writeHdf5(HDF5::DatasetIO& datasetReader) override
   {
-    throw std::runtime_error("EmptyListStore cannot write to HDF5");
+    throw std::runtime_error("ListStore cannot write to HDF5");
   }
 
 private:

--- a/src/simplnx/DataStructure/ListStore.hpp
+++ b/src/simplnx/DataStructure/ListStore.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "simplnx/DataStructure/AbstractListStore.hpp"
+#include "simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp"
 
 #include <memory>
 #include <vector>
@@ -258,7 +259,30 @@ public:
     m_Array = lists;
   }
 
+  void readHdf5(const HDF5::DatasetIO& datasetReader) override
+  {
+    throw std::runtime_error("EmptyListStore cannot read from HDF5");
+  }
+
+  void writeHdf5(HDF5::DatasetIO& datasetReader) override
+  {
+    throw std::runtime_error("EmptyListStore cannot write to HDF5");
+  }
+
 private:
   std::vector<std::vector<T>> m_Array;
 };
+
+using UInt8ListStore = ListStore<uint8>;
+using UInt16ListStore = ListStore<uint16>;
+using UInt32ListStore = ListStore<uint32>;
+using UInt64ListStore = ListStore<uint64>;
+
+using Int8ListStore = ListStore<int8>;
+using Int16ListStore = ListStore<int16>;
+using Int32ListStore = ListStore<int32>;
+using Int64ListStore = ListStore<int64>;
+
+using Float32ListStore = ListStore<float32>;
+using Float64ListStore = ListStore<float64>;
 } // namespace nx::core

--- a/src/simplnx/DataStructure/NeighborList.cpp
+++ b/src/simplnx/DataStructure/NeighborList.cpp
@@ -26,6 +26,24 @@ NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& n
 }
 
 template <typename T>
+NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& name, const std::shared_ptr<store_type>& dataStore, IdType importId)
+: INeighborList(dataStructure, name, dataStore->size(), importId)
+, m_Store(dataStore)
+, m_IsAllocated(true)
+, m_InitValue(static_cast<T>(0.0))
+{
+}
+
+template <typename T>
+NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& name, const std::shared_ptr<store_type>& dataStore)
+: INeighborList(dataStructure, name, dataStore->size())
+, m_Store(dataStore)
+, m_IsAllocated(true)
+, m_InitValue(static_cast<T>(0.0))
+{
+}
+
+template <typename T>
 NeighborList<T>* NeighborList<T>::Create(DataStructure& dataStructure, const std::string& name, usize numTuples, const std::optional<IdType>& parentId)
 {
   auto data = std::shared_ptr<NeighborList>(new NeighborList(dataStructure, name, numTuples));
@@ -37,9 +55,36 @@ NeighborList<T>* NeighborList<T>::Create(DataStructure& dataStructure, const std
 }
 
 template <typename T>
+NeighborList<T>* NeighborList<T>::Create(DataStructure& dataStructure, const std::string& name, const std::shared_ptr<store_type>& listStore, const std::optional<IdType>& parentId)
+{
+  if(listStore == nullptr)
+  {
+    return nullptr;
+  }
+
+  auto data = std::shared_ptr<NeighborList>(new NeighborList(dataStructure, name, listStore));
+  if(!AttemptToAddObject(dataStructure, data, parentId))
+  {
+    return nullptr;
+  }
+  return data.get();
+}
+
+template <typename T>
 NeighborList<T>* NeighborList<T>::Import(DataStructure& dataStructure, const std::string& name, IdType importId, const std::vector<SharedVectorType>& dataVector, const std::optional<IdType>& parentId)
 {
   auto data = std::shared_ptr<NeighborList>(new NeighborList(dataStructure, name, dataVector, importId));
+  if(!AttemptToAddObject(dataStructure, data, parentId))
+  {
+    return nullptr;
+  }
+  return data.get();
+}
+
+template <typename T>
+NeighborList<T>* NeighborList<T>::Import(DataStructure& dataStructure, const std::string& name, IdType importId, const std::shared_ptr<store_type>& dataStore, const std::optional<IdType>& parentId)
+{
+  auto data = std::shared_ptr<NeighborList>(new NeighborList(dataStructure, name, dataStore, importId));
   if(!AttemptToAddObject(dataStructure, data, parentId))
   {
     return nullptr;
@@ -394,6 +439,12 @@ template <typename T>
 std::shared_ptr<typename NeighborList<T>::store_type> NeighborList<T>::getStore() const
 {
   return m_Store;
+}
+
+template <typename T>
+void NeighborList<T>::setStore(const std::shared_ptr<store_type>& store)
+{
+  m_Store = store;
 }
 
 template <typename T>

--- a/src/simplnx/DataStructure/NeighborList.hpp
+++ b/src/simplnx/DataStructure/NeighborList.hpp
@@ -47,12 +47,34 @@ public:
    * @brief
    * @param dataStructure
    * @param name
+   * @param numTuples
+   * @param parentId = {}
+   * @tparam T
+   * @return NeighborList<T>*
+   */
+  static NeighborList* Create(DataStructure& dataStructure, const std::string& name, const std::shared_ptr<store_type>& listStore, const std::optional<IdType>& parentId = {});
+
+  /**
+   * @brief
+   * @param dataStructure
+   * @param name
    * @param importId
    * @param data
    * @param parentId
    * @return NeighborList<T>*
    */
   static NeighborList* Import(DataStructure& dataStructure, const std::string& name, IdType importId, const std::vector<SharedVectorType>& data, const std::optional<IdType>& parentId = {});
+
+  /**
+   * @brief
+   * @param dataStructure
+   * @param name
+   * @param importId
+   * @param storeData
+   * @param parentId
+   * @return NeighborList<T>*
+   */
+  static NeighborList* Import(DataStructure& dataStructure, const std::string& name, IdType importId, const std::shared_ptr<store_type>& storeData, const std::optional<IdType>& parentId = {});
 
   ~NeighborList() override = default;
 
@@ -364,6 +386,12 @@ public:
   std::shared_ptr<store_type> getStore() const;
 
   /**
+   * @brief Replaces the AbstractListStore used to store values.
+   * @param store
+   */
+  void setStore(const std::shared_ptr<store_type>& store);
+
+  /**
    * @brief Returns a vector of vectors containing the current values.
    */
   std::vector<VectorType> getVectors() const;
@@ -387,7 +415,17 @@ protected:
   /**
    * @brief NeighborList
    */
+  NeighborList(DataStructure& dataStructure, const std::string& name, const std::shared_ptr<store_type>& dataStore);
+
+  /**
+   * @brief NeighborList
+   */
   NeighborList(DataStructure& dataStructure, const std::string& name, const std::vector<SharedVectorType>& dataVector, IdType importId);
+
+  /**
+   * @brief NeighborList
+   */
+  NeighborList(DataStructure& dataStructure, const std::string& name, const std::shared_ptr<store_type>& listStore, IdType importId);
 
 private:
   std::shared_ptr<store_type> m_Store;

--- a/src/simplnx/DataStructure/StringArray.cpp
+++ b/src/simplnx/DataStructure/StringArray.cpp
@@ -234,4 +234,9 @@ void StringArray::swapTuples(usize index0, usize index1)
   (*m_Strings)[index1] = value;
 }
 
+
+void StringArray::setStore(const std::shared_ptr<AbstractStringStore>& newStore)
+{
+  m_Strings = newStore;
+}
 } // namespace nx::core

--- a/src/simplnx/DataStructure/StringArray.cpp
+++ b/src/simplnx/DataStructure/StringArray.cpp
@@ -234,7 +234,6 @@ void StringArray::swapTuples(usize index0, usize index1)
   (*m_Strings)[index1] = value;
 }
 
-
 void StringArray::setStore(const std::shared_ptr<AbstractStringStore>& newStore)
 {
   m_Strings = newStore;

--- a/src/simplnx/DataStructure/StringArray.hpp
+++ b/src/simplnx/DataStructure/StringArray.hpp
@@ -124,6 +124,8 @@ public:
    */
   void resizeTuples(const std::vector<usize>& tupleShape) override;
 
+  void setStore(const std::shared_ptr<AbstractStringStore>& newStore);
+
 protected:
   StringArray(DataStructure& dataStructure, std::string name);
   StringArray(DataStructure& dataStructure, std::string name, collection_type strings);

--- a/src/simplnx/Filter/Actions/ImportH5ObjectPathsAction.cpp
+++ b/src/simplnx/Filter/Actions/ImportH5ObjectPathsAction.cpp
@@ -75,7 +75,7 @@ Result<> ImportH5ObjectPathsAction::apply(DataStructure& dataStructure, Mode mod
 
     if(!dataStructure.insert(importData, targetPath.getParent()))
     {
-      //return MakeErrorResult(k_InsertFailureError, fmt::format("{}Unable to import DataObject at '{}'", prefix, targetPath.toString()));
+      // return MakeErrorResult(k_InsertFailureError, fmt::format("{}Unable to import DataObject at '{}'", prefix, targetPath.toString()));
     }
     if(auto result = DREAM3D::FinishImportingObject(dataStructure, targetPath, fileReader); result.invalid())
     {

--- a/src/simplnx/Filter/Actions/ImportH5ObjectPathsAction.cpp
+++ b/src/simplnx/Filter/Actions/ImportH5ObjectPathsAction.cpp
@@ -41,7 +41,7 @@ Result<> ImportH5ObjectPathsAction::apply(DataStructure& dataStructure, Mode mod
   bool preflighting = (mode == Mode::Preflight);
 
   auto fileReader = nx::core::HDF5::FileIO::ReadFile(m_H5FilePath);
-  Result<DataStructure> dataStructureResult = DREAM3D::ImportDataStructureFromFile(fileReader, preflighting);
+  Result<DataStructure> dataStructureResult = DREAM3D::ImportDataStructureFromFile(fileReader, true);
   if(dataStructureResult.invalid())
   {
     return ConvertResult(std::move(dataStructureResult));
@@ -75,6 +75,10 @@ Result<> ImportH5ObjectPathsAction::apply(DataStructure& dataStructure, Mode mod
     if(!dataStructure.insert(importData, targetPath.getParent()))
     {
       return MakeErrorResult(k_InsertFailureError, fmt::format("{}Unable to import DataObject at '{}'", prefix, targetPath.toString()));
+    }
+    if(auto result = DREAM3D::FinishImportingObject(dataStructure, targetPath, fileReader); result.invalid())
+    {
+      return result;
     }
   }
   if(!errorMessages.str().empty())

--- a/src/simplnx/Filter/Actions/ImportH5ObjectPathsAction.cpp
+++ b/src/simplnx/Filter/Actions/ImportH5ObjectPathsAction.cpp
@@ -69,12 +69,13 @@ Result<> ImportH5ObjectPathsAction::apply(DataStructure& dataStructure, Mode mod
 
     if(dataStructure.getDataAs<DataObject>(targetPath) != nullptr)
     {
-      return MakeErrorResult(-6203, fmt::format("{}Unable to import DataObject at '{}' because an object already exists there. Consider a rename of existing object.", prefix, targetPath.toString()));
+      // return MakeErrorResult(-6203, fmt::format("{}Unable to import DataObject at '{}' because an object already exists there. Consider a rename of existing object.", prefix,
+      // targetPath.toString()));
     }
 
     if(!dataStructure.insert(importData, targetPath.getParent()))
     {
-      return MakeErrorResult(k_InsertFailureError, fmt::format("{}Unable to import DataObject at '{}'", prefix, targetPath.toString()));
+      //return MakeErrorResult(k_InsertFailureError, fmt::format("{}Unable to import DataObject at '{}'", prefix, targetPath.toString()));
     }
     if(auto result = DREAM3D::FinishImportingObject(dataStructure, targetPath, fileReader); result.invalid())
     {

--- a/src/simplnx/Filter/Actions/ImportH5ObjectPathsAction.cpp
+++ b/src/simplnx/Filter/Actions/ImportH5ObjectPathsAction.cpp
@@ -69,7 +69,7 @@ Result<> ImportH5ObjectPathsAction::apply(DataStructure& dataStructure, Mode mod
 
     if(!dataStructure.insert(importData, targetPath.getParent()))
     {
-      // return MakeErrorResult(k_InsertFailureError, fmt::format("{}Unable to import DataObject at '{}'", prefix, targetPath.toString()));
+      return MakeErrorResult(k_InsertFailureError, fmt::format("{}Unable to import DataObject at '{}'", prefix, targetPath.toString()));
     }
     if(mode == Mode::Execute)
     {

--- a/src/simplnx/Filter/Actions/ImportH5ObjectPathsAction.cpp
+++ b/src/simplnx/Filter/Actions/ImportH5ObjectPathsAction.cpp
@@ -67,19 +67,16 @@ Result<> ImportH5ObjectPathsAction::apply(DataStructure& dataStructure, Mode mod
       importGroup->clear();
     }
 
-    if(dataStructure.getDataAs<DataObject>(targetPath) != nullptr)
-    {
-      // return MakeErrorResult(-6203, fmt::format("{}Unable to import DataObject at '{}' because an object already exists there. Consider a rename of existing object.", prefix,
-      // targetPath.toString()));
-    }
-
     if(!dataStructure.insert(importData, targetPath.getParent()))
     {
       // return MakeErrorResult(k_InsertFailureError, fmt::format("{}Unable to import DataObject at '{}'", prefix, targetPath.toString()));
     }
-    if(auto result = DREAM3D::FinishImportingObject(dataStructure, targetPath, fileReader); result.invalid())
+    if(mode == Mode::Execute)
     {
-      return result;
+      if(auto result = DREAM3D::FinishImportingObject(dataStructure, targetPath, fileReader); result.invalid())
+      {
+        return result;
+      }
     }
   }
   if(!errorMessages.str().empty())

--- a/src/simplnx/Utilities/DataStoreUtilities.hpp
+++ b/src/simplnx/Utilities/DataStoreUtilities.hpp
@@ -64,8 +64,7 @@ std::shared_ptr<AbstractDataStore<T>> CreateDataStore(const typename IDataStore:
 }
 
 template <class T>
-std::shared_ptr<AbstractListStore<T>> CreateListStore(usize tupleCount, IDataAction::Mode mode = IDataAction::Mode::Execute,
-  std::string dataFormat = "")
+std::shared_ptr<AbstractListStore<T>> CreateListStore(usize tupleCount, IDataAction::Mode mode = IDataAction::Mode::Execute, std::string dataFormat = "")
 {
   switch(mode)
   {

--- a/src/simplnx/Utilities/DataStoreUtilities.hpp
+++ b/src/simplnx/Utilities/DataStoreUtilities.hpp
@@ -4,6 +4,7 @@
 
 #include "simplnx/DataStructure/AbstractDataStore.hpp"
 #include "simplnx/DataStructure/EmptyDataStore.hpp"
+#include "simplnx/DataStructure/EmptyListStore.hpp"
 #include "simplnx/DataStructure/IO/Generic/DataIOCollection.hpp"
 #include "simplnx/Filter/Output.hpp"
 
@@ -55,6 +56,28 @@ std::shared_ptr<AbstractDataStore<T>> CreateDataStore(const typename IDataStore:
     auto ioCollection = GetIOCollection();
     ioCollection->checkStoreDataFormat(dataSize, dataFormat);
     return ioCollection->createDataStoreWithType<T>(dataFormat, tupleShape, componentShape);
+  }
+  default: {
+    throw std::runtime_error("Invalid mode");
+  }
+  }
+}
+
+template <class T>
+std::shared_ptr<AbstractListStore<T>> CreateListStore(usize tupleCount, IDataAction::Mode mode = IDataAction::Mode::Execute,
+  std::string dataFormat = "")
+{
+  switch(mode)
+  {
+  case IDataAction::Mode::Preflight: {
+    return std::make_unique<EmptyListStore<T>>(tupleCount);
+  }
+  case IDataAction::Mode::Execute: {
+    uint64 dataSize = CalculateDataSize<T>({tupleCount}, {10});
+    TryForceLargeDataFormatFromPrefs(dataFormat);
+    auto ioCollection = GetIOCollection();
+    ioCollection->checkStoreDataFormat(dataSize, dataFormat);
+    return ioCollection->createListStoreWithType<T>(dataFormat, tupleCount);
   }
   default: {
     throw std::runtime_error("Invalid mode");

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -2053,8 +2053,8 @@ Result<> DREAM3D::FinishImportingObject(DataStructure& dataStructure, const Data
   else if(fileVersion == k_LegacyFileVersion)
   {
     auto dataStructureReader = fileReader.openGroup(k_LegacyDataStructureGroupTag);
-    //std::string parentPathStr = dataPath.getParent().toString();
-    //auto parentGroup = dataStructureReader.openGroup(dataPath.getParent().toString());
+    // std::string parentPathStr = dataPath.getParent().toString();
+    // auto parentGroup = dataStructureReader.openGroup(dataPath.getParent().toString());
 
     return FinishImportingLegacyDataObject(dataStructure, dataStructureReader, dataPath);
   }

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -1629,14 +1629,7 @@ Result<> finishImportingLegacyEdgeGeom(DataStructure& dataStructure, IGeometry* 
     return MakeErrorResult(-502677, "Failed to finish importing legacy Edge Geometry. Existing geometry is not of the correct type");
   }
 
-  const bool preflight = false;
   readGenericGeomDims(edgeGeom, geomGroup);
-  auto sharedVertexList = readLegacyGeomArrayAs<Float32Array>(dataStructure, edgeGeom, geomGroup, Legacy::VertexListName, preflight);
-  auto sharedEdgeList = readLegacyNodeConnectivityList(dataStructure, edgeGeom, geomGroup, Legacy::EdgeListName, preflight);
-
-  edgeGeom->setVertices(*sharedVertexList.value());
-  edgeGeom->setEdgeList(*sharedEdgeList.value());
-
   return {};
 }
 
@@ -1648,14 +1641,7 @@ Result<> finishImportingLegacyHexGeom(DataStructure& dataStructure, IGeometry* g
     return MakeErrorResult(-502676, "Failed to finish importing legacy Hex Geometry. Existing geometry is not of the correct type");
   }
 
-  const bool preflight = false;
   readGenericGeomDims(hexGeom, geomGroup);
-  auto sharedVertexList = readLegacyGeomArrayAs<Float32Array>(dataStructure, hexGeom, geomGroup, Legacy::VertexListName, preflight);
-  auto sharedHexList = readLegacyNodeConnectivityList(dataStructure, hexGeom, geomGroup, Legacy::HexListName, preflight);
-
-  hexGeom->setVertices(*sharedVertexList.value());
-  hexGeom->setPolyhedraList(*sharedHexList.value());
-
   return {};
 }
 
@@ -1667,14 +1653,7 @@ Result<> finishImportingLegacyQuadGeom(DataStructure& dataStructure, IGeometry* 
     return MakeErrorResult(-502675, "Failed to finish importing legacy Quad Geometry. Existing geometry is not of the correct type");
   }
 
-  const bool preflight = false;
   readGenericGeomDims(quadGeom, geomGroup);
-  auto sharedVertexList = readLegacyGeomArrayAs<Float32Array>(dataStructure, quadGeom, geomGroup, Legacy::VertexListName, preflight);
-  auto sharedQuadList = readLegacyNodeConnectivityList(dataStructure, quadGeom, geomGroup, Legacy::QuadListName, preflight);
-
-  quadGeom->setVertices(*sharedVertexList.value());
-  quadGeom->setFaceList(*sharedQuadList.value());
-
   return {};
 }
 
@@ -1686,7 +1665,6 @@ Result<> finishImportingLegacyRectGridGeom(DataStructure& dataStructure, IGeomet
     return MakeErrorResult(-502674, "Failed to finish importing legacy RectGrid Geometry. Existing geometry is not of the correct type");
   }
 
-  const bool preflight = false;
   readGenericGeomDims(rectGridGeom, geomGroup);
 
   // DIMENSIONS array
@@ -1695,12 +1673,6 @@ Result<> finishImportingLegacyRectGridGeom(DataStructure& dataStructure, IGeomet
     auto dims = dimsDataset.readAsVector<int64>();
     rectGridGeom->setDimensions(SizeVec3(dims[0], dims[1], dims[2]));
   }
-
-  auto xBoundsArray = readLegacyGeomArrayAs<Float32Array>(dataStructure, rectGridGeom, geomGroup, Legacy::XBoundsName, preflight);
-  auto yBoundsArray = readLegacyGeomArrayAs<Float32Array>(dataStructure, rectGridGeom, geomGroup, Legacy::YBoundsName, preflight);
-  auto zBoundsArray = readLegacyGeomArrayAs<Float32Array>(dataStructure, rectGridGeom, geomGroup, Legacy::ZBoundsName, preflight);
-
-  rectGridGeom->setBounds(xBoundsArray.value(), yBoundsArray.value(), zBoundsArray.value());
 
   return {};
 }
@@ -1713,14 +1685,7 @@ Result<> finishImportingLegacyTetrahedralGeom(DataStructure& dataStructure, IGeo
     return MakeErrorResult(-502673, "Failed to finish importing legacy Tetrahedral Geometry. Existing geometry is not of the correct type");
   }
 
-  const bool preflight = false;
   readGenericGeomDims(tetrahedralGeom, geomGroup);
-  auto sharedVertexList = readLegacyGeomArrayAs<Float32Array>(dataStructure, tetrahedralGeom, geomGroup, Legacy::VertexListName, preflight);
-  auto sharedTetList = readLegacyNodeConnectivityList(dataStructure, tetrahedralGeom, geomGroup, Legacy::TetraListName, preflight);
-
-  tetrahedralGeom->setVertices(*sharedVertexList.value());
-  tetrahedralGeom->setPolyhedraList(*sharedTetList.value());
-
   return {};
 }
 
@@ -1732,14 +1697,7 @@ Result<> finishImportingLegacyTriangleGeom(DataStructure& dataStructure, IGeomet
     return MakeErrorResult(-502672, "Failed to finish importing legacy Triangle Geometry. Existing geometry is not of the correct type");
   }
 
-  const bool preflight = false;
   readGenericGeomDims(triangleGeom, geomGroup);
-  auto sharedVertexList = readLegacyGeomArrayAs<Float32Array>(dataStructure, triangleGeom, geomGroup, Legacy::VertexListName, preflight);
-  auto sharedTriList = readLegacyNodeConnectivityList(dataStructure, triangleGeom, geomGroup, Legacy::TriListName, preflight);
-
-  triangleGeom->setVertices(*sharedVertexList.value());
-  triangleGeom->setFaceList(*sharedTriList.value());
-
   return {};
 }
 
@@ -1751,12 +1709,7 @@ Result<> finishImportingLegacyVertexGeom(DataStructure& dataStructure, IGeometry
     return MakeErrorResult(-502671, "Failed to finish importing legacy Vertex Geometry. Existing geometry is not of the correct type");
   }
 
-  const bool preflight = false;
   readGenericGeomDims(vertexGeom, geomGroup);
-  Result<Float32Array*> sharedVertexList = readLegacyGeomArrayAs<Float32Array>(dataStructure, vertexGeom, geomGroup, Legacy::VertexListName, preflight);
-
-  vertexGeom->setVertices(*sharedVertexList.value());
-
   return {};
 }
 
@@ -2053,9 +2006,6 @@ Result<> DREAM3D::FinishImportingObject(DataStructure& dataStructure, const Data
   else if(fileVersion == k_LegacyFileVersion)
   {
     auto dataStructureReader = fileReader.openGroup(k_LegacyDataStructureGroupTag);
-    // std::string parentPathStr = dataPath.getParent().toString();
-    // auto parentGroup = dataStructureReader.openGroup(dataPath.getParent().toString());
-
     return FinishImportingLegacyDataObject(dataStructure, dataStructureReader, dataPath);
   }
   return {};

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -1248,7 +1248,7 @@ Result<> readLegacyArray(DataStructure& dataStructure, const nx::core::HDF5::Gro
   }
 }
 
-Result<> FinishImportingLegacyArray(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& parentReader, const DataPath& dataPath)
+Result<> finishImportingLegacyArray(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& parentReader, const DataPath& dataPath)
 {
   auto dataArraySet = parentReader.openDataset(dataPath.getTargetName());
   if(isLegacyNeighborList(dataArraySet))
@@ -1549,31 +1549,31 @@ Result<> readLegacyDataContainer(DataStructure& dataStructure, const nx::core::H
     }
     else if(geomName == Legacy::Type::EdgeGeom)
     {
-      container = readLegacyEdgeGeom(dataStructure, geomGroup, dcName, preflight);
+      container = readLegacyEdgeGeom(dataStructure, geomGroup, dcName, false);
     }
     else if(geomName == Legacy::Type::HexGeom)
     {
-      container = readLegacyHexGeom(dataStructure, geomGroup, dcName, preflight);
+      container = readLegacyHexGeom(dataStructure, geomGroup, dcName, false);
     }
     else if(geomName == Legacy::Type::QuadGeom)
     {
-      container = readLegacyQuadGeom(dataStructure, geomGroup, dcName, preflight);
+      container = readLegacyQuadGeom(dataStructure, geomGroup, dcName, false);
     }
     else if(geomName == Legacy::Type::RectGridGeom)
     {
-      container = readLegacyRectGridGeom(dataStructure, geomGroup, dcName, preflight);
+      container = readLegacyRectGridGeom(dataStructure, geomGroup, dcName, false);
     }
     else if(geomName == Legacy::Type::TetrahedralGeom)
     {
-      container = readLegacyTetrahedralGeom(dataStructure, geomGroup, dcName, preflight);
+      container = readLegacyTetrahedralGeom(dataStructure, geomGroup, dcName, false);
     }
     else if(geomName == Legacy::Type::TriangleGeom)
     {
-      container = readLegacyTriangleGeom(dataStructure, geomGroup, dcName, preflight);
+      container = readLegacyTriangleGeom(dataStructure, geomGroup, dcName, false);
     }
     else if(geomName == Legacy::Type::VertexGeom)
     {
-      container = readLegacyVertexGeom(dataStructure, geomGroup, dcName, preflight);
+      container = readLegacyVertexGeom(dataStructure, geomGroup, dcName, false);
     }
   }
 
@@ -1604,6 +1604,216 @@ Result<> readLegacyDataContainer(DataStructure& dataStructure, const nx::core::H
   return nx::core::MergeResults(amResults);
 }
 
+
+Result<> finishImportingLegacyImageGeom(DataStructure& dataStructure, IGeometry* geometry, const HDF5::GroupIO& geometryReader)
+{
+  auto* imageGeom = dynamic_cast<ImageGeom*>(geometry);
+  if (imageGeom == nullptr)
+  {
+    return MakeErrorResult(-502678, "Failed to finish importing legacy Image Geometry. Existing geometry is not of the correct type");
+  }
+
+  return {};
+}
+
+Result<> finishImportingLegacyEdgeGeom(DataStructure& dataStructure, IGeometry* geometryPtr, const HDF5::GroupIO& geomGroup)
+{
+  auto* edgeGeom = dynamic_cast<EdgeGeom*>(geometryPtr);
+  if(edgeGeom == nullptr)
+  {
+    return MakeErrorResult(-502677, "Failed to finish importing legacy Edge Geometry. Existing geometry is not of the correct type");
+  }
+
+  const bool preflight = false;
+  readGenericGeomDims(edgeGeom, geomGroup);
+  auto sharedVertexList = readLegacyGeomArrayAs<Float32Array>(dataStructure, edgeGeom, geomGroup, Legacy::VertexListName, preflight);
+  auto sharedEdgeList = readLegacyNodeConnectivityList(dataStructure, edgeGeom, geomGroup, Legacy::EdgeListName, preflight);
+
+  edgeGeom->setVertices(*sharedVertexList.value());
+  edgeGeom->setEdgeList(*sharedEdgeList.value());
+
+  return {};
+}
+
+Result<> finishImportingLegacyHexGeom(DataStructure& dataStructure, IGeometry* geometryPtr, const HDF5::GroupIO& geomGroup)
+{
+  auto* hexGeom = dynamic_cast<HexahedralGeom*>(geometryPtr);
+  if(hexGeom == nullptr)
+  {
+    return MakeErrorResult(-502676, "Failed to finish importing legacy Hex Geometry. Existing geometry is not of the correct type");
+  }
+
+  const bool preflight = false;
+  readGenericGeomDims(hexGeom, geomGroup);
+  auto sharedVertexList = readLegacyGeomArrayAs<Float32Array>(dataStructure, hexGeom, geomGroup, Legacy::VertexListName, preflight);
+  auto sharedHexList = readLegacyNodeConnectivityList(dataStructure, hexGeom, geomGroup, Legacy::HexListName, preflight);
+
+  hexGeom->setVertices(*sharedVertexList.value());
+  hexGeom->setPolyhedraList(*sharedHexList.value());
+
+  return {};
+}
+
+Result<> finishImportingLegacyQuadGeom(DataStructure& dataStructure, IGeometry* geometryPtr, const HDF5::GroupIO& geomGroup)
+{
+  auto* quadGeom = dynamic_cast<QuadGeom*>(geometryPtr);
+  if(quadGeom == nullptr)
+  {
+    return MakeErrorResult(-502675, "Failed to finish importing legacy Quad Geometry. Existing geometry is not of the correct type");
+  }
+
+  const bool preflight = false;
+  readGenericGeomDims(quadGeom, geomGroup);
+  auto sharedVertexList = readLegacyGeomArrayAs<Float32Array>(dataStructure, quadGeom, geomGroup, Legacy::VertexListName, preflight);
+  auto sharedQuadList = readLegacyNodeConnectivityList(dataStructure, quadGeom, geomGroup, Legacy::QuadListName, preflight);
+
+  quadGeom->setVertices(*sharedVertexList.value());
+  quadGeom->setFaceList(*sharedQuadList.value());
+
+  return {};
+}
+
+Result<> finishImportingLegacyRectGridGeom(DataStructure& dataStructure, IGeometry* geometryPtr, const HDF5::GroupIO& geomGroup)
+{
+  auto* rectGridGeom = dynamic_cast<RectGridGeom*>(geometryPtr);
+  if(rectGridGeom == nullptr)
+  {
+    return MakeErrorResult(-502674, "Failed to finish importing legacy RectGrid Geometry. Existing geometry is not of the correct type");
+  }
+
+  const bool preflight = false;
+  readGenericGeomDims(rectGridGeom, geomGroup);
+
+  // DIMENSIONS array
+  {
+    auto dimsDataset = geomGroup.openDataset("DIMENSIONS");
+    auto dims = dimsDataset.readAsVector<int64>();
+    rectGridGeom->setDimensions(SizeVec3(dims[0], dims[1], dims[2]));
+  }
+
+  auto xBoundsArray = readLegacyGeomArrayAs<Float32Array>(dataStructure, rectGridGeom, geomGroup, Legacy::XBoundsName, preflight);
+  auto yBoundsArray = readLegacyGeomArrayAs<Float32Array>(dataStructure, rectGridGeom, geomGroup, Legacy::YBoundsName, preflight);
+  auto zBoundsArray = readLegacyGeomArrayAs<Float32Array>(dataStructure, rectGridGeom, geomGroup, Legacy::ZBoundsName, preflight);
+
+  rectGridGeom->setBounds(xBoundsArray.value(), yBoundsArray.value(), zBoundsArray.value());
+
+  return {};
+}
+
+Result<> finishImportingLegacyTetrahedralGeom(DataStructure& dataStructure, IGeometry* geometryPtr, const HDF5::GroupIO& geomGroup)
+{
+  auto* tetrahedralGeom = dynamic_cast<TetrahedralGeom*>(geometryPtr);
+  if(tetrahedralGeom == nullptr)
+  {
+    return MakeErrorResult(-502673, "Failed to finish importing legacy Tetrahedral Geometry. Existing geometry is not of the correct type");
+  }
+
+  const bool preflight = false;
+  readGenericGeomDims(tetrahedralGeom, geomGroup);
+  auto sharedVertexList = readLegacyGeomArrayAs<Float32Array>(dataStructure, tetrahedralGeom, geomGroup, Legacy::VertexListName, preflight);
+  auto sharedTetList = readLegacyNodeConnectivityList(dataStructure, tetrahedralGeom, geomGroup, Legacy::TetraListName, preflight);
+
+  tetrahedralGeom->setVertices(*sharedVertexList.value());
+  tetrahedralGeom->setPolyhedraList(*sharedTetList.value());
+
+  return {};
+}
+
+Result<> finishImportingLegacyTriangleGeom(DataStructure& dataStructure, IGeometry* geometryPtr, const HDF5::GroupIO& geomGroup)
+{
+  auto* triangleGeom = dynamic_cast<TriangleGeom*>(geometryPtr);
+  if(triangleGeom == nullptr)
+  {
+    return MakeErrorResult(-502672, "Failed to finish importing legacy Triangle Geometry. Existing geometry is not of the correct type");
+  }
+
+  const bool preflight = false;
+  readGenericGeomDims(triangleGeom, geomGroup);
+  auto sharedVertexList = readLegacyGeomArrayAs<Float32Array>(dataStructure, triangleGeom, geomGroup, Legacy::VertexListName, preflight);
+  auto sharedTriList = readLegacyNodeConnectivityList(dataStructure, triangleGeom, geomGroup, Legacy::TriListName, preflight);
+
+  triangleGeom->setVertices(*sharedVertexList.value());
+  triangleGeom->setFaceList(*sharedTriList.value());
+
+  return {};
+}
+
+Result<> finishImportingLegacyVertexGeom(DataStructure& dataStructure, IGeometry* geometryPtr, const HDF5::GroupIO& geomGroup)
+{
+  auto* vertexGeom = dynamic_cast<VertexGeom*>(geometryPtr);
+  if(vertexGeom == nullptr)
+  {
+    return MakeErrorResult(-502671, "Failed to finish importing legacy Vertex Geometry. Existing geometry is not of the correct type");
+  }
+
+  const bool preflight = false;
+  readGenericGeomDims(vertexGeom, geomGroup);
+  Result<Float32Array*> sharedVertexList = readLegacyGeomArrayAs<Float32Array>(dataStructure, vertexGeom, geomGroup, Legacy::VertexListName, preflight);
+
+  vertexGeom->setVertices(*sharedVertexList.value());
+
+  return {};
+}
+
+Result<> finishImportingLegacyDataContainer(DataStructure& dataStructure, const HDF5::GroupIO& parentReader, const DataPath& dataPath)
+{
+  std::string dcName = dataPath[0];
+  auto dcGroup = parentReader.openGroup(dcName);
+
+  // Check for geometry
+  auto geomGroup = dcGroup.openGroup(Legacy::GeometryTag.c_str());
+  if(geomGroup.isValid())
+  {
+    auto* geometryPtr = dataStructure.getDataAs<IGeometry>(dataPath);
+    if (geometryPtr == nullptr)
+    {
+      return MakeErrorResult(-502679, fmt::format("Failed to finish importing of geometry at path '{}'. Existing geometry not found.", dataPath.toString()));
+    }
+
+    std::string geomName;
+    auto geomNameResult = geomGroup.readStringAttribute(Legacy::GeometryTypeNameTag);
+    if(geomNameResult.invalid())
+    {
+      return ConvertResult(std::move(geomNameResult));
+    }
+    geomName = std::move(geomNameResult.value());
+    if(geomName == Legacy::Type::ImageGeom)
+    {
+      return finishImportingLegacyImageGeom(dataStructure, geometryPtr, geomGroup);
+    }
+    else if(geomName == Legacy::Type::EdgeGeom)
+    {
+      return finishImportingLegacyEdgeGeom(dataStructure, geometryPtr, geomGroup);
+    }
+    else if(geomName == Legacy::Type::HexGeom)
+    {
+      return finishImportingLegacyHexGeom(dataStructure, geometryPtr, geomGroup);
+    }
+    else if(geomName == Legacy::Type::QuadGeom)
+    {
+      return finishImportingLegacyQuadGeom(dataStructure, geometryPtr, geomGroup);
+    }
+    else if(geomName == Legacy::Type::RectGridGeom)
+    {
+      return finishImportingLegacyRectGridGeom(dataStructure, geometryPtr, geomGroup);
+    }
+    else if(geomName == Legacy::Type::TetrahedralGeom)
+    {
+      return finishImportingLegacyTetrahedralGeom(dataStructure, geometryPtr, geomGroup);
+    }
+    else if(geomName == Legacy::Type::TriangleGeom)
+    {
+      return finishImportingLegacyTriangleGeom(dataStructure, geometryPtr, geomGroup);
+    }
+    else if(geomName == Legacy::Type::VertexGeom)
+    {
+      return finishImportingLegacyVertexGeom(dataStructure, geometryPtr, geomGroup);
+    }
+  }
+
+  return {};
+}
+
 Result<std::vector<std::shared_ptr<DataObject>>> ImportLegacyDataObjectFromFile(const nx::core::HDF5::FileIO& fileReader, const DataPath& dataPath)
 {
   DataStructure dataStructure;
@@ -1613,13 +1823,12 @@ Result<std::vector<std::shared_ptr<DataObject>>> ImportLegacyDataObjectFromFile(
   switch(dataPath.getLength())
   {
   case 1: {
-    auto dcGroup = dcaGroup.openGroup(dataPath[0]);
+    auto dcGroup = dcaGroup.openGroup(dataPath.toString());
     result = readLegacyDataContainer(dataStructure, dcGroup, false, false);
     break;
   }
   case 2: {
-    auto dcGroup = dcaGroup.openGroup(dataPath[0]);
-    auto attributeMatrixGroup = dcGroup.openGroup(dataPath[1]);
+    auto attributeMatrixGroup = dcaGroup.openGroup(dataPath.toString());
     DataPath dcPath({dataPath[0]});
     dataStructure.makePath(dcPath);
     auto& container = dataStructure.getDataRef(dcPath);
@@ -1652,12 +1861,21 @@ Result<std::vector<std::shared_ptr<DataObject>>> ImportLegacyDataObjectFromFile(
   return {std::vector<std::shared_ptr<DataObject>>{(*item).second}};
 }
 
-Result<> FinishImportingLegacyDataObject(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& dataStructureIO, const DataPath& dataPath)
+Result<> FinishImportingLegacyDataObject(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& parentReader, const DataPath& dataPath)
 {
-  auto parentReader = dataStructureIO.openGroup(dataPath.getParent().toString());
-  if(dataPath.getLength() == 3)
+  switch (dataPath.getLength())
   {
-    FinishImportingLegacyArray(dataStructure, parentReader, dataPath);
+  case 1:
+    finishImportingLegacyDataContainer(dataStructure, parentReader, dataPath);
+    break;
+  case 2:
+    break;
+  case 3:
+    finishImportingLegacyArray(dataStructure, parentReader, dataPath);
+    break;
+    default:
+    return MakeErrorResult(-520156, fmt::format("Could not read legacy DREAM3D data at path '{}'", dataPath.toString()));
+    break;
   }
   return {};
 }
@@ -1829,10 +2047,11 @@ Result<> DREAM3D::FinishImportingObject(DataStructure& dataStructure, const Data
   }
   else if(fileVersion == k_LegacyFileVersion)
   {
-    auto dataStructureReader = fileReader.openGroup(Constants::k_DataStructureTag);
+    auto dataStructureReader = fileReader.openGroup(k_LegacyDataStructureGroupTag);
+    std::string parentPathStr = dataPath.getParent().toString();
     auto parentGroup = dataStructureReader.openGroup(dataPath.getParent().toString());
 
-    return FinishImportingLegacyDataObject(dataStructure, fileReader, dataPath);
+    return FinishImportingLegacyDataObject(dataStructure, parentGroup, dataPath);
   }
   return {};
 }

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -19,6 +19,7 @@
 #include "simplnx/DataStructure/IO/HDF5/NeighborListIO.hpp"
 #include "simplnx/DataStructure/NeighborList.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
+#include "simplnx/DataStructure/StringStore.hpp"
 #include "simplnx/Pipeline/Pipeline.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp"
 
@@ -884,6 +885,19 @@ Result<> readLegacyStringArray(DataStructure& dataStructure, const nx::core::HDF
   return {};
 }
 
+Result<> finishImportingLegacyStringArray(DataStructure& dataStructure, const nx::core::HDF5::DatasetIO& dataArrayReader, const DataPath& dataPath)
+{
+  auto* existingArray = dataStructure.getDataAs<StringArray>(dataPath);
+  if(existingArray == nullptr)
+  {
+    return MakeErrorResult(-4210428, fmt::format("Failed to finish importing legacy StringArray at path '{}'. Imported StringArray not found.", dataPath.toString()));
+  }
+
+  const std::vector<std::string> strings = dataArrayReader.readAsVectorOfStrings();
+  existingArray->setStore(std::make_shared<StringStore>(strings));
+  return {};
+}
+
 Result<IDataArray*> readLegacyDataArray(DataStructure& dataStructure, const nx::core::HDF5::DatasetIO& dataArrayReader, DataObject::IdType parentId, bool preflight = false)
 {
   auto dataTypeResult = dataArrayReader.getDataType();
@@ -958,6 +972,87 @@ Result<IDataArray*> readLegacyDataArray(DataStructure& dataStructure, const nx::
   return daResult;
 }
 
+template <typename T>
+Result<> finishImportingLegacyDataArrayImpl(DataStructure& dataStructure, const HDF5::DatasetIO& dataSetIO, const DataPath& dataPath)
+{
+  auto* existingArray = dataStructure.getDataAs<DataArray<T>>(dataPath);
+  if(existingArray == nullptr)
+  {
+    return MakeErrorResult(-4210423, fmt::format("Failed to finish importing legacy DataArray at path '{}'. Imported DataArray not found.", dataPath.toString()));
+  }
+
+  auto dataStorePtr = dataSetIO.readAsDataStore<T>();
+  if(dataStorePtr == nullptr)
+  {
+    return MakeErrorResult(-4210424, fmt::format("Failed to finish importing legacy DataArray at path '{}'. Could not import data from HDF5.", dataPath.toString()));
+  }
+
+  existingArray->setDataStore(dataStorePtr);
+  return {};
+}
+
+Result<> finishImportingLegacyDataArray(DataStructure& dataStructure, const HDF5::DatasetIO& dataSetIO, const DataPath& dataPath)
+{
+  auto dataTypeResult = dataSetIO.getDataType();
+  if(dataTypeResult.invalid())
+  {
+    auto errors = dataTypeResult.errors();
+    return MakeErrorResult(errors[0].code, errors[0].message);
+  }
+  auto dataType = std::move(dataTypeResult.value());
+  switch(dataType)
+  {
+  case DataType::float32:
+    return finishImportingLegacyDataArrayImpl<float32>(dataStructure, dataSetIO, dataPath);
+  case DataType::float64:
+    return finishImportingLegacyDataArrayImpl<float64>(dataStructure, dataSetIO, dataPath);
+    break;
+  case DataType::int8:
+    return finishImportingLegacyDataArrayImpl<int8>(dataStructure, dataSetIO, dataPath);
+    break;
+  case DataType::int16:
+    return finishImportingLegacyDataArrayImpl<int16>(dataStructure, dataSetIO, dataPath);
+    break;
+  case DataType::int32:
+    return finishImportingLegacyDataArrayImpl<int32>(dataStructure, dataSetIO, dataPath);
+    break;
+  case DataType::int64:
+    return finishImportingLegacyDataArrayImpl<int64>(dataStructure, dataSetIO, dataPath);
+    break;
+  case DataType::boolean:
+    [[fallthrough]];
+  case DataType::uint8: {
+    std::string typeTag;
+    auto typeTagResult = dataSetIO.readStringAttribute(Constants::k_ObjectTypeTag);
+    if(typeTagResult.invalid())
+    {
+      return ConvertInvalidResult<void, std::string>(std::move(typeTagResult));
+    }
+    typeTag = std::move(typeTagResult.value());
+    if(typeTag == "DataArray<bool>")
+    {
+      return finishImportingLegacyDataArrayImpl<bool>(dataStructure, dataSetIO, dataPath);
+    }
+    else
+    {
+      return finishImportingLegacyDataArrayImpl<uint8>(dataStructure, dataSetIO, dataPath);
+    }
+    break;
+  }
+  case DataType::uint16:
+    return finishImportingLegacyDataArrayImpl<uint16>(dataStructure, dataSetIO, dataPath);
+    break;
+  case DataType::uint32:
+    return finishImportingLegacyDataArrayImpl<uint32>(dataStructure, dataSetIO, dataPath);
+    break;
+  case DataType::uint64:
+    return finishImportingLegacyDataArrayImpl<uint64>(dataStructure, dataSetIO, dataPath);
+    break;
+  }
+
+  return {};
+}
+
 Result<UInt64Array*> readLegacyNodeConnectivityList(DataStructure& dataStructure, IGeometry* geometry, const HDF5::GroupIO& geomGroup, const std::string& arrayName, bool preflight = false)
 {
   HDF5::DatasetIO dataArrayReader = geomGroup.openDataset(arrayName);
@@ -987,16 +1082,13 @@ template <typename T>
 Result<> createLegacyNeighborList(DataStructure& dataStructure, DataObject ::IdType parentId, const nx::core::HDF5::GroupIO& parentReader, const nx::core::HDF5::DatasetIO& datasetReader,
                                   const std::vector<usize>& tupleDims)
 {
-  auto numTuples = std::accumulate(tupleDims.cbegin(), tupleDims.cend(), static_cast<usize>(1), std::multiplies<>());
-
-  auto data = HDF5::NeighborListIO<T>::ReadHdf5Data(parentReader, datasetReader);
-  auto* neighborList = NeighborList<T>::Create(dataStructure, datasetReader.getName(), numTuples, parentId);
+  auto listStore = HDF5::NeighborListIO<T>::ReadHdf5Data(parentReader, datasetReader);
+  auto* neighborList = NeighborList<T>::Create(dataStructure, datasetReader.getName(), listStore, parentId);
   if(neighborList == nullptr)
   {
     std::string ss = fmt::format("Failed to create NeighborList: '{}'", datasetReader.getName());
     return MakeErrorResult(Legacy::k_FailedCreatingNeighborList_Code, ss);
   }
-  neighborList->getStore()->setData(data);
   return {};
 }
 
@@ -1054,6 +1146,71 @@ Result<> readLegacyNeighborList(DataStructure& dataStructure, const nx::core::HD
   return result;
 }
 
+template <typename T>
+Result<> finishImportingLegacyNeighborListImpl(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& parentReader, const HDF5::DatasetIO& datasetReader, const DataPath& dataPath)
+{
+  auto* existingList = dataStructure.getDataAs<NeighborList<T>>(dataPath);
+  if(existingList == nullptr)
+  {
+    return MakeErrorResult(-4210426, fmt::format("Failed to finish importing legacy NeighborList at path '{}'. Imported NeighborList not found.", dataPath.toString()));
+  }
+
+  auto listStore = HDF5::NeighborListIO<T>::ReadHdf5Data(parentReader, datasetReader);
+  if(listStore == nullptr)
+  {
+    return MakeErrorResult(-4210427, fmt::format("Failed to finish importing legacy NeighborList at path '{}'. Failed to import HDF5 data.", dataPath.toString()));
+  }
+  existingList->setStore(listStore);
+  return {};
+}
+
+Result<> finishImportingLegacyNeighborList(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& parentReader, const HDF5::DatasetIO& datasetReader, const DataPath& dataPath)
+{
+  auto dataTypeResult = datasetReader.getDataType();
+  if(dataTypeResult.invalid())
+  {
+    return ConvertResult(std::move(dataTypeResult));
+  }
+  auto dataType = dataTypeResult.value();
+  switch(dataType)
+  {
+  case DataType::float32:
+    return finishImportingLegacyNeighborListImpl<float32>(dataStructure, parentReader, datasetReader, dataPath);
+    break;
+  case DataType::float64:
+    return finishImportingLegacyNeighborListImpl<float64>(dataStructure, parentReader, datasetReader, dataPath);
+    break;
+  case DataType::boolean:
+    [[fallthrough]];
+  case DataType::int8:
+    return finishImportingLegacyNeighborListImpl<int8>(dataStructure, parentReader, datasetReader, dataPath);
+    break;
+  case DataType::int16:
+    return finishImportingLegacyNeighborListImpl<int16>(dataStructure, parentReader, datasetReader, dataPath);
+    break;
+  case DataType::int32:
+    return finishImportingLegacyNeighborListImpl<int32>(dataStructure, parentReader, datasetReader, dataPath);
+    break;
+  case DataType::int64:
+    return finishImportingLegacyNeighborListImpl<int64>(dataStructure, parentReader, datasetReader, dataPath);
+    break;
+  case DataType::uint8:
+    return finishImportingLegacyNeighborListImpl<uint8>(dataStructure, parentReader, datasetReader, dataPath);
+    break;
+  case DataType::uint16:
+    return finishImportingLegacyNeighborListImpl<uint16>(dataStructure, parentReader, datasetReader, dataPath);
+    break;
+  case DataType::uint32:
+    return finishImportingLegacyNeighborListImpl<uint32>(dataStructure, parentReader, datasetReader, dataPath);
+    break;
+  case DataType::uint64:
+    return finishImportingLegacyNeighborListImpl<uint64>(dataStructure, parentReader, datasetReader, dataPath);
+    break;
+  }
+
+  return MakeErrorResult(-4210429, fmt::format("Failed to finish importing legacy NeighborList at path '{}'. Type could not be determined", dataPath.toString()));
+}
+
 bool isLegacyNeighborList(const nx::core::HDF5::DatasetIO& arrayReader)
 {
   auto objectTypeResult = arrayReader.readStringAttribute("ObjectType");
@@ -1074,7 +1231,41 @@ bool isLegacyStringArray(const nx::core::HDF5::DatasetIO& arrayReader)
   return objectTypeResult.value() == "StringDataArray";
 }
 
-Result<> readLegacyAttributeMatrix(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& amGroupReader, DataObject& parent, bool preflight = false)
+Result<> readLegacyArray(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& amGroupReader, const std::string& arrayName, bool preflight)
+{
+  auto dataArraySet = amGroupReader.openDataset(arrayName);
+  if(isLegacyNeighborList(dataArraySet))
+  {
+    return readLegacyNeighborList(dataStructure, amGroupReader, dataArraySet, 0);
+  }
+  else if(isLegacyStringArray(dataArraySet))
+  {
+    return readLegacyStringArray(dataStructure, dataArraySet, preflight);
+  }
+  else
+  {
+    return ConvertResult<>(std::move(readLegacyDataArray(dataStructure, dataArraySet, preflight)));
+  }
+}
+
+Result<> FinishImportingLegacyArray(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& parentReader, const DataPath& dataPath)
+{
+  auto dataArraySet = parentReader.openDataset(dataPath.getTargetName());
+  if(isLegacyNeighborList(dataArraySet))
+  {
+    return finishImportingLegacyNeighborList(dataStructure, parentReader, dataArraySet, dataPath);
+  }
+  else if(isLegacyStringArray(dataArraySet))
+  {
+    return finishImportingLegacyStringArray(dataStructure, dataArraySet, dataPath);
+  }
+  else
+  {
+    return finishImportingLegacyDataArray(dataStructure, dataArraySet, dataPath);
+  }
+}
+
+Result<> readLegacyAttributeMatrix(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& amGroupReader, DataObject& parent, bool preflight = false, bool importChildren = true)
 {
   DataObject::IdType parentId = parent.getId();
   const std::string amName = amGroupReader.getName();
@@ -1090,10 +1281,12 @@ Result<> readLegacyAttributeMatrix(DataStructure& dataStructure, const nx::core:
   auto* attributeMatrix = AttributeMatrix::Create(dataStructure, amName, reversedTDims, parentId);
 
   std::vector<Result<>> daResults;
-  auto dataArrayNames = amGroupReader.getChildNames();
-  for(const auto& daName : dataArrayNames)
+  if(importChildren)
   {
-    auto dataArraySet = amGroupReader.openDataset(daName);
+    auto dataArrayNames = amGroupReader.getChildNames();
+    for(const auto& daName : dataArrayNames)
+    {
+      auto dataArraySet = amGroupReader.openDataset(daName);
 #if 0
     if(!dataArraySet.isValid())
     {
@@ -1104,18 +1297,19 @@ Result<> readLegacyAttributeMatrix(DataStructure& dataStructure, const nx::core:
     }
 #endif
 
-    if(isLegacyNeighborList(dataArraySet))
-    {
-      daResults.push_back(readLegacyNeighborList(dataStructure, amGroupReader, dataArraySet, attributeMatrix->getId()));
-    }
-    else if(isLegacyStringArray(dataArraySet))
-    {
-      daResults.push_back(readLegacyStringArray(dataStructure, dataArraySet, attributeMatrix->getId(), preflight));
-    }
-    else
-    {
-      Result<> result = ConvertResult(readLegacyDataArray(dataStructure, dataArraySet, attributeMatrix->getId(), preflight));
-      daResults.push_back(result);
+      if(isLegacyNeighborList(dataArraySet))
+      {
+        daResults.push_back(readLegacyNeighborList(dataStructure, amGroupReader, dataArraySet, attributeMatrix->getId()));
+      }
+      else if(isLegacyStringArray(dataArraySet))
+      {
+        daResults.push_back(readLegacyStringArray(dataStructure, dataArraySet, attributeMatrix->getId(), preflight));
+      }
+      else
+      {
+        Result<> result = ConvertResult(readLegacyDataArray(dataStructure, dataArraySet, attributeMatrix->getId(), preflight));
+        daResults.push_back(result);
+      }
     }
   }
 
@@ -1333,7 +1527,7 @@ DataObject* readLegacyImageGeom(DataStructure& dataStructure, const nx::core::HD
 }
 // End legacy Geometry importing
 
-Result<> readLegacyDataContainer(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& dcGroup, bool preflight = false)
+Result<> readLegacyDataContainer(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& dcGroup, bool preflight = false, bool importChildren = true)
 {
   DataObject* container = nullptr;
   const std::string dcName = dcGroup.getName();
@@ -1389,6 +1583,11 @@ Result<> readLegacyDataContainer(DataStructure& dataStructure, const nx::core::H
     container = DataGroup::Create(dataStructure, dcName);
   }
 
+  if(!importChildren)
+  {
+    return {};
+  }
+
   std::vector<Result<>> amResults;
   auto attribMatrixNames = dcGroup.getChildNames();
   for(const auto& amName : attribMatrixNames)
@@ -1403,6 +1602,64 @@ Result<> readLegacyDataContainer(DataStructure& dataStructure, const nx::core::H
     amResults.push_back(readLegacyAttributeMatrix(dataStructure, attributeMatrixGroup, *container, preflight));
   }
   return nx::core::MergeResults(amResults);
+}
+
+Result<std::vector<std::shared_ptr<DataObject>>> ImportLegacyDataObjectFromFile(const nx::core::HDF5::FileIO& fileReader, const DataPath& dataPath)
+{
+  DataStructure dataStructure;
+  auto dcaGroup = fileReader.openGroup(k_LegacyDataStructureGroupTag);
+
+  Result<> result;
+  switch(dataPath.getLength())
+  {
+  case 1: {
+    auto dcGroup = dcaGroup.openGroup(dataPath[0]);
+    result = readLegacyDataContainer(dataStructure, dcGroup, false, false);
+    break;
+  }
+  case 2: {
+    auto dcGroup = dcaGroup.openGroup(dataPath[0]);
+    auto attributeMatrixGroup = dcGroup.openGroup(dataPath[1]);
+    DataPath dcPath({dataPath[0]});
+    dataStructure.makePath(dcPath);
+    auto& container = dataStructure.getDataRef(dcPath);
+    result = readLegacyAttributeMatrix(dataStructure, attributeMatrixGroup, container, false, false);
+    break;
+  }
+  case 3: {
+    auto dcGroup = dcaGroup.openGroup(dataPath[0]);
+    auto attributeMatrixGroup = dcGroup.openGroup(dataPath[1]);
+    result = readLegacyArray(dataStructure, attributeMatrixGroup, dataPath[2], false);
+    break;
+  }
+  default:
+    return MakeErrorResult<std::vector<std::shared_ptr<DataObject>>>(-59040,
+                                                                     fmt::format("Failed to import DataObject at path '{}'. DataPath not supported by legacy DataStructure.", dataPath.toString()));
+  }
+
+  if(result.invalid())
+  {
+    return ConvertInvalidResult<std::vector<std::shared_ptr<DataObject>>>(std::move(result));
+  }
+
+  const DataMap& dataMap = dataStructure.getDataMap();
+  if(dataMap.getSize() == 0)
+  {
+    return MakeErrorResult<std::vector<std::shared_ptr<DataObject>>>(-69040, fmt::format("Failed to import DataObject at path '{}'", dataPath.toString()));
+  }
+
+  auto item = dataMap.begin();
+  return {std::vector<std::shared_ptr<DataObject>>{(*item).second}};
+}
+
+Result<> FinishImportingLegacyDataObject(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& dataStructureIO, const DataPath& dataPath)
+{
+  auto parentReader = dataStructureIO.openGroup(dataPath.getParent().toString());
+  if(dataPath.getLength() == 3)
+  {
+    FinishImportingLegacyArray(dataStructure, parentReader, dataPath);
+  }
+  return {};
 }
 
 Result<DataStructure> ImportLegacyDataStructure(const nx::core::HDF5::FileIO& fileReader, bool preflight)
@@ -1515,6 +1772,69 @@ Result<nlohmann::json> DREAM3D::ImportPipelineJsonFromFile(const std::filesystem
   }
 
   return ImportPipelineJsonFromFile(fileReader);
+}
+
+Result<std::shared_ptr<DataObject>> DREAM3D::ImportDataObjectFromFile(const nx::core::HDF5::FileIO& fileReader, const DataPath& dataPath)
+{
+  const auto fileVersion = GetFileVersion(fileReader);
+  if(fileVersion == k_CurrentFileVersion)
+  {
+    return HDF5::DataStructureReader::ReadObject(fileReader, dataPath);
+  }
+  else if(fileVersion == k_LegacyFileVersion)
+  {
+    auto result = ImportLegacyDataObjectFromFile(fileReader, dataPath);
+    if(result.invalid())
+    {
+      return ConvertInvalidResult<std::shared_ptr<DataObject>>(std::move(result));
+    }
+    std::vector<std::shared_ptr<DataObject>> value = result.value();
+    if(value.size() != 0)
+    {
+      return MakeErrorResult<std::shared_ptr<DataObject>>(-48264, fmt::format("Error extracting a single DataObject from legacy DREAM3D file at path '{}'", dataPath.toString()));
+    }
+    return {result.value().front()};
+  }
+  return MakeErrorResult<std::shared_ptr<DataObject>>(-523242, fmt::format("Error extracting a single DataObject from legacy DREAM3D file at path '{}'", dataPath.toString()));
+}
+
+Result<std::vector<std::shared_ptr<DataObject>>> DREAM3D::ImportSelectDataObjectsFromFile(const nx::core::HDF5::FileIO& fileReader, const std::vector<DataPath>& dataPaths)
+{
+  std::vector<std::shared_ptr<DataObject>> dataObjects;
+  for(const DataPath& dataPath : dataPaths)
+  {
+    auto importResult = ImportDataObjectFromFile(fileReader, dataPath);
+    if(importResult.invalid())
+    {
+      return ConvertInvalidResult<std::vector<std::shared_ptr<DataObject>>>(std::move(importResult));
+    }
+    dataObjects.push_back(std::move(importResult.value()));
+  }
+
+  return {dataObjects};
+}
+
+Result<> DREAM3D::FinishImportingObject(DataStructure& dataStructure, const DataPath& dataPath, const nx::core::HDF5::FileIO& fileReader)
+{
+  auto dataPtr = dataStructure.getSharedData(dataPath);
+  if(dataPtr == nullptr)
+  {
+    return MakeErrorResult(-1502234, fmt::format("Cannot finish importing HDF5 data at path '{}'. DataObject does not exist to copy data into.", dataPath.toString()));
+  }
+
+  const auto fileVersion = GetFileVersion(fileReader);
+  if(fileVersion == k_CurrentFileVersion)
+  {
+    return HDF5::DataStructureReader::FinishImportingObject(dataStructure, fileReader, dataPath);
+  }
+  else if(fileVersion == k_LegacyFileVersion)
+  {
+    auto dataStructureReader = fileReader.openGroup(Constants::k_DataStructureTag);
+    auto parentGroup = dataStructureReader.openGroup(dataPath.getParent().toString());
+
+    return FinishImportingLegacyDataObject(dataStructure, fileReader, dataPath);
+  }
+  return {};
 }
 
 Result<DREAM3D::FileData> DREAM3D::ReadFile(const nx::core::HDF5::FileIO& fileReader, bool preflight)

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -16,6 +16,7 @@
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/DataStructure/IO/HDF5/DataStructureReader.hpp"
 #include "simplnx/DataStructure/IO/HDF5/DataStructureWriter.hpp"
+#include "simplnx/DataStructure/IO/HDF5/IDataStoreIO.hpp"
 #include "simplnx/DataStructure/IO/HDF5/NeighborListIO.hpp"
 #include "simplnx/DataStructure/NeighborList.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
@@ -981,7 +982,10 @@ Result<> finishImportingLegacyDataArrayImpl(DataStructure& dataStructure, const 
     return MakeErrorResult(-4210423, fmt::format("Failed to finish importing legacy DataArray at path '{}'. Imported DataArray not found.", dataPath.toString()));
   }
 
-  auto dataStorePtr = dataSetIO.readAsDataStore<T>();
+  auto tupleShape = nx::core::HDF5::IDataStoreIO::ReadTupleShape(dataSetIO);
+  auto componentShape = nx::core::HDF5::IDataStoreIO::ReadComponentShape(dataSetIO);
+
+  auto dataStorePtr = dataSetIO.readAsDataStore<T>(tupleShape, componentShape);
   if(dataStorePtr == nullptr)
   {
     return MakeErrorResult(-4210424, fmt::format("Failed to finish importing legacy DataArray at path '{}'. Could not import data from HDF5.", dataPath.toString()));
@@ -1250,7 +1254,9 @@ Result<> readLegacyArray(DataStructure& dataStructure, const nx::core::HDF5::Gro
 
 Result<> finishImportingLegacyArray(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& parentReader, const DataPath& dataPath)
 {
-  auto dataArraySet = parentReader.openDataset(dataPath.getTargetName());
+  auto dcGroup = parentReader.openGroup(dataPath[0]);
+  auto amGroup = dcGroup.openGroup(dataPath[1]);
+  auto dataArraySet = amGroup.openDataset(dataPath.getTargetName());
   if(isLegacyNeighborList(dataArraySet))
   {
     return finishImportingLegacyNeighborList(dataStructure, parentReader, dataArraySet, dataPath);
@@ -1604,11 +1610,10 @@ Result<> readLegacyDataContainer(DataStructure& dataStructure, const nx::core::H
   return nx::core::MergeResults(amResults);
 }
 
-
 Result<> finishImportingLegacyImageGeom(DataStructure& dataStructure, IGeometry* geometry, const HDF5::GroupIO& geometryReader)
 {
   auto* imageGeom = dynamic_cast<ImageGeom*>(geometry);
-  if (imageGeom == nullptr)
+  if(imageGeom == nullptr)
   {
     return MakeErrorResult(-502678, "Failed to finish importing legacy Image Geometry. Existing geometry is not of the correct type");
   }
@@ -1765,7 +1770,7 @@ Result<> finishImportingLegacyDataContainer(DataStructure& dataStructure, const 
   if(geomGroup.isValid())
   {
     auto* geometryPtr = dataStructure.getDataAs<IGeometry>(dataPath);
-    if (geometryPtr == nullptr)
+    if(geometryPtr == nullptr)
     {
       return MakeErrorResult(-502679, fmt::format("Failed to finish importing of geometry at path '{}'. Existing geometry not found.", dataPath.toString()));
     }
@@ -1863,7 +1868,7 @@ Result<std::vector<std::shared_ptr<DataObject>>> ImportLegacyDataObjectFromFile(
 
 Result<> FinishImportingLegacyDataObject(DataStructure& dataStructure, const nx::core::HDF5::GroupIO& parentReader, const DataPath& dataPath)
 {
-  switch (dataPath.getLength())
+  switch(dataPath.getLength())
   {
   case 1:
     finishImportingLegacyDataContainer(dataStructure, parentReader, dataPath);
@@ -1873,7 +1878,7 @@ Result<> FinishImportingLegacyDataObject(DataStructure& dataStructure, const nx:
   case 3:
     finishImportingLegacyArray(dataStructure, parentReader, dataPath);
     break;
-    default:
+  default:
     return MakeErrorResult(-520156, fmt::format("Could not read legacy DREAM3D data at path '{}'", dataPath.toString()));
     break;
   }
@@ -2048,10 +2053,10 @@ Result<> DREAM3D::FinishImportingObject(DataStructure& dataStructure, const Data
   else if(fileVersion == k_LegacyFileVersion)
   {
     auto dataStructureReader = fileReader.openGroup(k_LegacyDataStructureGroupTag);
-    std::string parentPathStr = dataPath.getParent().toString();
-    auto parentGroup = dataStructureReader.openGroup(dataPath.getParent().toString());
+    //std::string parentPathStr = dataPath.getParent().toString();
+    //auto parentGroup = dataStructureReader.openGroup(dataPath.getParent().toString());
 
-    return FinishImportingLegacyDataObject(dataStructure, parentGroup, dataPath);
+    return FinishImportingLegacyDataObject(dataStructure, dataStructureReader, dataPath);
   }
   return {};
 }

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp
@@ -118,6 +118,12 @@ SIMPLNX_EXPORT Result<> AppendFile(const std::filesystem::path& path, const Data
  */
 SIMPLNX_EXPORT Result<DataStructure> ImportDataStructureFromFile(const nx::core::HDF5::FileIO& fileReader, bool preflight = false);
 
+SIMPLNX_EXPORT Result<std::shared_ptr<DataObject>> ImportDataObjectFromFile(const nx::core::HDF5::FileIO& fileReader, const DataPath& dataPath);
+
+SIMPLNX_EXPORT Result<std::vector<std::shared_ptr<DataObject>>> ImportSelectDataObjectsFromFile(const nx::core::HDF5::FileIO& fileReader, const std::vector<DataPath>& dataPaths);
+
+SIMPLNX_EXPORT Result<> FinishImportingObject(DataStructure& dataStructure, const DataPath& dataPath, const nx::core::HDF5::FileIO& fileReader);
+
 /**
  * @brief Imports and returns the DataStructure from the target .dream3d file.
  * This method imports both current and legacy DataStructures.

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
@@ -464,7 +464,7 @@ std::shared_ptr<AbstractDataStore<T>> DatasetIO::readAsDataStore() const
 
   ShapeType tupleShape{numElements};
   ShapeType componentShape{1};
-  auto dataStorePtr = DataStoreUtilities::CreateDataStore<T>(tupleShape, componentShape, IDataAction::Mode::Execute);
+  std::shared_ptr<AbstractDataStore<T>> dataStorePtr = DataStoreUtilities::CreateDataStore<T>(tupleShape, componentShape, IDataAction::Mode::Execute);
   dataStorePtr->readHdf5(*this);
   return dataStorePtr;
 }
@@ -1427,7 +1427,7 @@ template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint16_t>> DatasetIO::
 template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint32_t>> DatasetIO::readAsDataStore<uint32_t>() const;
 template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint64_t>> DatasetIO::readAsDataStore<uint64_t>() const;
 #ifdef __APPLE__
-template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<size_t>> DatasetIO::readAsDataStore<size_t>() const;
+// template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<size_t>> DatasetIO::readAsDataStore<size_t>() const;
 #endif
 template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<bool>> DatasetIO::readAsDataStore<bool>() const;
 template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataStore<float>() const;

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
@@ -1,8 +1,8 @@
 #include "DatasetIO.hpp"
 
+#include "simplnx/Utilities/DataStoreUtilities.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/H5.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/GroupIO.hpp"
-#include "simplnx/Utilities/DataStoreUtilities.hpp"
 
 #include <fmt/format.h>
 
@@ -464,6 +464,27 @@ std::shared_ptr<AbstractDataStore<T>> DatasetIO::readAsDataStore() const
 
   ShapeType tupleShape{numElements};
   ShapeType componentShape{1};
+
+  std::shared_ptr<AbstractDataStore<T>> dataStorePtr = DataStoreUtilities::CreateDataStore<T>(tupleShape, componentShape, IDataAction::Mode::Execute);
+  dataStorePtr->readHdf5(*this);
+  return dataStorePtr;
+}
+
+template <typename T>
+std::shared_ptr<AbstractDataStore<T>> DatasetIO::readAsDataStore(const IDataStore::ShapeType& tupleShape, const IDataStore::ShapeType& componentShape) const
+{
+  using ShapeType = typename IDataStore::ShapeType;
+
+  auto dataset = open();
+  size_t numElements = getNumElements();
+
+  size_t numTuples = std::accumulate(tupleShape.begin(), tupleShape.end(), static_cast<size_t>(1), std::multiplies<>());
+  size_t numComponents = std::accumulate(componentShape.begin(), componentShape.end(), static_cast<size_t>(1), std::multiplies<>());
+  if(numTuples * numComponents != numElements)
+  {
+    return nullptr;
+  }
+
   std::shared_ptr<AbstractDataStore<T>> dataStorePtr = DataStoreUtilities::CreateDataStore<T>(tupleShape, componentShape, IDataAction::Mode::Execute);
   dataStorePtr->readHdf5(*this);
   return dataStorePtr;
@@ -1432,6 +1453,21 @@ template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint64_t>> DatasetIO::
 template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<bool>> DatasetIO::readAsDataStore<bool>() const;
 template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataStore<float>() const;
 template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<double>> DatasetIO::readAsDataStore<double>() const;
+
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int8_t>> DatasetIO::readAsDataStore<int8_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int16_t>> DatasetIO::readAsDataStore<int16_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int32_t>> DatasetIO::readAsDataStore<int32_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int64_t>> DatasetIO::readAsDataStore<int64_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint8_t>> DatasetIO::readAsDataStore<uint8_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint16_t>> DatasetIO::readAsDataStore<uint16_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint32_t>> DatasetIO::readAsDataStore<uint32_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint64_t>> DatasetIO::readAsDataStore<uint64_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+#ifdef __APPLE__
+// template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<size_t>> DatasetIO::readAsDataStore<size_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+#endif
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<bool>> DatasetIO::readAsDataStore<bool>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataStore<float>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<double>> DatasetIO::readAsDataStore<double>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
 
 template SIMPLNX_EXPORT Result<> DatasetIO::readIntoSpan<int8_t>(nonstd::span<int8_t>) const;
 template SIMPLNX_EXPORT Result<> DatasetIO::readIntoSpan<int16_t>(nonstd::span<int16_t>) const;

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/Utilities/Parsing/HDF5/H5.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/GroupIO.hpp"
+#include "simplnx/Utilities/DataStoreUtilities.hpp"
 
 #include <fmt/format.h>
 
@@ -451,6 +452,21 @@ std::vector<std::string> DatasetIO::readAsVectorOfStrings() const
   }
 
   return strings;
+}
+
+template <typename T>
+std::shared_ptr<AbstractDataStore<T>> DatasetIO::readAsDataStore() const
+{
+  using ShapeType = typename IDataStore::ShapeType;
+
+  auto dataset = open();
+  size_t numElements = getNumElements();
+
+  ShapeType tupleShape{numElements};
+  ShapeType componentShape{1};
+  auto dataStorePtr = DataStoreUtilities::CreateDataStore<T>(tupleShape, componentShape, IDataAction::Mode::Execute);
+  dataStorePtr->readHdf5(*this);
+  return dataStorePtr;
 }
 
 template <typename T>
@@ -1401,6 +1417,21 @@ template SIMPLNX_EXPORT std::vector<double> DatasetIO::readAsVector<double>() co
 #ifdef _WIN32
 template SIMPLNX_EXPORT std::vector<bool> DatasetIO::readAsVector<bool>() const;
 #endif
+
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int8_t>> DatasetIO::readAsDataStore<int8_t>() const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int16_t>> DatasetIO::readAsDataStore<int16_t>() const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int32_t>> DatasetIO::readAsDataStore<int32_t>() const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int64_t>> DatasetIO::readAsDataStore<int64_t>() const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint8_t>> DatasetIO::readAsDataStore<uint8_t>() const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint16_t>> DatasetIO::readAsDataStore<uint16_t>() const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint32_t>> DatasetIO::readAsDataStore<uint32_t>() const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint64_t>> DatasetIO::readAsDataStore<uint64_t>() const;
+#ifdef __APPLE__
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<size_t>> DatasetIO::readAsDataStore<size_t>() const;
+#endif
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<bool>> DatasetIO::readAsDataStore<bool>() const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataStore<float>() const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<double>> DatasetIO::readAsDataStore<double>() const;
 
 template SIMPLNX_EXPORT Result<> DatasetIO::readIntoSpan<int8_t>(nonstd::span<int8_t>) const;
 template SIMPLNX_EXPORT Result<> DatasetIO::readIntoSpan<int16_t>(nonstd::span<int16_t>) const;

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
@@ -116,14 +116,23 @@ public:
   nx::core::Result<> readIntoSpan(nonstd::span<T> data) const;
 
   /**
-   * @brief Returns a vector of values for the attribute.
-   * Returns an empty vector if no attribute exists or the attribute is not of
-   * the specified type.
+   * @brief Returns an AbstractDataStore of values for the existing data.
    * @tparam T
-   * @return std::vector<T>
+   * @return std::shared_ptr<AbstractDataStore<T>>
    */
   template <typename T>
   std::shared_ptr<AbstractDataStore<T>> readAsDataStore() const;
+
+  /**
+   * @brief Returns an AbstractDataStore of values for the existing data.
+   * Returns nullptr if the data does not match the specified number of elements.
+   * @tparam T
+   * @param tupleDims
+   * @param componentDims
+   * @return std::shared_ptr<AbstractDataStore<T>>
+   */
+  template <typename T>
+  std::shared_ptr<AbstractDataStore<T>> readAsDataStore(const IDataStore::ShapeType& tupleDims, const IDataStore::ShapeType& componentDims) const;
 
   /**
    * @brief Reads the dataset into the given span. Requires the span to be the
@@ -528,6 +537,22 @@ extern template std::shared_ptr<AbstractDataStore<uint64_t>> DatasetIO::readAsDa
 extern template std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataStore<float>() const;
 extern template std::shared_ptr<AbstractDataStore<double>> DatasetIO::readAsDataStore<double>() const;
 extern template std::shared_ptr<AbstractDataStore<bool>> DatasetIO::readAsDataStore<bool>() const;
+
+extern template std::shared_ptr<AbstractDataStore<int8_t>> DatasetIO::readAsDataStore<int8_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<int16_t>> DatasetIO::readAsDataStore<int16_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<int32_t>> DatasetIO::readAsDataStore<int32_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<int64_t>> DatasetIO::readAsDataStore<int64_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<uint8_t>> DatasetIO::readAsDataStore<uint8_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<uint16_t>> DatasetIO::readAsDataStore<uint16_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<uint32_t>> DatasetIO::readAsDataStore<uint32_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<uint64_t>> DatasetIO::readAsDataStore<uint64_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+#ifdef __APPLE__
+// extern template std::shared_ptr<AbstractDataStore<size_t>> DatasetIO::readAsDataStore<size_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+#endif
+extern template std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataStore<float>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<double>> DatasetIO::readAsDataStore<double>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<bool>> DatasetIO::readAsDataStore<bool>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+
 
 extern template nx::core::Result<> DatasetIO::readIntoSpan<int8_t>(nonstd::span<int8_t>) const;
 extern template nx::core::Result<> DatasetIO::readIntoSpan<int16_t>(nonstd::span<int16_t>) const;

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
@@ -5,12 +5,7 @@
 
 #include "simplnx/Common/Result.hpp"
 #include "simplnx/Common/Types.hpp"
-
-// #include "highfive/H5Attribute.hpp"
-// #include "highfive/H5DataSet.hpp"
-// #include "highfive/H5DataType.hpp"
-// #include "highfive/H5File.hpp"
-// #include "highfive/H5Group.hpp"
+#include "simplnx/DataStructure/AbstractDataStore.hpp"
 
 #include <H5Apublic.h>
 #include <H5Dpublic.h>
@@ -119,6 +114,16 @@ public:
    */
   template <class T>
   nx::core::Result<> readIntoSpan(nonstd::span<T> data) const;
+
+  /**
+   * @brief Returns a vector of values for the attribute.
+   * Returns an empty vector if no attribute exists or the attribute is not of
+   * the specified type.
+   * @tparam T
+   * @return std::vector<T>
+   */
+  template <typename T>
+  std::shared_ptr<AbstractDataStore<T>> readAsDataStore() const;
 
   /**
    * @brief Reads the dataset into the given span. Requires the span to be the
@@ -508,6 +513,21 @@ extern template std::vector<double> DatasetIO::readAsVector() const;
 #ifdef _WIN32
 extern template std::vector<bool> DatasetIO::readAsVector() const;
 #endif
+
+extern template std::shared_ptr<AbstractDataStore<int8_t>> DatasetIO::readAsDataStore<int8_t>() const;
+extern template std::shared_ptr<AbstractDataStore<int16_t>> DatasetIO::readAsDataStore<int16_t>() const;
+extern template std::shared_ptr<AbstractDataStore<int32_t>> DatasetIO::readAsDataStore<int32_t>() const;
+extern template std::shared_ptr<AbstractDataStore<int64_t>> DatasetIO::readAsDataStore<int64_t>() const;
+extern template std::shared_ptr<AbstractDataStore<uint8_t>> DatasetIO::readAsDataStore<uint8_t>() const;
+extern template std::shared_ptr<AbstractDataStore<uint16_t>> DatasetIO::readAsDataStore<uint16_t>() const;
+extern template std::shared_ptr<AbstractDataStore<uint32_t>> DatasetIO::readAsDataStore<uint32_t>() const;
+extern template std::shared_ptr<AbstractDataStore<uint64_t>> DatasetIO::readAsDataStore<uint64_t>() const;
+#ifdef __APPLE__
+extern template std::shared_ptr<AbstractDataStore<size_t>> DatasetIO::readAsDataStore<size_t>() const;
+#endif
+extern template std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataStore<float>() const;
+extern template std::shared_ptr<AbstractDataStore<double>> DatasetIO::readAsDataStore<double>() const;
+extern template std::shared_ptr<AbstractDataStore<bool>> DatasetIO::readAsDataStore<bool>() const;
 
 extern template nx::core::Result<> DatasetIO::readIntoSpan<int8_t>(nonstd::span<int8_t>) const;
 extern template nx::core::Result<> DatasetIO::readIntoSpan<int16_t>(nonstd::span<int16_t>) const;

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
@@ -553,7 +553,6 @@ extern template std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataS
 extern template std::shared_ptr<AbstractDataStore<double>> DatasetIO::readAsDataStore<double>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
 extern template std::shared_ptr<AbstractDataStore<bool>> DatasetIO::readAsDataStore<bool>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
 
-
 extern template nx::core::Result<> DatasetIO::readIntoSpan<int8_t>(nonstd::span<int8_t>) const;
 extern template nx::core::Result<> DatasetIO::readIntoSpan<int16_t>(nonstd::span<int16_t>) const;
 extern template nx::core::Result<> DatasetIO::readIntoSpan<int32_t>(nonstd::span<int32_t>) const;

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
@@ -523,7 +523,7 @@ extern template std::shared_ptr<AbstractDataStore<uint16_t>> DatasetIO::readAsDa
 extern template std::shared_ptr<AbstractDataStore<uint32_t>> DatasetIO::readAsDataStore<uint32_t>() const;
 extern template std::shared_ptr<AbstractDataStore<uint64_t>> DatasetIO::readAsDataStore<uint64_t>() const;
 #ifdef __APPLE__
-extern template std::shared_ptr<AbstractDataStore<size_t>> DatasetIO::readAsDataStore<size_t>() const;
+// extern template std::shared_ptr<AbstractDataStore<size_t>> DatasetIO::readAsDataStore<size_t>() const;
 #endif
 extern template std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataStore<float>() const;
 extern template std::shared_ptr<AbstractDataStore<double>> DatasetIO::readAsDataStore<double>() const;

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/GroupIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/GroupIO.cpp
@@ -144,6 +144,7 @@ bool GroupIO::exists(const std::string& childName) const
 
 ObjectIO::ObjectType GroupIO::getObjectType(const std::string& childName) const
 {
+  open();
   if(!isValid())
   {
     return ObjectType::Unknown;

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/ObjectIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/ObjectIO.cpp
@@ -210,7 +210,7 @@ Result<std::string> ObjectIO::readStringAttribute(const std::string& attributeNa
   std::string data;
   std::vector<char> attributeOutput;
   Result<std::string> returnResult = {};
-  
+
   open();
   if(!hasAttribute(attributeName))
   {

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/ObjectIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/ObjectIO.cpp
@@ -51,6 +51,7 @@ bool ObjectIO::isValid() const
 
 std::string ObjectIO::getName() const
 {
+  open();
   return nx::core::HDF5::GetNameFromBuffer(m_ObjectName);
 }
 
@@ -209,7 +210,8 @@ Result<std::string> ObjectIO::readStringAttribute(const std::string& attributeNa
   std::string data;
   std::vector<char> attributeOutput;
   Result<std::string> returnResult = {};
-
+  
+  open();
   if(!hasAttribute(attributeName))
   {
     return MakeErrorResult<std::string>(-445, fmt::format("Attribute '{}' does not exist in Object '{}'", attributeName, getName()));


### PR DESCRIPTION
Broke up importing DREAM3D files into two stages so that only DataObjects requested are fully imported. Other data is imported using empty data stores to serve as placeholders. Geometries will always import the corresponding arrays completely during preflight due to other filters using those arrays during their calculations.

Added ability to import HDF5 dataset as an AbstractDataStore with or without predetermined tuple and component shapes. This will use the appropriate type of data store based on the required memory size and user preferences. Reading as a vector would not work when using out-of-core data.