### PR TITLE
BUG: Laplacian was not releasing internal connectivity arrays. Now smooth edges, Hex and Tet Geometries

### DIFF
--- a/src/Plugins/SimplnxCore/docs/LaplacianSmoothingFilter.md
+++ b/src/Plugins/SimplnxCore/docs/LaplacianSmoothingFilter.md
@@ -6,7 +6,7 @@ Surface Meshing (Smoothing)
 
 ## Description
 
-This **Filter** applies Laplacian smoothing to a **Triangle Geometry** that represents a surface mesh. A. Belyaev [2] has a concise explanation of the Laplacian Smoothing as follows:
+This **Filter** applies Laplacian smoothing to any node based geometry except for **vertex**. A. Belyaev [2] has a concise explanation of the Laplacian Smoothing as follows:
 
 ---------------------------
 
@@ -45,13 +45,19 @@ Currently, if you lock the *Default Lambda* value to zero (0), the triple lines 
 
 This **Filter** will create additional internal arrays in order to facilitate the calculations. These arrays are
 
-- Float - &lambda; values (same size as nodes array)
+- Float - lambda values (same size as nodes array)
 - 64 bit integer - unique edges array
 - 8 bit integer for node type (same size as nodes array)
 - Integer for number of connections for each node (same size as nodes array)
 - 64 bit float for delta values (3x size of nodes array)
 
 Due to these array allocations this **Filter** can consume large amounts of memory if the starting mesh has a large number of nodes.
+
+At the conclusion of the filter these extra internal arrays will be reclaimed by the system.
+
+
+### Node Type Values
+
 The values for the *Node Type* array can take one of the following values.
 
     namespace SurfaceMesh {
@@ -65,6 +71,8 @@ The values for the *Node Type* array can take one of the following values.
         const int8_t SurfaceQuadPoint = 14;
       }
     }
+
+If your surface mesh is lacking a `Node Type` array, you can simply create a DataArray inside the Vertex Data Attribute Matrix. The type should be "int8" and have an initialization value of 3. This will allow **all** nodes to move.
 
 For more information on surface meshing, visit the tutorial.
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LaplacianSmoothing.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LaplacianSmoothing.cpp
@@ -24,14 +24,15 @@ Result<> LaplacianSmoothing::operator()()
 
   // At the end of the algorithm, the 2D Node Geometry will have edges that are not
   // needed. This will remove those from the DataStructure
-  auto& nodeGeom1DRef = m_DataStructure.getDataRefAs<INodeGeometry1D>(m_InputValues->pTriangleGeometryDataPath);
-  auto edgeListId = nodeGeom1DRef.getEdgeListId();
-  nodeGeom1DRef.setEdgeListId(0);
-  auto edgeDataId = nodeGeom1DRef.getEdgeListDataArrayId();
-  nodeGeom1DRef.setEdgeDataId(0);
-  m_DataStructure.removeData(edgeListId);
-  m_DataStructure.removeData(edgeDataId);
-
+  if(auto* nodeGeom2DPtr = m_DataStructure.getDataAs<INodeGeometry2D>(m_InputValues->pTriangleGeometryDataPath); nullptr != nodeGeom2DPtr)
+  {
+    auto edgeListId = nodeGeom2DPtr->getEdgeListId();
+    nodeGeom2DPtr->setEdgeListId(0);
+    auto edgeDataId = nodeGeom2DPtr->getEdgeListDataArrayId();
+    nodeGeom2DPtr->setEdgeDataId(0);
+    m_DataStructure.removeData(edgeListId);
+    m_DataStructure.removeData(edgeDataId);
+  }
   return result;
 }
 
@@ -40,32 +41,35 @@ Result<> LaplacianSmoothing::operator()()
 // -----------------------------------------------------------------------------
 Result<> LaplacianSmoothing::edgeBasedSmoothing()
 {
-  auto& surfaceMesh = m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues->pTriangleGeometryDataPath);
+  auto& nodeGeom1DRef = m_DataStructure.getDataRefAs<INodeGeometry1D>(m_InputValues->pTriangleGeometryDataPath);
 
-  if(surfaceMesh.getVertices() == nullptr)
+  if(nodeGeom1DRef.getVertices() == nullptr)
   {
     return MakeErrorResult(-559, "Error finding TriangleGeom vertices.");
   }
 
-  Float32AbstractDataStore& verts = surfaceMesh.getVertices()->getDataStoreRef();
-
-  IGeometry::MeshIndexType nvert = surfaceMesh.getNumberOfVertices();
+  Float32AbstractDataStore& vertDataStoreRef = nodeGeom1DRef.getVertices()->getDataStoreRef();
+  IGeometry::MeshIndexType numberOfVertices = nodeGeom1DRef.getNumberOfVertices();
 
   // Generate the Lambda Array
   std::vector<float> lambdas = generateLambdaArray();
 
