### PR TITLE
FILT: Read Zeiss TXM File filter added

### DIFF
--- a/src/Plugins/SimplnxCore/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/CMakeLists.txt
@@ -115,6 +115,7 @@ set(FilterList
   ReadTextDataArrayFilter
   ReadVolumeGraphicsFileFilter
   ReadVtkStructuredPointsFilter
+  ReadZeissTxmFileFilter
   RegularGridSampleSurfaceMeshFilter
   RemoveFlaggedEdgesFilter
   RemoveFlaggedFeaturesFilter
@@ -233,6 +234,7 @@ set(AlgorithmList
   ReadStringDataArray
   ReadVolumeGraphicsFile
   ReadVtkStructuredPoints
+  ReadZeissTxmFile
   RegularGridSampleSurfaceMesh
   RemoveFlaggedEdges
   RemoveFlaggedFeatures
@@ -391,14 +393,22 @@ set(PLUGIN_EXTRA_SOURCES
 
 )
 
-target_sources(${PLUGIN_NAME}
-  PRIVATE
-    ${PLUGIN_EXTRA_SOURCES}
+set(OLESS_SOURCES 
+    "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/oless/oless/oless_common.hpp"
+    "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/oless/oless/oless.cpp"
+    "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/oless/oless/oless.h"
+    "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/oless/oless/pole.cpp"
+    "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/oless/oless/pole.h"
 )
 
-source_group(TREE "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}" PREFIX ${PLUGIN_NAME}
-  FILES
-    ${PLUGIN_EXTRA_SOURCES}
+target_sources(${PLUGIN_NAME}
+  PRIVATE
+    ${PLUGIN_EXTRA_SOURCES} ${OLESS_SOURCES}
+)
+
+source_group(TREE "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}" 
+            PREFIX ${PLUGIN_NAME}
+            FILES  ${PLUGIN_EXTRA_SOURCES}
 )
 
 #------------------------------------------------------------------------------
@@ -442,10 +452,10 @@ cmpConfigureFileWithMD5Check(CONFIGURED_TEMPLATE_PATH "${${PLUGIN_NAME}_SOURCE_D
                                #------------------------------------------------------------------------------
 # If there are additional include directories that are needed for this plugin
 # you can use the target_include_directories(.....) cmake call
-# target_include_directories(${PLUGIN_NAME}
-#     PRIVATE
-#     additional include directories here
-# )
+target_include_directories(${PLUGIN_NAME}
+  PUBLIC
+    "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/oless"
+)
 
 # -----------------------------------------------------------------------
 # Install example pipelines
@@ -562,3 +572,20 @@ install(FILES
   DESTINATION Data/${PLUGIN_NAME}
   COMPONENT Applications
 )
+
+add_executable(txm_reader ${OLESS_SOURCES} ${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/oless/txm_reader.cpp)
+target_include_directories(txm_reader PRIVATE ${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/oless)
+
+target_compile_features(txm_reader
+                        PUBLIC
+                        cxx_std_17
+)
+
+set_target_properties(txm_reader
+                      PROPERTIES
+                      DEBUG_POSTFIX "_d"
+)
+# target_include_directories(txm_reader
+#   PUBLIC
+#     ${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/oless
+# )

--- a/src/Plugins/SimplnxCore/docs/ReadZeissTxmFileFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReadZeissTxmFileFilter.md
@@ -7,7 +7,7 @@ IO (Read)
 ## Description ##
 
 This filter will read the entire volume or optionally a subvolume from a .txm or .txrm file. These files
-are Zeiss xCT reconstrucion files.
+are Zeiss xCT reconstruction files.
 
 The minimum slice always starts at 1.
 The last slice is inclusive.

--- a/src/Plugins/SimplnxCore/docs/ReadZeissTxmFileFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReadZeissTxmFileFilter.md
@@ -1,0 +1,34 @@
+# Read Zeiss TXM & TXRM File
+
+## Group (Subgroup) ##
+
+IO (Read)
+
+## Description ##
+
+This filter will read the entire volume or optionally a subvolume from a .txm or .txrm file. These files
+are Zeiss xCT reconstrucion files.
+
+The minimum slice always starts at 1.
+The last slice is inclusive.
+
+## WARNING
+
+Be aware of how large of data you are reading into DREAM3D-NX as these files can become quite large and will overwhelm the visualization system.
+It is recommended that you view the data as a "2D Slice/Image View" or "Volume Render" view.
+
+% Auto generated parameter table will be inserted here
+
+## References
+
+This code uses the MIT licensed OLESS software library.
+
+## Example Pipelines
+
+## License & Copyright
+
+Please see the description file distributed with this **Plugin**
+
+## DREAM3D-NX Help
+
+If you need help, need to file a bug report or want to request a new feature, please head over to the [DREAM3DNX-Issues](https://github.com/BlueQuartzSoftware/DREAM3DNX-Issues/discussions) GitHub site where the community of DREAM3D-NX users can help answer your questions.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadZeissTxmFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadZeissTxmFile.cpp
@@ -1,0 +1,187 @@
+#include "ReadZeissTxmFile.hpp"
+
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/DataStructure/NeighborList.hpp"
+#include "simplnx/Utilities/Math/GeometryMath.hpp"
+
+#include "oless/oless.h"
+#include "oless/pole.h"
+
+using namespace nx::core;
+namespace fs = std::filesystem;
+
+namespace read_zeiss_txm
+{
+
+// -----------------------------------------------------------------------------
+Result<ZeissTxmHeaderMetadata> ReadHeaderMetaData(const std::string& inputFilePath)
+{
+  const StoragePtrType storage = std::make_shared<POLE::Storage>(inputFilePath.c_str());
+  storage->open();
+
+  if(storage->result() != POLE::Storage::Ok)
+  {
+    MakeErrorResult(-33504, fmt::format("Could not open '{}' for reading", inputFilePath));
+  }
+
+  std::string path = "/ImageInfo/ImageWidth";
+  const auto imageWidth = static_cast<size_t>(ReadValue<int32_t>(storage, path));
+
+  path = "/ImageInfo/ImageHeight";
+  const auto imageHeight = static_cast<size_t>(ReadValue<int32_t>(storage, path));
+
+  path = "/ImageInfo/PixelSize";
+  const auto pixelSize = ReadValue<float>(storage, path);
+
+  path = "/ImageInfo/DataType";
+  const auto dataType = static_cast<ZeissTxmDataType>(ReadValue<int32>(storage, path));
+
+  path = "/ImageInfo/NoOfImages";
+  const auto numImages = static_cast<size_t>(ReadValue<int32_t>(storage, path));
+
+  // int numImageGroups = std::ceil(static_cast<float>(NoOfImages) / 100.0f);
+  // fmt::print("Image Width: {}\n Image Height: {}\n PixelSize:{}\n DataType: {}\n NumImages: {}\n", imageWidth, imageHeight, pixelSize, to_underlying(dataType), numImages);
+  storage->close();
+
+  ZeissTxmHeaderMetadata metadata;
+  metadata.Dimensions = {imageWidth, imageHeight, numImages};
+  metadata.Spacing = {pixelSize, pixelSize, pixelSize};
+  metadata.DataFilePath = inputFilePath;
+  metadata.DataType = dataType;
+  return {metadata};
+}
+
+} // namespace read_zeiss_txm
+
+using namespace read_zeiss_txm;
+
+namespace
+{
+
+size_t ConvertDataTypeToByteCount(ZeissTxmDataType txmDataType)
+{
+  switch(txmDataType)
+  {
+  case ZeissTxmDataType::FLOAT_TYPE:
+    return 4;
+  case ZeissTxmDataType::INT16_TYPE:
+    return 2;
+  case ZeissTxmDataType::UCHAR_TYPE:
+    return 1;
+  }
+  return 0;
+}
+
+template <typename T>
+Result<> ReadImages(const ReadZeissTxmFileInputValues* inputValues, DataStructure& dataStructure, const ZeissTxmHeaderMetadata& metadata, const IFilter::MessageHandler& m_MessageHandler)
+{
+  using DataArrayType = DataArray<T>;
+
+  const DataPath dataArrayPath = inputValues->ImageGeometryPath.createChildPath(inputValues->CellAttributeMatrixName).createChildPath(inputValues->DensityArrayName);
+  auto& outputDataArray = dataStructure.getDataRefAs<DataArrayType>(dataArrayPath).getDataStoreRef();
+
+  StoragePtrType storage = std::make_shared<POLE::Storage>(inputValues->TxmDataFile.string().c_str());
+  storage->open();
+
+  if(storage->result() != POLE::Storage::Ok)
+  {
+    MakeErrorResult(-33504, fmt::format("Could not open '{}' for reading", inputValues->TxmDataFile.string()));
+  }
+
+  size_t totalPixels = metadata.Dimensions[0] * metadata.Dimensions[1];
+  usize elementsRead = totalPixels;
+  size_t totalBytes = totalPixels * ConvertDataTypeToByteCount(metadata.DataType);
+  size_t readBytes = 0;
+  std::vector<T> buffer(totalPixels);
+
+  usize elementCounter = 0;
+
+  int32 startSlice = 1;
+  int32 endSlice = metadata.Dimensions[2];
+  if(inputValues->UseSubVolume)
+  {
+    startSlice = inputValues->SubVolumeStartSlice;
+    endSlice = inputValues->SubVolumeEndSlice;
+  }
+
+  int32 imageGroupIndex = (startSlice - 1) / 100 + 1;
+
+  for(int32_t i = startSlice; i <= endSlice; i++)
+  {
+    std::stringstream pathStrm;
+    pathStrm << "/ImageData" << imageGroupIndex << "/Image" << i;
+    // m_MessageHandler({IFilter::Message::Type::Info, fmt::format("Constructing Image Path: {}", pathStrm.str())});
+
+    StreamPtrType stream = std::make_shared<POLE::Stream>(storage.get(), pathStrm.str());
+    if(!stream->fail())
+    {
+      m_MessageHandler({IFilter::Message::Type::Info, fmt::format("Reading Image: {}", pathStrm.str())});
+      readBytes = stream->read(reinterpret_cast<unsigned char*>(buffer.data()), totalBytes);
+      if(readBytes != totalBytes)
+      {
+        MakeErrorResult(-33510, fmt::format("Not enough bytes were read: {} vs {}", readBytes, totalBytes));
+      }
+      for(usize e = 0; e < elementsRead; e++)
+      {
+        outputDataArray[e + elementCounter] = buffer[e];
+      }
+
+      elementCounter += elementsRead;
+    }
+    else
+    {
+      return MakeErrorResult(-33511, fmt::format("Failed to read image from OLE Path '{}'", pathStrm.str()));
+    }
+    if(i % 100 == 0)
+    {
+      imageGroupIndex++;
+    }
+  }
+
+  storage->close();
+  return {};
+}
+
+} // namespace
+
+// -----------------------------------------------------------------------------
+ReadZeissTxmFile::ReadZeissTxmFile(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ReadZeissTxmFileInputValues* inputValues)
+: m_DataStructure(dataStructure)
+, m_InputValues(inputValues)
+, m_ShouldCancel(shouldCancel)
+, m_MessageHandler(mesgHandler)
+{
+}
+
+// -----------------------------------------------------------------------------
+ReadZeissTxmFile::~ReadZeissTxmFile() noexcept = default;
+
+// -----------------------------------------------------------------------------
+const std::atomic_bool& ReadZeissTxmFile::getCancel() const
+{
+  return m_ShouldCancel;
+}
+
+// -----------------------------------------------------------------------------
+Result<> ReadZeissTxmFile::operator()() const
+{
+
+  Result<ZeissTxmHeaderMetadata> metadataResult = ReadHeaderMetaData(m_InputValues->TxmDataFile.string());
+  if(metadataResult.invalid())
+  {
+    return ConvertResult(std::move(metadataResult));
+  }
+  ZeissTxmHeaderMetadata metaData = metadataResult.value();
+
+  switch(metaData.DataType)
+  {
+  case ZeissTxmDataType::FLOAT_TYPE:
+    return ReadImages<float32>(m_InputValues, m_DataStructure, metaData, m_MessageHandler);
+  case ZeissTxmDataType::INT16_TYPE:
+    return ReadImages<uint16>(m_InputValues, m_DataStructure, metaData, m_MessageHandler);
+  case ZeissTxmDataType::UCHAR_TYPE:
+    return ReadImages<uint8>(m_InputValues, m_DataStructure, metaData, m_MessageHandler);
+  default:;
+  }
+  return MakeErrorResult(-33520, fmt::format("Unsupported data type: {}", to_underlying(metaData.DataType)));
+}

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadZeissTxmFile.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadZeissTxmFile.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "SimplnxCore/SimplnxCore_export.hpp"
+
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/DataStructure/DataPath.hpp"
+#include "simplnx/DataStructure/DataStructure.hpp"
+#include "simplnx/Filter/Actions/CreateImageGeometryAction.hpp"
+#include "simplnx/Filter/IFilter.hpp"
+
+#include "oless/pole.h"
+
+#include <filesystem>
+namespace fs = std::filesystem;
+
+using namespace nx::core;
+
+namespace read_zeiss_txm
+{
+
+using StoragePtrType = std::shared_ptr<POLE::Storage>;
+using StreamPtrType = std::shared_ptr<POLE::Stream>;
+
+enum class ZeissTxmDataType : int32
+{
+  UCHAR_TYPE = 3,
+  INT16_TYPE = 5,
+  FLOAT_TYPE = 10,
+};
+
+struct SIMPLNXCORE_EXPORT ReadZeissTxmFileInputValues
+{
+  DataPath ImageGeometryPath;
+  std::string CellAttributeMatrixName;
+  std::string DensityArrayName;
+  std::filesystem::path TxmDataFile;
+  bool UseSubVolume;
+  usize SubVolumeStartSlice;
+  usize SubVolumeEndSlice;
+};
+
+/**
+ * @brief
+ */
+struct ZeissTxmHeaderMetadata
+{
+  CreateImageGeometryAction::DimensionType Dimensions = {0, 0, 0};
+  CreateImageGeometryAction::SpacingType Spacing = {0.0f, 0.0f, 0.0f};
+  CreateImageGeometryAction::OriginType Origin = {0.0f, 0.0f, 0.0f};
+  IGeometry::LengthUnit Units = IGeometry::LengthUnit::Micrometer;
+  std::string DataFilePath = {};
+  ZeissTxmDataType DataType = ZeissTxmDataType::FLOAT_TYPE;
+  void clear()
+  {
+    Dimensions = {0, 0, 0};
+    Spacing = {0.0f, 0.0f, 0.0f};
+    Origin = {0.0f, 0.0f, 0.0f};
+    Units = IGeometry::LengthUnit::Micrometer;
+    DataFilePath = {};
+    DataType = ZeissTxmDataType::FLOAT_TYPE;
+  }
+};
+
+/**
+ * @brief
+ */
+struct SIMPLNXCORE_EXPORT ReadZeissTxmFilterFileCache
+{
+  fs::path inputFile;
+  fs::file_time_type timeStamp;
+  ZeissTxmHeaderMetadata metaData;
+  void flush()
+  {
+    inputFile.clear();
+    metaData.clear();
+    timeStamp = fs::file_time_type();
+  }
+};
+
+/**
+ * @brief
+ * @tparam T
+ * @param storage
+ * @param path
+ * @return
+ */
+template <typename T>
+T ReadValue(const StoragePtrType& storage, const std::string& path)
+{
+  T value = 0;
+  if(const StreamPtrType stream = std::make_shared<POLE::Stream>(storage.get(), path); !stream->fail())
+  {
+    stream->read(reinterpret_cast<unsigned char*>(&value), sizeof(T));
+  }
+  return value;
+}
+
+/**
+ * @brief Reads selected meta-data from the .txm or .txrm file
+ * @param inputFilePath The file path to the input file
+ * @return
+ */
+Result<ZeissTxmHeaderMetadata> ReadHeaderMetaData(const std::string& inputFilePath);
+
+/**
+ * @class ReadZeissTxmFile
+ */
+class SIMPLNXCORE_EXPORT ReadZeissTxmFile
+{
+
+public:
+  ReadZeissTxmFile(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ReadZeissTxmFileInputValues* inputValues);
+  ~ReadZeissTxmFile() noexcept;
+
+  ReadZeissTxmFile(const ReadZeissTxmFile&) = delete;
+  ReadZeissTxmFile(ReadZeissTxmFile&&) noexcept = delete;
+  ReadZeissTxmFile& operator=(const ReadZeissTxmFile&) = delete;
+  ReadZeissTxmFile& operator=(ReadZeissTxmFile&&) noexcept = delete;
+
+  Result<> operator()() const;
+
+  const std::atomic_bool& getCancel() const;
+
+private:
+  DataStructure& m_DataStructure;
+  const ReadZeissTxmFileInputValues* m_InputValues = nullptr;
+  const std::atomic_bool& m_ShouldCancel;
+  const IFilter::MessageHandler& m_MessageHandler;
+};
+} // namespace read_zeiss_txm

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadZeissTxmFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadZeissTxmFileFilter.cpp
@@ -1,0 +1,217 @@
+#include "ReadZeissTxmFileFilter.hpp"
+
+#include "SimplnxCore/Filters/Algorithms/ReadZeissTxmFile.hpp"
+
+#include "simplnx/DataStructure/DataPath.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Filter/Actions/CreateArrayAction.hpp"
+#include "simplnx/Filter/Actions/CreateImageGeometryAction.hpp"
+#include "simplnx/Parameters/BoolParameter.hpp"
+#include "simplnx/Parameters/DataGroupCreationParameter.hpp"
+#include "simplnx/Parameters/DataObjectNameParameter.hpp"
+#include "simplnx/Parameters/FileSystemPathParameter.hpp"
+#include "simplnx/Parameters/NumberParameter.hpp"
+#include "simplnx/Utilities/GeometryHelpers.hpp"
+#include "simplnx/Utilities/SIMPLConversion.hpp"
+#include "simplnx/Utilities/StringUtilities.hpp"
+
+using namespace nx::core;
+using namespace read_zeiss_txm;
+
+namespace
+{
+std::atomic_int32_t s_InstanceId = 0;
+std::map<int32, ReadZeissTxmFilterFileCache> s_HeaderCache;
+} // namespace
+
+namespace nx::core
+{
+//------------------------------------------------------------------------------
+ReadZeissTxmFileFilter::ReadZeissTxmFileFilter()
+: m_InstanceId(s_InstanceId.fetch_add(1))
+{
+  s_HeaderCache[m_InstanceId] = {};
+}
+
+//------------------------------------------------------------------------------
+ReadZeissTxmFileFilter::~ReadZeissTxmFileFilter() noexcept
+{
+  s_HeaderCache.erase(m_InstanceId);
+}
+
+//------------------------------------------------------------------------------
+std::string ReadZeissTxmFileFilter::name() const
+{
+  return FilterTraits<ReadZeissTxmFileFilter>::name.str();
+}
+
+//------------------------------------------------------------------------------
+std::string ReadZeissTxmFileFilter::className() const
+{
+  return FilterTraits<ReadZeissTxmFileFilter>::className;
+}
+
+//------------------------------------------------------------------------------
+Uuid ReadZeissTxmFileFilter::uuid() const
+{
+  return FilterTraits<ReadZeissTxmFileFilter>::uuid;
+}
+
+//------------------------------------------------------------------------------
+std::string ReadZeissTxmFileFilter::humanName() const
+{
+  return "Read Zeiss TXM/TXRM Files";
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> ReadZeissTxmFileFilter::defaultTags() const
+{
+  return {"Read", "Import", "Zeiss", "CT", "xCT"};
+}
+
+//------------------------------------------------------------------------------
+Parameters ReadZeissTxmFileFilter::parameters() const
+{
+  Parameters params;
+
+  params.insertSeparator(Parameters::Separator{"Input Parameter(s)"});
+  params.insert(std::make_unique<FileSystemPathParameter>(k_TxmInputFilePath_Key, "Zeiss TXM/TXRM File", "The input Zeiss TXM/TXRM file", fs::path("input.txm"),
+                                                          FileSystemPathParameter::ExtensionsType{".txm", ".txrm"}, FileSystemPathParameter::PathType::InputFile));
+
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_Use_SubVolume_Key, "Use Z Sub-volume", "Only import a sub-set of the slices", false));
+  params.insert(std::make_unique<UInt32Parameter>(k_SubVolumeStartSlice_Key, "Slice Start", "The starting slice to import", 1));
+  params.insert(std::make_unique<UInt32Parameter>(k_SubVolumeEndSlice_Key, "Slice End (inclusive)", "The ending slice to import (inclusive)", 2));
+  params.linkParameters(k_Use_SubVolume_Key, k_SubVolumeStartSlice_Key, true);
+  params.linkParameters(k_Use_SubVolume_Key, k_SubVolumeEndSlice_Key, true);
+
+  params.insertSeparator(Parameters::Separator{"Output Geometry"});
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_CreatedImageGeometryPath_Key, "Image Geometry", "Path to create the Image Geometry", DataPath({"Zeiss CT"})));
+  params.insertSeparator(Parameters::Separator{"Output Cell Attribute Matrix"});
+  params.insert(std::make_unique<DataObjectNameParameter>(k_CellAttributeMatrixName_Key, "Cell Attribute Matrix", "The attribute matrix created as a child of the image geometry", "Cell Data"));
+  params.insertSeparator(Parameters::Separator{"Output Data Array"});
+  params.insert(std::make_unique<DataObjectNameParameter>(k_CTDataArrayName_Key, "CT Data", "The data array created as a child of the attribute matrix", "CT_Data"));
+
+  return params;
+}
+
+//------------------------------------------------------------------------------
+IFilter::UniquePointer ReadZeissTxmFileFilter::clone() const
+{
+  return std::make_unique<ReadZeissTxmFileFilter>();
+}
+
+//------------------------------------------------------------------------------
+IFilter::VersionType ReadZeissTxmFileFilter::parametersVersion() const
+{
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+IFilter::PreflightResult ReadZeissTxmFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
+                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+{
+  auto pInputFilePathValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_TxmInputFilePath_Key);
+  auto pNewImageGeometryPathValue = filterArgs.value<DataPath>(k_CreatedImageGeometryPath_Key);
+  auto pCellAttributeMatrixNameValue = filterArgs.value<std::string>(k_CellAttributeMatrixName_Key);
+  auto pDensityArrayNameValue = filterArgs.value<std::string>(k_CTDataArrayName_Key);
+
+  auto pUseSubVolume = filterArgs.value<bool>(k_Use_SubVolume_Key);
+  auto pSliceStart = filterArgs.value<uint32>(k_SubVolumeStartSlice_Key);
+  auto pSliceEnd = filterArgs.value<uint32>(k_SubVolumeEndSlice_Key);
+
+  nx::core::Result<OutputActions> resultOutputActions;
+  std::vector<PreflightValue> preflightUpdatedValues;
+
+  // Read from the file if the input file has changed or the input file's time stamp is out of date.
+  if(pInputFilePathValue != s_HeaderCache[m_InstanceId].inputFile || s_HeaderCache[m_InstanceId].timeStamp < fs::last_write_time(pInputFilePathValue))
+  {
+    Result<ZeissTxmHeaderMetadata> metadataResult = ReadHeaderMetaData(pInputFilePathValue.string());
+    if(metadataResult.invalid())
+    {
+      return {ConvertResultTo<OutputActions>(ConvertResult(std::move(metadataResult)), {})};
+    }
+
+    // Cache the results from algorithm run
+    ReadZeissTxmFilterFileCache inputFileCache = {};
+    inputFileCache.inputFile = pInputFilePathValue.string();
+    inputFileCache.timeStamp = fs::last_write_time(pInputFilePathValue.string());
+    inputFileCache.metaData = metadataResult.value();
+    s_HeaderCache[m_InstanceId] = inputFileCache;
+  }
+
+  ZeissTxmHeaderMetadata& metadata = s_HeaderCache[m_InstanceId].metaData;
+  preflightUpdatedValues.push_back({"Full Input Geometry", nx::core::GeometryHelpers::Description::GenerateGeometryInfo(metadata.Dimensions, metadata.Spacing, metadata.Origin, metadata.Units)});
+
+  // Sanity Check Sub-Volumes
+  if(pUseSubVolume && pSliceEnd < pSliceStart)
+  {
+    return {MakeErrorResult<OutputActions>(-33530, fmt::format("The start slice '{}' is greater than the slice end '{}'", pSliceStart, pSliceEnd)), preflightUpdatedValues};
+  }
+  if(pUseSubVolume && pSliceStart >= metadata.Dimensions[2])
+  {
+    return {MakeErrorResult<OutputActions>(-33531, fmt::format("The start slice '{}' is greater than the total number of slices", pSliceStart, metadata.Dimensions[2])), preflightUpdatedValues};
+  }
+  if(pUseSubVolume && pSliceEnd > metadata.Dimensions[2])
+  {
+    return {MakeErrorResult<OutputActions>(-33532, fmt::format("The end slice '{}' is greater than the total number of slices", pSliceEnd, metadata.Dimensions[2])), preflightUpdatedValues};
+  }
+  if(pUseSubVolume && pSliceStart < 1)
+  {
+    return {MakeErrorResult<OutputActions>(-33533, fmt::format("The start slice '{}' must be 0 or greater", pSliceStart)), preflightUpdatedValues};
+  }
+
+  CreateImageGeometryAction::DimensionType finalDimensions = metadata.Dimensions;
+  CreateImageGeometryAction::OriginType finalOrigin = metadata.Origin;
+  // If we are using a sub-volume, update the dimensions
+  if(pUseSubVolume)
+  {
+    finalDimensions[2] = pSliceEnd - pSliceStart + 1;
+    finalOrigin[2] = metadata.Spacing[2] * static_cast<float>(pSliceStart - 1);
+  }
+
+  auto createImageGeometryAction = std::make_unique<CreateImageGeometryAction>(pNewImageGeometryPathValue, finalDimensions, finalOrigin, metadata.Spacing, pCellAttributeMatrixNameValue);
+  resultOutputActions.value().appendAction(std::move(createImageGeometryAction));
+
+  // Create the input data array
+  const DataPath dap = pNewImageGeometryPathValue.createChildPath(pCellAttributeMatrixNameValue).createChildPath(pDensityArrayNameValue);
+  CreateImageGeometryAction::DimensionType revDimensions = {finalDimensions[2], finalDimensions[1], finalDimensions[0]};
+
+  if(metadata.DataType == ZeissTxmDataType::FLOAT_TYPE)
+  {
+    auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::float32, revDimensions, std::vector<usize>{1}, dap);
+    resultOutputActions.value().appendAction(std::move(createArrayAction));
+  }
+  if(metadata.DataType == ZeissTxmDataType::INT16_TYPE)
+  {
+    auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::uint16, revDimensions, std::vector<usize>{1}, dap);
+    resultOutputActions.value().appendAction(std::move(createArrayAction));
+  }
+  if(metadata.DataType == ZeissTxmDataType::UCHAR_TYPE)
+  {
+    auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::uint8, revDimensions, std::vector<usize>{1}, dap);
+    resultOutputActions.value().appendAction(std::move(createArrayAction));
+  }
+
+  preflightUpdatedValues.push_back({"Imported Geometry Info", nx::core::GeometryHelpers::Description::GenerateGeometryInfo(finalDimensions, metadata.Spacing, finalOrigin, metadata.Units)});
+
+  return {std::move(resultOutputActions), preflightUpdatedValues};
+}
+
+//------------------------------------------------------------------------------
+Result<> ReadZeissTxmFileFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                                             const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+{
+  ReadZeissTxmFileInputValues inputValues;
+
+  inputValues.ImageGeometryPath = filterArgs.value<DataPath>(k_CreatedImageGeometryPath_Key);
+  inputValues.CellAttributeMatrixName = filterArgs.value<std::string>(k_CellAttributeMatrixName_Key);
+  inputValues.DensityArrayName = filterArgs.value<std::string>(k_CTDataArrayName_Key);
+  inputValues.TxmDataFile = filterArgs.value<FileSystemPathParameter::ValueType>(k_TxmInputFilePath_Key);
+
+  inputValues.UseSubVolume = filterArgs.value<bool>(k_Use_SubVolume_Key);
+  inputValues.SubVolumeStartSlice = filterArgs.value<uint32>(k_SubVolumeStartSlice_Key);
+  inputValues.SubVolumeEndSlice = filterArgs.value<uint32>(k_SubVolumeEndSlice_Key);
+
+  return ReadZeissTxmFile(dataStructure, messageHandler, shouldCancel, &inputValues)();
+}
+} // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadZeissTxmFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadZeissTxmFileFilter.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "SimplnxCore/SimplnxCore_export.hpp"
+
+#include "simplnx/DataStructure/Geometry/IGeometry.hpp"
+#include "simplnx/Filter/FilterTraits.hpp"
+#include "simplnx/Filter/IFilter.hpp"
+
+namespace nx::core
+{
+/**
+ * @class ReadZeissTxmFileFilter
+ * @brief This filter will read a .txm or .txrm file that is generated from a Zeiss x-ray computed tomography machine
+ */
+class SIMPLNXCORE_EXPORT ReadZeissTxmFileFilter : public IFilter
+{
+public:
+  ReadZeissTxmFileFilter();
+  ~ReadZeissTxmFileFilter() noexcept override;
+
+  ReadZeissTxmFileFilter(const ReadZeissTxmFileFilter&) = delete;
+  ReadZeissTxmFileFilter(ReadZeissTxmFileFilter&&) noexcept = delete;
+
+  ReadZeissTxmFileFilter& operator=(const ReadZeissTxmFileFilter&) = delete;
+  ReadZeissTxmFileFilter& operator=(ReadZeissTxmFileFilter&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_TxmInputFilePath_Key = "input_file_path";
+  static inline constexpr StringLiteral k_CreatedImageGeometryPath_Key = "output_image_geometry_path";
+  static inline constexpr StringLiteral k_CellAttributeMatrixName_Key = "cell_attribute_matrix_name";
+  static inline constexpr StringLiteral k_CTDataArrayName_Key = "ct_data_array_name";
+  static inline constexpr StringLiteral k_Use_SubVolume_Key = "use_sub_volume";
+  static inline constexpr StringLiteral k_SubVolumeStartSlice_Key = "sub_volume_start_slice";
+  static inline constexpr StringLiteral k_SubVolumeEndSlice_Key = "sub_volume_end_slice";
+
+  /**
+   * @brief Returns the name of the filter.
+   * @return
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the C++ classname of this filter.
+   * @return
+   */
+  std::string className() const override;
+
+  /**
+   * @brief Returns the uuid of the filter.
+   * @return
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief Returns the human-readable name of the filter.
+   * @return
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
+   * @brief Returns the parameters of the filter (i.e. its inputs)
+   * @return
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief Returns parameters version integer.
+   * Initial version should always be 1.
+   * Should be incremented everytime the parameters change.
+   * @return VersionType
+   */
+  VersionType parametersVersion() const override;
+
+  /**
+   * @brief Returns a copy of the filter.
+   * @return
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
+
+  /**
+   * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
+   * On failure, there is no guarantee that the DataStructure is in a correct state.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
+
+private:
+  int32 m_InstanceId;
+};
+} // namespace nx::core
+
+SIMPLNX_DEF_FILTER_TRAITS(nx::core, ReadZeissTxmFileFilter, "7e3ffc15-51a3-182c-97c2-a82f7af325bf");

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/oless/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/oless/CMakeLists.txt
@@ -1,0 +1,94 @@
+cmake_minimum_required(VERSION 3.26)
+
+cmake_policy(SET CMP0074 NEW) # ``find_package()`` uses ``<PackageName>_ROOT`` variables.
+cmake_policy(SET CMP0077 NEW) # ``option()`` honors normal variables.
+cmake_policy(SET CMP0080 NEW) # ``BundleUtilities`` cannot be included at configure time.
+
+# The ``FindPythonInterp`` and ``FindPythonLibs`` modules are removed.
+# if(CMAKE_VERSION VERSION_GREATER "3.27.0")
+#   cmake_policy(SET CMP0148 NEW)
+# endif()
+
+# resolves symlinks before collapsing ../ components.
+if(CMAKE_VERSION VERSION_GREATER "3.28.0")
+  cmake_policy(SET CMP0152 NEW)
+endif()
+
+
+
+project(oless
+  VERSION 1.5.0
+  DESCRIPTION ""
+  HOMEPAGE_URL "https://github.com/DBHeise/oless/"
+  LANGUAGES CXX
+)
+
+
+set(SIMPLNX_BIN_DIR ${PROJECT_BINARY_DIR}/bin)
+
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${SIMPLNX_BIN_DIR} CACHE PATH "Single Directory for all Libraries")
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${SIMPLNX_BIN_DIR} CACHE PATH "Single Directory for all Executables.")
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${SIMPLNX_BIN_DIR} CACHE PATH "Single Directory for all static libraries.")
+
+list(APPEND CMAKE_MODULE_PATH ${simplnx_SOURCE_DIR}/cmake)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+
+
+set(OLESS_SRCS
+    ${oless_SOURCE_DIR}/oless/common.hpp
+    ${oless_SOURCE_DIR}/oless/oless.h
+    #${oless_SOURCE_DIR}/oless/olessoffice.h
+    ${oless_SOURCE_DIR}/oless/pole.h
+    #{oless_SOURCE_DIR}/oless/vbahelper.h
+)
+
+set(OLESS_HDRS
+    ${oless_SOURCE_DIR}/oless/pole.cpp
+    #${oless_SOURCE_DIR}/oless/olessoffice.cpp
+    ${oless_SOURCE_DIR}/oless/oless.cpp
+    #${oless_SOURCE_DIR}/oless/vbahelper.cpp
+
+
+)
+
+
+add_executable(oless ${OLESS_SRCS} ${OLESS_HDRS} ${oless_SOURCE_DIR}/oless/program.cpp)
+target_include_directories(oless PRIVATE ${oless_SOURCE_DIR})
+
+target_compile_features(oless
+                        PUBLIC
+                        cxx_std_17
+)
+
+set_target_properties(oless
+                      PROPERTIES
+                      DEBUG_POSTFIX "_d"
+)
+
+add_executable(txm_reader ${OLESS_SRCS} ${OLESS_HDRS} ${oless_SOURCE_DIR}/txm_reader.cpp)
+target_include_directories(txm_reader PRIVATE ${oless_SOURCE_DIR})
+
+target_compile_features(txm_reader
+                        PUBLIC
+                        cxx_std_17
+)
+
+set_target_properties(txm_reader
+                      PROPERTIES
+                      DEBUG_POSTFIX "_d"
+)
+
+
+
+
+

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/oless/OLESS_LICENSE
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/oless/OLESS_LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/oless/oless/oless.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/oless/oless/oless.cpp
@@ -1,0 +1,139 @@
+#include "oless.h"
+
+#include "oless/pole.h"
+
+#include <fstream>
+#include <iostream>
+#include <unordered_map>
+
+namespace OleStructuredStorage
+{
+POLE::Storage* OpenFile(char* file)
+{
+  POLE::Storage* storage = new POLE::Storage(file);
+  storage->open();
+  if(storage->result() != POLE::Storage::Ok)
+  {
+    storage->close();
+    std::cerr << "Unable to open OLESS file" << std::endl;
+    delete storage;
+  }
+  return storage;
+}
+
+void Oless::recurse(POLE::Storage* storage, const std::string path, void (Oless::*pCallback)(POLE::Storage*, std::string, std::string))
+{
+  std::list<std::string> entries;
+  entries = storage->entries(path);
+
+  std::list<std::string>::iterator it;
+  for(it = entries.begin(); it != entries.end(); ++it)
+  {
+    std::string name = *it;
+    std::string fullname = path + name;
+
+    (this->*pCallback)(storage, name, fullname);
+    if(storage->isDirectory(fullname))
+    {
+      this->recurse(storage, fullname + "/", pCallback);
+    }
+  }
+}
+
+void Oless::printStreamInfo(POLE::Storage* storage, std::string name, std::string fullname)
+{
+  if(!storage->isDirectory(fullname))
+  {
+    POLE::Stream* stream = new POLE::Stream(storage, fullname.c_str());
+    if(!stream->fail())
+    {
+      OleSummary* summary = new OleSummary();
+      summary->FullName = stream->fullName();
+      summary->Size = stream->size();
+      this->m_results.push_back((IExportable*)summary);
+    }
+  }
+}
+
+template <class T>
+std::vector<T*> convert(std::vector<IExportable*> vector)
+{
+  std::vector<T*> ans;
+  std::vector<IExportable*>::iterator it;
+  for(it = vector.begin(); it != vector.end(); ++it)
+  {
+    ans.push_back((T*)(*it));
+  }
+  return ans;
+}
+
+std::vector<OleSummary*> Oless::List()
+{
+  this->m_results.clear();
+  POLE::Storage* storage = new POLE::Storage(this->m_file);
+  storage->open();
+
+  if(storage->result() != POLE::Storage::Ok)
+  {
+    std::cerr << "Unable to open OLESS file" << std::endl;
+  }
+  else
+  {
+    this->recurse(storage, "/", &Oless::printStreamInfo);
+  }
+
+  storage->close();
+  delete storage;
+
+  return convert<OleSummary>(this->m_results);
+}
+
+void Oless::Dump(char* name, std::string outFile)
+{
+  POLE::Storage* storage = OpenFile(this->m_file);
+  if(storage)
+  {
+    POLE::Stream* stream = new POLE::Stream(storage, name);
+    if(stream && !stream->fail())
+    {
+      std::ofstream file;
+      file.open(outFile, std::ios::out | std::ios::binary);
+      unsigned char buffer[16];
+      for(;;)
+      {
+        POLE::uint64 read = stream->read(buffer, sizeof(buffer));
+        file.write((const char*)buffer, read);
+        if(read < sizeof(buffer))
+          break;
+      }
+      file.close();
+    }
+    else
+    {
+      std::cerr << "Unable to open stream" << std::endl;
+    }
+    storage->close();
+    delete storage;
+  }
+}
+
+bool Oless::IsOless()
+{
+  bool ans = true;
+  std::ifstream file;
+  file.open(this->m_file, std::ios::in | std::ios::binary);
+  unsigned char mustbe[] = {0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1};
+  char* buffer = new char[8];
+  file.read(buffer, 8);
+  for(int i = 0; i < 8; i++)
+  {
+    ans &= (((unsigned char)buffer[i]) == mustbe[i]);
+  }
+  return ans;
+};
+
+Oless::Oless(char* file)
+{
+  m_file = file;
+}
+} // namespace OleStructuredStorage

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/oless/oless/oless.h
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/oless/oless/oless.h
@@ -1,0 +1,34 @@
+#ifndef OLESS_H
+#define OLESS_H
+
+#include "oless/oless_common.hpp"
+#include "oless/pole.h"
+
+#include <list>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace OleStructuredStorage
+{
+
+class Oless
+{
+private:
+  char* m_file;
+  std::vector<IExportable*> m_results;
+
+  void printStreamInfo(POLE::Storage*, std::string, std::string);
+  void recurse(POLE::Storage*, const std::string, void (Oless::*)(POLE::Storage*, std::string, std::string));
+
+public:
+  Oless(){};
+  Oless(char*);
+
+  std::vector<OleSummary*> List();
+  void Dump(char*, std::string);
+  bool IsOless();
+};
+} // namespace OleStructuredStorage
+#endif

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/oless/oless/oless_common.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/oless/oless/oless_common.hpp
@@ -1,0 +1,309 @@
+#pragma once
+
+#include "oless/pole.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <iomanip>
+#include <list>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+class IExportable
+{
+public:
+  virtual std::string ToJson() = 0;
+  virtual std::string ToXml() = 0;
+  virtual std::string ToCsv() = 0;
+  virtual std::string ToText() = 0;
+};
+
+enum class OutputFormat : uint8_t
+{
+  TEXT,
+  JSON,
+  XML,
+  CSV
+};
+
+std::string const base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+class helper
+{
+
+public:
+  helper()
+  {
+  }
+  ~helper()
+  {
+  }
+
+  template <typename T>
+  static T* GetStructFromStream(POLE::Stream* stream)
+  {
+    size_t size = sizeof(T);
+    unsigned char* bytes = new unsigned char[size];
+
+    POLE::uint64 read = stream->read(bytes, size);
+    T* s = (T*)bytes;
+
+    return s;
+  }
+
+  template <class T>
+  static std::string vector_join(const std::vector<T>& v, const std::string& token, const bool useQuotes = false)
+  {
+    std::ostringstream result;
+    for(typename std::vector<T>::const_iterator i = v.begin(); i != v.end(); i++)
+    {
+      if(i != v.begin())
+        result << token;
+      if(useQuotes)
+        result << "\"" << *i << "\"";
+      else
+        result << *i;
+    }
+    return result.str();
+  }
+
+  static std::string JsonEscape(const std::string& source)
+  {
+    std::string result;
+    for(const char* c = source.c_str(); *c != 0; ++c)
+    {
+      switch(*c)
+      {
+      case '\"':
+        result += "\\\"";
+        break;
+      case '\\':
+        result += "\\\\";
+        break;
+      case '\b':
+        result += "\\b";
+        break;
+      case '\f':
+        result += "\\f";
+        break;
+      case '\n':
+        result += "\\n";
+        break;
+      case '\r':
+        result += "\\r";
+        break;
+      case '\t':
+        result += "\\t";
+        break;
+      default:
+        if(iscntrl(*c))
+        {
+          std::ostringstream oss;
+          oss << "\\u" << std::hex << std::uppercase << std::setfill('0') << std::setw(4) << static_cast<int>(*c);
+          result += oss.str();
+        }
+        else
+        {
+          result += *c;
+        }
+        break;
+      }
+    }
+    return result;
+  }
+
+  static unsigned short GetItem2Byte(const unsigned char* data, unsigned int index)
+  {
+    return (data[index + 1] << 8) | data[index + 0];
+  }
+
+  static unsigned int GetItem4Byte(const unsigned char* data, unsigned int index)
+  {
+    return (((unsigned long long)data[index + 3]) << 32) | (((unsigned int)data[index + 2]) << 16) | (((unsigned int)data[index + 1]) << 8) | data[index + 0];
+  }
+
+  static std::string GetItemString(const unsigned char* data, unsigned int index, unsigned int length)
+  {
+    std::string str((char*)&data[index], (size_t)length);
+    return str;
+  }
+
+  static std::wstring GetItemStringW(const unsigned char* data, unsigned int index, unsigned int length)
+  {
+    std::wstring str(reinterpret_cast<wchar_t*>(data[index]), (size_t)length / sizeof(wchar_t));
+    return str;
+  }
+
+  static inline bool is_base64(unsigned char c)
+  {
+    return (isalnum(c) || (c == '+') || (c == '/'));
+  }
+
+  static std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len)
+  {
+    std::string ret;
+    int i = 0;
+    int j = 0;
+    unsigned char char_array_3[3];
+    unsigned char char_array_4[4];
+
+    while(in_len--)
+    {
+      char_array_3[i++] = *(bytes_to_encode++);
+      if(i == 3)
+      {
+        char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
+        char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+        char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+        char_array_4[3] = char_array_3[2] & 0x3f;
+
+        for(i = 0; (i < 4); i++)
+          ret += base64_chars[char_array_4[i]];
+        i = 0;
+      }
+    }
+
+    if(i)
+    {
+      for(j = i; j < 3; j++)
+        char_array_3[j] = '\0';
+
+      char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
+      char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+      char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+      char_array_4[3] = char_array_3[2] & 0x3f;
+
+      for(j = 0; (j < i + 1); j++)
+        ret += base64_chars[char_array_4[j]];
+
+      while((i++ < 3))
+        ret += '=';
+    }
+
+    return ret;
+  }
+  static std::string base64_decode(std::string const& encoded_string)
+  {
+    size_t in_len = encoded_string.size();
+    size_t i = 0;
+    size_t j = 0;
+    int in_ = 0;
+    unsigned char char_array_4[4], char_array_3[3];
+    std::string ret;
+
+    while(in_len-- && (encoded_string[in_] != '=') && is_base64(encoded_string[in_]))
+    {
+      char_array_4[i++] = encoded_string[in_];
+      in_++;
+      if(i == 4)
+      {
+        for(i = 0; i < 4; i++)
+          char_array_4[i] = static_cast<unsigned char>(base64_chars.find(char_array_4[i]));
+
+        char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+        char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+        char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+        for(i = 0; (i < 3); i++)
+          ret += char_array_3[i];
+        i = 0;
+      }
+    }
+
+    if(i)
+    {
+      for(j = i; j < 4; j++)
+        char_array_4[j] = 0;
+
+      for(j = 0; j < 4; j++)
+        char_array_4[j] = static_cast<unsigned char>(base64_chars.find(char_array_4[j]));
+
+      char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+      char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+      char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+      for(j = 0; (j < i - 1); j++)
+        ret += char_array_3[j];
+    }
+
+    return ret;
+  }
+};
+
+class OleSummary : public IExportable
+{
+public:
+  std::string FullName;
+  unsigned long long Size;
+
+  virtual std::string ToJson()
+  {
+    std::ostringstream str;
+    str << "{ \"path\" : \"" << helper::JsonEscape(this->FullName) << "\", \"size\" : \"" << this->Size << "\"}";
+    return str.str();
+  }
+  virtual std::string ToXml()
+  {
+    std::ostringstream str;
+    str << "<item>";
+    str << "<path>" << this->FullName << "</path>";
+    str << "<size>" << this->Size << "</size>";
+    str << "</item>";
+    return str.str();
+  }
+  virtual std::string ToText()
+  {
+    std::ostringstream str;
+    str << this->FullName << "\t" << this->Size;
+    return str.str();
+  }
+  virtual std::string ToCsv()
+  {
+    std::ostringstream str;
+    str << this->FullName << "," << this->Size;
+    return str.str();
+  }
+};
+
+class ExtensionInfo : public IExportable
+{
+public:
+  std::string Extension;
+  unsigned short Version;
+  std::string VersionName;
+
+public:
+  virtual std::string ToJson()
+  {
+    std::ostringstream str;
+    str << "{ \"extension\" : \"" << this->Extension << "\", \"version\" : \"" << this->Version << "\", \"name\" : \"" << this->VersionName << "\"}";
+    return str.str();
+  }
+  virtual std::string ToXml()
+  {
+    std::ostringstream str;
+    str << "<item>";
+    str << "<extension>" << this->Extension << "</extension>";
+    str << "<version>" << this->Version << "</version>";
+    str << "<name>" << this->VersionName << "</name>";
+    str << "</item>";
+    return str.str();
+  }
+  virtual std::string ToText()
+  {
+    std::ostringstream str;
+    str << this->Extension << "\t" << this->Version << "\t" << this->VersionName;
+    return str.str();
+  }
+  virtual std::string ToCsv()
+  {
+    std::ostringstream str;
+    str << this->Extension << "," << this->Version << "," << this->VersionName;
+    return str.str();
+  }
+};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/oless/oless/pole.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/oless/oless/pole.cpp
@@ -1,0 +1,2483 @@
+/* POLE - Portable C++ library to access OLE Storage
+   Copyright (C) 2002-2005 Ariya Hidayat <ariya@kde.org>
+
+   Performance optimization: Dmitry Fedorov
+   Copyright 2009 <www.bioimage.ucsb.edu> <www.dimin.net>
+
+   Fix for more than 236 mbat block entries : Michel Boudinot
+   Copyright 2010 <Michel.Boudinot@inaf.cnrs-gif.fr>
+
+   Considerable rework to allow for creation and updating of structured storage : Stephen Baum
+   Copyright 2013 <srbaum@gmail.com>
+
+   Added GetAllStreams, reworked datatypes
+   Copyright 2013 Felix Gorny from Bitplane
+
+   More datatype changes to allow for 32 and 64 bit code, some fixes involving incremental updates, flushing
+   Copyright 2013 <srbaum@gmail.com>
+
+   Version: 0.5.2
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+   * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   * Neither the name of the authors nor the names of its contributors may be
+     used to endorse or promote products derived from this software without
+     specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+   THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "oless/pole.h"
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <list>
+#include <queue>
+#include <string>
+#include <vector>
+
+#ifdef POLE_USE_UTF16_FILENAMES
+#include <codecvt>
+#endif // POLE_USE_UTF16_FILENAMES
+
+// enable to activate debugging output
+// #define POLE_DEBUG
+#define CACHEBUFSIZE 4096 // a presumably reasonable size for the read cache
+
+namespace POLE
+{
+
+class Header
+{
+public:
+  unsigned char id[8]; // signature, or magic identifier
+  uint64 b_shift;      // bbat->blockSize = 1 << b_shift
+  uint64 s_shift;      // sbat->blockSize = 1 << s_shift
+  uint64 num_bat;      // blocks allocated for big bat
+  uint64 dirent_start; // starting block for directory info
+  uint64 threshold;    // switch from small to big file (usually 4K)
+  uint64 sbat_start;   // starting block index to store small bat
+  uint64 num_sbat;     // blocks allocated for small bat
+  uint64 mbat_start;   // starting block to store meta bat
+  uint64 num_mbat;     // blocks allocated for meta bat
+  uint64 bb_blocks[109];
+  bool dirty; // Needs to be written
+
+  Header();
+  bool valid();
+  void load(const unsigned char* buffer);
+  void save(unsigned char* buffer);
+  void debug();
+};
+
+class AllocTable
+{
+public:
+  static const uint64 Eof;
+  static const uint64 Avail;
+  static const uint64 Bat;
+  static const uint64 MetaBat;
+  uint64 blockSize;
+  AllocTable();
+  void clear();
+  uint64 count();
+  uint64 unusedCount();
+  void resize(uint64 newsize);
+  void preserve(uint64 n);
+  void set(uint64 index, uint64 val);
+  unsigned unused();
+  void setChain(std::vector<uint64>);
+  std::vector<uint64> follow(uint64 start);
+  uint64 operator[](uint64 index);
+  void load(const unsigned char* buffer, uint64 len);
+  void save(unsigned char* buffer);
+  uint64 size();
+  void debug();
+  bool isDirty();
+  void markAsDirty(uint64 dataIndex, int64 bigBlockSize);
+  void flush(std::vector<uint64> blocks, StorageIO* const io, int64 bigBlockSize);
+
+private:
+  std::vector<uint64> data;
+  std::vector<uint64> dirtyBlocks;
+  bool bMaybeFragmented;
+  AllocTable(const AllocTable&);
+  AllocTable& operator=(const AllocTable&);
+};
+
+class DirEntry
+{
+public:
+  DirEntry()
+  : valid()
+  , name()
+  , dir()
+  , size()
+  , start()
+  , prev()
+  , next()
+  , child()
+  {
+  }
+  bool valid;       // false if invalid (should be skipped)
+  std::string name; // the name, not in unicode anymore
+  bool dir;         // true if directory
+  uint64 size;      // size (not valid if directory)
+  uint64 start;     // starting block
+  uint64 prev;      // previous sibling
+  uint64 next;      // next sibling
+  uint64 child;     // first child
+  int compare(const DirEntry& de);
+  int compare(const std::string& name2);
+};
+
+class DirTree
+{
+public:
+  static const uint64 End;
+  DirTree(int64 bigBlockSize);
+  void clear(int64 bigBlockSize);
+  inline uint64 entryCount();
+  uint64 unusedEntryCount();
+  DirEntry* entry(uint64 index);
+  DirEntry* entry(const std::string& name, bool create = false, int64 bigBlockSize = 0, StorageIO* const io = 0, int64 streamSize = 0);
+  int64 indexOf(DirEntry* e);
+  int64 parent(uint64 index);
+  std::string fullName(uint64 index);
+  std::vector<uint64> children(uint64 index);
+  uint64 find_child(uint64 index, const std::string& name, uint64& closest);
+  void load(unsigned char* buffer, uint64 len);
+  void save(unsigned char* buffer);
+  uint64 size();
+  void debug();
+  bool isDirty();
+  void markAsDirty(uint64 dataIndex, int64 bigBlockSize);
+  void flush(std::vector<uint64> blocks, StorageIO* const io, int64 bigBlockSize, uint64 sb_start, uint64 sb_size);
+  uint64 unused();
+  void findParentAndSib(uint64 inIdx, const std::string& inFullName, uint64& parentIdx, uint64& sibIdx);
+  uint64 findSib(uint64 inIdx, uint64 sibIdx);
+  void deleteEntry(DirEntry* entry, const std::string& inFullName, int64 bigBlockSize);
+
+private:
+  std::vector<DirEntry> entries;
+  std::vector<uint64> dirtyBlocks;
+  DirTree(const DirTree&);
+  DirTree& operator=(const DirTree&);
+};
+
+class StorageIO
+{
+public:
+  Storage* storage;     // owner
+  std::string filename; // filename
+  std::fstream file;    // associated with above name
+  int64 result;         // result of operation
+  bool opened;          // true if file is opened
+  uint64 filesize;      // size of the file
+  bool writeable;       // true if the file can be modified
+
+  Header* header;   // storage header
+  DirTree* dirtree; // directory tree
+  AllocTable* bbat; // allocation table for big blocks
+  AllocTable* sbat; // allocation table for small blocks
+
+  std::vector<uint64> sb_blocks;   // blocks for "small" files
+  std::vector<uint64> mbat_blocks; // blocks for doubly indirect indices to big blocks
+  std::vector<uint64> mbat_data;   // the additional indices to big blocks
+  bool mbatDirty;                  // If true, mbat_blocks need to be written
+
+  std::list<Stream*> streams;
+
+  StorageIO(Storage* storage, const char* filename);
+  ~StorageIO();
+
+  bool open(bool bWriteAccess = false, bool bCreate = false);
+  void close();
+  void flush();
+  void load(bool bWriteAccess);
+  void create();
+  void init();
+  bool deleteByName(const std::string& fullName);
+
+  bool deleteNode(DirEntry* entry, const std::string& fullName);
+
+  bool deleteLeaf(DirEntry* entry, const std::string& fullName);
+
+  uint64 loadBigBlocks(std::vector<uint64> blocks, unsigned char* buffer, uint64 maxlen);
+
+  uint64 loadBigBlock(uint64 block, unsigned char* buffer, uint64 maxlen);
+
+  uint64 saveBigBlocks(std::vector<uint64> blocks, uint64 offset, unsigned char* buffer, uint64 len);
+
+  uint64 saveBigBlock(uint64 block, uint64 offset, unsigned char* buffer, uint64 len);
+
+  uint64 loadSmallBlocks(std::vector<uint64> blocks, unsigned char* buffer, uint64 maxlen);
+
+  uint64 loadSmallBlock(uint64 block, unsigned char* buffer, uint64 maxlen);
+
+  uint64 saveSmallBlocks(std::vector<uint64> blocks, uint64 offset, unsigned char* buffer, uint64 len, int64 startAtBlock = 0);
+
+  uint64 saveSmallBlock(uint64 block, uint64 offset, unsigned char* buffer, uint64 len);
+
+  StreamIO* streamIO(const std::string& name, bool bCreate = false, int64 streamSize = 0);
+
+  void flushbbat();
+
+  void flushsbat();
+
+  std::vector<uint64> getbbatBlocks(bool bLoading);
+
+  uint64 ExtendFile(std::vector<uint64>* chain);
+
+  void addbbatBlock();
+
+private:
+  // no copy or assign
+  StorageIO(const StorageIO&);
+  StorageIO& operator=(const StorageIO&);
+};
+
+class StreamIO
+{
+public:
+  StorageIO* io;
+  int64 entryIdx; // needed because a pointer to DirEntry will change whenever entries vector changes.
+  std::string fullName;
+  bool eof;
+  bool fail;
+
+  StreamIO(StorageIO* io, DirEntry* entry);
+  ~StreamIO();
+  uint64 size();
+  void setSize(uint64 newSize);
+  void seek(uint64 pos);
+  uint64 tell();
+  int64 getch();
+  uint64 read(unsigned char* data, uint64 maxlen);
+  uint64 read(uint64 pos, unsigned char* data, uint64 maxlen);
+  uint64 write(unsigned char* data, uint64 len);
+  uint64 write(uint64 pos, unsigned char* data, uint64 len);
+  void flush();
+
+private:
+  std::vector<uint64> blocks;
+
+  // no copy or assign
+  StreamIO(const StreamIO&);
+  StreamIO& operator=(const StreamIO&);
+
+  // pointer for read
+  uint64 m_pos;
+
+  // simple cache system to speed-up getch()
+  unsigned char* cache_data;
+  uint64 cache_size;
+  uint64 cache_pos;
+  void updateCache();
+};
+
+}; // namespace POLE
+
+using namespace POLE;
+
+#ifdef POLE_USE_UTF16_FILENAMES
+
+std::string POLE::UTF16toUTF8(const std::wstring& utf16)
+{
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> converter;
+  return converter.to_bytes(utf16);
+}
+
+std::wstring POLE::UTF8toUTF16(const std::string& utf8)
+{
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> converter;
+  return converter.from_bytes(utf8);
+}
+
+#endif // POLE_USE_UTF16_FILENAMES
+
+static void fileCheck(std::fstream& file)
+{
+  bool bFail, bEof, bBad;
+
+  bool bGood = file.good();
+  bFail = file.fail();
+  bEof = file.eof();
+  bBad = file.bad();
+  if(bFail || bEof || bBad)
+  {
+    bool bNOTOK = true;
+  } // this doesn't really do anything, but it is a good place to set a breakpoint!
+  file.clear();
+}
+
+static inline uint32 readU16(const unsigned char* ptr)
+{
+  return ptr[0] + (ptr[1] << 8);
+}
+
+static inline uint32 readU32(const unsigned char* ptr)
+{
+  return ptr[0] + (ptr[1] << 8) + (ptr[2] << 16) + (ptr[3] << 24);
+}
+
+static inline void writeU16(unsigned char* ptr, uint32 data)
+{
+  ptr[0] = (unsigned char)(data & 0xff);
+  ptr[1] = (unsigned char)((data >> 8) & 0xff);
+}
+
+static inline void writeU32(unsigned char* ptr, uint32 data)
+{
+  ptr[0] = (unsigned char)(data & 0xff);
+  ptr[1] = (unsigned char)((data >> 8) & 0xff);
+  ptr[2] = (unsigned char)((data >> 16) & 0xff);
+  ptr[3] = (unsigned char)((data >> 24) & 0xff);
+}
+
+static const unsigned char pole_magic[] = {0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1};
+
+// =========== Header ==========
+
+Header::Header()
+: b_shift(9)
+, // [1EH,02] size of sectors in power-of-two; typically 9 indicating 512-byte sectors
+s_shift(6)
+, // [20H,02] size of mini-sectors in power-of-two; typically 6 indicating 64-byte mini-sectors
+num_bat(0)
+, // [2CH,04] number of SECTs in the FAT chain
+dirent_start(0)
+, // [30H,04] first SECT in the directory chain
+threshold(4096)
+, // [38H,04] maximum size for a mini stream; typically 4096 bytes
+sbat_start(0)
+, // [3CH,04] first SECT in the MiniFAT chain
+num_sbat(0)
+, // [40H,04] number of SECTs in the MiniFAT chain
+mbat_start(AllocTable::Eof)
+, // [44H,04] first SECT in the DIFAT chain
+num_mbat(0)
+, // [48H,04] number of SECTs in the DIFAT chain
+dirty(true)
+
+{
+  for(unsigned int i = 0; i < 8; i++)
+    id[i] = pole_magic[i];
+  for(unsigned int i = 0; i < 109; i++)
+    bb_blocks[i] = AllocTable::Avail;
+}
+
+bool Header::valid()
+{
+  if(threshold != 4096)
+    return false;
+  if(num_bat == 0)
+    return false;
+  // if( (num_bat > 109) && (num_bat > (num_mbat * 127) + 109)) return false; // dima: incorrect check, number may be arbitrary larger
+  if((num_bat < 109) && (num_mbat != 0))
+    return false;
+  if(s_shift > b_shift)
+    return false;
+  if(b_shift <= 6)
+    return false;
+  if(b_shift >= 31)
+    return false;
+
+  return true;
+}
+
+void Header::load(const unsigned char* buffer)
+{
+  b_shift = readU16(buffer + 0x1e);      // [1EH,02] size of sectors in power-of-two; typically 9 indicating 512-byte sectors and 12 for 4096
+  s_shift = readU16(buffer + 0x20);      // [20H,02] size of mini-sectors in power-of-two; typically 6 indicating 64-byte mini-sectors
+  num_bat = readU32(buffer + 0x2c);      // [2CH,04] number of SECTs in the FAT chain
+  dirent_start = readU32(buffer + 0x30); // [30H,04] first SECT in the directory chain
+  threshold = readU32(buffer + 0x38);    // [38H,04] maximum size for a mini stream; typically 4096 bytes
+  sbat_start = readU32(buffer + 0x3c);   // [3CH,04] first SECT in the MiniFAT chain
+  num_sbat = readU32(buffer + 0x40);     // [40H,04] number of SECTs in the MiniFAT chain
+  mbat_start = readU32(buffer + 0x44);   // [44H,04] first SECT in the DIFAT chain
+  num_mbat = readU32(buffer + 0x48);     // [48H,04] number of SECTs in the DIFAT chain
+
+  for(unsigned int i = 0; i < 8; i++)
+    id[i] = buffer[i];
+
+  // [4CH,436] the SECTs of first 109 FAT sectors
+  for(unsigned int i = 0; i < 109; i++)
+    bb_blocks[i] = readU32(buffer + 0x4C + i * 4);
+  dirty = false;
+}
+
+void Header::save(unsigned char* buffer)
+{
+  memset(buffer, 0, 0x4c);
+  memcpy(buffer, pole_magic, 8); // ole signature
+  writeU32(buffer + 8, 0);       // unknown
+  writeU32(buffer + 12, 0);      // unknown
+  writeU32(buffer + 16, 0);      // unknown
+  writeU16(buffer + 24, 0x003e); // revision ?
+  writeU16(buffer + 26, 3);      // version ?
+  writeU16(buffer + 28, 0xfffe); // unknown
+  writeU16(buffer + 0x1e, (uint32)b_shift);
+  writeU16(buffer + 0x20, (uint32)s_shift);
+  writeU32(buffer + 0x2c, (uint32)num_bat);
+  writeU32(buffer + 0x30, (uint32)dirent_start);
+  writeU32(buffer + 0x38, (uint32)threshold);
+  writeU32(buffer + 0x3c, (uint32)sbat_start);
+  writeU32(buffer + 0x40, (uint32)num_sbat);
+  writeU32(buffer + 0x44, (uint32)mbat_start);
+  writeU32(buffer + 0x48, (uint32)num_mbat);
+
+  for(unsigned int i = 0; i < 109; i++)
+    writeU32(buffer + 0x4C + i * 4, (uint32)bb_blocks[i]);
+  dirty = false;
+}
+
+void Header::debug()
+{
+  std::cout << std::endl;
+  std::cout << "b_shift " << b_shift << std::endl;
+  std::cout << "s_shift " << s_shift << std::endl;
+  std::cout << "num_bat " << num_bat << std::endl;
+  std::cout << "dirent_start " << dirent_start << std::endl;
+  std::cout << "threshold " << threshold << std::endl;
+  std::cout << "sbat_start " << sbat_start << std::endl;
+  std::cout << "num_sbat " << num_sbat << std::endl;
+  std::cout << "mbat_start " << mbat_start << std::endl;
+  std::cout << "num_mbat " << num_mbat << std::endl;
+
+  uint64 s = (num_bat <= 109) ? num_bat : 109;
+  std::cout << "bat blocks: ";
+  for(uint64 i = 0; i < s; i++)
+    std::cout << bb_blocks[i] << " ";
+  std::cout << std::endl;
+}
+
+// =========== AllocTable ==========
+
+const uint64 AllocTable::Avail = 0xffffffff;
+const uint64 AllocTable::Eof = 0xfffffffe;
+const uint64 AllocTable::Bat = 0xfffffffd;
+const uint64 AllocTable::MetaBat = 0xfffffffc;
+
+AllocTable::AllocTable()
+: blockSize(4096)
+, data()
+, dirtyBlocks()
+, bMaybeFragmented(true)
+{
+  // initial size
+  resize(128);
+}
+
+uint64 AllocTable::count()
+{
+  return static_cast<uint64>(data.size());
+}
+
+uint64 AllocTable::unusedCount()
+{
+  uint64 maxIdx = count();
+  uint64 nFound = 0;
+  for(uint64 idx = 0; idx < maxIdx; idx++)
+  {
+    if(data[idx] == Avail)
+      nFound++;
+  }
+  return nFound;
+}
+
+void AllocTable::resize(uint64 newsize)
+{
+  uint64 oldsize = static_cast<uint64>(data.size());
+  data.resize(newsize);
+  if(newsize > oldsize)
+    for(uint64 i = oldsize; i < newsize; i++)
+      data[i] = Avail;
+}
+
+// make sure there're still free blocks
+void AllocTable::preserve(uint64 n)
+{
+  std::vector<uint64> pre;
+  for(unsigned i = 0; i < n; i++)
+    pre.push_back(unused());
+}
+
+uint64 AllocTable::operator[](uint64 index)
+{
+  uint64 result;
+  result = data[index];
+  return result;
+}
+
+void AllocTable::set(uint64 index, uint64 value)
+{
+  if(index >= count())
+    resize(index + 1);
+  data[index] = value;
+  if(value == Avail)
+    bMaybeFragmented = true;
+}
+
+void AllocTable::setChain(std::vector<uint64> chain)
+{
+  if(chain.size())
+  {
+    for(unsigned i = 0; i < chain.size() - 1; i++)
+      set(chain[i], chain[i + 1]);
+    set(chain[chain.size() - 1], AllocTable::Eof);
+  }
+}
+
+// follow
+std::vector<uint64> AllocTable::follow(uint64 start)
+{
+  std::vector<uint64> chain;
+
+  if(start >= count())
+    return chain;
+
+  uint64 p = start;
+  while(p < count())
+  {
+    if(p == (uint64)Eof)
+      break;
+    if(p == (uint64)Bat)
+      break;
+    if(p == (uint64)MetaBat)
+      break;
+    if(p >= count())
+      break;
+    chain.push_back(p);
+    if(data[p] >= count())
+      break;
+    p = data[p];
+  }
+
+  return chain;
+}
+
+unsigned AllocTable::unused()
+{
+  // find first available block
+  unsigned int maxIdx = (unsigned int)data.size();
+  if(bMaybeFragmented)
+  {
+    for(unsigned i = 0; i < maxIdx; i++)
+      if(data[i] == Avail)
+        return i;
+  }
+
+  // completely full, so enlarge the table
+  unsigned int block = maxIdx;
+  resize(maxIdx);
+  bMaybeFragmented = false;
+  return block;
+}
+
+void AllocTable::load(const unsigned char* buffer, uint64 len)
+{
+  resize(len / 4);
+  for(unsigned i = 0; i < count(); i++)
+    set(i, readU32(buffer + i * 4));
+}
+
+// return space required to save this dirtree
+uint64 AllocTable::size()
+{
+  return count() * 4;
+}
+
+void AllocTable::save(unsigned char* buffer)
+{
+  for(uint64 i = 0; i < count(); i++)
+    writeU32(buffer + i * 4, (uint32)data[i]);
+}
+
+bool AllocTable::isDirty()
+{
+  return (dirtyBlocks.size() > 0);
+}
+
+void AllocTable::markAsDirty(uint64 dataIndex, int64 bigBlockSize)
+{
+  uint64 dbidx = dataIndex / (bigBlockSize / sizeof(uint32));
+  for(uint64 idx = 0; idx < static_cast<uint64>(dirtyBlocks.size()); idx++)
+  {
+    if(dirtyBlocks[idx] == dbidx)
+      return;
+  }
+  dirtyBlocks.push_back(dbidx);
+}
+
+void AllocTable::flush(std::vector<uint64> blocks, StorageIO* const io, int64 bigBlockSize)
+{
+  unsigned char* buffer = new unsigned char[bigBlockSize * blocks.size()];
+  save(buffer);
+  for(uint64 idx = 0; idx < static_cast<uint64>(blocks.size()); idx++)
+  {
+    bool bDirty = false;
+    for(uint64 idx2 = 0; idx2 < static_cast<uint64>(dirtyBlocks.size()); idx2++)
+    {
+      if(dirtyBlocks[idx2] == idx)
+      {
+        bDirty = true;
+        break;
+      }
+    }
+    if(bDirty)
+      io->saveBigBlock(blocks[idx], 0, &buffer[bigBlockSize * idx], bigBlockSize);
+  }
+  dirtyBlocks.clear();
+  delete[] buffer;
+}
+
+void AllocTable::debug()
+{
+  std::cout << "block size " << data.size() << std::endl;
+  for(unsigned i = 0; i < data.size(); i++)
+  {
+    if(data[i] == Avail)
+      continue;
+    std::cout << i << ": ";
+    if(data[i] == Eof)
+      std::cout << "[eof]";
+    else if(data[i] == Bat)
+      std::cout << "[bat]";
+    else if(data[i] == MetaBat)
+      std::cout << "[metabat]";
+    else
+      std::cout << data[i];
+    std::cout << std::endl;
+  }
+}
+
+// =========== DirEntry ==========
+// "A node with a shorter name is less than a node with a inter name"
+// "For nodes with the same length names, compare the two names."
+// --Windows Compound Binary File Format Specification, Section 2.5
+int DirEntry::compare(const DirEntry& de)
+{
+  return compare(de.name);
+}
+
+int DirEntry::compare(const std::string& name2)
+{
+  if(name.length() < name2.length())
+    return -1;
+  else if(name.length() > name2.length())
+    return 1;
+  else
+    return name.compare(name2);
+}
+
+// =========== DirTree ==========
+
+const uint64 DirTree::End = 0xffffffff;
+
+DirTree::DirTree(int64 bigBlockSize)
+: entries()
+, dirtyBlocks()
+{
+  clear(bigBlockSize);
+}
+
+void DirTree::clear(int64 bigBlockSize)
+{
+  // leave only root entry
+  entries.resize(1);
+  entries[0].valid = true;
+  entries[0].name = "Root Entry";
+  entries[0].dir = true;
+  entries[0].size = 0;
+  entries[0].start = End;
+  entries[0].prev = End;
+  entries[0].next = End;
+  entries[0].child = End;
+  markAsDirty(0, bigBlockSize);
+}
+
+inline uint64 DirTree::entryCount()
+{
+  return entries.size();
+}
+
+uint64 DirTree::unusedEntryCount()
+{
+  uint64 nFound = 0;
+  for(uint64 idx = 0; idx < entryCount(); idx++)
+  {
+    if(!entries[idx].valid)
+      nFound++;
+  }
+  return nFound;
+}
+
+DirEntry* DirTree::entry(uint64 index)
+{
+  if(index >= entryCount())
+    return (DirEntry*)0;
+  return &entries[index];
+}
+
+int64 DirTree::indexOf(DirEntry* e)
+{
+  for(uint64 i = 0; i < entryCount(); i++)
+    if(entry(i) == e)
+      return i;
+
+  return -1;
+}
+
+int64 DirTree::parent(uint64 index)
+{
+  // brute-force, basically we iterate for each entries, find its children
+  // and check if one of the children is 'index'
+  for(uint64 j = 0; j < entryCount(); j++)
+  {
+    std::vector<uint64> chi = children(j);
+    for(unsigned i = 0; i < chi.size(); i++)
+      if(chi[i] == index)
+        return j;
+  }
+
+  return -1;
+}
+
+std::string DirTree::fullName(uint64 index)
+{
+  // don't use root name ("Root Entry"), just give "/"
+  if(index == 0)
+    return "/";
+
+  std::string result = entry(index)->name;
+  result.insert(0, "/");
+  uint64 p = parent(index);
+  DirEntry* _entry = 0;
+  while(p > 0)
+  {
+    _entry = entry(p);
+    if(_entry->dir && _entry->valid)
+    {
+      result.insert(0, _entry->name);
+      result.insert(0, "/");
+    }
+    --p;
+    index = p;
+    if(index <= 0)
+      break;
+  }
+  return result;
+}
+
+// given a fullname (e.g "/ObjectPool/_1020961869"), find the entry
+// if not found and create is false, return 0
+// if create is true, a new entry is returned
+DirEntry* DirTree::entry(const std::string& name, bool create, int64 bigBlockSize, StorageIO* const io, int64 streamSize)
+{
+  if(!name.length())
+    return (DirEntry*)0;
+
+  // quick check for "/" (that's root)
+  if(name == "/")
+    return entry(0);
+
+  // split the names, e.g  "/ObjectPool/_1020961869" will become:
+  // "ObjectPool" and "_1020961869"
+  std::list<std::string> names;
+  std::string::size_type start = 0, end = 0;
+  if(name[0] == '/')
+    start++;
+  int levelsLeft = 0;
+  while(start < name.length())
+  {
+    end = name.find_first_of('/', start);
+    if(end == std::string::npos)
+      end = name.length();
+    names.push_back(name.substr(start, end - start));
+    levelsLeft++;
+    start = end + 1;
+  }
+
+  // start from root
+  int64 index = 0;
+
+  // trace one by one
+  std::list<std::string>::iterator it;
+
+  for(it = names.begin(); it != names.end(); ++it)
+  {
+    // find among the children of index
+    levelsLeft--;
+    uint64 child = 0;
+
+    /*
+    // dima: this block is really inefficient
+    std::vector<unsigned> chi = children( index );
+    for( unsigned i = 0; i < chi.size(); i++ )
+    {
+      DirEntry* ce = entry( chi[i] );
+      if( ce )
+      if( ce->valid && ( ce->name.length()>1 ) )
+      if( ce->name == *it ) {
+            child = chi[i];
+            break;
+      }
+    }
+    */
+    // dima: performance optimisation of the previous
+    uint64 closest = End;
+    child = find_child(index, *it, closest);
+
+    // traverse to the child
+    if(child > 0)
+      index = child;
+    else
+    {
+      // not found among children
+      if(!create || !io->writeable)
+        return (DirEntry*)0;
+
+      // create a new entry
+      uint64 parent2 = index;
+      index = unused();
+      DirEntry* e = entry(index);
+      e->valid = true;
+      e->name = *it;
+      e->dir = (levelsLeft > 0);
+      if(!e->dir)
+        e->size = streamSize;
+      else
+        e->size = 0;
+      e->start = AllocTable::Eof;
+      e->child = End;
+      if(closest == End)
+      {
+        e->prev = End;
+        e->next = entry(parent2)->child;
+        entry(parent2)->child = index;
+        markAsDirty(parent2, bigBlockSize);
+      }
+      else
+      {
+        DirEntry* closeE = entry(closest);
+        if(closeE->compare(*e) < 0)
+        {
+          e->prev = closeE->next;
+          e->next = End;
+          closeE->next = index;
+        }
+        else
+        {
+          e->next = closeE->prev;
+          e->prev = End;
+          closeE->prev = index;
+        }
+        markAsDirty(closest, bigBlockSize);
+      }
+      markAsDirty(index, bigBlockSize);
+      uint64 bbidx = index / (bigBlockSize / 128);
+      std::vector<uint64> blocks = io->bbat->follow(io->header->dirent_start);
+      while(blocks.size() <= bbidx)
+      {
+        uint64 nblock = io->bbat->unused();
+        if(blocks.size() > 0)
+        {
+          io->bbat->set(blocks[static_cast<uint64>(blocks.size()) - 1], nblock);
+          io->bbat->markAsDirty(blocks[static_cast<uint64>(blocks.size()) - 1], bigBlockSize);
+        }
+        io->bbat->set(nblock, AllocTable::Eof);
+        io->bbat->markAsDirty(nblock, bigBlockSize);
+        blocks.push_back(nblock);
+        uint64 bbidx_temp = nblock / (io->bbat->blockSize / sizeof(uint64));
+        while(bbidx_temp >= io->header->num_bat)
+          io->addbbatBlock();
+      }
+    }
+  }
+
+  return entry(index);
+}
+
+// helper function: recursively find siblings of index
+void dirtree_find_siblings(DirTree* dirtree, std::vector<uint64>& result, uint64 index)
+{
+  DirEntry* e = dirtree->entry(index);
+  if(!e)
+    return;
+  if(e->prev != DirTree::End)
+    dirtree_find_siblings(dirtree, result, e->prev);
+  result.push_back(index);
+  if(e->next != DirTree::End)
+    dirtree_find_siblings(dirtree, result, e->next);
+}
+
+std::vector<uint64> DirTree::children(uint64 index)
+{
+  std::vector<uint64> result;
+
+  DirEntry* e = entry(index);
+  if(e)
+    if(e->valid && e->child < entryCount())
+      dirtree_find_siblings(this, result, e->child);
+
+  return result;
+}
+
+uint64 dirtree_find_sibling(DirTree* dirtree, uint64 index, const std::string& name, uint64& closest)
+{
+
+  uint64 count = dirtree->entryCount();
+  DirEntry* e = dirtree->entry(index);
+  if(!e || !e->valid)
+    return 0;
+  int cval = e->compare(name);
+  if(cval == 0)
+    return index;
+  if(cval > 0)
+  {
+    if(e->prev > 0 && e->prev < count)
+      return dirtree_find_sibling(dirtree, e->prev, name, closest);
+  }
+  else
+  {
+    if(e->next > 0 && e->next < count)
+      return dirtree_find_sibling(dirtree, e->next, name, closest);
+  }
+  closest = index;
+  return 0;
+}
+
+uint64 DirTree::find_child(uint64 index, const std::string& name, uint64& closest)
+{
+
+  uint64 count = entryCount();
+  DirEntry* p = entry(index);
+  if(p && p->valid && p->child < count)
+    return dirtree_find_sibling(this, p->child, name, closest);
+
+  return 0;
+}
+
+void DirTree::load(unsigned char* buffer, uint64 size)
+{
+  entries.clear();
+
+  for(uint64 i = 0; i < size / 128; i++)
+  {
+    uint64 p = i * 128;
+
+    // would be < 32 if first char in the name isn't printable
+    // unsigned prefix = 32;
+
+    // parse name of this entry, which stored as Unicode 16-bit
+    std::string name;
+    int name_len = readU16(buffer + 0x40 + p);
+    if(name_len > 64)
+      name_len = 64;
+    for(int j = 0; (buffer[j + p]) && (j < name_len); j += 2)
+      name.append(1, buffer[j + p]);
+
+    // first char isn't printable ? remove it...
+    if(buffer[p] < 32)
+    {
+      // prefix = buffer[0];
+      name.erase(0, 1);
+    }
+
+    // 2 = file (aka stream), 1 = directory (aka storage), 5 = root
+    unsigned type = buffer[0x42 + p];
+
+    DirEntry e;
+    e.valid = (type != 0);
+    e.name = name;
+    e.start = readU32(buffer + 0x74 + p);
+    e.size = readU32(buffer + 0x78 + p);
+    e.prev = readU32(buffer + 0x44 + p);
+    e.next = readU32(buffer + 0x48 + p);
+    e.child = readU32(buffer + 0x4C + p);
+    e.dir = (type != 2);
+
+    // sanity checks
+    if((type != 2) && (type != 1) && (type != 5))
+      e.valid = false;
+    if(name_len < 1)
+      e.valid = false;
+
+    entries.push_back(e);
+  }
+}
+
+// return space required to save this dirtree
+uint64 DirTree::size()
+{
+  return entryCount() * 128;
+}
+
+void DirTree::save(unsigned char* buffer)
+{
+  memset(buffer, 0, size());
+
+  // root is fixed as "Root Entry"
+  DirEntry* root = entry(0);
+  std::string name_root = "Root Entry";
+  for(unsigned int j = 0; j < name_root.length(); j++)
+  {
+    buffer[j * 2] = name_root[j];
+  }
+  writeU16(buffer + 0x40, static_cast<uint32>(name_root.length() * 2 + 2));
+  writeU32(buffer + 0x74, 0xffffffff);
+  writeU32(buffer + 0x78, 0);
+  writeU32(buffer + 0x44, 0xffffffff);
+  writeU32(buffer + 0x48, 0xffffffff);
+  writeU32(buffer + 0x4c, (uint32)root->child);
+  buffer[0x42] = 5;
+  // buffer[ 0x43 ] = 1;
+
+  for(unsigned int i = 1; i < entryCount(); i++)
+  {
+    DirEntry* e = entry(i);
+    if(!e)
+      continue;
+    if(e->dir)
+    {
+      e->start = 0xffffffff;
+      e->size = 0;
+    }
+
+    // max length for name is 32 chars
+    std::string name = e->name;
+    if(name.length() > 32)
+    {
+      name.erase(32, name.length());
+    }
+
+    // write name as Unicode 16-bit
+    for(unsigned j = 0; j < name.length(); j++)
+      buffer[i * 128 + j * 2] = name[j];
+
+    writeU16(buffer + i * 128 + 0x40, static_cast<uint32>(name.length() * 2 + 2));
+    writeU32(buffer + i * 128 + 0x74, (uint32)e->start);
+    writeU32(buffer + i * 128 + 0x78, (uint32)e->size);
+    writeU32(buffer + i * 128 + 0x44, (uint32)e->prev);
+    writeU32(buffer + i * 128 + 0x48, (uint32)e->next);
+    writeU32(buffer + i * 128 + 0x4c, (uint32)e->child);
+    if(!e->valid)
+      buffer[i * 128 + 0x42] = 0; // STGTY_INVALID
+    else
+      buffer[i * 128 + 0x42] = e->dir ? 1 : 2; // STGTY_STREAM or STGTY_STORAGE
+    buffer[i * 128 + 0x43] = 1;                // always black
+  }
+}
+
+bool DirTree::isDirty()
+{
+  return (dirtyBlocks.size() > 0);
+}
+
+void DirTree::markAsDirty(uint64 dataIndex, int64 bigBlockSize)
+{
+  uint64 dbidx = dataIndex / (bigBlockSize / 128);
+  for(uint64 idx = 0; idx < static_cast<uint64>(dirtyBlocks.size()); idx++)
+  {
+    if(dirtyBlocks[idx] == dbidx)
+      return;
+  }
+  dirtyBlocks.push_back(dbidx);
+}
+
+void DirTree::flush(std::vector<uint64> blocks, StorageIO* const io, int64 bigBlockSize, uint64 sb_start, uint64 sb_size)
+{
+  uint64 bufLen = size();
+  unsigned char* buffer = new unsigned char[bufLen];
+  save(buffer);
+  writeU32(buffer + 0x74, (uint32)sb_start);
+  writeU32(buffer + 0x78, (uint32)sb_size);
+  for(uint64 idx = 0; idx < static_cast<uint64>(blocks.size()); idx++)
+  {
+    bool bDirty = false;
+    for(uint64 idx2 = 0; idx2 < static_cast<uint64>(dirtyBlocks.size()); idx2++)
+    {
+      if(dirtyBlocks[idx2] == idx)
+      {
+        bDirty = true;
+        break;
+      }
+    }
+    uint64 bytesToWrite = bigBlockSize;
+    uint64 pos = bigBlockSize * idx;
+    if((bufLen - pos) < bytesToWrite)
+      bytesToWrite = bufLen - pos;
+    if(bDirty)
+      io->saveBigBlock(blocks[idx], 0, &buffer[pos], bytesToWrite);
+  }
+  dirtyBlocks.clear();
+  delete[] buffer;
+}
+
+uint64 DirTree::unused()
+{
+  for(uint64 idx = 0; idx < static_cast<uint64>(entryCount()); idx++)
+  {
+    if(!entries[idx].valid)
+      return idx;
+  }
+  entries.push_back(DirEntry());
+  return entryCount() - 1;
+}
+
+// Utility function to get the index of the parent dirEntry, given that we already have a full name it is relatively fast.
+// Then look for a sibling dirEntry that points to inIdx. In some circumstances, the dirEntry at inIdx will be the direct child
+// of the parent, in which case sibIdx will be returned as 0. A failure is indicated if both parentIdx and sibIdx are returned as 0.
+
+void DirTree::findParentAndSib(uint64 inIdx, const std::string& inFullName, uint64& parentIdx, uint64& sibIdx)
+{
+  sibIdx = 0;
+  parentIdx = 0;
+  if(inIdx == 0 || inIdx >= entryCount() || inFullName == "/" || inFullName == "")
+    return;
+  std::string localName = inFullName;
+  if(localName[0] != '/')
+    localName = '/' + localName;
+  std::string parentName = localName;
+  if(parentName[parentName.size() - 1] == '/')
+    parentName = parentName.substr(0, parentName.size() - 1);
+  std::string::size_type lastSlash;
+  lastSlash = parentName.find_last_of('/');
+  if(lastSlash == std::string::npos)
+    return;
+  if(lastSlash == 0)
+    lastSlash = 1; // leave root
+  parentName = parentName.substr(0, lastSlash);
+  DirEntry* parent2 = entry(parentName);
+  parentIdx = indexOf(parent2);
+  if(parent2->child == inIdx)
+    return; // successful return, no sibling points to inIdx
+  sibIdx = findSib(inIdx, parent2->child);
+}
+
+// Utility function to get the index of the sibling dirEntry which points to inIdx. It is the responsibility of the original caller
+// to start with the root sibling - i.e., sibIdx should be pointed to by the parent node's child.
+
+uint64 DirTree::findSib(uint64 inIdx, uint64 sibIdx)
+{
+  DirEntry* sib = entry(sibIdx);
+  if(!sib || !sib->valid)
+    return 0;
+  if(sib->next == inIdx || sib->prev == inIdx)
+    return sibIdx;
+  DirEntry* targetSib = entry(inIdx);
+  int cval = sib->compare(*targetSib);
+  if(cval > 0)
+    return findSib(inIdx, sib->prev);
+  else
+    return findSib(inIdx, sib->next);
+}
+
+void DirTree::deleteEntry(DirEntry* dirToDel, const std::string& inFullName, int64 bigBlockSize)
+{
+  uint64 parentIdx;
+  uint64 sibIdx;
+  uint64 inIdx = indexOf(dirToDel);
+  uint64 nEntries = entryCount();
+  findParentAndSib(inIdx, inFullName, parentIdx, sibIdx);
+  uint64 replIdx;
+  if(!dirToDel->next || dirToDel->next > nEntries)
+    replIdx = dirToDel->prev;
+  else
+  {
+    DirEntry* sibNext = entry(dirToDel->next);
+    if(!sibNext->prev || sibNext->prev > nEntries)
+    {
+      replIdx = dirToDel->next;
+      sibNext->prev = dirToDel->prev;
+      markAsDirty(replIdx, bigBlockSize);
+    }
+    else
+    {
+      DirEntry* smlSib = sibNext;
+      int64 smlIdx = dirToDel->next;
+      DirEntry* smlrSib;
+      int64 smlrIdx = -1;
+      for(;;)
+      {
+        smlrIdx = smlSib->prev;
+        smlrSib = entry(smlrIdx);
+        if(!smlrSib->prev || smlrSib->prev > nEntries)
+          break;
+        smlSib = smlrSib;
+        smlIdx = smlrIdx;
+      }
+      replIdx = smlSib->prev;
+      smlSib->prev = smlrSib->next;
+      smlrSib->prev = dirToDel->prev;
+      smlrSib->next = dirToDel->next;
+      markAsDirty(smlIdx, bigBlockSize);
+      markAsDirty(smlrIdx, bigBlockSize);
+    }
+  }
+  if(sibIdx)
+  {
+    DirEntry* sib = entry(sibIdx);
+    if(sib->next == inIdx)
+      sib->next = replIdx;
+    else
+      sib->prev = replIdx;
+    markAsDirty(sibIdx, bigBlockSize);
+  }
+  else
+  {
+    DirEntry* parNode = entry(parentIdx);
+    parNode->child = replIdx;
+    markAsDirty(parentIdx, bigBlockSize);
+  }
+  dirToDel->valid = false; // indicating that this entry is not in use
+  markAsDirty(inIdx, bigBlockSize);
+}
+
+void DirTree::debug()
+{
+  for(unsigned i = 0; i < entryCount(); i++)
+  {
+    DirEntry* e = entry(i);
+    if(!e)
+      continue;
+    std::cout << i << ": ";
+    if(!e->valid)
+      std::cout << "INVALID ";
+    std::cout << e->name << " ";
+    if(e->dir)
+      std::cout << "(Dir) ";
+    else
+      std::cout << "(File) ";
+    std::cout << e->size << " ";
+    std::cout << "s:" << e->start << " ";
+    std::cout << "(";
+    if(e->child == End)
+      std::cout << "-";
+    else
+      std::cout << e->child;
+    std::cout << " ";
+    if(e->prev == End)
+      std::cout << "-";
+    else
+      std::cout << e->prev;
+    std::cout << ":";
+    if(e->next == End)
+      std::cout << "-";
+    else
+      std::cout << e->next;
+    std::cout << ")";
+    std::cout << std::endl;
+  }
+}
+
+// =========== StorageIO ==========
+
+StorageIO::StorageIO(Storage* st, const char* fname)
+: storage(st)
+, filename(fname)
+, file()
+, result(Storage::Ok)
+, opened(false)
+, filesize(0)
+, writeable(false)
+, header(new Header())
+, dirtree(new DirTree(1 << header->b_shift))
+, bbat(new AllocTable())
+, sbat(new AllocTable())
+, sb_blocks()
+, mbat_blocks()
+, mbat_data()
+, mbatDirty()
+, streams()
+{
+  bbat->blockSize = (uint64)1 << header->b_shift;
+  sbat->blockSize = (uint64)1 << header->s_shift;
+}
+
+StorageIO::~StorageIO()
+{
+  if(opened)
+    close();
+  delete sbat;
+  delete bbat;
+  delete dirtree;
+  delete header;
+}
+
+bool StorageIO::open(bool bWriteAccess, bool bCreate)
+{
+  // already opened ? close first
+  if(opened)
+    close();
+  if(bCreate)
+  {
+    create();
+    init();
+    writeable = true;
+  }
+  else
+  {
+    writeable = bWriteAccess;
+    load(bWriteAccess);
+  }
+
+  return result == Storage::Ok;
+}
+
+void StorageIO::load(bool bWriteAccess)
+{
+  unsigned char* buffer = 0;
+  uint64 buflen = 0;
+  std::vector<uint64> blocks;
+
+  // open the file, check for error
+  result = Storage::OpenFailed;
+
+#if defined(POLE_USE_UTF16_FILENAMES)
+  if(bWriteAccess)
+    file.open(UTF8toUTF16(filename).c_str(), std::ios::binary | std::ios::in | std::ios::out);
+  else
+    file.open(UTF8toUTF16(filename).c_str(), std::ios::binary | std::ios::in);
+#else
+  if(bWriteAccess)
+    file.open(filename.c_str(), std::ios::binary | std::ios::in | std::ios::out);
+  else
+    file.open(filename.c_str(), std::ios::binary | std::ios::in);
+#endif // defined(POLE_USE_UTF16_FILENAMES) && defined(POLE_WIN)
+
+  if(!file.good())
+    return;
+
+  // find size of input file
+  file.seekg(0, std::ios::end);
+  filesize = static_cast<uint64>(file.tellg());
+
+  // load header
+  buffer = new unsigned char[512];
+  file.seekg(0);
+  file.read((char*)buffer, 512);
+  fileCheck(file);
+  header->load(buffer);
+  delete[] buffer;
+
+  // check OLE magic id
+  result = Storage::NotOLE;
+  for(unsigned i = 0; i < 8; i++)
+    if(header->id[i] != pole_magic[i])
+      return;
+
+  // sanity checks
+  result = Storage::BadOLE;
+  if(!header->valid())
+    return;
+  if(header->threshold != 4096)
+    return;
+
+  // important block size
+  bbat->blockSize = (uint64)1 << header->b_shift;
+  sbat->blockSize = (uint64)1 << header->s_shift;
+
+  blocks = getbbatBlocks(true);
+
+  // load big bat
+  buflen = static_cast<uint64>(blocks.size()) * bbat->blockSize;
+  if(buflen > 0)
+  {
+    buffer = new unsigned char[buflen];
+    loadBigBlocks(blocks, buffer, buflen);
+    bbat->load(buffer, buflen);
+    delete[] buffer;
+  }
+
+  // load small bat
+  blocks.clear();
+  blocks = bbat->follow(header->sbat_start);
+  buflen = static_cast<uint64>(blocks.size()) * bbat->blockSize;
+  if(buflen > 0)
+  {
+    buffer = new unsigned char[buflen];
+    loadBigBlocks(blocks, buffer, buflen);
+    sbat->load(buffer, buflen);
+    delete[] buffer;
+  }
+
+  // load directory tree
+  blocks.clear();
+  blocks = bbat->follow(header->dirent_start);
+  buflen = static_cast<uint64>(blocks.size()) * bbat->blockSize;
+  buffer = new unsigned char[buflen];
+  loadBigBlocks(blocks, buffer, buflen);
+  dirtree->load(buffer, buflen);
+  unsigned sb_start = readU32(buffer + 0x74);
+  delete[] buffer;
+
+  // fetch block chain as data for small-files
+  sb_blocks = bbat->follow(sb_start); // small files
+
+  // for troubleshooting, just enable this block
+#if 0
+  header->debug();
+  sbat->debug();
+  bbat->debug();
+  dirtree->debug();
+#endif
+
+  // so far so good
+  result = Storage::Ok;
+  opened = true;
+}
+
+void StorageIO::create()
+{
+  // std::cout << "Creating " << filename << std::endl;
+
+#if defined(POLE_USE_UTF16_FILENAMES)
+  file.open(UTF8toUTF16(filename).c_str(), std::ios::binary | std::ios::in | std::ios::out | std::ios::trunc);
+#else
+  file.open(filename.c_str(), std::ios::binary | std::ios::in | std::ios::out | std::ios::trunc);
+#endif
+  if(!file.good())
+  {
+    std::cerr << "Can't create " << filename << std::endl;
+    result = Storage::OpenFailed;
+    return;
+  }
+
+  // so far so good
+  opened = true;
+  result = Storage::Ok;
+}
+
+void StorageIO::init()
+{
+  // Initialize parts of the header, directory entries, and big and small allocation tables
+  header->bb_blocks[0] = 0;
+  header->dirent_start = 1;
+  header->sbat_start = 2;
+  header->num_bat = 1;
+  header->num_sbat = 1;
+  header->dirty = true;
+  bbat->set(0, AllocTable::Eof);
+  bbat->markAsDirty(0, bbat->blockSize);
+  bbat->set(1, AllocTable::Eof);
+  bbat->markAsDirty(1, bbat->blockSize);
+  bbat->set(2, AllocTable::Eof);
+  bbat->markAsDirty(2, bbat->blockSize);
+  bbat->set(3, AllocTable::Eof);
+  bbat->markAsDirty(3, bbat->blockSize);
+  sb_blocks = bbat->follow(3);
+  mbatDirty = false;
+}
+
+void StorageIO::flush()
+{
+  if(header->dirty)
+  {
+    unsigned char* buffer = new unsigned char[512];
+    header->save(buffer);
+    file.seekp(0);
+    file.write((char*)buffer, 512);
+    fileCheck(file);
+    delete[] buffer;
+  }
+  if(bbat->isDirty())
+    flushbbat();
+  if(sbat->isDirty())
+    flushsbat();
+  if(dirtree->isDirty())
+  {
+    std::vector<uint64> blocks;
+    blocks = bbat->follow(header->dirent_start);
+    uint64 sb_start = 0xffffffff;
+    if(sb_blocks.size() > 0)
+      sb_start = sb_blocks[0];
+    dirtree->flush(blocks, this, bbat->blockSize, sb_start, static_cast<uint64>(sb_blocks.size()) * bbat->blockSize);
+  }
+  if(mbatDirty && mbat_blocks.size() > 0)
+  {
+    uint64 nBytes = bbat->blockSize * static_cast<uint64>(mbat_blocks.size());
+    unsigned char* buffer = new unsigned char[nBytes];
+    uint64 sIdx = 0;
+    uint64 dcount = 0;
+    uint64 blockCapacity = bbat->blockSize / sizeof(uint64) - 1;
+    uint64 blockIdx = 0;
+    for(unsigned mdIdx = 0; mdIdx < mbat_data.size(); mdIdx++)
+    {
+      writeU32(buffer + sIdx, (uint32)mbat_data[mdIdx]);
+      sIdx += 4;
+      dcount++;
+      if(dcount == blockCapacity)
+      {
+        blockIdx++;
+        if(blockIdx == mbat_blocks.size())
+          writeU32(buffer + sIdx, AllocTable::Eof);
+        else
+          writeU32(buffer + sIdx, (uint32)mbat_blocks[blockIdx]);
+        sIdx += 4;
+        dcount = 0;
+      }
+    }
+    saveBigBlocks(mbat_blocks, 0, buffer, nBytes);
+    delete[] buffer;
+    mbatDirty = false;
+  }
+  file.flush();
+  fileCheck(file);
+
+  /* Note on Microsoft implementation:
+     - directory entries are stored in the last block(s)
+     - BATs are as second to the last
+     - Meta BATs are third to the last
+  */
+}
+
+void StorageIO::close()
+{
+  if(!opened)
+    return;
+
+  file.close();
+  opened = false;
+
+  std::list<Stream*>::iterator it;
+  for(it = streams.begin(); it != streams.end(); ++it)
+    delete *it;
+}
+
+StreamIO* StorageIO::streamIO(const std::string& name, bool bCreate, int64 streamSize)
+{
+  // sanity check
+  if(!name.length())
+    return (StreamIO*)0;
+
+  // search in the entries
+  DirEntry* entry = dirtree->entry(name, bCreate, bbat->blockSize, this, streamSize);
+  // if( entry) std::cout << "FOUND\n";
+  if(!entry)
+    return (StreamIO*)0;
+  // if( !entry->dir ) std::cout << "  NOT DIR\n";
+  if(entry->dir)
+    return (StreamIO*)0;
+
+  StreamIO* result2 = new StreamIO(this, entry);
+  result2->fullName = name;
+
+  return result2;
+}
+
+bool StorageIO::deleteByName(const std::string& fullName)
+{
+  if(!fullName.length())
+    return false;
+  if(!writeable)
+    return false;
+  DirEntry* entry = dirtree->entry(fullName);
+  if(!entry)
+    return false;
+  bool retVal;
+  if(entry->dir)
+    retVal = deleteNode(entry, fullName);
+  else
+    retVal = deleteLeaf(entry, fullName);
+  if(retVal)
+    flush();
+  return retVal;
+}
+
+bool StorageIO::deleteNode(DirEntry* entry, const std::string& fullName)
+{
+  std::string lclName = fullName;
+  if(lclName[lclName.size() - 1] != '/')
+    lclName += '/';
+  bool retVal = true;
+  while(entry->child && entry->child < dirtree->entryCount())
+  {
+    DirEntry* childEnt = dirtree->entry(entry->child);
+    std::string childFullName = lclName + childEnt->name;
+    if(childEnt->dir)
+      retVal = deleteNode(childEnt, childFullName);
+    else
+      retVal = deleteLeaf(childEnt, childFullName);
+    if(!retVal)
+      return false;
+  }
+  dirtree->deleteEntry(entry, fullName, bbat->blockSize);
+  return retVal;
+}
+
+bool StorageIO::deleteLeaf(DirEntry* entry, const std::string& fullName)
+{
+  std::vector<uint64> blocks;
+  if(entry->size >= header->threshold)
+  {
+    blocks = bbat->follow(entry->start);
+    for(unsigned idx = 0; idx < blocks.size(); idx++)
+    {
+      bbat->set(blocks[idx], AllocTable::Avail);
+      bbat->markAsDirty(idx, bbat->blockSize);
+    }
+  }
+  else
+  {
+    blocks = sbat->follow(entry->start);
+    for(unsigned idx = 0; idx < blocks.size(); idx++)
+    {
+      sbat->set(blocks[idx], AllocTable::Avail);
+      sbat->markAsDirty(idx, bbat->blockSize);
+    }
+  }
+  dirtree->deleteEntry(entry, fullName, bbat->blockSize);
+  return true;
+}
+
+uint64 StorageIO::loadBigBlocks(std::vector<uint64> blocks, unsigned char* data, uint64 maxlen)
+{
+  // sentinel
+  if(!data)
+    return 0;
+  fileCheck(file);
+  if(!file.good())
+    return 0;
+  if(blocks.size() < 1)
+    return 0;
+  if(maxlen == 0)
+    return 0;
+
+  // read block one by one, seems fast enough
+  uint64 bytes = 0;
+  for(unsigned int i = 0; (i < blocks.size()) & (bytes < maxlen); i++)
+  {
+    uint64 block = blocks[i];
+    uint64 pos = bbat->blockSize * (block + 1);
+    uint64 p = (bbat->blockSize < maxlen - bytes) ? bbat->blockSize : maxlen - bytes;
+    if(pos + p > filesize)
+      p = filesize - pos;
+    file.seekg(pos);
+    file.read((char*)data + bytes, p);
+    fileCheck(file);
+    // should use gcount to see how many bytes were really returned - eof check...
+    bytes += p;
+  }
+
+  return bytes;
+}
+
+uint64 StorageIO::loadBigBlock(uint64 block, unsigned char* data, uint64 maxlen)
+{
+  // sentinel
+  if(!data)
+    return 0;
+  fileCheck(file);
+  if(!file.good())
+    return 0;
+
+  // wraps call for loadBigBlocks
+  std::vector<uint64> blocks;
+  blocks.resize(1);
+  blocks[0] = block;
+
+  return loadBigBlocks(blocks, data, maxlen);
+}
+
+uint64 StorageIO::saveBigBlocks(std::vector<uint64> blocks, uint64 offset, unsigned char* data, uint64 len)
+{
+  // sentinel
+  if(!data)
+    return 0;
+  fileCheck(file);
+  if(!file.good())
+    return 0;
+  if(blocks.size() < 1)
+    return 0;
+  if(len == 0)
+    return 0;
+
+  // write block one by one, seems fast enough
+  uint64 bytes = 0;
+  for(unsigned int i = 0; (i < blocks.size()) & (bytes < len); i++)
+  {
+    uint64 block = blocks[i];
+    uint64 pos = (bbat->blockSize * (block + 1)) + offset;
+    uint64 maxWrite = bbat->blockSize - offset;
+    uint64 tobeWritten = len - bytes;
+    if(tobeWritten > maxWrite)
+      tobeWritten = maxWrite;
+    file.seekp(pos);
+    file.write((char*)data + bytes, tobeWritten);
+    fileCheck(file);
+
+    bytes += tobeWritten;
+    offset = 0;
+    if(filesize < pos + tobeWritten)
+      filesize = pos + tobeWritten;
+  }
+
+  return bytes;
+}
+
+uint64 StorageIO::saveBigBlock(uint64 block, uint64 offset, unsigned char* data, uint64 len)
+{
+  if(!data)
+    return 0;
+  fileCheck(file);
+  if(!file.good())
+    return 0;
+  // wrap call for saveBigBlocks
+  std::vector<uint64> blocks;
+  blocks.resize(1);
+  blocks[0] = block;
+  return saveBigBlocks(blocks, offset, data, len);
+}
+
+// return number of bytes which has been read
+uint64 StorageIO::loadSmallBlocks(std::vector<uint64> blocks, unsigned char* data, uint64 maxlen)
+{
+  // sentinel
+  if(!data)
+    return 0;
+  fileCheck(file);
+  if(!file.good())
+    return 0;
+  if(blocks.size() < 1)
+    return 0;
+  if(maxlen == 0)
+    return 0;
+
+  // our own local buffer
+  unsigned char* buf = new unsigned char[bbat->blockSize];
+
+  // read small block one by one
+  uint64 bytes = 0;
+  for(unsigned int i = 0; (i < blocks.size()) & (bytes < maxlen); i++)
+  {
+    uint64 block = blocks[i];
+
+    // find where the small-block exactly is
+    uint64 pos = block * sbat->blockSize;
+    uint64 bbindex = pos / bbat->blockSize;
+    if(bbindex >= sb_blocks.size())
+      break;
+
+    loadBigBlock(sb_blocks[bbindex], buf, bbat->blockSize);
+
+    // copy the data
+    uint64 offset = pos % bbat->blockSize;
+    uint64 p = (maxlen - bytes < bbat->blockSize - offset) ? maxlen - bytes : bbat->blockSize - offset;
+    p = (sbat->blockSize < p) ? sbat->blockSize : p;
+    memcpy(data + bytes, buf + offset, p);
+    bytes += p;
+  }
+
+  delete[] buf;
+
+  return bytes;
+}
+
+uint64 StorageIO::loadSmallBlock(uint64 block, unsigned char* data, uint64 maxlen)
+{
+  // sentinel
+  if(!data)
+    return 0;
+  fileCheck(file);
+  if(!file.good())
+    return 0;
+
+  // wraps call for loadSmallBlocks
+  std::vector<uint64> blocks;
+  blocks.resize(1);
+  blocks.assign(1, block);
+
+  return loadSmallBlocks(blocks, data, maxlen);
+}
+
+uint64 StorageIO::saveSmallBlocks(std::vector<uint64> blocks, uint64 offset, unsigned char* data, uint64 len, int64 startAtBlock)
+{
+  // sentinel
+  if(!data)
+    return 0;
+  fileCheck(file);
+  if(!file.good())
+    return 0;
+  if(blocks.size() < 1)
+    return 0;
+  if(len == 0)
+    return 0;
+
+  // write block one by one, seems fast enough
+  uint64 bytes = 0;
+  for(uint64 i = startAtBlock; (i < blocks.size()) & (bytes < len); i++)
+  {
+    uint64 block = blocks[i];
+    // find where the small-block exactly is
+    uint64 pos = block * sbat->blockSize;
+    uint64 bbindex = pos / bbat->blockSize;
+    if(bbindex >= sb_blocks.size())
+      break;
+    uint64 offset2 = pos % bbat->blockSize;
+    uint64 maxWrite = sbat->blockSize - offset;
+    uint64 tobeWritten = len - bytes;
+    if(tobeWritten > maxWrite)
+      tobeWritten = maxWrite;
+    saveBigBlock(sb_blocks[bbindex], offset2 + offset, data + bytes, tobeWritten);
+    bytes += tobeWritten;
+    offset = 0;
+    if(filesize < pos + tobeWritten)
+      filesize = pos + tobeWritten;
+  }
+  return bytes;
+}
+
+uint64 StorageIO::saveSmallBlock(uint64 block, uint64 offset, unsigned char* data, uint64 len)
+{
+  if(!data)
+    return 0;
+  fileCheck(file);
+  if(!file.good())
+    return 0;
+  // wrap call for saveSmallBlocks
+  std::vector<uint64> blocks;
+  blocks.resize(1);
+  blocks[0] = block;
+  return saveSmallBlocks(blocks, offset, data, len);
+}
+
+void StorageIO::flushbbat()
+{
+  std::vector<uint64> blocks;
+  blocks = getbbatBlocks(false);
+  bbat->flush(blocks, this, bbat->blockSize);
+}
+
+void StorageIO::flushsbat()
+{
+  std::vector<uint64> blocks;
+  blocks = bbat->follow(header->sbat_start);
+  sbat->flush(blocks, this, bbat->blockSize);
+}
+
+std::vector<uint64> StorageIO::getbbatBlocks(bool bLoading)
+{
+  std::vector<uint64> blocks;
+  // find blocks allocated to store big bat
+  // the first 109 blocks are in header, the rest in meta bat
+  blocks.clear();
+  blocks.resize(header->num_bat);
+
+  for(unsigned i = 0; i < 109; i++)
+  {
+    if(i >= header->num_bat)
+      break;
+    else
+      blocks[i] = header->bb_blocks[i];
+  }
+  if(bLoading)
+  {
+    mbat_blocks.clear();
+    mbat_data.clear();
+    if((header->num_bat > 109) && (header->num_mbat > 0))
+    {
+      unsigned char* buffer2 = new unsigned char[bbat->blockSize];
+      uint64 k = 109;
+      uint64 sector;
+      uint64 mdidx = 0;
+      for(uint64 r = 0; r < header->num_mbat; r++)
+      {
+        if(r == 0) // 1st meta bat location is in file header.
+          sector = header->mbat_start;
+        else // next meta bat location is the last current block value.
+        {
+          sector = blocks[--k];
+          mdidx--;
+        }
+        mbat_blocks.push_back(sector);
+        mbat_data.resize(mbat_blocks.size() * (bbat->blockSize / 4));
+        loadBigBlock(sector, buffer2, bbat->blockSize);
+        for(uint64 s = 0; s < bbat->blockSize; s += 4)
+        {
+          if(k >= header->num_bat)
+            break;
+          else
+          {
+            blocks[k] = readU32(buffer2 + s);
+            mbat_data[mdidx++] = blocks[k];
+            k++;
+          }
+        }
+      }
+      if(mbat_data.size() != mdidx)
+        mbat_data.resize(mdidx);
+      delete[] buffer2;
+    }
+  }
+  else
+  {
+    unsigned i = 109;
+    for(unsigned int idx = 0; idx < mbat_data.size(); idx++)
+    {
+      blocks[i++] = mbat_data[idx];
+      if(i == header->num_bat)
+        break;
+    }
+  }
+  return blocks;
+}
+
+uint64 StorageIO::ExtendFile(std::vector<uint64>* chain)
+{
+  uint64 newblockIdx = bbat->unused();
+  bbat->set(newblockIdx, AllocTable::Eof);
+  uint64 bbidx = newblockIdx / (bbat->blockSize / sizeof(uint64));
+  while(bbidx >= header->num_bat)
+    addbbatBlock();
+  bbat->markAsDirty(newblockIdx, bbat->blockSize);
+  if(chain->size() > 0)
+  {
+    bbat->set((*chain)[chain->size() - 1], newblockIdx);
+    bbat->markAsDirty((*chain)[chain->size() - 1], bbat->blockSize);
+  }
+  chain->push_back(newblockIdx);
+  return newblockIdx;
+}
+
+void StorageIO::addbbatBlock()
+{
+  uint64 newblockIdx = bbat->unused();
+  bbat->set(newblockIdx, AllocTable::MetaBat);
+
+  if(header->num_bat < 109)
+    header->bb_blocks[header->num_bat] = newblockIdx;
+  else
+  {
+    mbatDirty = true;
+    mbat_data.push_back(newblockIdx);
+    uint64 metaIdx = header->num_bat - 109;
+    uint64 idxPerBlock = bbat->blockSize / sizeof(uint64) - 1; // reserve room for index to next block
+    uint64 idxBlock = metaIdx / idxPerBlock;
+    if(idxBlock == mbat_blocks.size())
+    {
+      uint64 newmetaIdx = bbat->unused();
+      bbat->set(newmetaIdx, AllocTable::MetaBat);
+      mbat_blocks.push_back(newmetaIdx);
+      if(header->num_mbat == 0)
+        header->mbat_start = newmetaIdx;
+      header->num_mbat++;
+    }
+  }
+  header->num_bat++;
+  header->dirty = true;
+}
+
+// =========== StreamIO ==========
+
+StreamIO::StreamIO(StorageIO* s, DirEntry* e)
+: io(s)
+, entryIdx(io->dirtree->indexOf(e))
+, fullName()
+, eof(false)
+, fail(false)
+, blocks()
+, m_pos(0)
+, cache_data(new unsigned char[CACHEBUFSIZE])
+, cache_size(0)
+, // indicating an empty cache
+cache_pos(0)
+{
+  if(e->size >= io->header->threshold)
+    blocks = io->bbat->follow(e->start);
+  else
+    blocks = io->sbat->follow(e->start);
+}
+
+// FIXME tell parent we're gone
+StreamIO::~StreamIO()
+{
+  delete[] cache_data;
+}
+
+void StreamIO::setSize(uint64 newSize)
+{
+  bool bThresholdCrossed = false;
+  bool bOver = false;
+
+  if(!io->writeable)
+    return;
+  DirEntry* entry = io->dirtree->entry(entryIdx);
+  if(newSize >= io->header->threshold && entry->size < io->header->threshold)
+  {
+    bThresholdCrossed = true;
+    bOver = true;
+  }
+  else if(newSize < io->header->threshold && entry->size >= io->header->threshold)
+  {
+    bThresholdCrossed = true;
+    bOver = false;
+  }
+  if(bThresholdCrossed)
+  {
+    // first, read what is already in the stream, limited by the requested new size. Note
+    // that the read can work precisely because we have not yet reset the size.
+    uint64 len = newSize;
+    if(len > entry->size)
+      len = entry->size;
+    unsigned char* buffer = 0;
+    uint64 savePos = tell();
+    if(len)
+    {
+      buffer = new unsigned char[len];
+      seek(0);
+      read(buffer, len);
+    }
+    // Now get rid of the existing blocks
+    if(bOver)
+    {
+      for(unsigned int idx = 0; idx < blocks.size(); idx++)
+      {
+        io->sbat->set(blocks[idx], AllocTable::Avail);
+        io->sbat->markAsDirty(idx, io->bbat->blockSize);
+      }
+    }
+    else
+    {
+      for(unsigned int idx = 0; idx < blocks.size(); idx++)
+      {
+        io->bbat->set(blocks[idx], AllocTable::Avail);
+        io->bbat->markAsDirty(idx, io->bbat->blockSize);
+      }
+    }
+    blocks.clear();
+    entry->start = DirTree::End;
+    // Now change the size, and write the old data back into the stream, if any
+    entry->size = newSize;
+    io->dirtree->markAsDirty(io->dirtree->indexOf(entry), io->bbat->blockSize);
+    if(len)
+    {
+      write(0, buffer, len);
+      delete buffer;
+    }
+    if(savePos <= entry->size)
+      seek(savePos);
+  }
+  else if(entry->size != newSize) // simple case - no threshold was crossed, so just change the size
+  {
+    entry->size = newSize;
+    io->dirtree->markAsDirty(io->dirtree->indexOf(entry), io->bbat->blockSize);
+  }
+}
+
+void StreamIO::seek(uint64 pos)
+{
+  m_pos = pos;
+}
+
+uint64 StreamIO::tell()
+{
+  return m_pos;
+}
+
+int64 StreamIO::getch()
+{
+  // past end-of-file ?
+  DirEntry* entry = io->dirtree->entry(entryIdx);
+  if(m_pos >= entry->size)
+    return -1;
+
+  // need to update cache ?
+  if(!cache_size || (m_pos < cache_pos) || (m_pos >= cache_pos + cache_size))
+    updateCache();
+
+  // something bad if we don't get good cache
+  if(!cache_size)
+    return -1;
+
+  int64 data = cache_data[m_pos - cache_pos];
+  m_pos++;
+
+  return data;
+}
+
+uint64 StreamIO::read(uint64 pos, unsigned char* data, uint64 maxlen)
+{
+  // sanity checks
+  if(!data)
+    return 0;
+  if(maxlen == 0)
+    return 0;
+
+  uint64 totalbytes = 0;
+
+  DirEntry* entry = io->dirtree->entry(entryIdx);
+  if(pos + maxlen > entry->size)
+    maxlen = entry->size - pos;
+  if(entry->size < io->header->threshold)
+  {
+    // small file
+    uint64 index = pos / io->sbat->blockSize;
+
+    if(index >= blocks.size())
+      return 0;
+
+    unsigned char* buf = new unsigned char[io->sbat->blockSize];
+    uint64 offset = pos % io->sbat->blockSize;
+    while(totalbytes < maxlen)
+    {
+      if(index >= blocks.size())
+        break;
+      io->loadSmallBlock(blocks[index], buf, io->bbat->blockSize);
+      uint64 count = io->sbat->blockSize - offset;
+      if(count > maxlen - totalbytes)
+        count = maxlen - totalbytes;
+      memcpy(data + totalbytes, buf + offset, count);
+      totalbytes += count;
+      offset = 0;
+      index++;
+    }
+    delete[] buf;
+  }
+  else
+  {
+    // big file
+    uint64 index = pos / io->bbat->blockSize;
+
+    if(index >= blocks.size())
+      return 0;
+
+    unsigned char* buf = new unsigned char[io->bbat->blockSize];
+    uint64 offset = pos % io->bbat->blockSize;
+    while(totalbytes < maxlen)
+    {
+      if(index >= blocks.size())
+        break;
+      io->loadBigBlock(blocks[index], buf, io->bbat->blockSize);
+      uint64 count = io->bbat->blockSize - offset;
+      if(count > maxlen - totalbytes)
+        count = maxlen - totalbytes;
+      memcpy(data + totalbytes, buf + offset, count);
+      totalbytes += count;
+      index++;
+      offset = 0;
+    }
+    delete[] buf;
+  }
+
+  return totalbytes;
+}
+
+uint64 StreamIO::read(unsigned char* data, uint64 maxlen)
+{
+  uint64 bytes = read(tell(), data, maxlen);
+  m_pos += bytes;
+  return bytes;
+}
+
+uint64 StreamIO::write(unsigned char* data, uint64 len)
+{
+  return write(tell(), data, len);
+}
+
+uint64 StreamIO::write(uint64 pos, unsigned char* data, uint64 len)
+{
+  // sanity checks
+  if(!data)
+    return 0;
+  if(len == 0)
+    return 0;
+  if(!io->writeable)
+    return 0;
+
+  DirEntry* entry = io->dirtree->entry(entryIdx);
+  if(pos + len > entry->size)
+    setSize(pos + len); // reset size, possibly changing from small to large blocks
+  uint64 totalbytes = 0;
+  if(entry->size < io->header->threshold)
+  {
+    // small file
+    uint64 index = (pos + len - 1) / io->sbat->blockSize;
+    while(index >= blocks.size())
+    {
+      uint64 nblock = io->sbat->unused();
+      if(blocks.size() > 0)
+      {
+        io->sbat->set(blocks[blocks.size() - 1], nblock);
+        io->sbat->markAsDirty(blocks[blocks.size() - 1], io->bbat->blockSize);
+      }
+      io->sbat->set(nblock, AllocTable::Eof);
+      io->sbat->markAsDirty(nblock, io->bbat->blockSize);
+      blocks.resize(blocks.size() + 1);
+      blocks[blocks.size() - 1] = nblock;
+      uint64 bbidx = nblock / (io->bbat->blockSize / sizeof(unsigned int));
+      while(bbidx >= io->header->num_sbat)
+      {
+        std::vector<uint64> sbat_blocks = io->bbat->follow(io->header->sbat_start);
+        io->ExtendFile(&sbat_blocks);
+        io->header->num_sbat++;
+        io->header->dirty = true; // Header will have to be rewritten
+      }
+      uint64 sidx = nblock * io->sbat->blockSize / io->bbat->blockSize;
+      while(sidx >= io->sb_blocks.size())
+      {
+        io->ExtendFile(&io->sb_blocks);
+        io->dirtree->markAsDirty(0, io->bbat->blockSize); // make sure to rewrite first directory block
+      }
+    }
+    uint64 offset = pos % io->sbat->blockSize;
+    index = pos / io->sbat->blockSize;
+    // if (index == 0)
+    totalbytes = io->saveSmallBlocks(blocks, offset, data, len, index);
+  }
+  else
+  {
+    uint64 index = (pos + len - 1) / io->bbat->blockSize;
+    while(index >= blocks.size())
+      io->ExtendFile(&blocks);
+    uint64 offset = pos % io->bbat->blockSize;
+    uint64 remainder = len;
+    index = pos / io->bbat->blockSize;
+    while(remainder > 0)
+    {
+      if(index >= blocks.size())
+        break;
+      uint64 count = io->bbat->blockSize - offset;
+      if(remainder < count)
+        count = remainder;
+      io->saveBigBlock(blocks[index], offset, data + totalbytes, count);
+      totalbytes += count;
+      remainder -= count;
+      index++;
+      offset = 0;
+    }
+  }
+  if(blocks.size() > 0 && entry->start != blocks[0])
+  {
+    entry->start = blocks[0];
+    io->dirtree->markAsDirty(io->dirtree->indexOf(entry), io->bbat->blockSize);
+  }
+  m_pos += len;
+  return totalbytes;
+}
+
+void StreamIO::flush()
+{
+  io->flush();
+}
+
+void StreamIO::updateCache()
+{
+  // sanity check
+  if(!cache_data)
+    return;
+
+  DirEntry* entry = io->dirtree->entry(entryIdx);
+  cache_pos = m_pos - (m_pos % CACHEBUFSIZE);
+  uint64 bytes = CACHEBUFSIZE;
+  if(cache_pos + bytes > entry->size)
+    bytes = entry->size - cache_pos;
+  cache_size = read(cache_pos, cache_data, bytes);
+}
+
+// =========== Storage ==========
+
+Storage::Storage(const char* filename)
+{
+  io = new StorageIO(this, filename);
+}
+
+Storage::~Storage()
+{
+  delete io;
+}
+
+int Storage::result()
+{
+  return (int)io->result;
+}
+
+bool Storage::open(bool bWriteAccess, bool bCreate)
+{
+  return io->open(bWriteAccess, bCreate);
+}
+
+void Storage::close()
+{
+  io->close();
+}
+
+std::list<std::string> Storage::entries(const std::string& path)
+{
+  std::list<std::string> localResult;
+  DirTree* dt = io->dirtree;
+  DirEntry* e = dt->entry(path, false);
+  if(e && e->dir)
+  {
+    uint64 parent = dt->indexOf(e);
+    std::vector<uint64> children = dt->children(parent);
+    for(uint64 i = 0; i < children.size(); i++)
+      localResult.push_back(dt->entry(children[i])->name);
+  }
+
+  return localResult;
+}
+
+bool Storage::isDirectory(const std::string& name)
+{
+  DirEntry* e = io->dirtree->entry(name, false);
+  return e ? e->dir : false;
+}
+
+bool Storage::exists(const std::string& name)
+{
+  DirEntry* e = io->dirtree->entry(name, false);
+  return (e != 0);
+}
+
+bool Storage::isWriteable()
+{
+  return io->writeable;
+}
+
+bool Storage::deleteByName(const std::string& name)
+{
+  return io->deleteByName(name);
+}
+
+void Storage::GetStats(uint64* pEntries, uint64* pUnusedEntries, uint64* pBigBlocks, uint64* pUnusedBigBlocks, uint64* pSmallBlocks, uint64* pUnusedSmallBlocks)
+{
+  *pEntries = io->dirtree->entryCount();
+  *pUnusedEntries = io->dirtree->unusedEntryCount();
+  *pBigBlocks = io->bbat->count();
+  *pUnusedBigBlocks = io->bbat->unusedCount();
+  *pSmallBlocks = io->sbat->count();
+  *pUnusedSmallBlocks = io->sbat->unusedCount();
+}
+
+// recursively collect stream names
+void CollectStreams(std::list<std::string>& result, DirTree* tree, DirEntry* parent, const std::string& path)
+{
+  DirEntry* c = tree->entry(parent->child);
+  std::queue<DirEntry*> queue;
+  if(c)
+    queue.push(c);
+  while(!queue.empty())
+  {
+    DirEntry* e = queue.front();
+    queue.pop();
+    if(e->dir)
+      CollectStreams(result, tree, e, path + e->name + "/");
+    else
+      result.push_back(path + e->name);
+    DirEntry* p = tree->entry(e->prev);
+    if(p)
+      queue.push(p);
+    DirEntry* n = tree->entry(e->next);
+    if(n)
+      queue.push(n);
+    // not testing if p or n have already been processed; potential infinite loop in case of closed Entry chain
+    // it seems not to happen, though
+  }
+}
+
+std::list<std::string> Storage::GetAllStreams(const std::string& storageName)
+{
+  std::list<std::string> vresult;
+  DirEntry* e = io->dirtree->entry(storageName, false);
+  if(e && e->dir)
+    CollectStreams(vresult, io->dirtree, e, storageName);
+  return vresult;
+}
+
+// =========== Stream ==========
+
+Stream::Stream(Storage* storage, const std::string& name, bool bCreate, int64 streamSize)
+: io(storage->io->streamIO(name, bCreate, (int)streamSize))
+{
+}
+
+// FIXME tell parent we're gone
+Stream::~Stream()
+{
+  delete io;
+}
+
+std::string Stream::fullName()
+{
+  return io ? io->fullName : std::string();
+}
+
+uint64 Stream::tell()
+{
+  return io ? io->tell() : 0;
+}
+
+void Stream::seek(uint64 newpos)
+{
+  if(io)
+    io->seek(newpos);
+}
+
+uint64 Stream::size()
+{
+  if(!io)
+    return 0;
+  DirEntry* entry = io->io->dirtree->entry(io->entryIdx);
+  return entry->size;
+}
+
+void Stream::setSize(int64 newSize)
+{
+  if(!io)
+    return;
+  if(newSize < 0)
+    return;
+  if(newSize > std::numeric_limits<int64>::max())
+    return;
+  io->setSize(newSize);
+}
+
+int64 Stream::getch()
+{
+  return io ? io->getch() : 0;
+}
+
+uint64 Stream::read(unsigned char* data, uint64 maxlen)
+{
+  return io ? io->read(data, maxlen) : 0;
+}
+
+uint64 Stream::write(unsigned char* data, uint64 len)
+{
+  return io ? io->write(data, len) : 0;
+}
+
+void Stream::flush()
+{
+  if(io)
+    io->flush();
+}
+
+bool Stream::eof()
+{
+  return io ? io->eof : false;
+}
+
+bool Stream::fail()
+{
+  return io ? io->fail : true;
+}

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/oless/oless/pole.h
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/oless/oless/pole.h
@@ -1,0 +1,262 @@
+/* POLE - Portable C++ library to access OLE Storage
+   Copyright (C) 2002-2005 Ariya Hidayat <ariya@kde.org>
+
+   Performance optimization, API improvements: Dmitry Fedorov
+   Copyright 2009-2014 <www.bioimage.ucsb.edu> <www.dimin.net>
+
+   Fix for more than 236 mbat block entries : Michel Boudinot
+   Copyright 2010 <Michel.Boudinot@inaf.cnrs-gif.fr>
+
+   Considerable rework to allow for creation and updating of structured storage: Stephen Baum
+   Copyright 2013 <srbaum@gmail.com>
+
+   Added GetAllStreams, reworked datatypes
+   Copyright 2013 Felix Gorny from Bitplane
+
+   More datatype changes to allow for 32 and 64 bit code, some fixes involving incremental updates, flushing
+   Copyright 2013 <srbaum@gmail.com>
+
+   Version: 0.5.3
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+   * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   * Neither the name of the authors nor the names of its contributors may be
+     used to endorse or promote products derived from this software without
+     specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+   THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+Unicode notes:
+
+Filenames are considered to be encoded in UTF-8 encoding. On windows they
+can be re-encoded into UTF16 and proper wchar_t APIs will be used to open files.
+This is a default behavior for windows and is defined by the macro POLE_USE_UTF16_FILENAMES.
+
+Using a provided function and a modern c++ compiler it's easy to encode a
+wide string into utf8 char*:
+    std::string POLE::UTF16toUTF8(const std::wstring &utf16);
+*/
+
+#ifndef POLE_H
+#define POLE_H
+
+#include <cstdio>
+#include <list>
+#include <string>
+
+namespace POLE
+{
+
+#if defined WIN32 || defined WIN64 || defined _WIN32 || defined _WIN64 || defined _MSVC
+#define POLE_USE_UTF16_FILENAMES
+#define POLE_WIN
+typedef __int32 int32;
+typedef __int64 int64;
+typedef unsigned __int32 uint32;
+typedef unsigned __int64 uint64;
+#else
+typedef int int32;
+typedef long long int64;
+typedef unsigned int uint32;
+typedef unsigned long long uint64;
+#endif
+
+typedef uint64 t_offset;
+
+#ifdef POLE_USE_UTF16_FILENAMES
+std::string UTF16toUTF8(const std::wstring& utf16);
+std::wstring UTF8toUTF16(const std::string& utf8);
+#endif // POLE_USE_UTF16_FILENAMES
+
+class StorageIO;
+class Stream;
+class StreamIO;
+
+class Storage
+{
+  friend class Stream;
+  friend class StreamOut;
+
+public:
+  // for Storage::result()
+  enum
+  {
+    Ok,
+    OpenFailed,
+    NotOLE,
+    BadOLE,
+    UnknownError
+  };
+
+  /**
+   * Constructs a storage with name filename.
+   **/
+  Storage(const char* filename);
+
+  /**
+   * Destroys the storage.
+   **/
+  ~Storage();
+
+  /**
+   * Opens the storage. Returns true if no error occurs.
+   **/
+  bool open(bool bWriteAccess = false, bool bCreate = false);
+
+  /**
+   * Closes the storage.
+   **/
+  void close();
+
+  /**
+   * Returns the error code of last operation.
+   **/
+  int result();
+
+  /**
+   * Finds all stream and directories in given path.
+   **/
+  std::list<std::string> entries(const std::string& path = "/");
+
+  /**
+   * Returns true if specified entry name is a directory.
+   */
+  bool isDirectory(const std::string& name);
+
+  /**
+   * Returns true if specified entry name exists.
+   */
+  bool exists(const std::string& name);
+
+  /**
+   * Returns true if storage can be modified.
+   */
+  bool isWriteable();
+
+  /**
+   * Deletes a specified stream or directory. If directory, it will
+   * recursively delete everything underneath said directory.
+   * returns true for success
+   */
+  bool deleteByName(const std::string& name);
+
+  /**
+   * Returns an accumulation of information, hopefully useful for determining if the storage
+   * should be defragmented.
+   */
+
+  void GetStats(uint64* pEntries, uint64* pUnusedEntries, uint64* pBigBlocks, uint64* pUnusedBigBlocks, uint64* pSmallBlocks, uint64* pUnusedSmallBlocks);
+
+  std::list<std::string> GetAllStreams(const std::string& storageName);
+
+private:
+  StorageIO* io;
+
+  // no copy or assign
+  Storage(const Storage&);
+  Storage& operator=(const Storage&);
+};
+
+class Stream
+{
+  friend class Storage;
+  friend class StorageIO;
+
+public:
+  /**
+   * Creates a new stream.
+   */
+  // name must be absolute, e.g "/Workbook"
+  Stream(Storage* storage, const std::string& name, bool bCreate = false, int64 streamSize = 0);
+
+  /**
+   * Destroys the stream.
+   */
+  ~Stream();
+
+  /**
+   * Returns the full stream name.
+   */
+  std::string fullName();
+
+  /**
+   * Returns the stream size.
+   **/
+  uint64 size();
+
+  /**
+   * Changes the stream size (note this is done automatically if you write beyond the old size.
+   * Use this primarily as a preamble to rewriting a stream that is already open. Of course, you
+   * could simply delete the stream first).
+   **/
+  void setSize(int64 newSize);
+
+  /**
+   * Returns the current read/write position.
+   **/
+  uint64 tell();
+
+  /**
+   * Sets the read/write position.
+   **/
+  void seek(uint64 pos);
+
+  /**
+   * Reads a byte.
+   **/
+  int64 getch();
+
+  /**
+   * Reads a block of data.
+   **/
+  uint64 read(unsigned char* data, uint64 maxlen);
+
+  /**
+   * Writes a block of data.
+   **/
+  uint64 write(unsigned char* data, uint64 len);
+
+  /**
+   * Makes sure that any changes for the stream (and the structured storage) have been written to disk.
+   **/
+  void flush();
+
+  /**
+   * Returns true if the read/write position is past the file.
+   **/
+  bool eof();
+
+  /**
+   * Returns true whenever error occurs.
+   **/
+  bool fail();
+
+private:
+  StreamIO* io;
+
+  // no copy or assign
+  Stream(const Stream&);
+  Stream& operator=(const Stream&);
+};
+
+} // namespace POLE
+
+#endif // POLE_H

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/oless/oless/program.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/oless/oless/program.cpp
@@ -1,0 +1,138 @@
+
+#include "oless/common.hpp"
+#include "oless/oless.h"
+#include "oless/pole.h"
+
+#include <iostream>
+#include <list>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+void ShowHelp()
+{
+  std::cout << "oless {cmd} [CommandSpecificParameters]" << std::endl;
+  std::cout << "Available Commands:" << std::endl;
+  std::cout << "\tlist {file} [outputformat] - Enumerates the streams and storage in the OLESS file, default output format is text" << std::endl;
+  std::cout << "\tguess {file} [outputformat] - Guess the extension of the file based on the OLESS contents, default output format is text" << std::endl;
+  std::cout << "\tdump {file} {streamname} {outfile} - Extracts the given stream/storage name to an external file" << std::endl;
+  std::cout << "Available Output Formats:" << std::endl;
+  std::cout << "\txml,csv,json,txt" << std::endl;
+}
+
+OutputFormat ParseOutputFormat(std::string input)
+{
+  std::unordered_map<std::string, OutputFormat> map = {{"xml", OutputFormat::XML}, {"csv", OutputFormat::CSV}, {"txt", OutputFormat::TEXT}, {"json", OutputFormat::JSON}};
+  std::unordered_map<std::string, OutputFormat>::const_iterator got = map.find(input);
+  if(got == map.end())
+  {
+    return OutputFormat::TEXT;
+  }
+  else
+  {
+    return got->second;
+  }
+}
+
+template <class T>
+void Output(OutputFormat format, std::string file, std::string headerName, std::vector<T*> summary)
+{
+  typename std::vector<T*>::iterator it;
+  switch(format)
+  {
+  case OutputFormat::TEXT:
+    std::cout << file << std::endl;
+    for(it = summary.begin(); it != summary.end(); it++)
+    {
+      std::cout << "\t" << (*it)->ToText() << std::endl;
+    }
+    break;
+  case OutputFormat::XML:
+    std::cout << "<file>" << std::endl;
+    std::cout << "\t<name>" << file << "</name>" << std::endl;
+    std::cout << "\t<" << headerName << ">" << std::endl;
+    for(it = summary.begin(); it != summary.end(); it++)
+    {
+      std::cout << "\t\t" << (*it)->ToXml() << std::endl;
+    }
+    std::cout << "\t</" << headerName << ">" << std::endl;
+    std::cout << "</file>" << std::endl;
+    break;
+  case OutputFormat::JSON:
+    std::cout << "{ \"name\" : \"" << helper::JsonEscape(file) << "\"," << std::endl;
+    std::cout << "\t \"" << headerName << "\": [" << std::endl;
+    for(it = summary.begin(); it != summary.end(); it++)
+    {
+      if(it != summary.begin())
+      {
+        std::cout << "," << std::endl;
+      }
+      std::cout << "\t\t" << (*it)->ToJson() << std::endl;
+    }
+    std::cout << "\n\t]\n}" << std::endl;
+    break;
+    break;
+  case OutputFormat::CSV:
+    for(it = summary.begin(); it != summary.end(); it++)
+    {
+      std::cout << (*it)->ToCsv() << std::endl;
+    }
+    break;
+  default:
+    std::cout << "Unknown Output Format!" << std::endl;
+  }
+}
+
+int main(int argc, char* argv[])
+{
+
+  if(argc > 2)
+  {
+    std::string command = argv[1];
+    std::string file = argv[2];
+
+    OutputFormat outFormat = OutputFormat::TEXT;
+    if(argc > 3)
+    {
+      outFormat = ParseOutputFormat(argv[3]);
+    }
+
+    OleStructuredStorage::Oless* oleItem = new OleStructuredStorage::Oless(argv[2]);
+    if(oleItem->IsOless())
+    {
+
+      if(command == "list")
+      {
+        std::vector<OleSummary*> summary = oleItem->List();
+        Output<OleSummary>(outFormat, file, "summary", summary);
+      }
+
+      else if(command == "dump")
+      {
+        if(argc > 4)
+        {
+          std::string outFile = argv[4];
+          oleItem->Dump(argv[3], outFile);
+        }
+        else
+        {
+          ShowHelp();
+        }
+      }
+      else
+      {
+        ShowHelp();
+      }
+    }
+    else
+    {
+      std::cerr << file << ": Invalid OLESS header" << std::endl;
+    }
+  }
+  else
+  {
+    ShowHelp();
+  }
+
+  return 0;
+}

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/oless/readme.md
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/oless/readme.md
@@ -1,0 +1,18 @@
+######## THIS IS A COPY OF THE REPO AT https://github.com/DBHeise/oless/ #######
+
+OLESS - OLE Structured Storage Utility
+======================================
+
+build scripts included for both windows (build.cmd) and linux (build.sh)
+
+Usage
+=====
+oless {cmd} [CommandSpecificParameters]
+Available Commands:
+-------------------
+        list {file} [outputformat] - Enumerates the streams and storage in the OLESS file, default output format is text
+        guess {file} [outputformat] - Guess the extension of the file based on the OLESS contents, default output format is text
+        dump {file} {streamname} {outfile} - Extracts the given stream/storage name to an external file
+Available Output Formats:
+-------------------------
+        xml,csv,json,txt

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/oless/txm_reader.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/oless/txm_reader.cpp
@@ -1,0 +1,285 @@
+/**
+This is just a test program that can be useful to debug a .txm file or dump
+the contents of a .txm file.
+*/
+
+#include "oless/oless.h"
+#include "oless/oless_common.hpp"
+#include "oless/pole.h"
+
+#include <array>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <list>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#ifdef _WIN32
+#define SIMPLNX_BYTE_ORDER little
+#elif defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__)
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define SIMPLNX_BYTE_ORDER little
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define SIMPLNX_BYTE_ORDER big
+#endif
+#endif
+
+namespace
+{
+
+const uint16_t k_PhotometricMinisblack = 0x0001;
+const uint16_t k_PhotometricRgb = 0x0002;
+
+struct TIFTAG
+{
+  int16_t TagId = 0;      // The tag identifier
+  int16_t DataType = 0;   // The scalar type of the data items
+  int32_t DataCount = 0;  // The number of items in the tag data
+  int32_t DataOffset = 0; // The byte offset to the data items
+
+  friend std::ostream& operator<<(std::ostream& out, const TIFTAG& tag)
+  {
+    out.write(reinterpret_cast<const char*>(&tag.TagId), sizeof(tag.TagId));
+    out.write(reinterpret_cast<const char*>(&tag.DataType), sizeof(tag.DataType));
+    out.write(reinterpret_cast<const char*>(&tag.DataCount), sizeof(tag.DataCount));
+    out.write(reinterpret_cast<const char*>(&tag.DataOffset), sizeof(tag.DataOffset));
+
+    return out;
+  }
+};
+
+} // namespace
+
+namespace nx::core
+{
+enum class endian : uint8_t
+{
+  little = 0,
+  big = 1,
+  native = SIMPLNX_BYTE_ORDER
+};
+
+inline endian checkEndian()
+{
+  constexpr uint32_t i = 0x01020304;
+  const auto* u8 = reinterpret_cast<const std::byte*>(&i);
+
+  return u8[0] == std::byte{0x01} ? endian::big : endian::little;
+}
+} // namespace nx::core
+
+namespace TiffWriter
+{
+std::pair<int32_t, std::string> WriteImage(const std::string& filepath, int32_t width, int32_t height, uint16_t bytesPerSample, uint16_t samplesPerPixel, const uint8_t* data)
+{
+  const uint16_t photometricInterpretation = (samplesPerPixel == 1 ? k_PhotometricMinisblack : k_PhotometricRgb);
+
+  // Check for Endianess of the system and write the appropriate magic number according to the tiff spec
+  std::array<char, 4> magicNumber = {0x49, 0x49, 0x2A, 0x00};
+
+  if(nx::core::checkEndian() == nx::core::endian::big)
+  {
+    magicNumber = {0x4D, 0x4D, 0x00, 0x2A};
+  }
+
+  // open file and write header
+  std::ofstream outputFile(filepath, std::ios::binary);
+  if(!outputFile.is_open())
+  {
+    return {-1, "TiffWriter::WriteImage Error: Could not open output file '{}' for writing."};
+  }
+
+  outputFile.write(magicNumber.data(), magicNumber.size());
+  // Generate the offset into the Image File Directory (ifd) which we are going to write first
+  constexpr uint32_t ifdOffset = 8;
+  outputFile.write(reinterpret_cast<const char*>(&ifdOffset), sizeof(ifdOffset));
+  const int k_NumTags = 12;
+  std::vector<TIFTAG> tags;
+  tags.push_back(TIFTAG{0x00FE, 0x0004, 1, 0x00000000});                // NewSubfileType
+  tags.push_back(TIFTAG{0x0100, 0x0004, 1, width});                     // ImageWidth
+  tags.push_back(TIFTAG{0x0101, 0x0004, 1, height});                    // ImageLength
+  tags.push_back(TIFTAG{0x0102, 0x0003, 1, 8 * bytesPerSample});        // BitsPerSample
+  tags.push_back(TIFTAG{0x0103, 0x0003, 1, 0x0001});                    // Compression
+  tags.push_back(TIFTAG{0x0106, 0x0003, 1, photometricInterpretation}); // PhotometricInterpretation  // For SamplesPerPixel = 3 or 4 (RGB or RGBA)
+  // Now compute the offset to the image data so that we can put that into the tag.
+  // The math on this ONLY Works if we have 11 total Tags.
+  // IF YOU ADD MORE TAGS, YOU NEED TO ADJUST THE NEXT LINE OF CODE
+  int32_t imageDataOffset = static_cast<int32_t>(8 + (k_NumTags * 12) + 6); // Header + tags + IDF Tag entry count and Next IFD Offset
+  tags.push_back(TIFTAG{0x0111, 0x0004, 1, imageDataOffset});               // StripOffsets
+
+  tags.push_back(TIFTAG{0x0112, 0x0003, 1, 1});                                                 // Orientation
+  tags.push_back(TIFTAG{0x0115, 0x0003, 1, samplesPerPixel});                                   // SamplesPerPixel
+  tags.push_back(TIFTAG{0x0116, 0x0004, 1, height});                                            // RowsPerStrip
+  tags.push_back(TIFTAG{0x0117, 0x0004, 1, width * height * samplesPerPixel * bytesPerSample}); // StripByteCounts
+
+  // TIFTAG XResolution;
+  // TIFTAG YResolution;
+  // TIFTAG ResolutionUnit;
+  tags.push_back(TIFTAG{0x011c, 0x0003, 1, 0x0001}); // PlanarConfiguration // 284
+
+  // Write the number of tags to the IFD section
+  uint16_t numEntries = static_cast<uint16_t>(tags.size());
+  outputFile.write(reinterpret_cast<const char*>(&numEntries), sizeof(numEntries));
+  // write the tags to the file.
+  for(const auto& tag : tags)
+  {
+    outputFile << tag;
+  }
+  // Write the "Next Tag Offset"
+  constexpr uint32_t nextOffset = 0;
+  outputFile.write(reinterpret_cast<const char*>(&nextOffset), sizeof(nextOffset));
+
+  // Now write the actual image data
+  const int32_t imageByteCount = width * height * samplesPerPixel * bytesPerSample;
+  outputFile.write(reinterpret_cast<const char*>(data), imageByteCount);
+
+  // and we are done.
+  return {0, "No Error"};
+}
+
+} // namespace TiffWriter
+
+using StoragePtrType = std::shared_ptr<POLE::Storage>;
+using StreamPtrType = std::shared_ptr<POLE::Stream>;
+
+void printStreamInfo(POLE::Storage* storage, const std::string& name, const std::string& fullname)
+{
+  POLE::Stream* stream = new POLE::Stream(storage, fullname.c_str());
+
+  if(!storage->isDirectory(fullname))
+  {
+    if(!stream->fail())
+    {
+      //      OleSummary* summary = new OleSummary();
+      //      summary->FullName = stream->fullName();
+      //      summary->Size = stream->size();
+      //      m_results.push_back((IExportable*)summary);
+      std::cout << stream->fullName() << "\t" << stream->size() << "\n";
+    }
+  }
+  else
+  {
+    std::cout << fullname << "\t DIRECTORY"
+              << "\n";
+  }
+}
+
+// -- Constants --
+static int FLOAT_TYPE = 10;
+static int INT16_TYPE = 5;
+static int UCHAR_TYPE = 3;
+
+template <typename T>
+T ReadValue(StoragePtrType storage, const std::string& path)
+{
+  T value = 0;
+  StreamPtrType stream = std::make_shared<POLE::Stream>(storage.get(), path);
+  if(!stream->fail())
+  {
+    stream->read(reinterpret_cast<unsigned char*>(&value), sizeof(T));
+  }
+  return value;
+}
+
+void ReadImages(StoragePtrType storage)
+{
+
+  std::string path = "/ImageInfo/ImageWidth";
+  int32_t ImageWidth = ReadValue<int32_t>(storage, path);
+  std::cout << path << "\t" << ImageWidth << " pixels\n";
+
+  path = "/ImageInfo/ImageHeight";
+  int32_t ImageHeight = ReadValue<int32_t>(storage, path);
+  std::cout << path << "\t" << ImageHeight << " pixels\n";
+
+  path = "/ImageInfo/PixelSize";
+  float PixelSize = ReadValue<float>(storage, path);
+  std::cout << path << "\t" << PixelSize << " microns\n";
+
+  path = "/ImageInfo/DataType";
+  int32_t DataType = ReadValue<int32_t>(storage, path);
+  std::cout << path << "\t" << DataType << "\n";
+
+  path = "/ImageInfo/NoOfImages";
+  int32_t NoOfImages = ReadValue<int32_t>(storage, path);
+  std::cout << path << "\t" << NoOfImages << "\n";
+
+  int numImageGroups = std::ceil(static_cast<float>(NoOfImages) / 100.0f);
+  std::cout << "numImageGroups:"
+            << "\t" << numImageGroups << "\n";
+
+  size_t bitsPerPixel = 0;
+  if(DataType == FLOAT_TYPE)
+  {
+    bitsPerPixel = 4;
+  }
+  if(DataType == INT16_TYPE)
+  {
+    bitsPerPixel = 2;
+  }
+  if(DataType == UCHAR_TYPE)
+  {
+    bitsPerPixel = 1;
+  }
+
+  size_t totalPixels = ImageWidth * ImageHeight;
+  size_t totalBytes = totalPixels * bitsPerPixel;
+  size_t readBytes = 0;
+  std::vector<unsigned char> buffer(totalBytes);
+
+  int imageGroupIndex = 1;
+  for(int32_t i = 1; i < NoOfImages + 1; i++)
+  {
+    std::stringstream pathStrm;
+    pathStrm << "/ImageData" << imageGroupIndex << "/Image" << i;
+    std::cout << "Reading Image: " << pathStrm.str() << "\n";
+    StreamPtrType stream = std::make_shared<POLE::Stream>(storage.get(), pathStrm.str());
+    if(!stream->fail())
+    {
+      readBytes = stream->read(buffer.data(), totalBytes);
+      if(readBytes != totalBytes)
+      {
+        std::cout << "Not enough bytes were read: " << readBytes << " vs " << totalBytes << "\n";
+        return;
+      }
+
+      // std::stringstream filepathstream;
+      // filepathstream << "/tmp/txm/Image_" << i << ".tif";
+      // TiffWriter::WriteImage(filepathstream.str(), ImageWidth, ImageHeight, bitsPerPixel, 1, buffer.data());
+    }
+    if(i % 100 == 0)
+    {
+      imageGroupIndex++;
+    }
+  }
+}
+
+int main(int argc, char* argv[])
+{
+  std::cout << "txm_reader Starting... \n";
+  if(argc != 3)
+  {
+    std::cout << "3 Args are required\n1-Command\n2-Input File\n";
+    return 1;
+  }
+
+  std::string command = argv[1];
+  std::string file = argv[2];
+
+  StoragePtrType storage = std::make_shared<POLE::Storage>(file.c_str());
+  storage->open();
+
+  if(storage->result() != POLE::Storage::Ok)
+  {
+    std::cout << "Unable to open OLESS file" << std::endl;
+    return 2;
+  }
+
+  ReadImages(storage);
+
+  storage->close();
+
+  return 0;
+}

--- a/src/Plugins/SimplnxCore/test/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/test/CMakeLists.txt
@@ -156,6 +156,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   WriteSPParksSitesTest.cpp
   WriteStlFileTest.cpp
   WriteVtkRectilinearGridTest.cpp
+  ReadZeissTxmFileTest.cpp
 )
 
 create_simplnx_plugin_unit_test(PLUGIN_NAME ${PLUGIN_NAME}
@@ -267,6 +268,7 @@ if(EXISTS "${DREAM3D_DATA_DIR}" AND SIMPLNX_DOWNLOAD_TEST_FILES)
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR} ARCHIVE_NAME extract_vertex_geometry.tar.gz SHA512 b34c877e6a150eb461aa21afc33529a8cde07e32d4c1e788cb2c98751ebf1d8f82ca9da010c8c3de6f15e53e9a8d030d62c93173815b101fe676edccac59ad0a)
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR} ARCHIVE_NAME extract_internal_surface.tar.gz SHA512 86d47a9850d03486a62707f2f0c48fe7bc5d88a0b71fc286f74ad13a1f3c982f36f55ac65dda43b67826b14b4fce0dc2d29dd5adbee6338a887a12f42e879ed7)
   download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR} ARCHIVE_NAME dbscan_test.tar.gz SHA512 77d7886e2550b63176b564e827d7de320b5a28b1c8a55bf107d53acd6962757275bc86b3382ff789f612a6838f55ab8f4af29435aec83a7a804b9487e57a6386)
