### PR TITLE
BUG: Fixes bug in BadDataNeighborOrientationCheck when finding the LaueOps instance

### DIFF
--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/AlignSectionsMisorientation.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/AlignSectionsMisorientation.cpp
@@ -140,12 +140,12 @@ Result<> AlignSectionsMisorientation::findShifts(std::vector<int64_t>& xShifts, 
                       if(cellPhases[refposition] > 0 && cellPhases[curposition] > 0)
                       {
                         QuatF quat1(quats[refposition * 4], quats[refposition * 4 + 1], quats[refposition * 4 + 2], quats[refposition * 4 + 3]); // Makes a copy into voxQuat!!!!
-                        auto phase1 = static_cast<int32_t>(crystalStructures[cellPhases[refposition]]);
+                        auto laueClass1 = static_cast<int32_t>(crystalStructures[cellPhases[refposition]]);
                         QuatF quat2(quats[curposition * 4], quats[curposition * 4 + 1], quats[curposition * 4 + 2], quats[curposition * 4 + 3]); // Makes a copy into voxQuat!!!!
-                        auto phase2 = static_cast<int32_t>(crystalStructures[cellPhases[curposition]]);
-                        if(phase1 == phase2 && phase1 < static_cast<uint32_t>(orientationOps.size()))
+                        auto laueClass2 = static_cast<int32_t>(crystalStructures[cellPhases[curposition]]);
+                        if(laueClass1 == laueClass2 && laueClass1 < static_cast<uint32_t>(orientationOps.size()))
                         {
-                          OrientationF axisAngle = orientationOps[phase1]->calculateMisorientation(quat1, quat2);
+                          OrientationF axisAngle = orientationOps[laueClass1]->calculateMisorientation(quat1, quat2);
                           angle = axisAngle[3];
                         }
                       }
@@ -248,12 +248,12 @@ Result<> AlignSectionsMisorientation::findShifts(std::vector<int64_t>& xShifts, 
                       if(cellPhases[refposition] > 0 && cellPhases[curposition] > 0)
                       {
                         QuatF quat1(quats[refposition * 4], quats[refposition * 4 + 1], quats[refposition * 4 + 2], quats[refposition * 4 + 3]); // Makes a copy into voxQuat!!!!
-                        auto phase1 = static_cast<int32_t>(crystalStructures[cellPhases[refposition]]);
+                        auto laueClass1 = static_cast<int32_t>(crystalStructures[cellPhases[refposition]]);
                         QuatF quat2(quats[curposition * 4], quats[curposition * 4 + 1], quats[curposition * 4 + 2], quats[curposition * 4 + 3]); // Makes a copy into voxQuat!!!!
-                        auto phase2 = static_cast<int32_t>(crystalStructures[cellPhases[curposition]]);
-                        if(phase1 == phase2 && phase1 < static_cast<uint32_t>(orientationOps.size()))
+                        auto laueClass2 = static_cast<int32_t>(crystalStructures[cellPhases[curposition]]);
+                        if(laueClass1 == laueClass2 && laueClass1 < static_cast<uint32_t>(orientationOps.size()))
                         {
-                          OrientationF axisAngle = orientationOps[phase1]->calculateMisorientation(quat1, quat2);
+                          OrientationF axisAngle = orientationOps[laueClass1]->calculateMisorientation(quat1, quat2);
                           angle = axisAngle[3];
                         }
                       }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/AlignSectionsMutualInformation.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/AlignSectionsMutualInformation.cpp
@@ -402,7 +402,7 @@ void AlignSectionsMutualInformation::formFeaturesSections(std::vector<int32>& mi
 
           auto q1TupleIndex = currentpoint * 4;
           QuatF quat1(quats[q1TupleIndex], quats[q1TupleIndex + 1], quats[q1TupleIndex + 2], quats[q1TupleIndex + 3]);
-          uint32_t phase1 = m_CrystalStructures[m_CellPhases[currentpoint]];
+          uint32_t laueClass1 = m_CrystalStructures[m_CellPhases[currentpoint]];
           for(int32_t i = 0; i < 4; i++)
           {
             int64 neighbor = currentpoint + neighborPoints[i];
@@ -429,9 +429,9 @@ void AlignSectionsMutualInformation::formFeaturesSections(std::vector<int32>& mi
               QuatF quat2(quats[q2TupleIndex], quats[q2TupleIndex + 1], quats[q2TupleIndex + 2], quats[q2TupleIndex + 3]);
               uint32_t phase2 = m_CrystalStructures[m_CellPhases[neighbor]];
 
-              if(phase1 == phase2)
+              if(laueClass1 == phase2)
               {
-                OrientationF axisAngle = orientationOps[phase1]->calculateMisorientation(quat1, quat2);
+                OrientationF axisAngle = orientationOps[laueClass1]->calculateMisorientation(quat1, quat2);
                 angle = axisAngle[3];
               }
               if(angle < misorientationTolerance)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/BadDataNeighborOrientationCheck.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/BadDataNeighborOrientationCheck.cpp
@@ -75,8 +75,6 @@ Result<> BadDataNeighborOrientationCheck::operator()()
 
   float w = 10000.0f;
 
-  uint32_t phase1 = 0;
-
   std::vector<LaueOps::Pointer> orientationOps = LaueOps::GetAllOrientationOps();
 
   std::vector<int32_t> neighborCount(totalPoints, 0);
@@ -122,13 +120,13 @@ Result<> BadDataNeighborOrientationCheck::operator()()
         }
         if(good == 1 && maskCompare->isTrue(neighbor))
         {
-          phase1 = crystalStructures[cellPhases[i]];
+          uint32 laueClass1 = crystalStructures[cellPhases[i]];
           QuatF quat1(quats[i * 4], quats[i * 4 + 1], quats[i * 4 + 2], quats[i * 4 + 3]);
           QuatF quat2(quats[neighbor * 4], quats[neighbor * 4 + 1], quats[neighbor * 4 + 2], quats[neighbor * 4 + 3]);
 
           if(cellPhases[i] == cellPhases[neighbor] && cellPhases[i] > 0)
           {
-            OrientationD axisAngle = orientationOps[phase1]->calculateMisorientation(quat1, quat2);
+            OrientationD axisAngle = orientationOps[laueClass1]->calculateMisorientation(quat1, quat2);
             w = axisAngle[3];
           }
           if(w < misorientationTolerance)
@@ -200,7 +198,8 @@ Result<> BadDataNeighborOrientationCheck::operator()()
 
               if(cellPhases[i] == cellPhases[neighbor] && cellPhases[i] > 0)
               {
-                OrientationD axisAngle = orientationOps[phase1]->calculateMisorientation(quat1, quat2);
+                uint32 laueClass1 = crystalStructures[cellPhases[i]];
+                OrientationD axisAngle = orientationOps[laueClass1]->calculateMisorientation(quat1, quat2);
                 w = axisAngle[3];
               }
               if(w < misorientationTolerance)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeBoundaryStrengths.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeBoundaryStrengths.cpp
@@ -69,14 +69,15 @@ Result<> ComputeBoundaryStrengths::operator()()
       }
       if(crystalStructures[laueClassG1] == crystalStructures[laueClassG2] && featurePhases[gName1] > 0)
       {
-        mPrime_1 = static_cast<float32>(orientationOps[crystalStructures[featurePhases[gName1]]]->getmPrime(q1, q2, LD));
-        mPrime_2 = static_cast<float32>(orientationOps[crystalStructures[featurePhases[gName1]]]->getmPrime(q2, q1, LD));
-        F1_1 = static_cast<float32>(orientationOps[crystalStructures[featurePhases[gName1]]]->getF1(q1, q2, LD, true));
-        F1_2 = static_cast<float32>(orientationOps[crystalStructures[featurePhases[gName1]]]->getF1(q2, q1, LD, true));
-        F1spt_1 = static_cast<float32>(orientationOps[crystalStructures[featurePhases[gName1]]]->getF1spt(q1, q2, LD, true));
-        F1spt_2 = static_cast<float32>(orientationOps[crystalStructures[featurePhases[gName1]]]->getF1spt(q2, q1, LD, true));
-        F7_1 = static_cast<float32>(orientationOps[crystalStructures[featurePhases[gName1]]]->getF7(q1, q2, LD, true));
-        F7_2 = static_cast<float32>(orientationOps[crystalStructures[featurePhases[gName1]]]->getF7(q2, q1, LD, true));
+        LaueOps::Pointer laueClass = orientationOps[crystalStructures[featurePhases[gName1]]];
+        mPrime_1 = static_cast<float32>(laueClass->getmPrime(q1, q2, LD));
+        mPrime_2 = static_cast<float32>(laueClass->getmPrime(q2, q1, LD));
+        F1_1 = static_cast<float32>(laueClass->getF1(q1, q2, LD, true));
+        F1_2 = static_cast<float32>(laueClass->getF1(q2, q1, LD, true));
+        F1spt_1 = static_cast<float32>(laueClass->getF1spt(q1, q2, LD, true));
+        F1spt_2 = static_cast<float32>(laueClass->getF1spt(q2, q1, LD, true));
+        F7_1 = static_cast<float32>(laueClass->getF7(q1, q2, LD, true));
+        F7_2 = static_cast<float32>(laueClass->getF7(q2, q1, LD, true));
       }
       else
       {

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureFaceMisorientation.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureFaceMisorientation.cpp
@@ -76,7 +76,7 @@ public:
           quat2 = m_Quats[feature2 * 4 + 2];
           quat3 = m_Quats[feature2 * 4 + 3];
           QuatD q2(quat0, quat1, quat2, quat3);
-          OrientationD axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+          OrientationD axisAngle = m_OrientationOps[m_CrystalStructures[phase1]]->calculateMisorientation(q1, q2);
 
           m_Colors[3 * i + 0] = axisAngle[0] * (axisAngle[3] * Constants::k_180OverPiD);
           m_Colors[3 * i + 1] = axisAngle[1] * (axisAngle[3] * Constants::k_180OverPiD);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureNeighborMisorientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureNeighborMisorientations.cpp
@@ -55,7 +55,7 @@ Result<> ComputeFeatureNeighborMisorientations::operator()()
     quatIndex = i * 4;
 
     QuatF q1(inAvgQuats[quatIndex], inAvgQuats[quatIndex + 1], inAvgQuats[quatIndex + 2], inAvgQuats[quatIndex + 3]);
-    uint32_t xtalType1 = inXtalStruct[inFeaturePhases[i]];
+    uint32_t laueClass1 = inXtalStruct[inFeaturePhases[i]];
 
     const NeighborList<int32_t>::VectorType featureNeighborList = inNeighborList.at(static_cast<int32_t>(i));
 
@@ -68,9 +68,9 @@ Result<> ComputeFeatureNeighborMisorientations::operator()()
       QuatF q2(inAvgQuats[quatIndex], inAvgQuats[quatIndex + 1], inAvgQuats[quatIndex + 2], inAvgQuats[quatIndex + 3]);
       uint32_t xtalType2 = inXtalStruct[inFeaturePhases[neighborFeatureId]];
       tempMisoList = featureNeighborList.size();
-      if(xtalType1 == xtalType2 && static_cast<int64_t>(xtalType1) < static_cast<int64_t>(orientationOps.size()))
+      if(laueClass1 == xtalType2 && static_cast<int64_t>(laueClass1) < static_cast<int64_t>(orientationOps.size()))
       {
-        OrientationD axisAngle = orientationOps[xtalType1]->calculateMisorientation(q1, q2);
+        OrientationD axisAngle = orientationOps[laueClass1]->calculateMisorientation(q1, q2);
 
         tempMisorientationLists[i][j] = static_cast<float>(axisAngle[3] * nx::core::Constants::k_180OverPiF);
         if(m_InputValues->ComputeAvgMisors)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureReferenceMisorientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureReferenceMisorientations.cpp
@@ -81,7 +81,7 @@ Result<> ComputeFeatureReferenceMisorientations::operator()()
     {
       QuatF q1(quats[point * 4 + 0], quats[point * 4 + 1], quats[point * 4 + 2], quats[point * 4 + 3]);
       QuatF q2;
-      uint32 phase1 = crystalStructures[cellPhases[point]];
+      uint32 laueClass1 = crystalStructures[cellPhases[point]];
       if(m_InputValues->ReferenceOrientation == 0)
       {
         auto gnum = static_cast<size_t>(featureIds[point]);
@@ -94,7 +94,7 @@ Result<> ComputeFeatureReferenceMisorientations::operator()()
         q2 = QuatF(avgQuats[centerGNum * 4 + 0], avgQuats[centerGNum * 4 + 1], avgQuats[centerGNum * 4 + 2], avgQuats[centerGNum * 4 + 3]);
       }
 
-      OrientationD axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+      OrientationD axisAngle = m_OrientationOps[laueClass1]->calculateMisorientation(q1, q2);
 
       featureReferenceMisorientations[point] = static_cast<float>((180.0 / nx::core::numbers::pi) * axisAngle[3]); // convert to degrees
       int32_t idx = featureIds[point] * 2;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeGBCD.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeGBCD.cpp
@@ -104,7 +104,7 @@ public:
 
       if(phases[feature1] == phases[feature2] && phases[feature1] > 0)
       {
-        uint32 cryst = crystalStructures[phases[feature1]];
+        uint32 laueClass1 = crystalStructures[phases[feature1]];
         for(int32 q = 0; q < 2; q++)
         {
           if(q == 1)
@@ -126,11 +126,11 @@ public:
 
           OrientationTransformation::eu2om<OrientationF, OrientationF>(OrientationF(g2ea, 3)).toGMatrix(g2);
 
-          int32 nSym = m_OrientationOps[cryst]->getNumSymOps();
+          int32 nSym = m_OrientationOps[laueClass1]->getNumSymOps();
           for(int32 j = 0; j < nSym; j++)
           {
             // rotate g1 by symOp
-            m_OrientationOps[cryst]->getMatSymOp(j, sym1);
+            m_OrientationOps[laueClass1]->getMatSymOp(j, sym1);
             MatrixMath::Multiply3x3with3x3(sym1, g1, g1s);
             // get the crystal directions along the triangle normals
             MatrixMath::Multiply3x3with3x1(g1s, normal, xstl1Norm1);
@@ -147,7 +147,7 @@ public:
             for(int32 k = 0; k < nSym; k++)
             {
               // calculate the symmetric misorienation
-              m_OrientationOps[cryst]->getMatSymOp(k, sym2);
+              m_OrientationOps[laueClass1]->getMatSymOp(k, sym2);
               // rotate g2 by symOp
               MatrixMath::Multiply3x3with3x3(sym2, g2, g2s);
               // transpose rotated g2

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeKernelAvgMisorientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeKernelAvgMisorientations.cpp
@@ -90,7 +90,6 @@ public:
             q1[2] = quats[quatIndex + 2];
             q1[3] = quats[quatIndex + 3];
 
-            uint32_t phase1 = crystalStructures[cellPhases[point]];
             for(int32_t j = -kernelSize[2]; j < kernelSize[2] + 1; j++)
             {
 
@@ -120,7 +119,8 @@ public:
                     q2[1] = quats[quatIndex + 1];
                     q2[2] = quats[quatIndex + 2];
                     q2[3] = quats[quatIndex + 3];
-                    OrientationF axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+                    uint32_t laueClass = crystalStructures[cellPhases[point]];
+                    OrientationF axisAngle = m_OrientationOps[laueClass]->calculateMisorientation(q1, q2);
                     totalMisorientation = totalMisorientation + (axisAngle[3] * nx::core::Constants::k_180OverPiF);
                     numVoxel++;
                   }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeSchmids.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeSchmids.cpp
@@ -75,8 +75,8 @@ Result<> ComputeSchmids::operator()()
 
   for(size_t i = 1; i < totalFeatures; i++)
   {
-    uint32_t xtal = crystalStructures[featurePhases[i]];
-    if(xtal >= EbsdLib::CrystalStructure::LaueGroupEnd)
+    uint32_t laueClass = crystalStructures[featurePhases[i]];
+    if(laueClass >= EbsdLib::CrystalStructure::LaueGroupEnd)
     {
       continue;
     }
@@ -86,11 +86,11 @@ Result<> ComputeSchmids::operator()()
 
     if(!m_InputValues->OverrideSystem)
     {
-      orientationOps[xtal]->getSchmidFactorAndSS(crystalLoading.data(), schmid, angleComps, slipSystem);
+      orientationOps[laueClass]->getSchmidFactorAndSS(crystalLoading.data(), schmid, angleComps, slipSystem);
     }
     else
     {
-      orientationOps[xtal]->getSchmidFactorAndSS(crystalLoading.data(), plane.data(), direction.data(), schmid, angleComps, slipSystem);
+      orientationOps[laueClass]->getSchmidFactorAndSS(crystalLoading.data(), plane.data(), direction.data(), schmid, angleComps, slipSystem);
     }
 
     schmidArray[i] = static_cast<float>(schmid);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeTwinBoundaries.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeTwinBoundaries.cpp
@@ -19,7 +19,7 @@ using namespace nx::core;
 namespace
 {
 template <typename T>
-bool IsTwinBoundary(const Eigen::Quaternion<T>& quat1, const Eigen::Quaternion<T>& quat2, const std::vector<LaueOps::Pointer>& orientationOps, uint32 crystalStructure, float32 angTolerance,
+bool IsTwinBoundary(const Eigen::Quaternion<T>& quat1, const Eigen::Quaternion<T>& quat2, const std::vector<LaueOps::Pointer>& orientationOps, uint32 laueClass, float32 angTolerance,
                     float32 axisTolerance)
 {
   T real = std::numeric_limits<T>::max();
@@ -34,13 +34,13 @@ bool IsTwinBoundary(const Eigen::Quaternion<T>& quat1, const Eigen::Quaternion<T
   Eigen::Quaternion<T> s1_misq;
   Eigen::Quaternion<T> s2_misq;
 
-  const int32 nsym = orientationOps[crystalStructure]->getNumSymOps();
+  const int32 nsym = orientationOps[laueClass]->getNumSymOps();
   const Eigen::Quaternion<T> q2 = quat2.conjugate();
   misq = quat1 * q2;
 
   for(int32 j = 0; j < nsym; j++)
   {
-    Quaternion<T> jQuat = orientationOps[crystalStructure]->getQuatSymOp(j);
+    Quaternion<T> jQuat = orientationOps[laueClass]->getQuatSymOp(j);
     sym_q = Eigen::Quaterniond(jQuat.w(), jQuat.x(), jQuat.y(), jQuat.z());
 
     // calculate crystal direction parallel to normal
@@ -49,7 +49,7 @@ bool IsTwinBoundary(const Eigen::Quaternion<T>& quat1, const Eigen::Quaternion<T
     for(int32 k = 0; k < nsym; k++)
     {
       // calculate the symmetric misorienation
-      Quaternion<T> kQuat = orientationOps[crystalStructure]->getQuatSymOp(k);
+      Quaternion<T> kQuat = orientationOps[laueClass]->getQuatSymOp(k);
       sym_q = Eigen::Quaterniond(kQuat.w(), kQuat.x(), kQuat.y(), kQuat.z());
       sym_q = sym_q.conjugate();
       s2_misq = sym_q * s1_misq;
@@ -71,7 +71,7 @@ bool IsTwinBoundary(const Eigen::Quaternion<T>& quat1, const Eigen::Quaternion<T
 
 template <typename T>
 std::optional<T> FindTwinBoundaryIncoherence(const Eigen::Vector3d& xstl_norm, const Eigen::Quaternion<T>& quat1, const Eigen::Quaternion<T>& quat2,
-                                             const std::vector<LaueOps::Pointer>& orientationOps, uint32 crystalStructure, float32 angTolerance, float32 axisTolerance)
+                                             const std::vector<LaueOps::Pointer>& orientationOps, uint32 laueClass, float32 angTolerance, float32 axisTolerance)
 {
   T real = std::numeric_limits<T>::max();
   T axisdiff111;
@@ -87,14 +87,14 @@ std::optional<T> FindTwinBoundaryIncoherence(const Eigen::Vector3d& xstl_norm, c
   Eigen::Quaternion<T> s1_misq;
   Eigen::Quaternion<T> s2_misq;
 
-  const int32 nsym = orientationOps[crystalStructure]->getNumSymOps();
+  const int32 nsym = orientationOps[laueClass]->getNumSymOps();
   const Eigen::Quaternion<T> q2 = quat2.conjugate();
   misq = quat1 * q2;
 
   bool valid = false;
   for(int32 j = 0; j < nsym; j++)
   {
-    Quaternion<T> jQuat = orientationOps[crystalStructure]->getQuatSymOp(j);
+    Quaternion<T> jQuat = orientationOps[laueClass]->getQuatSymOp(j);
     j_sym_q = Eigen::Quaterniond(jQuat.w(), jQuat.x(), jQuat.y(), jQuat.z());
 
     // calculate crystal direction parallel to normal
@@ -103,7 +103,7 @@ std::optional<T> FindTwinBoundaryIncoherence(const Eigen::Vector3d& xstl_norm, c
     for(int32 k = 0; k < nsym; k++)
     {
       // calculate the symmetric misorienation
-      Quaternion<T> kQuat = orientationOps[crystalStructure]->getQuatSymOp(k);
+      Quaternion<T> kQuat = orientationOps[laueClass]->getQuatSymOp(k);
       sym_q = Eigen::Quaterniond(kQuat.w(), kQuat.x(), kQuat.y(), kQuat.z());
       sym_q = sym_q.conjugate();
       s2_misq = sym_q * s1_misq;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
@@ -117,10 +117,10 @@ bool EBSDSegmentFeatures::determineGrouping(int64 referencePoint, int64 neighbor
   // Get the phases for each voxel
   nx::core::AbstractDataStore<int32>* cellPhases = m_CellPhases->getDataStore();
 
-  int32_t phase1 = (*m_CrystalStructures)[(*cellPhases)[referencePoint]];
-  int32_t phase2 = (*m_CrystalStructures)[(*cellPhases)[neighborPoint]];
+  int32_t laueClass1 = (*m_CrystalStructures)[(*cellPhases)[referencePoint]];
+  int32_t laueClass2 = (*m_CrystalStructures)[(*cellPhases)[neighborPoint]];
   // If either of the phases is 999 then we bail out now.
-  if(phase1 >= m_OrientationOps.size() || phase2 >= m_OrientationOps.size())
+  if(laueClass1 >= m_OrientationOps.size() || laueClass2 >= m_OrientationOps.size())
   {
     return group;
   }
@@ -141,7 +141,7 @@ bool EBSDSegmentFeatures::determineGrouping(int64 referencePoint, int64 neighbor
 
     if((*cellPhases)[referencePoint] == (*cellPhases)[neighborPoint])
     {
-      OrientationF axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+      OrientationF axisAngle = m_OrientationOps[laueClass1]->calculateMisorientation(q1, q2);
       w = axisAngle[3];
     }
     if(w < m_InputValues->MisorientationTolerance)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/MergeTwins.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/MergeTwins.cpp
@@ -80,15 +80,15 @@ bool MergeTwins::determineGrouping(int32 referenceFeature, int32 neighborFeature
 
   if(featureParentIds[neighborFeature] == -1 && phases[referenceFeature] > 0 && phases[neighborFeature] > 0)
   {
-    uint32 phase1 = crystalStructures[phases[referenceFeature]];
+    uint32 laueClass = crystalStructures[phases[referenceFeature]];
 
     QuatF q1(avgQuats[referenceFeature * 4], avgQuats[referenceFeature * 4 + 1], avgQuats[referenceFeature * 4 + 2], avgQuats[referenceFeature * 4 + 3]);
     QuatF q2(avgQuats[neighborFeature * 4], avgQuats[neighborFeature * 4 + 1], avgQuats[neighborFeature * 4 + 2], avgQuats[neighborFeature * 4 + 3]);
 
     uint32 phase2 = crystalStructures[phases[neighborFeature]];
-    if(phase1 == phase2 && (phase1 == EbsdLib::CrystalStructure::Cubic_High))
+    if(laueClass == phase2 && (laueClass == EbsdLib::CrystalStructure::Cubic_High))
     {
-      OrientationD axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+      OrientationD axisAngle = m_OrientationOps[laueClass]->calculateMisorientation(q1, q2);
       double w = axisAngle[3];
       w *= (180.0f / numbers::pi);
       double axisDiff111 = std::acos(std::fabs(axisAngle[0]) * 0.57735f + std::fabs(axisAngle[1]) * 0.57735f + fabs(axisAngle[2]) * 0.57735f);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/NeighborOrientationCorrelation.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/NeighborOrientationCorrelation.cpp
@@ -112,8 +112,6 @@ Result<> NeighborOrientationCorrelation::operator()()
   neighpoints[4] = static_cast<int64_t>(dims[0]);
   neighpoints[5] = static_cast<int64_t>(dims[0] * dims[1]);
 
-  uint32_t phase1 = 0;
-
   std::vector<int32_t> neighborDiffCount(totalPoints, 0);
   std::vector<int32_t> neighborSimCount(6, 0);
   std::vector<int64_t> bestNeighbor(totalPoints, -1);
@@ -172,13 +170,13 @@ Result<> NeighborOrientationCorrelation::operator()()
           }
           if(good)
           {
-            phase1 = crystalStructures[cellPhases[i]];
+            uint32 laueClass = crystalStructures[cellPhases[i]];
             QuatF quat1(quats[i * 4], quats[i * 4 + 1], quats[i * 4 + 2], quats[i * 4 + 3]);
             QuatF quat2(quats[neighbor * 4], quats[neighbor * 4 + 1], quats[neighbor * 4 + 2], quats[neighbor * 4 + 3]);
             OrientationD axisAngle(0.0, 0.0, 0.0, std::numeric_limits<double>::max());
             if(cellPhases[i] == cellPhases[neighbor] && cellPhases[i] > 0)
             {
-              axisAngle = orientationOps[phase1]->calculateMisorientation(quat1, quat2);
+              axisAngle = orientationOps[laueClass]->calculateMisorientation(quat1, quat2);
             }
             if(axisAngle[3] > misorientationToleranceR)
             {
@@ -214,13 +212,13 @@ Result<> NeighborOrientationCorrelation::operator()()
               }
               if(good2)
               {
-                phase1 = crystalStructures[cellPhases[neighbor2]];
+                laueClass = crystalStructures[cellPhases[neighbor2]];
                 quat1 = QuatF(quats[neighbor2 * 4], quats[neighbor2 * 4 + 1], quats[neighbor2 * 4 + 2], quats[neighbor2 * 4 + 3]);
                 quat2 = QuatF(quats[neighbor * 4], quats[neighbor * 4 + 1], quats[neighbor * 4 + 2], quats[neighbor * 4 + 3]);
                 axisAngle = OrientationD(0.0, 0.0, 0.0, std::numeric_limits<double>::max());
                 if(cellPhases[neighbor2] == cellPhases[neighbor] && cellPhases[neighbor2] > 0)
                 {
-                  axisAngle = orientationOps[phase1]->calculateMisorientation(quat1, quat2);
+                  axisAngle = orientationOps[laueClass]->calculateMisorientation(quat1, quat2);
                 }
                 if(axisAngle[3] < misorientationToleranceR)
                 {


### PR DESCRIPTION
- Also brings consistency to all uses of the LaueOps classes to use 'laueClass' as a variable.
- Fixes bug where the phase value was indexing directly into orientation ops instead of going through crystal structures first in ComputeFeatureFaceMisorientation