### PR TITLE
VER: Update EBSDLib to v1.0.39

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -9,7 +9,7 @@ source:
   - path: ../
     folder: simplnx
   - git_url: https://github.com/BlueQuartzSoftware/EbsdLib
-    git_rev: v1.0.38
+    git_rev: v1.0.39
     folder: EbsdLib
   - git_url: https://github.com/BlueQuartzSoftware/H5Support
     git_rev: v1.0.13

--- a/docs/Build_From_Source.md
+++ b/docs/Build_From_Source.md
@@ -15,7 +15,7 @@
 | pybind11  | <https://github.com/pybind/pybind11.git>  | 2.12 |
 | span-lite  | <https://github.com/martinmoene/span-lite>  | 0.10.3 |
 | tbb  | <https://github.com/oneapi-src/onetbb>  | 2021.4.0 |
-| ebsdlib  | <https://www.github.com/bluequartzsoftware/EBSDLib>   | 1.0.30 |
+| ebsdlib  | <https://www.github.com/bluequartzsoftware/EBSDLib>   | 1.0.39 |
 | h5support  | <https://www.github.com/bluequartzsoftware/H5Support>  | 1.0.13 |
 | nod  | <https://github.com/fr00b0/nod.git>  | 0.5.4 |
 | reproc  | <https://github.com/DaanDeMeyer/reproc>  | 14.2.4 |

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -34,7 +34,7 @@
         "zlib",
         "zstd"
       ],
-      "baseline": "15680da3eca788b39360f60f0271f5dfa54dcb43"
+      "baseline": "29bc0b17debdcb1341eb98992ecefb62d768b892"
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -77,7 +77,7 @@
       "dependencies": [
         {
           "name": "ebsdlib",
-          "version>=": "1.0.38"
+          "version>=": "1.0.39"
         }
       ]
     },


### PR DESCRIPTION
The vcpkg-configuration needs to be updated when https://github.com/BlueQuartzSoftware/simplnx-registry/pulls is merged.