### PR TITLE
BUG: Fix off-by-one when computing upper chunk bounds in DataStore.hpp

### DIFF
--- a/src/simplnx/DataStructure/DataStore.hpp
+++ b/src/simplnx/DataStructure/DataStore.hpp
@@ -459,7 +459,7 @@ public:
     }
 
     IDataStore::ShapeType upperBounds(getTupleShape());
-    for(auto value : upperBounds)
+    for(auto& value : upperBounds)
     {
       value -= 1;
     }


### PR DESCRIPTION
- Missed using a reference instead of a value

