### PR TITLE
ENH/BUG: RandomizeFeatureIds Repairs AM, Added Tests, Fixes Last Tuple Being Ignored

### DIFF
--- a/src/Plugins/SimplnxCore/docs/RandomizeFeatureIdsFilter.md
+++ b/src/Plugins/SimplnxCore/docs/RandomizeFeatureIdsFilter.md
@@ -6,16 +6,9 @@ Core (Filters)
 
 ## Description
 
-This filter will randomize a user selected "FeatureIds" array. This is not generating random data but instead
-it is using the existing values and swapping the positions of the values in the array.
-This can be useful when visualizing some kinds of data so that the data does not
-appear as a smooth gradient.
+***WARNING:** This filter can throw a pipeline terminating error (at runtime) if the number of tuples in the supplied Feature `Attribute Matrix` is less than the max value in the Feature Ids `DataArray`*
 
-## IMPORTANT NOTE
-
-If you already have a feature attribute matrix and you run this filter on the cell level 
-'featureIds' array, *EVERY* array inside of the Feature level attribute matrix should
-be deleted.
+This filter will randomize a user selected "Feature Ids" array and update every container (`DataArray`, `NeighborList`, and `StringArray`) in the feature `Attribute Matrix`. This does not generate random data but instead uses the existing values and swaps the positions of the values in the array. The intended use case is primarily for visualization, so feature data does not appear as a smooth gradient.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.cpp
@@ -3,7 +3,9 @@
 #include "simplnx/Common/TypesUtility.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
+#include "simplnx/Parameters/AttributeMatrixSelectionParameter.hpp"
 #include "simplnx/Utilities/ClusteringUtilities.hpp"
+#include "simplnx/Utilities/DataGroupUtilities.hpp"
 
 #include <stdexcept>
 