-  //  Generate the Unique Edges
-  if(surfaceMesh.findEdges(false) < 0)
+  auto inode2DPtr = m_DataStructure.getDataAs<INodeGeometry2D>(m_InputValues->pTriangleGeometryDataPath);
+  if(nullptr != inode2DPtr)
   {
-    return MakeErrorResult(-560, "Error retrieving the shared edge list");
+    //  Generate the Unique Edges
+    if(inode2DPtr->findEdges(false) < 0)
+    {
+      return MakeErrorResult(-560, "Error retrieving or creating the shared edge list");
+    }
   }
 
-  AbstractDataStore<IGeometry::SharedEdgeList::value_type>& edges = surfaceMesh.getEdges()->getDataStoreRef();
+  AbstractDataStore<IGeometry::SharedEdgeList::value_type>& edges = nodeGeom1DRef.getEdges()->getDataStoreRef();
   IGeometry::MeshIndexType numEdges = edges.getNumberOfTuples();
 
-  std::vector<int32> numConnections(nvert, 0);
+  std::vector<int32> numConnections(numberOfVertices, 0);
 
-  std::vector<double> deltaArray(nvert * 3);
+  std::vector<double> deltaArray(numberOfVertices * 3);
   double dlta = 0.0;
 
   for(int32_t q = 0; q < m_InputValues->pIterationSteps; q++)
@@ -84,10 +88,10 @@ Result<> LaplacianSmoothing::edgeBasedSmoothing()
       for(IGeometry::MeshIndexType j = 0; j < 3; j++)
       {
 #if 0
-        Q_ASSERT(static_cast<size_t>(3 * in1 + j) < static_cast<size_t>(nvert * 3));
-        Q_ASSERT(static_cast<size_t>(3 * in2 + j) < static_cast<size_t>(nvert * 3));
+        Q_ASSERT(static_cast<size_t>(3 * in1 + j) < static_cast<size_t>(numberOfVertices * 3));
+        Q_ASSERT(static_cast<size_t>(3 * in2 + j) < static_cast<size_t>(numberOfVertices * 3));
 #endif
-        dlta = static_cast<double>(verts[3 * in2 + j] - verts[3 * in1 + j]);
+        dlta = static_cast<double>(vertDataStoreRef[3 * in2 + j] - vertDataStoreRef[3 * in1 + j]);
         deltaArray[3 * in1 + j] += dlta;
         deltaArray[3 * in2 + j] += -1.0 * dlta;
       }
@@ -96,7 +100,7 @@ Result<> LaplacianSmoothing::edgeBasedSmoothing()
     }
 
     // Move each point
-    for(IGeometry::MeshIndexType i = 0; i < nvert; i++)
+    for(IGeometry::MeshIndexType i = 0; i < numberOfVertices; i++)
     {
       for(IGeometry::MeshIndexType j = 0; j < 3; j++)
       {
@@ -104,7 +108,7 @@ Result<> LaplacianSmoothing::edgeBasedSmoothing()
         dlta = deltaArray[in0] / numConnections[i];
 
         float ll = lambdas[i];
-        verts[3 * i + j] += ll * dlta;
+        vertDataStoreRef[3 * i + j] += ll * dlta;
         deltaArray[in0] = 0.0; // reset for next iteration
       }
       numConnections[i] = 0; // reset for next iteration
@@ -130,10 +134,10 @@ Result<> LaplacianSmoothing::edgeBasedSmoothing()
         for(int32_t j = 0; j < 3; j++)
         {
 #if 0
-          Q_ASSERT(static_cast<size_t>(3 * in1 + j) < static_cast<size_t>(nvert * 3));
-          Q_ASSERT(static_cast<size_t>(3 * in2 + j) < static_cast<size_t>(nvert * 3));
+          Q_ASSERT(static_cast<size_t>(3 * in1 + j) < static_cast<size_t>(numberOfVertices * 3));
+          Q_ASSERT(static_cast<size_t>(3 * in2 + j) < static_cast<size_t>(numberOfVertices * 3));
 #endif
-          dlta = verts[3 * in2 + j] - verts[3 * in1 + j];
+          dlta = vertDataStoreRef[3 * in2 + j] - vertDataStoreRef[3 * in1 + j];
           deltaArray[3 * in1 + j] += dlta;
           deltaArray[3 * in2 + j] += -1.0 * dlta;
         }
@@ -141,8 +145,8 @@ Result<> LaplacianSmoothing::edgeBasedSmoothing()
         numConnections[in2] += 1;
       }
 
-      // MOve the points
-      for(IGeometry::MeshIndexType i = 0; i < nvert; i++)
+      // Move the points
+      for(IGeometry::MeshIndexType i = 0; i < numberOfVertices; i++)
       {
         for(IGeometry::MeshIndexType j = 0; j < 3; j++)
         {
@@ -150,7 +154,7 @@ Result<> LaplacianSmoothing::edgeBasedSmoothing()
           dlta = deltaArray[in0] / numConnections[i];
 
           float ll = lambdas[i] * m_InputValues->pMuFactor;
-          verts[3 * i + j] += ll * dlta;
+          vertDataStoreRef[3 * i + j] += ll * dlta;
           deltaArray[in0] = 0.0; // reset for next iteration
         }
         numConnections[i] = 0; // reset for next iteration
@@ -162,7 +166,7 @@ Result<> LaplacianSmoothing::edgeBasedSmoothing()
 }
 
 // -----------------------------------------------------------------------------