+  download_test_data(DREAM3D_DATA_DIR ${DREAM3D_DATA_DIR} ARCHIVE_NAME ReadZeissTxmFileTest.tar.gz SHA512 35e74a11eccfe838547fce46cad0e36fd29029af11ec322caa2a580a583f6c341bf38dc1a6c853a99733115a9971fef39e6035639af892c3898a109610d2f1e7)
 
 endif()
 

--- a/src/Plugins/SimplnxCore/test/ReadZeissTxmFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReadZeissTxmFileTest.cpp
@@ -1,0 +1,122 @@
+#include <catch2/catch.hpp>
+
+#include "simplnx/Parameters/ArrayCreationParameter.hpp"
+#include "simplnx/Parameters/BoolParameter.hpp"
+#include "simplnx/Parameters/DataGroupCreationParameter.hpp"
+#include "simplnx/Parameters/DataObjectNameParameter.hpp"
+#include "simplnx/Parameters/FileSystemPathParameter.hpp"
+#include "simplnx/Parameters/NumberParameter.hpp"
+#include "simplnx/UnitTest/UnitTestCommon.hpp"
+
+#include "SimplnxCore/Filters/ReadZeissTxmFileFilter.hpp"
+#include "SimplnxCore/SimplnxCore_test_dirs.hpp"
+
+#include <filesystem>
+namespace fs = std::filesystem;
+
+using namespace nx::core;
+using namespace nx::core::Constants;
+using namespace nx::core::UnitTest;
+
+using namespace nx::core;
+
+namespace
+{
+const DataPath k_CreatedImageGeometryPath({"Computed Geometry"});
+const std::string k_CellAttributeMatrixName("Cell Data");
+const std::string k_CTDataArrayName("CT Data");
+
+const DataPath k_ExemplarFullVolumePath({"Exemplar Full Volume"});
+const DataPath k_ExemplarSubVolumePath({"Exemplar Sub Volume"});
+
+} // namespace
+
+TEST_CASE("SimplnxReview::ReadZeissTxmFileFilter:Read_Full_Volume", "[SimplnxReview][ReadZeissTxmFileFilter]")
+{
+
+  const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_CMakeExecutable, nx::core::unit_test::k_TestFilesDir, "ReadZeissTxmFileTest.tar.gz", "ReadZeissTxmFileTest");
+
+  // Read Exemplar DREAM3D File Filter
+  auto exemplarFilePath = fs::path(fmt::format("{}/ReadZeissTxmFileTest/ReadZeissTxmFileTest.dream3d", unit_test::k_TestFilesDir));
+  DataStructure dataStructure = LoadDataStructure(exemplarFilePath);
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  ReadZeissTxmFileFilter filter;
+  Arguments args;
+
+  std::filesystem::path filePath = fs::path(fmt::format("{}/ReadZeissTxmFileTest/ReadZeissTxmFileTest.txm", unit_test::k_TestFilesDir));
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ReadZeissTxmFileFilter::k_TxmInputFilePath_Key, std::make_any<FileSystemPathParameter::ValueType>(filePath));
+  args.insertOrAssign(ReadZeissTxmFileFilter::k_CreatedImageGeometryPath_Key, std::make_any<DataGroupCreationParameter::ValueType>(k_CreatedImageGeometryPath));
+  args.insertOrAssign(ReadZeissTxmFileFilter::k_CellAttributeMatrixName_Key, std::make_any<DataObjectNameParameter::ValueType>(k_CellAttributeMatrixName));
+  args.insertOrAssign(ReadZeissTxmFileFilter::k_CTDataArrayName_Key, std::make_any<DataObjectNameParameter::ValueType>(k_CTDataArrayName));
+
+  args.insertOrAssign(ReadZeissTxmFileFilter::k_Use_SubVolume_Key, std::make_any<BoolParameter::ValueType>(false));
+  args.insertOrAssign(ReadZeissTxmFileFilter::k_SubVolumeStartSlice_Key, std::make_any<UInt32Parameter::ValueType>(1));
+  args.insertOrAssign(ReadZeissTxmFileFilter::k_SubVolumeEndSlice_Key, std::make_any<UInt32Parameter::ValueType>(1));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+  // Write the DataStructure out to the file system
+#ifdef SIMPLNX_WRITE_TEST_OUTPUT
+  UnitTest::WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/read_zeiss_txm_file_test_output.dream3d", unit_test::k_BinaryTestOutputDir)));
+#endif
+
+  UnitTest::CompareImageGeometry(dataStructure, ::k_ExemplarFullVolumePath, ::k_CreatedImageGeometryPath);
+
+  UnitTest::CompareExemplarToGenerateAttributeMatrix(dataStructure, ::k_ExemplarFullVolumePath.createChildPath("Cell Data"), dataStructure, ::k_CreatedImageGeometryPath.createChildPath("Cell Data"));
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxReview::ReadZeissTxmFileFilter:Read_Sub_Volume", "[SimplnxReview][ReadZeissTxmFileFilter]")
+{
+
+  const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_CMakeExecutable, nx::core::unit_test::k_TestFilesDir, "ReadZeissTxmFileTest.tar.gz", "ReadZeissTxmFileTest");
+
+  // Read Exemplar DREAM3D File Filter
+  auto exemplarFilePath = fs::path(fmt::format("{}/ReadZeissTxmFileTest/ReadZeissTxmFileTest.dream3d", unit_test::k_TestFilesDir));
+  DataStructure dataStructure = LoadDataStructure(exemplarFilePath);
+
+  // Instantiate the filter, a DataStructure object and an Arguments Object
+  ReadZeissTxmFileFilter filter;
+  Arguments args;
+
+  std::filesystem::path filePath = fs::path(fmt::format("{}/ReadZeissTxmFileTest/ReadZeissTxmFileTest.txm", unit_test::k_TestFilesDir));
+
+  // Create default Parameters for the filter.
+  args.insertOrAssign(ReadZeissTxmFileFilter::k_TxmInputFilePath_Key, std::make_any<FileSystemPathParameter::ValueType>(filePath));
+  args.insertOrAssign(ReadZeissTxmFileFilter::k_CreatedImageGeometryPath_Key, std::make_any<DataGroupCreationParameter::ValueType>(k_CreatedImageGeometryPath));
+  args.insertOrAssign(ReadZeissTxmFileFilter::k_CellAttributeMatrixName_Key, std::make_any<DataObjectNameParameter::ValueType>(k_CellAttributeMatrixName));
+  args.insertOrAssign(ReadZeissTxmFileFilter::k_CTDataArrayName_Key, std::make_any<DataObjectNameParameter::ValueType>(k_CTDataArrayName));
+
+  args.insertOrAssign(ReadZeissTxmFileFilter::k_Use_SubVolume_Key, std::make_any<BoolParameter::ValueType>(true));
+  args.insertOrAssign(ReadZeissTxmFileFilter::k_SubVolumeStartSlice_Key, std::make_any<UInt32Parameter::ValueType>(50));
+  args.insertOrAssign(ReadZeissTxmFileFilter::k_SubVolumeEndSlice_Key, std::make_any<UInt32Parameter::ValueType>(55));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+  // Write the DataStructure out to the file system
+#ifdef SIMPLNX_WRITE_TEST_OUTPUT
+  UnitTest::WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/read_zeiss_txm_file_test_output.dream3d", unit_test::k_BinaryTestOutputDir)));
+#endif
+
+  UnitTest::CompareImageGeometry(dataStructure, ::k_ExemplarSubVolumePath, ::k_CreatedImageGeometryPath);
+
+  UnitTest::CompareExemplarToGenerateAttributeMatrix(dataStructure, ::k_ExemplarSubVolumePath.createChildPath("Cell Data"), dataStructure, ::k_CreatedImageGeometryPath.createChildPath("Cell Data"));
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}


### PR DESCRIPTION
This filter allows users to read files with a .txm file extension. The data inside the file represents a CT data set.

Unit Test data was donated by AFRL and is marked as such with a US Air Force Public Affairs (PA) case number.