@@ -51,8 +53,9 @@ Parameters RandomizeFeatureIdsFilter::parameters() const
 {
   Parameters params;
 
-  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIds_Key, "Feature IDs Array", "Array storing the Feature IDs", DataPath(),
+  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureIdsPath_Key, "Feature IDs Array", "Array storing the Feature IDs", DataPath(),
                                                           ArraySelectionParameter::AllowedTypes{nx::core::DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
+  params.insert(std::make_unique<AttributeMatrixSelectionParameter>(k_FeatureAMPath_Key, "Feature Attribute Matrix", "The path to the Feature Attribute Matrix, so it can be updated", DataPath{}));
 
   return params;
 }
@@ -60,7 +63,12 @@ Parameters RandomizeFeatureIdsFilter::parameters() const
 //------------------------------------------------------------------------------
 IFilter::VersionType RandomizeFeatureIdsFilter::parametersVersion() const
 {
-  return 1;
+  return 2;
+
+  // Version 1 -> 2
+  // Change 1:
+  // Added - k_FeatureAMPath_Key = "feature_am_path";
+  // Solution - supply a valid Feature Attribute Matrix;
 }
 
 //------------------------------------------------------------------------------
@@ -80,13 +88,25 @@ IFilter::PreflightResult RandomizeFeatureIdsFilter::preflightImpl(const DataStru
 Result<> RandomizeFeatureIdsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
-  auto featureIdsPath = filterArgs.value<DataPath>(k_FeatureIds_Key);
+  auto featureIdsPath = args.value<ArraySelectionParameter::ValueType>(k_FeatureIdsPath_Key);
+  auto featureAMPath = args.value<AttributeMatrixSelectionParameter::ValueType>(k_FeatureAMPath_Key);
 
-  Int32Array& featureIdsArray = dataStructure.getDataRefAs<Int32Array>(featureIdsPath);
+  auto& featureIdsArray = dataStructure.getDataRefAs<Int32Array>(featureIdsPath);
   auto& featureIdsStore = featureIdsArray.getDataStoreRef();
   usize totalFeatures = *std::max_element(featureIdsStore.begin(), featureIdsStore.end());
 
-  ClusterUtilities::RandomizeFeatureIds(featureIdsStore, totalFeatures);
+  std::optional<std::vector<DataPath>> amChildPaths = GetAllChildArrayDataPaths(dataStructure, featureAMPath);
+
+  std::vector<IArray*> featureIArrays = {};
+  if(amChildPaths.has_value())
+  {
+    for(const auto& childPath : amChildPaths.value())
+    {
+      featureIArrays.push_back(dataStructure.getDataAs<IArray>(childPath));
+    }
+  }
+
+  ClusterUtilities::RandomizeFeatureIds(featureIdsStore, (totalFeatures + 1), featureIArrays);
 
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.cpp
@@ -88,8 +88,8 @@ IFilter::PreflightResult RandomizeFeatureIdsFilter::preflightImpl(const DataStru
 Result<> RandomizeFeatureIdsFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
-  auto featureIdsPath = args.value<ArraySelectionParameter::ValueType>(k_FeatureIdsPath_Key);
-  auto featureAMPath = args.value<AttributeMatrixSelectionParameter::ValueType>(k_FeatureAMPath_Key);
+  auto featureIdsPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_FeatureIdsPath_Key);
+  auto featureAMPath = filterArgs.value<AttributeMatrixSelectionParameter::ValueType>(k_FeatureAMPath_Key);
 
   auto& featureIdsArray = dataStructure.getDataRefAs<Int32Array>(featureIdsPath);
   auto& featureIdsStore = featureIdsArray.getDataStoreRef();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.cpp
@@ -1,6 +1,7 @@
 #include "RandomizeFeatureIdsFilter.hpp"
 
 #include "simplnx/Common/TypesUtility.hpp"
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/AttributeMatrixSelectionParameter.hpp"
@@ -93,7 +94,14 @@ Result<> RandomizeFeatureIdsFilter::executeImpl(DataStructure& dataStructure, co
 
   auto& featureIdsArray = dataStructure.getDataRefAs<Int32Array>(featureIdsPath);
   auto& featureIdsStore = featureIdsArray.getDataStoreRef();
-  usize totalFeatures = *std::max_element(featureIdsStore.begin(), featureIdsStore.end());
+  usize totalFeatures = (*std::max_element(featureIdsStore.begin(), featureIdsStore.end())) + 1;
+
+  const auto* featureAM = dataStructure.getDataAs<AttributeMatrix>(featureAMPath);
+  if(totalFeatures > featureAM->getNumTuples())
+  {
+    return MakeErrorResult(
+        -82640, fmt::format("The number of tuples in the supplied Attribute Matrix ({}) is less than the max feature in the Feature Ids Array ({})", featureAM->getNumTuples(), totalFeatures - 1));
+  }
 
   std::optional<std::vector<DataPath>> amChildPaths = GetAllChildArrayDataPaths(dataStructure, featureAMPath);
 
@@ -106,7 +114,7 @@ Result<> RandomizeFeatureIdsFilter::executeImpl(DataStructure& dataStructure, co
     }
   }
 
-  ClusterUtilities::RandomizeFeatureIds(featureIdsStore, (totalFeatures + 1), featureIArrays);
+  ClusterUtilities::RandomizeFeatureIds(featureIdsStore, totalFeatures, featureIArrays);
 
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RandomizeFeatureIdsFilter.hpp
@@ -21,7 +21,8 @@ public:
   RandomizeFeatureIdsFilter& operator=(RandomizeFeatureIdsFilter&&) noexcept = delete;
 
   // Parameter Keys
-  static inline constexpr StringLiteral k_FeatureIds_Key = "feature_ids_path";
+  static inline constexpr StringLiteral k_FeatureIdsPath_Key = "feature_ids_path";
+  static inline constexpr StringLiteral k_FeatureAMPath_Key = "feature_am_path";
 
   /**
    * @brief Returns the filter's name.

--- a/src/Plugins/SimplnxCore/test/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/test/CMakeLists.txt
@@ -105,6 +105,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   PointSampleEdgeGeometryTest.cpp
   PointSampleTriangleGeometryFilterTest.cpp
   QuickSurfaceMeshFilterTest.cpp
+  RandomizeFeatureIdsTest.cpp
   ReadBinaryCTNorthstarTest.cpp
   ReadCSVFileTest.cpp
   ReadHDF5DatasetTest.cpp

--- a/src/Plugins/SimplnxCore/test/RandomizeFeatureIdsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/RandomizeFeatureIdsTest.cpp
@@ -9,11 +9,82 @@ using namespace nx::core;
 
 namespace
 {
+constexpr StringLiteral k_FeatureIdsArrayName = "Feature Ids Array";
+constexpr StringLiteral k_FeatureAMName = "Feature AM";
+constexpr StringLiteral k_FeatureArrayName = "Feature Array";
+
+const DataPath k_FeatureIdsPath = DataPath{{k_FeatureIdsArrayName}};
+const DataPath k_FeatureAMPath = DataPath{{k_FeatureAMName}};
+const DataPath k_FeatureArrayPath = k_FeatureAMPath.createChildPath(k_FeatureArrayName);
+/**
+ * | Feature Id | Count |
+ * |------------|-------|
+ * |     0      |   4   |
+ * |     1      |   2   |
+ * |     2      |   3   |
+ * |     3      |   1   |
+ * |     4      |   5   |
+ */
+constexpr std::array<int32, 15> k_OriginalFeatureIds = {0, 1, 2, 3, 0, 1, 2, 0, 0, 2, 4, 4, 4, 4, 4};
+// constexpr std::array<int32, 5> k_OriginalFeatureArray = {1, 2, 3, 4, 5};
+constexpr std::array<int32, 5> k_OriginalFeatureArray = {0, 1, 2, 3, 4};
+
+void ValidateOutput(const DataStructure& dataStructure)
+{
+  const auto& featureIdsArray = dataStructure.getDataRefAs<Int32Array>(k_FeatureIdsPath);
+  const auto& featureArray = dataStructure.getDataRefAs<Int32Array>(k_FeatureArrayPath);
+
+  // Check mapping is preserved
+  for(usize i = 0; i < featureIdsArray.getNumberOfTuples(); i++)
+  {
+    REQUIRE(featureArray[featureIdsArray[i]] == k_OriginalFeatureArray[k_OriginalFeatureIds[i]]);
+  }
+
+  // Check new array is actually sorted. Assumption: k_OriginalFeatureArray was created with an ascending sort
+  usize sequentialValueCount = 0;
+  for(usize i = 0; i < featureArray.getNumberOfTuples() - 1; i++)
+  {
+    if(featureArray[i] > featureArray[i + 1])
+    {
+      break;
+    }
+    sequentialValueCount++;
+  }
+
+  REQUIRE_FALSE(sequentialValueCount == featureArray.getNumberOfTuples() - 1);
+}
 } // namespace
 
-TEST_CASE("SimplnxCore::RandomizeFeatureIdsFilter: Baseline Test", "[SimplnxCore][RandomizeFeatureIdsFilter]")
+TEST_CASE("SimplnxCore::RandomizeFeatureIdsFilter: 5 Feature Test", "[SimplnxCore][RandomizeFeatureIdsFilter]")
 {
   DataStructure dataStructure;
+  {
+    Int32Array* featureIdsArray = Int32Array::CreateWithStore<DataStore<int32>>(dataStructure, k_FeatureIdsArrayName, std::vector<usize>{15}, std::vector<usize>{1});
+    (*featureIdsArray)[0] = k_OriginalFeatureIds[0];
+    (*featureIdsArray)[1] = k_OriginalFeatureIds[1];
+    (*featureIdsArray)[2] = k_OriginalFeatureIds[2];
+    (*featureIdsArray)[3] = k_OriginalFeatureIds[3];
+    (*featureIdsArray)[4] = k_OriginalFeatureIds[4];
+    (*featureIdsArray)[5] = k_OriginalFeatureIds[5];
+    (*featureIdsArray)[6] = k_OriginalFeatureIds[6];
+    (*featureIdsArray)[7] = k_OriginalFeatureIds[7];
+    (*featureIdsArray)[8] = k_OriginalFeatureIds[8];
+    (*featureIdsArray)[9] = k_OriginalFeatureIds[9];
+    (*featureIdsArray)[10] = k_OriginalFeatureIds[10];
+    (*featureIdsArray)[11] = k_OriginalFeatureIds[11];
+    (*featureIdsArray)[12] = k_OriginalFeatureIds[12];
+    (*featureIdsArray)[13] = k_OriginalFeatureIds[13];
+    (*featureIdsArray)[14] = k_OriginalFeatureIds[14];
+
+    AttributeMatrix* featureAM = AttributeMatrix::Create(dataStructure, k_FeatureAMName, std::vector<usize>{5});
+
+    Int32Array* featureArray = Int32Array::CreateWithStore<DataStore<int32>>(dataStructure, k_FeatureArrayName, featureAM->getShape(), std::vector<usize>{1}, featureAM->getId());
+    (*featureArray)[0] = k_OriginalFeatureArray[0];
+    (*featureArray)[1] = k_OriginalFeatureArray[1];
+    (*featureArray)[2] = k_OriginalFeatureArray[2];
+    (*featureArray)[3] = k_OriginalFeatureArray[3];
+    (*featureArray)[4] = k_OriginalFeatureArray[4];
+  }
 
   {
     // Instantiate the filter, a DataStructure object and an Arguments Object
@@ -21,8 +92,8 @@ TEST_CASE("SimplnxCore::RandomizeFeatureIdsFilter: Baseline Test", "[SimplnxCore
     Arguments args;
 
     // Create default Parameters for the filter.
-    args.insertOrAssign(RandomizeFeatureIdsFilter::k_FeatureIdsPath_Key, std::make_any<DataPath>());
-    args.insertOrAssign(RandomizeFeatureIdsFilter::k_FeatureAMPath_Key, std::make_any<DataPath>());
+    args.insertOrAssign(RandomizeFeatureIdsFilter::k_FeatureIdsPath_Key, std::make_any<DataPath>(k_FeatureIdsPath));
+    args.insertOrAssign(RandomizeFeatureIdsFilter::k_FeatureAMPath_Key, std::make_any<DataPath>(k_FeatureAMPath));
 
     // Preflight the filter and check result
     auto preflightResult = filter.preflight(dataStructure, args);
@@ -32,4 +103,52 @@ TEST_CASE("SimplnxCore::RandomizeFeatureIdsFilter: Baseline Test", "[SimplnxCore
     auto executeResult = filter.execute(dataStructure, args);
     SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
+
+  ValidateOutput(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::RandomizeFeatureIdsFilter: 4 Feature Test", "[SimplnxCore][RandomizeFeatureIdsFilter]")
+{
+  DataStructure dataStructure;
+  {
+    Int32Array* featureIdsArray = Int32Array::CreateWithStore<DataStore<int32>>(dataStructure, k_FeatureIdsArrayName, std::vector<usize>{10}, std::vector<usize>{1});
+    (*featureIdsArray)[0] = k_OriginalFeatureIds[0];
+    (*featureIdsArray)[1] = k_OriginalFeatureIds[1];
+    (*featureIdsArray)[2] = k_OriginalFeatureIds[2];
+    (*featureIdsArray)[3] = k_OriginalFeatureIds[3];
+    (*featureIdsArray)[4] = k_OriginalFeatureIds[4];
+    (*featureIdsArray)[5] = k_OriginalFeatureIds[5];
+    (*featureIdsArray)[6] = k_OriginalFeatureIds[6];
+    (*featureIdsArray)[7] = k_OriginalFeatureIds[7];
+    (*featureIdsArray)[8] = k_OriginalFeatureIds[8];
+    (*featureIdsArray)[9] = k_OriginalFeatureIds[9];
+
+    AttributeMatrix* featureAM = AttributeMatrix::Create(dataStructure, k_FeatureAMName, std::vector<usize>{4});
+
+    Int32Array* featureArray = Int32Array::CreateWithStore<DataStore<int32>>(dataStructure, k_FeatureArrayName, featureAM->getShape(), std::vector<usize>{1}, featureAM->getId());
+    (*featureArray)[0] = k_OriginalFeatureArray[0];
+    (*featureArray)[1] = k_OriginalFeatureArray[1];
+    (*featureArray)[2] = k_OriginalFeatureArray[2];
+    (*featureArray)[3] = k_OriginalFeatureArray[3];
+  }
+
+  {
+    // Instantiate the filter, a DataStructure object and an Arguments Object
+    RandomizeFeatureIdsFilter filter;
+    Arguments args;
+
+    // Create default Parameters for the filter.
+    args.insertOrAssign(RandomizeFeatureIdsFilter::k_FeatureIdsPath_Key, std::make_any<DataPath>(k_FeatureIdsPath));
+    args.insertOrAssign(RandomizeFeatureIdsFilter::k_FeatureAMPath_Key, std::make_any<DataPath>(k_FeatureAMPath));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+  }
+
+  ValidateOutput(dataStructure);
 }

--- a/src/Plugins/SimplnxCore/test/RandomizeFeatureIdsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/RandomizeFeatureIdsTest.cpp
@@ -1,0 +1,35 @@
+#include <catch2/catch.hpp>
+
+#include "simplnx/UnitTest/UnitTestCommon.hpp"
+
+#include "SimplnxCore/Filters/RandomizeFeatureIdsFilter.hpp"
+#include "SimplnxCore/SimplnxCore_test_dirs.hpp"
+
+using namespace nx::core;
+
+namespace
+{
+} // namespace
+
+TEST_CASE("SimplnxCore::RandomizeFeatureIdsFilter: Baseline Test", "[SimplnxCore][RandomizeFeatureIdsFilter]")
+{
+  DataStructure dataStructure;
+
+  {
+    // Instantiate the filter, a DataStructure object and an Arguments Object
+    RandomizeFeatureIdsFilter filter;
+    Arguments args;
+
+    // Create default Parameters for the filter.
+    args.insertOrAssign(RandomizeFeatureIdsFilter::k_FeatureIdsPath_Key, std::make_any<DataPath>());
+    args.insertOrAssign(RandomizeFeatureIdsFilter::k_FeatureAMPath_Key, std::make_any<DataPath>());
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+  }
+}

--- a/src/simplnx/Utilities/ClusteringUtilities.cpp
+++ b/src/simplnx/Utilities/ClusteringUtilities.cpp
@@ -63,8 +63,18 @@ void RandomizeFeatureIds(Int32AbstractDataStore& featureIdsStore, usize totalFea
 
   if(!featureIArrays.empty())
   {
-    for(usize i = 0; i < totalFeatures; i++)
+    // We use a visitation pattern to prevent reverting swaps
+    std::vector<bool> visited(randomIds.size(), false);
+    for(usize i = 0; i < randomIds.size(); i++)
     {
+      if(visited[i])
+      {
+        continue;
+      }
+
+      visited[i] = true;
+      visited[randomIds[i]] = true;
+
       for(auto* iArray : featureIArrays)
       {
         iArray->swapTuples(i, randomIds[i]);

--- a/src/simplnx/Utilities/ClusteringUtilities.cpp
+++ b/src/simplnx/Utilities/ClusteringUtilities.cpp
@@ -4,19 +4,18 @@
 
 #include <random>
 
-namespace nx::core::ClusterUtilities
+using namespace nx::core;
+
+namespace
 {
-void RandomizeFeatureIds(Int32AbstractDataStore& featureIdsStore, usize totalFeatures)
+std::vector<int32> CreateRandomizedIdsList(usize totalFeatures)
 {
   const usize rangeMin = 1;
   const usize rangeMax = totalFeatures - 1;
   auto gen = std::mt19937_64(std::mt19937_64::default_seed);
   std::uniform_real_distribution<float64> dist(0, 1);
 
-  IDataStore::ShapeType tupleShape{totalFeatures};
-  IDataStore::ShapeType componentShape{1};
-  std::shared_ptr<AbstractDataStore<int32>> randomIdsPtr = nx::core::DataStoreUtilities::CreateDataStore<int32>(tupleShape, componentShape, IDataAction::Mode::Execute);
-  Int32AbstractDataStore& randomIds = *randomIdsPtr.get();
+  std::vector<int32> randomIds(totalFeatures);
   std::iota(randomIds.begin(), randomIds.end(), 0);
 
   //--- Shuffle elements by randomly exchanging each with one other.
@@ -28,10 +27,18 @@ void RandomizeFeatureIds(Int32AbstractDataStore& featureIdsStore, usize totalFea
       continue;
     }
 
-    int32 randId_i = randomIds[i];
-    randomIds[i] = randomIds[r];
-    randomIds[r] = randId_i;
+    std::swap(randomIds[i], randomIds[r]);
   }
+
+  return randomIds;
+}
+} // namespace
+
+namespace nx::core::ClusterUtilities
+{
+void RandomizeFeatureIds(Int32AbstractDataStore& featureIdsStore, usize totalFeatures)
+{
+  std::vector<int32> randomIds = CreateRandomizedIdsList(totalFeatures);
 
   // Now adjust all the Grain ID values for each Voxel
   // instead of taking total points as an input just extract the size, so we don't walk off
@@ -39,6 +46,30 @@ void RandomizeFeatureIds(Int32AbstractDataStore& featureIdsStore, usize totalFea
   for(int64 i = 0; i < totalPoints; ++i)
   {
     featureIdsStore[i] = randomIds[featureIdsStore[i]];
+  }
+}
+
+void RandomizeFeatureIds(Int32AbstractDataStore& featureIdsStore, usize totalFeatures, std::vector<IArray*>& featureIArrays)
+{
+  std::vector<int32> randomIds = CreateRandomizedIdsList(totalFeatures);
+
+  // Now adjust all the Grain ID values for each Voxel
+  // instead of taking total points as an input just extract the size, so we don't walk off
+  usize totalPoints = featureIdsStore.getSize();
+  for(int64 i = 0; i < totalPoints; ++i)
+  {
+    featureIdsStore[i] = randomIds[featureIdsStore[i]];
+  }
+
+  if(!featureIArrays.empty())
+  {
+    for(usize i = 0; i < totalFeatures; i++)
+    {
+      for(auto* iArray : featureIArrays)
+      {
+        iArray->swapTuples(i, randomIds[i]);
+      }
+    }
   }
 }
 } // namespace nx::core::ClusterUtilities

--- a/src/simplnx/Utilities/ClusteringUtilities.hpp
+++ b/src/simplnx/Utilities/ClusteringUtilities.hpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/Common/Types.hpp"
 #include "simplnx/DataStructure/AbstractDataStore.hpp"
+#include "simplnx/DataStructure/IArray.hpp"
 #include "simplnx/simplnx_export.hpp"
 
 #include <cmath>
@@ -138,8 +139,22 @@ float64 GetDistance(const leftDataType& leftVector, usize leftOffset, const righ
 
 /**
  * @brief Randomize the provided Feature IDs.
- * @param featureIds
- * @param totalFeatures
+ * @param featureIds the array that maps cell data to feature data via IDs
+ * @param totalFeatures the total feature count in the feature ids array (equivalent to max value in feature ids + 1)
+ * (Note: this can be derived implicitly, however,the calling functions should have already have this value so we are saving additional parsing)
+ * @return void
  */
 SIMPLNX_EXPORT void RandomizeFeatureIds(Int32AbstractDataStore& featureIds, usize totalFeatures);
+
+/**
+ * @brief Randomize the provided Feature IDs and update supplied feature IArray data.
+ * Assumption: Every array in `featureIArrays` are at least the length of totalFeatures
+ * @param featureIds the array that maps cell data to feature data via IDs
+ * @param totalFeatures the total feature count in the feature ids array (equivalent to max value in feature ids + 1)
+ * (Note: this can be derived implicitly, however,the calling functions should have already have this value so we are saving additional parsing)
+ * @param featureIArrays a vector of pointers to the IArrays in the Feature Attribute Matrix
+ * (Note: These are not found from a datapath, so calling functions can threshold out feature arrays if necessary)
+ * @return void
+ */
+SIMPLNX_EXPORT void RandomizeFeatureIds(Int32AbstractDataStore& featureIds, usize totalFeatures, std::vector<IArray*>& featureIArrays);
 } // namespace nx::core::ClusterUtilities


### PR DESCRIPTION
Fixes: #1349 

This has several patches related to RandomizeFeatureIds rolled into it:
- The last tuple value is now properly handled and included in randomization
- There is now two test cases for this filter (previously no test file)
- This now repairs all the arrays in the feature AM
- Proper documentation for related API