-std::vector<float> LaplacianSmoothing::generateLambdaArray()
+std::vector<float> LaplacianSmoothing::generateLambdaArray() const
 {
   auto& surfaceMeshNode = m_DataStructure.getDataAs<Int8Array>(m_InputValues->pSurfaceMeshNodeTypeArrayPath)->getDataStoreRef();
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LaplacianSmoothing.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LaplacianSmoothing.cpp
@@ -20,7 +20,19 @@ LaplacianSmoothing::~LaplacianSmoothing() noexcept = default;
 
 Result<> LaplacianSmoothing::operator()()
 {
-  return edgeBasedSmoothing();
+  auto result = edgeBasedSmoothing();
+
+  // At the end of the algorithm, the 2D Node Geometry will have edges that are not
+  // needed. This will remove those from the DataStructure
+  auto& nodeGeom1DRef = m_DataStructure.getDataRefAs<INodeGeometry1D>(m_InputValues->pTriangleGeometryDataPath);
+  auto edgeListId = nodeGeom1DRef.getEdgeListId();
+  nodeGeom1DRef.setEdgeListId(0);
+  auto edgeDataId = nodeGeom1DRef.getEdgeListDataArrayId();
+  nodeGeom1DRef.setEdgeDataId(0);
+  m_DataStructure.removeData(edgeListId);
+  m_DataStructure.removeData(edgeDataId);
+
+  return result;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LaplacianSmoothing.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LaplacianSmoothing.hpp
@@ -48,7 +48,7 @@ private:
   const std::atomic_bool& m_ShouldCancel;
   const IFilter::MessageHandler& m_MessageHandler;
 
-  std::vector<float> generateLambdaArray();
+  std::vector<float> generateLambdaArray() const;
   Result<> edgeBasedSmoothing();
 };
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LaplacianSmoothingFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LaplacianSmoothingFilter.cpp
@@ -67,9 +67,9 @@ Parameters LaplacianSmoothingFilter::parameters() const
 
   params.insertSeparator(Parameters::Separator{"Input Triangle Geometry"});
   // Create the parameter descriptors that are needed for this filter
-  params.insert(std::make_unique<GeometrySelectionParameter>(k_TriangleGeometryDataPath_Key, "Triangle Geometry",
-                                                             "The complete path to the surface mesh Geometry for which to apply Laplacian smoothing", DataPath{},
-                                                             GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Triangle, IGeometry::Type::Tetrahedral}));
+  params.insert(std::make_unique<GeometrySelectionParameter>(
+      k_TriangleGeometryDataPath_Key, "Node Geometry", "The complete path to the surface mesh Geometry for which to apply Laplacian smoothing", DataPath{},
+      GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Edge, IGeometry::Type::Triangle, IGeometry::Type::Quad, IGeometry::Type::Tetrahedral, IGeometry::Type::Hexahedral}));
   params.insertSeparator(Parameters::Separator{"Input Cell Data"});
   params.insert(std::make_unique<ArraySelectionParameter>(k_SurfaceMeshNodeTypeArrayPath_Key, "Node Type", "The complete path to the array specifying the type of node in the Geometry", DataPath{},
                                                           ArraySelectionParameter::AllowedTypes{DataType::int8}, ArraySelectionParameter::AllowedComponentShapes{{1}}));

--- a/src/Plugins/SimplnxCore/test/LaplacianSmoothingFilterTest.cpp
+++ b/src/Plugins/SimplnxCore/test/LaplacianSmoothingFilterTest.cpp
@@ -3,7 +3,6 @@
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
 
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
-#include "simplnx/Parameters/ArrayCreationParameter.hpp"
 #include "simplnx/Parameters/FileSystemPathParameter.hpp"
 #include "simplnx/Parameters/NumberParameter.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
@@ -112,11 +111,7 @@ TEST_CASE("SimplnxCore::LaplacianSmoothingFilter", "[SurfaceMeshing][LaplacianSm
   }
 
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT
-  Result<nx::core::HDF5::FileWriter> result = nx::core::HDF5::FileIO::WriteFile(fmt::format("{}/LaplacianSmoothing.dream3d", unit_test::k_BinaryTestOutputDir));
-  nx::core::HDF5::FileWriter fileWriter = std::move(result.value());
-
-  auto resultH5 = HDF5::DataStructureWriter::WriteFile(dataStructure, fileWriter);
-  SIMPLNX_RESULT_REQUIRE_VALID(resultH5);
+  WriteTestDataStructure(dataStructure, fmt::format("{}/laplacian_smoothing_test.dream3d", unit_test::k_BinaryTestOutputDir));
 #endif
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);


### PR DESCRIPTION
- The algorithm left the internal "Edge" data arrays (connectivity) - FIXED
- We can now smooth Edge, Triangle, Quad, Tet and Hex meshes.
