### PR TITLE
ENH/API: Multi-Dimensional Tuple Support For StringArray and NeighborList

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,7 @@ set(CoreParameters
 set(SIMPLNX_SOURCE_DIR ${simplnx_SOURCE_DIR}/src/simplnx)
 
 set(SIMPLNX_HDRS
+  ${SIMPLNX_SOURCE_DIR}/Common/Aliases.hpp
   ${SIMPLNX_SOURCE_DIR}/Common/Any.hpp
   ${SIMPLNX_SOURCE_DIR}/Common/Array.hpp
   ${SIMPLNX_SOURCE_DIR}/Common/AtomicFile.hpp

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Common/ITKArrayHelper.hpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Common/ITKArrayHelper.hpp
@@ -402,8 +402,8 @@ void ConvertImageToDataStore(itk::Image<PixelT, Dimension>& image, AbstractDataS
   using ImageType = itk::Image<PixelT, Dimension>;
   using T = UnderlyingType_t<PixelT>;
   typename ImageType::SizeType imageSize = image.GetLargestPossibleRegion().GetSize();
-  typename DataStore<T>::ShapeType tDims(imageSize.rbegin(), imageSize.rend());
-  typename DataStore<T>::ShapeType cDims = GetComponentDimensions<PixelT>();
+  ShapeType tDims(imageSize.rbegin(), imageSize.rend());
+  ShapeType cDims = GetComponentDimensions<PixelT>();
   if constexpr(Dimension == 2)
   {
     tDims.insert(tDims.begin(), 1);
@@ -441,8 +441,8 @@ Result<> ConvertImageToDataStore(DataStore<NewStoreT>& dataStore, itk::Image<Pix
   using ImageType = itk::Image<PixelT, Dimension>;
   using T = UnderlyingType_t<PixelT>;
   typename ImageType::SizeType imageSize = image.GetLargestPossibleRegion().GetSize();
-  std::vector<usize> tDims(imageSize.rbegin(), imageSize.rend());
-  std::vector<usize> cDims = GetComponentDimensions<PixelT>();
+  ShapeType tDims(imageSize.rbegin(), imageSize.rend());
+  ShapeType cDims = GetComponentDimensions<PixelT>();
   if constexpr(Dimension == 2)
   {
     tDims.insert(tDims.begin(), 1);
@@ -655,7 +655,7 @@ Result<OutputActions> DataCheckImpl(const DataStructure& dataStructure, const Da
     return MakeErrorResult<OutputActions>(nx::core::ITK::Constants::k_ImageGeometryDimensionMismatch, errMessage);
   }
 
-  std::vector<usize> cDims = dataStore.getComponentShape();
+  ShapeType cDims = dataStore.getComponentShape();
   std::vector<usize> inputPixelDims = ITK::GetComponentDimensions<InputPixelT>();
 
   if(cDims != inputPixelDims)
@@ -669,7 +669,7 @@ Result<OutputActions> DataCheckImpl(const DataStructure& dataStructure, const Da
 
   DataType outputType = GetDataType<OutputValueType>();
   SizeVec3 imageDims = imageGeom.getDimensions();
-  std::vector<usize> tDims(std::make_reverse_iterator(imageDims.end()), std::make_reverse_iterator(imageDims.begin()));
+  ShapeType tDims(std::make_reverse_iterator(imageDims.end()), std::make_reverse_iterator(imageDims.begin()));
   std::vector<usize> outputPixelDims = ITK::GetComponentDimensions<OutputPixelT>();
 
   outputActions.appendAction(std::make_unique<CreateArrayAction>(outputType, tDims, outputPixelDims, outputArrayPath, dataStore.getDataFormat()));

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Common/ReadImageUtils.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Common/ReadImageUtils.cpp
@@ -75,7 +75,7 @@ Result<OutputActions> ReadImagePreflight(const std::string& fileName, DataPath i
     // DataArray dimensions are stored slowest to fastest, the opposite of ImageGeometry
     std::vector<usize> arrayDims(dims.crbegin(), dims.crend());
 
-    std::vector<usize> cDims = {nComponents};
+    ShapeType cDims = {nComponents};
 
     actions.appendAction(std::make_unique<CreateImageGeometryAction>(std::move(imageGeomPath), std::move(dims), origin.toContainer<CreateImageGeometryAction::OriginType>(),
                                                                      spacing.toContainer<CreateImageGeometryAction::SpacingType>(), cellDataName));

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMaskImageFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMaskImageFilter.cpp
@@ -72,7 +72,7 @@ typename MaskImageT<Dimension>::Pointer CastIDataStoreToUInt32Image(IDataStore& 
 template <class InputPixelT, class OutputPixelT>
 OutputPixelT MakeOutsideValue(float64 value)
 {
-  std::vector<usize> cDims = ITK::GetComponentDimensions<InputPixelT>();
+  ShapeType cDims = ITK::GetComponentDimensions<InputPixelT>();
   usize numComponents = std::accumulate(cDims.cbegin(), cDims.cend(), static_cast<usize>(1), std::multiplies<>());
   OutputPixelT outsideValue{};
   itk::NumericTraits<OutputPixelT>::SetLength(outsideValue, numComponents);

--- a/src/Plugins/ITKImageProcessing/test/ITKTestBase.cpp
+++ b/src/Plugins/ITKImageProcessing/test/ITKTestBase.cpp
@@ -22,8 +22,6 @@ using namespace nx::core;
 
 namespace
 {
-using ShapeType = std::vector<usize>;
-
 template <class T>
 std::string ComputeMD5HashTyped(const IDataArray& outputDataArray)
 {

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.cpp
@@ -73,7 +73,7 @@ Result<> CAxisSegmentFeatures::operator()()
   }
 
   // Resize the Feature Attribute Matrix
-  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures + 1)};
+  ShapeType tDims = {static_cast<usize>(this->m_FoundFeatures + 1)};
   auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->CellFeatureAttributeMatrixPath);
   cellFeaturesAM.resizeTuples(tDims); // This will resize the active array
 
@@ -125,7 +125,7 @@ int64 CAxisSegmentFeatures::getSeed(int32 gnum, int64 nextSeed) const
   {
     auto& cellFeatureAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->CellFeatureAttributeMatrixPath);
     featureIds[static_cast<usize>(seed)] = gnum;
-    const std::vector<usize> tDims = {static_cast<usize>(gnum) + 1};
+    const ShapeType tDims = {static_cast<usize>(gnum) + 1};
     cellFeatureAM.resizeTuples(tDims); // This will resize the active array
   }
   return seed;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeGBCDPoleFigure.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeGBCDPoleFigure.cpp
@@ -298,7 +298,7 @@ Result<> ComputeGBCDPoleFigure::operator()()
   gbcdLimits[9] = sqrtf(Constants::k_PiOver2D);
 
   // get num components of GBCD
-  std::vector<usize> cDims = gbcd.getComponentShape();
+  ShapeType cDims = gbcd.getComponentShape();
 
   gbcdSizes[0] = static_cast<int32>(cDims[0]);
   gbcdSizes[1] = static_cast<int32>(cDims[1]);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
@@ -53,7 +53,7 @@ Result<> EBSDSegmentFeatures::operator()()
   }
 
   // Resize the Feature Attribute Matrix
-  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures + 1)};
+  ShapeType tDims = {static_cast<usize>(this->m_FoundFeatures + 1)};
   auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->CellFeatureAttributeMatrixPath);
   cellFeaturesAM.resizeTuples(tDims); // This will resize the active array
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/MergeTwins.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/MergeTwins.cpp
@@ -61,7 +61,7 @@ int MergeTwins::getSeed(int32 newFid) const
   if(seed >= 0)
   {
     featureParentIds[seed] = newFid;
-    std::vector<usize> tDims(1, newFid + 1);
+    ShapeType tDims(1, newFid + 1);
     cellFeaturesAttMatrix.resizeTuples(tDims); // this will resize the active array as well
   }
   return seed;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteGBCDGMTFile.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteGBCDGMTFile.cpp
@@ -114,7 +114,7 @@ Result<> WriteGBCDGMTFile::operator()()
   gbcdLimits[9] = sqrtf(Constants::k_PiOver2D);
 
   // get num components of GBCD
-  std::vector<usize> cDims = gbcd.getComponentShape();
+  ShapeType cDims = gbcd.getComponentShape();
 
   gbcdSizes[0] = static_cast<int>(cDims[0]);
   gbcdSizes[1] = static_cast<int>(cDims[1]);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WritePoleFigure.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WritePoleFigure.cpp
@@ -703,7 +703,7 @@ Result<> WritePoleFigure::operator()()
   // Create the Image Geometry that will serve as the final storage location for each
   // pole figure. We are just giving it a default size for now, it will be resized
   // further down the algorithm.
-  std::vector<usize> tupleShape = {1, static_cast<usize>(m_InputValues->ImageSize), static_cast<usize>(m_InputValues->ImageSize)};
+  ShapeType tupleShape = {1, static_cast<usize>(m_InputValues->ImageSize), static_cast<usize>(m_InputValues->ImageSize)};
   auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->OutputImageGeometryPath);
   auto cellAttrMatPath = imageGeom.getCellDataPath();
   imageGeom.setDimensions({static_cast<usize>(m_InputValues->ImageSize), static_cast<usize>(m_InputValues->ImageSize), 1});

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMisorientationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMisorientationFilter.cpp
@@ -203,7 +203,7 @@ IFilter::PreflightResult AlignSectionsMisorientationFilter::preflightImpl(const 
     const DataPath amPath = inputImageGeometry.createChildPath(pAlignmentAMName);
 
     // Create Parent AM
-    resultOutputActions.value().appendAction(std::make_unique<CreateAttributeMatrixAction>(amPath, AttributeMatrix::ShapeType{dims}));
+    resultOutputActions.value().appendAction(std::make_unique<CreateAttributeMatrixAction>(amPath, ShapeType{dims}));
 
     // Create slices Array
     auto pSlicesName = filterArgs.value<DataObjectNameParameter::ValueType>(k_SlicesArrayName_Key);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMutualInformationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/AlignSectionsMutualInformationFilter.cpp
@@ -173,7 +173,7 @@ IFilter::PreflightResult AlignSectionsMutualInformationFilter::preflightImpl(con
     const DataPath amPath = imageGeometryPath.createChildPath(pAlignmentAMName);
 
     // Create Parent AM
-    resultOutputActions.value().appendAction(std::make_unique<CreateAttributeMatrixAction>(amPath, AttributeMatrix::ShapeType{dims}));
+    resultOutputActions.value().appendAction(std::make_unique<CreateAttributeMatrixAction>(amPath, ShapeType{dims}));
 
     // Create slices Array
     auto pSlicesName = filterArgs.value<DataObjectNameParameter::ValueType>(k_SlicesArrayName_Key);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgCAxesFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgCAxesFilter.cpp
@@ -103,7 +103,7 @@ IFilter::PreflightResult ComputeAvgCAxesFilter::preflightImpl(const DataStructur
   }
 
   {
-    std::vector<usize> tupleShape = dataStructure.getDataRefAs<AttributeMatrix>(pCellFeatureAttributeMatrixPathValue).getShape();
+    ShapeType tupleShape = dataStructure.getDataRefAs<AttributeMatrix>(pCellFeatureAttributeMatrixPathValue).getShape();
     auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::float32, tupleShape, std::vector<usize>{3}, avgCAxesPath);
     resultOutputActions.value().appendAction(std::move(createArrayAction));
   }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeCAxisLocationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeCAxisLocationsFilter.cpp
@@ -97,7 +97,7 @@ IFilter::PreflightResult ComputeCAxisLocationsFilter::preflightImpl(const DataSt
 
   {
     const DataPath pCAxisLocationsPathValue = pQuatsArrayPathValue.replaceName(filterArgs.value<std::string>(k_CAxisLocationsArrayName_Key));
-    const std::vector<usize> tupleShape = dataStructure.getDataRefAs<Float32Array>(pQuatsArrayPathValue).getTupleShape();
+    const ShapeType tupleShape = dataStructure.getDataRefAs<Float32Array>(pQuatsArrayPathValue).getTupleShape();
     auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::float32, tupleShape, std::vector<usize>{3}, pCAxisLocationsPathValue);
     resultOutputActions.value().appendAction(std::move(createArrayAction));
   }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureNeighborCAxisMisalignmentsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureNeighborCAxisMisalignmentsFilter.cpp
@@ -115,7 +115,7 @@ IFilter::PreflightResult ComputeFeatureNeighborCAxisMisalignmentsFilter::preflig
   const auto& featurePhases = dataStructure.getDataRefAs<Int32Array>(pFeaturePhasesArrayPathValue);
   {
     auto createArrayAction =
-        std::make_unique<CreateNeighborListAction>(DataType::float32, featurePhases.getNumberOfTuples(), pFeaturePhasesArrayPathValue.replaceName(pCAxisMisalignmentListArrayNameValue));
+        std::make_unique<CreateNeighborListAction>(DataType::float32, featurePhases.getTupleShape(), pFeaturePhasesArrayPathValue.replaceName(pCAxisMisalignmentListArrayNameValue));
     resultOutputActions.value().appendAction(std::move(createArrayAction));
   }
   if(pFindAvgMisalsValue)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureNeighborMisorientationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureNeighborMisorientationsFilter.cpp
@@ -151,7 +151,7 @@ IFilter::PreflightResult ComputeFeatureNeighborMisorientationsFilter::preflightI
   }
 
   // Create the NeighborList array
-  auto createArrayAction = std::make_unique<CreateNeighborListAction>(nx::core::DataType::float32, avgQuats->getNumberOfTuples(), pMisorientationListArrayPath);
+  auto createArrayAction = std::make_unique<CreateNeighborListAction>(nx::core::DataType::float32, avgQuats->getTupleShape(), pMisorientationListArrayPath);
   resultOutputActions.value().appendAction(std::move(createArrayAction));
 
   std::vector<PreflightValue> preflightUpdatedValues;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceCAxisMisorientationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceCAxisMisorientationsFilter.cpp
@@ -114,7 +114,7 @@ IFilter::PreflightResult ComputeFeatureReferenceCAxisMisorientationsFilter::pref
     return {MakeErrorResult<OutputActions>(-9800, fmt::format("The following DataArrays all must have equal number of tuples but this was not satisfied.\n{}", tupleValidityCheck.error()))};
   }
 
-  std::vector<usize> tupleShape = dataStructure.getDataRefAs<Int32Array>(pFeatureIdsArrayPathValue).getTupleShape();
+  ShapeType tupleShape = dataStructure.getDataRefAs<Int32Array>(pFeatureIdsArrayPathValue).getTupleShape();
   {
     auto createArrayAction =
         std::make_unique<CreateArrayAction>(DataType::float32, tupleShape, std::vector<usize>{1}, pFeatureIdsArrayPathValue.replaceName(pFeatureReferenceCAxisMisorientationsArrayNameValue));

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceMisorientationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceMisorientationsFilter.cpp
@@ -151,7 +151,7 @@ IFilter::PreflightResult ComputeFeatureReferenceMisorientationsFilter::preflight
   // Create output Feature Average Misorientations
   {
     DataPath featAvgMisorientationsPath;
-    std::vector<usize> tupleShape;
+    ShapeType tupleShape;
     if(pReferenceOrientationValue == 0)
     {
       auto cellFeatPath = pAvgQuatsArrayPathValue.getParent();

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDFilter.cpp
@@ -140,7 +140,7 @@ IFilter::PreflightResult ComputeGBCDFilter::preflightImpl(const DataStructure& d
     return {MakeErrorResult<OutputActions>(-74353, fmt::format("Could not find triangle geometry array at path '{}'", pTriangleGeometryPathValue.toString()))};
   }
 
-  std::vector<usize> tupleShape(1, crystalStructures->getNumberOfTuples());
+  ShapeType tupleShape(1, crystalStructures->getNumberOfTuples());
   auto createAttributeMatrixAction = std::make_unique<CreateAttributeMatrixAction>(faceEnsembleAttributeMatrixPath, tupleShape);
   resultOutputActions.value().appendAction(std::move(createAttributeMatrixAction));
 
@@ -159,7 +159,7 @@ IFilter::PreflightResult ComputeGBCDFilter::preflightImpl(const DataStructure& d
 
   // call the sizeGBCD function to get the GBCD ranges, dimensions, etc.  Note that the input parameters do not affect the size and can be dummy values here;
   SizeGBCD sizeGbcd(0, 0, pGBCDResValue);
-  std::vector<usize> componentShape(6);
+  ShapeType componentShape(6);
   componentShape[0] = sizeGbcd.m_GbcdSizes[0];
   componentShape[1] = sizeGbcd.m_GbcdSizes[1];
   componentShape[2] = sizeGbcd.m_GbcdSizes[2];

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDPoleFigureFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDPoleFigureFilter.cpp
@@ -128,8 +128,8 @@ IFilter::PreflightResult ComputeGBCDPoleFigureFilter::preflightImpl(const DataSt
       CreateImageGeometryAction::SpacingType{2.0f / pOutputImageDimension, 2.0f / pOutputImageDimension, 2.0f / pOutputImageDimension}, pCellAttributeMatrixName);
   resultOutputActions.value().appendAction(std::move(createImageGeometryAction));
 
-  std::vector<usize> cDims = {1};
-  std::vector<usize> tDims = {1ULL, pOutputImageDimension, pOutputImageDimension}; // The DataArray Tuple Dims should be slowest to fastest, "C" Order
+  ShapeType cDims = {1};
+  ShapeType tDims = {1ULL, pOutputImageDimension, pOutputImageDimension}; // The DataArray Tuple Dims should be slowest to fastest, "C" Order
 
   DataPath cellIntensityArrayPath = pImageGeometryPath.createChildPath(pCellAttributeMatrixName).createChildPath(pCellIntensityArrayName);
   auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::float64, tDims, cDims, cellIntensityArrayPath);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesFilter.cpp
@@ -125,7 +125,7 @@ IFilter::PreflightResult ComputeShapesFilter::preflightImpl(const DataStructure&
     return {MakeErrorResult<OutputActions>(-12802, "Centroids Feature Data Array is not of the correct type")};
   }
 
-  IDataStore::ShapeType tupleShape = featureAttrMatrix->getShape();
+  ShapeType tupleShape = featureAttrMatrix->getShape();
 
   // Create the CreateArrayAction within a scope so that we do not accidentally use the variable is it is getting "moved"
   {

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSlipTransmissionMetricsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSlipTransmissionMetricsFilter.cpp
@@ -100,7 +100,7 @@ IFilter::PreflightResult ComputeSlipTransmissionMetricsFilter::preflightImpl(con
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  INeighborList::ShapeType tupShape = dataStructure.getDataAs<Int32NeighborList>(pNeighborListPathValue)->getTupleShape();
+  ShapeType tupShape = dataStructure.getDataAs<Int32NeighborList>(pNeighborListPathValue)->getTupleShape();
 
   {
     auto action = std::make_unique<CreateNeighborListAction>(DataType::float32, tupShape, pNeighborListPathValue.replaceName(pF1ListNameValue));

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSlipTransmissionMetricsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeSlipTransmissionMetricsFilter.cpp
@@ -100,7 +100,7 @@ IFilter::PreflightResult ComputeSlipTransmissionMetricsFilter::preflightImpl(con
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  usize tupShape = dataStructure.getDataAs<Int32NeighborList>(pNeighborListPathValue)->getNumberOfTuples();
+  INeighborList::ShapeType tupShape = dataStructure.getDataAs<Int32NeighborList>(pNeighborListPathValue)->getTupleShape();
 
   {
     auto action = std::make_unique<CreateNeighborListAction>(DataType::float32, tupShape, pNeighborListPathValue.replaceName(pF1ListNameValue));

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CreateEnsembleInfoFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CreateEnsembleInfoFilter.cpp
@@ -94,7 +94,7 @@ IFilter::PreflightResult CreateEnsembleInfoFilter::preflightImpl(const DataStruc
   std::vector<PreflightValue> preflightUpdatedValues;
 
   int numPhases = pEnsembleValue.size();
-  std::vector<usize> tDims(1, numPhases + 1);
+  ShapeType tDims(1, numPhases + 1);
   auto createAttributeMatrixAction = std::make_unique<CreateAttributeMatrixAction>(pCellEnsembleAttributeMatrixNameValue, tDims);
   outputActions.appendAction(std::move(createAttributeMatrixAction));
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadEnsembleInfoFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadEnsembleInfoFilter.cpp
@@ -122,7 +122,7 @@ IFilter::PreflightResult ReadEnsembleInfoFilter::preflightImpl(const DataStructu
     return MakePreflightErrorResult(-13003, fmt::format("The {} in the {} group must be greater than 0", ReadEnsembleInfo::k_NumberPhases, ReadEnsembleInfo::k_EnsembleInfo));
   }
 
-  std::vector<usize> tupleDims(1, numPhases + 1);
+  ShapeType tupleDims(1, numPhases + 1);
   auto attributeMatrixAction = std::make_unique<CreateAttributeMatrixAction>(cellEnsembleAttributeMatrixPath, tupleDims);
   resultOutputActions.value().appendAction(std::move(attributeMatrixAction));
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadGrainMapper3DFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadGrainMapper3DFilter.cpp
@@ -166,7 +166,7 @@ IFilter::PreflightResult ReadGrainMapper3DFilter::preflightImpl(const DataStruct
     }
 
     // Reverse the DCT Image Dimensions
-    const std::vector<usize> tupleDims = {dims[2], dims[1], dims[0]};
+    const ShapeType tupleDims = {dims[2], dims[1], dims[0]};
 
     // Get the available Data sets
     DataPath cellAMPath = pLabDCTImageGeometryPath.createChildPath(pLabDCTCellAttributeMatrixNameValue);
@@ -251,7 +251,7 @@ IFilter::PreflightResult ReadGrainMapper3DFilter::preflightImpl(const DataStruct
     }
 
     // Reverse the ABSORPTION Image Dimensions
-    const std::vector<usize> tupleDims = {dims[2], dims[1], dims[0]};
+    const ShapeType tupleDims = {dims[2], dims[1], dims[0]};
     // Create the 'Data' data array
     resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(
         DataType::uint16, tupleDims, std::vector<usize>{1ULL},

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EspritDataFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EspritDataFilter.cpp
@@ -141,7 +141,7 @@ IFilter::PreflightResult ReadH5EspritDataFilter::preflightImpl(const DataStructu
 
   // create the Image Geometry and it's attribute matrices
   const CreateImageGeometryAction::DimensionType dims = {static_cast<usize>(reader->getXDimension()), static_cast<usize>(reader->getYDimension()), pSelectedScanNamesValue.scanNames.size()};
-  const std::vector<usize> tupleDims = {dims[2], dims[1], dims[0]};
+  const ShapeType tupleDims = {dims[2], dims[1], dims[0]};
   {
     CreateImageGeometryAction::SpacingType spacing = {static_cast<float32>(reader->getXStep()), static_cast<float32>(reader->getYStep()), pZSpacingValue};
     for(float& value : spacing)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OimDataFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OimDataFilter.cpp
@@ -136,7 +136,7 @@ IFilter::PreflightResult ReadH5OimDataFilter::preflightImpl(const DataStructure&
 
   // create the Image Geometry and it's attribute matrices
   const CreateImageGeometryAction::DimensionType dims = {static_cast<usize>(reader->getXDimension()), static_cast<usize>(reader->getYDimension()), pSelectedScanNamesValue.scanNames.size()};
-  const std::vector<usize> tupleDims = {dims[2], dims[1], dims[0]};
+  const ShapeType tupleDims = {dims[2], dims[1], dims[0]};
   {
     CreateImageGeometryAction::SpacingType spacing = {reader->getXStep(), reader->getYStep(), pZSpacingValue};
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OinaDataFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5OinaDataFilter.cpp
@@ -140,7 +140,7 @@ IFilter::PreflightResult ReadH5OinaDataFilter::preflightImpl(const DataStructure
 
   // create the Image Geometry and it's attribute matrices
   const CreateImageGeometryAction::DimensionType dims = {static_cast<usize>(reader.getXDimension()), static_cast<usize>(reader.getYDimension()), pSelectedScanNamesValue.scanNames.size()};
-  const std::vector<usize> tupleDims = {dims[2], dims[1], dims[0]};
+  const ShapeType tupleDims = {dims[2], dims[1], dims[0]};
   {
     CreateImageGeometryAction::SpacingType spacing = {reader.getXStep(), reader.getYStep(), pZSpacingValue};
 

--- a/src/Plugins/OrientationAnalysis/test/AlignSectionsMisorientationTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/AlignSectionsMisorientationTest.cpp
@@ -83,7 +83,7 @@ TEST_CASE("OrientationAnalysis::AlignSectionsMisorientation Small IN100 Pipeline
   UnitTest::WriteTestDataStructure(dataStructure, fmt::format("{}/align_sections_misorientation.dream3d", unit_test::k_BinaryTestOutputDir));
 #endif
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, SmallIn100::k_TupleCheckIgnoredPaths);
 }
 
 TEST_CASE("OrientationAnalysis::AlignSectionsMisorientationFilter: output test", "[Reconstruction][AlignSectionsMisorientationFilter]")
@@ -159,5 +159,5 @@ TEST_CASE("OrientationAnalysis::AlignSectionsMisorientationFilter: output test",
   UnitTest::WriteTestDataStructure(dataStructure, fmt::format("{}/output_align_sections_misorientation.dream3d", unit_test::k_BinaryTestOutputDir));
 #endif
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, SmallIn100::k_TupleCheckIgnoredPaths);
 }

--- a/src/Plugins/OrientationAnalysis/test/BadDataNeighborOrientationCheckTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/BadDataNeighborOrientationCheckTest.cpp
@@ -185,5 +185,5 @@ TEST_CASE("OrientationAnalysis::BadDataNeighborOrientationCheckFilter: Small IN1
   WriteTestDataStructure(dataStructure, fmt::format("{}/bad_data_neighbor_orientation_check.dream3d", unit_test::k_BinaryTestOutputDir));
 #endif
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, SmallIn100::k_TupleCheckIgnoredPaths);
 }

--- a/src/Plugins/OrientationAnalysis/test/ComputeMisorientationsTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/ComputeMisorientationsTest.cpp
@@ -38,7 +38,7 @@ std::vector<usize> k_TupleShape = {k_Size * k_Size * k_Size};
 Result<> CreateDataStructure(DataStructure& dataStructure, uint32 xtal)
 {
   UnitTest::LoadPlugins();
-  std::vector<usize> compShape = {3};
+  ShapeType compShape = {3};
   DataPath k_EulersDataPath = DataPath::FromString(fmt::format("{}/Eulers", xtal)).value();
 
   DataGroup* dgPtr = DataGroup::Create(dataStructure, fmt::format("{}", xtal));

--- a/src/Plugins/OrientationAnalysis/test/EBSDSegmentFeaturesFilterTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/EBSDSegmentFeaturesFilterTest.cpp
@@ -97,5 +97,5 @@ TEST_CASE("OrientationAnalysis::EBSDSegmentFeatures: Valid Execution", "[Orienta
     UnitTest::CompareDataArrays<int32>(generatedDataArray, exemplarDataArray);
   }
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, SmallIn100::k_TupleCheckIgnoredPaths);
 }

--- a/src/Plugins/OrientationAnalysis/test/NeighborOrientationCorrelationTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/NeighborOrientationCorrelationTest.cpp
@@ -193,5 +193,5 @@ TEST_CASE("OrientationAnalysis::NeighborOrientationCorrelationFilter: Small IN10
   WriteTestDataStructure(dataStructure, fmt::format("{}/neighbor_orientation_correlation.dream3d", unit_test::k_BinaryTestOutputDir));
 #endif
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, SmallIn100::k_TupleCheckIgnoredPaths);
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CalculateTriangleGroupCurvatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CalculateTriangleGroupCurvatures.cpp
@@ -56,7 +56,7 @@ namespace
  */
 std::shared_ptr<Float64DataStore> extractPatchData(int64_t triId, FindNRingNeighbors::UniqueFaceIds_t& triPatch, Float64AbstractDataStore& data)
 {
-  IDataStore::ShapeType cDims = {3ULL};
+  ShapeType cDims = {3ULL};
 
   for(auto iter = triPatch.begin(); iter != triPatch.end();)
   {
@@ -87,7 +87,7 @@ std::shared_ptr<Float64DataStore> extractPatchData(int64_t triId, FindNRingNeigh
     totalTuples++;
   }
 
-  IDataStore::ShapeType tupleShape = {totalTuples};
+  ShapeType tupleShape = {totalTuples};
   std::optional<float64> initValue = {};
   std::shared_ptr<Float64DataStore> extractedData = std::make_shared<Float64DataStore>(tupleShape, cDims, initValue);
   // This little chunk makes sure the current seed triangles centroid and normal data appear

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureCentroids.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureCentroids.cpp
@@ -150,8 +150,8 @@ Result<> ComputeFeatureCentroids::operator()()
   size_t yPoints = imageGeom.getNumYCells();
   size_t zPoints = imageGeom.getNumZCells();
 
-  IDataStore::ShapeType tupleShape{totalFeatures};
-  IDataStore::ShapeType componentShape{3};
+  ShapeType tupleShape{totalFeatures};
+  ShapeType componentShape{3};
 
   auto sumPtr = DataStoreUtilities::CreateDataStore<float64>(tupleShape, componentShape, IDataAction::Mode::Execute);
   auto centerPtr = DataStoreUtilities::CreateDataStore<float64>(tupleShape, componentShape, IDataAction::Mode::Execute);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeTriangleGeomCentroids.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeTriangleGeomCentroids.cpp
@@ -48,7 +48,7 @@ Result<> ComputeTriangleGeomCentroids::operator()()
   if(featAttrMat.getNumTuples() < *maxFeatureId + 1)
   {
     m_MessageHandler(IFilter::Message::Type::Info, "Increasing Number of tuples in target feature attribute matrix...");
-    featAttrMat.resizeTuples(AttributeMatrix::ShapeType{static_cast<usize>(*maxFeatureId + 1)});
+    featAttrMat.resizeTuples(ShapeType{static_cast<usize>(*maxFeatureId + 1)});
   }
   MeshIndexType numFeatures = featAttrMat.getNumTuples();
   auto& centroids = m_DataStructure.getDataAs<Float32Array>(m_InputValues->CentroidsArrayPath)->getDataStoreRef();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeTriangleGeomVolumes.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeTriangleGeomVolumes.cpp
@@ -40,7 +40,7 @@ Result<> ComputeTriangleGeomVolumes::operator()()
 
   auto maxFaceLabel = std::max_element(faceLabels.begin(), faceLabels.end()); // Ensure the max value is set.
 
-  AttributeMatrix::ShapeType tDims = {static_cast<usize>(*maxFaceLabel) + 1ULL};
+  ShapeType tDims = {static_cast<usize>(*maxFaceLabel) + 1ULL};
   auto& featAttrMat = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->FeatureAttributeMatrixPath);
   featAttrMat.resizeTuples(tDims);
   auto& volumes = m_DataStructure.getDataAs<Float32Array>(m_InputValues->VolumesArrayPath)->getDataStoreRef();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/DBSCAN.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/DBSCAN.cpp
@@ -1134,7 +1134,7 @@ Result<> DBSCAN::operator()()
   messageHelper.sendMessage("Resizing clustering Attribute Matrix:");
   auto& featureIdsDataStore = featureIds.getDataStoreRef();
   int32 maxCluster = *std::max_element(featureIdsDataStore.begin(), featureIdsDataStore.end());
-  m_DataStructure.getDataAs<AttributeMatrix>(m_InputValues->FeatureAM)->resizeTuples(AttributeMatrix::ShapeType{static_cast<usize>(maxCluster + 1)});
+  m_DataStructure.getDataAs<AttributeMatrix>(m_InputValues->FeatureAM)->resizeTuples(ShapeType{static_cast<usize>(maxCluster + 1)});
 
   return result;
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/QuickSurfaceMesh.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/QuickSurfaceMesh.cpp
@@ -365,7 +365,7 @@ Result<> QuickSurfaceMesh::operator()()
   }
 
   // now create node and triangle arrays knowing the number that will be needed
-  std::vector<usize> tupleShape = {triangleCount};
+  ShapeType tupleShape = {triangleCount};
   triangleGeom.resizeFaceList(triangleCount);
   triangleGeom.resizeVertexList(nodeCount);
   triangleGeom.getFaceAttributeMatrix()->resizeTuples(tupleShape);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadCSVFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadCSVFile.cpp
@@ -27,7 +27,7 @@ ReadCSVFile::ReadCSVFile() = default;
 ReadCSVFile::~ReadCSVFile() noexcept = default;
 
 Result<> ReadCSVFile::readFile(DataStructure& dataStructure, const std::string& inputFilePath, usize importStartingRow, usize headersLineNumber, const std::vector<CSVType>& columnDataTypes,
-                               const std::vector<bool>& columnsSkipped, const DataPath& groupPath, const std::vector<usize>& tupleDims, const std::vector<char>& delimiters, bool consecutiveDelimiters,
+                               const std::vector<bool>& columnsSkipped, const DataPath& groupPath, const ShapeType& tupleDims, const std::vector<char>& delimiters, bool consecutiveDelimiters,
                                const std::atomic_bool& shouldCancel, const IFilter::MessageHandler& msgHandler)
 {
   auto result = FileUtilities::CSV::ReadHeaders(inputFilePath, headersLineNumber, delimiters, consecutiveDelimiters);
@@ -39,7 +39,7 @@ Result<> ReadCSVFile::readFile(DataStructure& dataStructure, const std::string& 
 }
 
 Result<> ReadCSVFile::readFile(DataStructure& dataStructure, const std::string& inputFilePath, usize importStartingRow, const std::vector<std::string>& columnHeaders,
-                               const std::vector<CSVType>& columnDataTypes, const std::vector<bool>& columnsSkipped, const DataPath& groupPath, const std::vector<usize>& tupleDims,
+                               const std::vector<CSVType>& columnDataTypes, const std::vector<bool>& columnsSkipped, const DataPath& groupPath, const ShapeType& tupleDims,
                                const std::vector<char>& delimiters, bool consecutiveDelimiters, const std::atomic_bool& shouldCancel, const IFilter::MessageHandler& msgHandler)
 {
   auto headers = columnHeaders;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadCSVFile.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadCSVFile.hpp
@@ -48,11 +48,11 @@ public:
   ReadCSVFile& operator=(ReadCSVFile&&) noexcept = delete;
 
   Result<> readFile(DataStructure& dataStructure, const std::string& inputFilePath, usize importStartingRow, const std::vector<std::string>& columnHeaders, const std::vector<CSVType>& columnDataTypes,
-                    const std::vector<bool>& columnsSkipped, const DataPath& groupPath, const std::vector<usize>& tupleDims, const std::vector<char>& delimiters, bool consecutiveDelimiters,
+                    const std::vector<bool>& columnsSkipped, const DataPath& groupPath, const ShapeType& tupleDims, const std::vector<char>& delimiters, bool consecutiveDelimiters,
                     const std::atomic_bool& shouldCancel, const IFilter::MessageHandler& msgHandler);
 
   Result<> readFile(DataStructure& dataStructure, const std::string& inputFilePath, usize importStartingRow, usize headersLineNumber, const std::vector<CSVType>& columnDataTypes,
-                    const std::vector<bool>& columnsSkipped, const DataPath& groupPath, const std::vector<usize>& tupleDims, const std::vector<char>& delimiters, bool consecutiveDelimiters,
+                    const std::vector<bool>& columnsSkipped, const DataPath& groupPath, const ShapeType& tupleDims, const std::vector<char>& delimiters, bool consecutiveDelimiters,
                     const std::atomic_bool& shouldCancel, const IFilter::MessageHandler& msgHandler);
 };
 } // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadVtkStructuredPoints.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadVtkStructuredPoints.cpp
@@ -181,8 +181,8 @@ Result<> readDataChunk(DataStructure* dataStructurePtr, std::istream& in, bool b
   using DataArrayType = DataArray<T>;
 
   auto& dataArrayRef = dataStructurePtr->getDataRefAs<DataArrayType>(dataArrayPath);
-  std::vector<usize> tDims = dataArrayRef.getTupleShape();
-  std::vector<usize> cDims = dataArrayRef.getComponentShape();
+  ShapeType tDims = dataArrayRef.getTupleShape();
+  ShapeType cDims = dataArrayRef.getComponentShape();
 
   dataArrayRef.fill(static_cast<T>(0));
   if(binary)
@@ -1025,7 +1025,7 @@ Result<> ReadVtkStructuredPoints::readScalarData(std::istream& in, int32 numPts)
     }
     nx::core::DataType nxDType = nxDTypeResult.value();
 
-    std::vector<usize> tupleShape = {m_CurrentGeomDims[2], m_CurrentGeomDims[1], m_CurrentGeomDims[0]};
+    ShapeType tupleShape = {m_CurrentGeomDims[2], m_CurrentGeomDims[1], m_CurrentGeomDims[0]};
     auto createArrayAction = std::make_unique<CreateArrayAction>(nxDType, tupleShape, std::vector<usize>{numComp}, arrayDataPath);
     m_OutputActions.value().appendAction(std::move(createArrayAction));
     preflightSkipVolume(nxDType, in, m_FileIsBinary, numPts * numComp);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
@@ -217,7 +217,7 @@ Result<> ScalarSegmentFeatures::operator()()
   }
 
   // Resize the Feature Attribute Matrix
-  std::vector<usize> tDims = {static_cast<usize>(this->m_FoundFeatures + 1)};
+  ShapeType tDims = {static_cast<usize>(this->m_FoundFeatures + 1)};
   auto& cellFeaturesAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->CellFeatureAttributeMatrixPath);
   cellFeaturesAM.resizeTuples(tDims); // This will resize the active array
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SharedFeatureFace.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SharedFeatureFace.cpp
@@ -191,7 +191,7 @@ Result<> SharedFeatureFace::operator()()
   // resize + update pointers
   // Grain Boundary Attribute Matrix
   auto& faceFeatureAttrMat = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->GrainBoundaryAttributeMatrixPath);
-  std::vector<usize> tDims = {static_cast<usize>(index)};
+  ShapeType tDims = {static_cast<usize>(index)};
   faceFeatureAttrMat.resizeTuples(tDims);
 
   auto& surfaceMeshFeatureFaceLabels = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureFaceLabelsArrayPath)->getDataStoreRef();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignSectionsFeatureCentroidFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignSectionsFeatureCentroidFilter.cpp
@@ -175,7 +175,7 @@ IFilter::PreflightResult AlignSectionsFeatureCentroidFilter::preflightImpl(const
     const DataPath amPath = inputImageGeometry.createChildPath(pAlignmentAMName);
 
     // Create Parent AM
-    resultOutputActions.value().appendAction(std::make_unique<CreateAttributeMatrixAction>(amPath, AttributeMatrix::ShapeType{dims}));
+    resultOutputActions.value().appendAction(std::make_unique<CreateAttributeMatrixAction>(amPath, ShapeType{dims}));
 
     // Create slices Array
     auto pSlicesName = filterArgs.value<DataObjectNameParameter::ValueType>(k_SlicesArrayName_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AppendImageGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AppendImageGeometryFilter.cpp
@@ -315,10 +315,9 @@ IFilter::PreflightResult AppendImageGeometryFilter::preflightImpl(const DataStru
           auto inputINeighborlist = dataStructure.getDataAs<INeighborList>(inputDataArrayPath);
           auto destINeighborlist = dataStructure.getDataAs<INeighborList>(destDataArrayPath);
           auto dataType = inputINeighborlist != nullptr ? inputINeighborlist->getDataType() : destINeighborlist->getDataType();
-          const usize numDestCellDataTuples = std::accumulate(destCellDataDims.cbegin(), destCellDataDims.cend(), static_cast<size_t>(1), std::multiplies<>());
-          auto numCellDataTuples = pSaveAsNewGeometry ? numNewCellDataTuples : numDestCellDataTuples;
+          auto cellDataDims = pSaveAsNewGeometry ? newCellDataDims : destCellDataDims;
           auto cellArrayPath = pSaveAsNewGeometry ? newArrayPath : destArrayPath;
-          auto createArrayAction = std::make_unique<CreateNeighborListAction>(dataType, numCellDataTuples, cellArrayPath);
+          auto createArrayAction = std::make_unique<CreateNeighborListAction>(dataType, cellDataDims, cellArrayPath);
           resultOutputActions.value().appendAction(std::move(createArrayAction));
         }
         if(arrayType == IArray::ArrayType::StringArray)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApplyTransformationToGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApplyTransformationToGeometryFilter.cpp
@@ -173,7 +173,7 @@ IFilter::PreflightResult ApplyTransformationToGeometryFilter::preflightImpl(cons
     return {MakeErrorResult<OutputActions>(-82000, "Input Geometry must be either ImageGeom or Vertex, Edge, Triangle, Quad, Hexahedron, Tetrahedron.")};
   }
 
-  const std::vector<usize> cDims = {4, 4};
+  const ShapeType cDims = {4, 4};
 
   // Reset the final Transformation Matrix to all Zeros before we fill it with what the user has entered.
   ImageRotationUtilities::Matrix4fR transformationMatrix;
@@ -399,7 +399,7 @@ IFilter::PreflightResult ApplyTransformationToGeometryFilter::preflightImpl(cons
         {
           const DataPath srcCellArrayDataPath = srcImagePath.createChildPath(cellDataName).createChildPath(cellArrayName);
           const auto& srcArray = dataStructure.getDataRefAs<IDataArray>(srcCellArrayDataPath);
-          const IDataStore::ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
+          const ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
           const std::string dataStoreFormat = srcArray.getDataFormat();
           resultOutputActions.value().appendAction(
               std::make_unique<CreateArrayAction>(srcArray.getDataType(), dataArrayShape, componentShape, targetCellAttrMatrix.createChildPath(srcArray.getName()), dataStoreFormat));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineNodeBasedGeometriesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineNodeBasedGeometriesFilter.cpp
@@ -32,7 +32,7 @@ namespace
 struct GeometryArrayInfo
 {
   std::string name;
-  std::vector<usize> compDims;
+  ShapeType compDims;
   IArray::ArrayType arrayType;
   std::optional<DataType> dataType;
 };
@@ -324,7 +324,7 @@ Result<> CreateINodeGeometry1DObjects(const DataPath& outputGeomPath, bool edges
     // Create Edge Attribute Matrix and Edges Array
     if(edgeAttrMatrixExists)
     {
-      actions.appendAction(std::make_unique<CreateAttributeMatrixAction>(outputGeomPath.createChildPath(INodeGeometry1D::k_EdgeAttributeMatrixName), AttributeMatrix::ShapeType{1}));
+      actions.appendAction(std::make_unique<CreateAttributeMatrixAction>(outputGeomPath.createChildPath(INodeGeometry1D::k_EdgeAttributeMatrixName), ShapeType{1}));
     }
     if(edgesArrayExists)
     {
@@ -353,7 +353,7 @@ Result<> CreateINodeGeometry2DObjects(const DataPath& outputGeomPath, bool faces
     // Create Face Attribute Matrix and Faces Array
     if(faceAttrMatrixExists)
     {
-      actions.appendAction(std::make_unique<CreateAttributeMatrixAction>(outputGeomPath.createChildPath(INodeGeometry2D::k_FaceAttributeMatrixName), AttributeMatrix::ShapeType{1}));
+      actions.appendAction(std::make_unique<CreateAttributeMatrixAction>(outputGeomPath.createChildPath(INodeGeometry2D::k_FaceAttributeMatrixName), ShapeType{1}));
     }
     if(facesArrayExists)
     {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineNodeBasedGeometriesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineNodeBasedGeometriesFilter.cpp
@@ -289,7 +289,7 @@ Result<> AddOutputArray(const GeometryArrayInfo& arrayInfo, const DataPath& outp
     break;
   }
   case IArray::ArrayType::NeighborListArray: {
-    actions.appendAction(std::make_unique<CreateNeighborListAction>(arrayInfo.dataType.value(), 1, outputGeomPath.createChildPath(attrMatrixName).createChildPath(arrayInfo.name)));
+    actions.appendAction(std::make_unique<CreateNeighborListAction>(arrayInfo.dataType.value(), std::vector<usize>{1}, outputGeomPath.createChildPath(attrMatrixName).createChildPath(arrayInfo.name)));
     break;
   }
   case IArray::ArrayType::Any: {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineTransformationMatricesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineTransformationMatricesFilter.cpp
@@ -97,7 +97,7 @@ IFilter::PreflightResult CombineTransformationMatricesFilter::preflightImpl(cons
   }
 
   // Check for unequal array types, data types, and component dimensions
-  std::vector<usize> cDims;
+  ShapeType cDims;
   IArray::ArrayType arrayType;
   std::string arrayTypeName;
   usize numTuples = 0;
@@ -145,7 +145,7 @@ IFilter::PreflightResult CombineTransformationMatricesFilter::preflightImpl(cons
 
   // create the destination array for the calculated results
   {
-    auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::float32, IArray::ShapeType{4, 4}, IArray::ShapeType{1}, outputArrayPath);
+    auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::float32, ShapeType{4, 4}, ShapeType{1}, outputArrayPath);
     resultOutputActions.value().appendAction(std::move(createArrayAction));
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayHistogramByFeatureFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayHistogramByFeatureFilter.cpp
@@ -186,7 +186,7 @@ IFilter::PreflightResult ComputeArrayHistogramByFeatureFilter::preflightImpl(con
     }
     if(pCalculateModalBinRanges)
     {
-      auto createArrayAction = std::make_unique<CreateNeighborListAction>(dataArray->getDataType(), 1, arrayGroupPath.createChildPath(pBinModalBinRangesName));
+      auto createArrayAction = std::make_unique<CreateNeighborListAction>(dataArray->getDataType(), std::vector<usize>{1}, arrayGroupPath.createChildPath(pBinModalBinRangesName));
       resultOutputActions.value().appendAction(std::move(createArrayAction));
     }
   }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayHistogramFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayHistogramFilter.cpp
@@ -186,7 +186,7 @@ IFilter::PreflightResult ComputeArrayHistogramFilter::preflightImpl(const DataSt
     }
     if(pCalculateModalBinRanges)
     {
-      auto createArrayAction = std::make_unique<CreateNeighborListAction>(dataArray->getDataType(), 1, arrayGroupPath.createChildPath(pBinModalBinRangesName));
+      auto createArrayAction = std::make_unique<CreateNeighborListAction>(dataArray->getDataType(), std::vector<usize>{1}, arrayGroupPath.createChildPath(pBinModalBinRangesName));
       resultOutputActions.value().appendAction(std::move(createArrayAction));
     }
   }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayStatisticsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayStatisticsFilter.cpp
@@ -54,8 +54,6 @@ OutputActions CreateCompatibleArrays(const DataStructure& dataStructure, const A
   auto destinationAttributeMatrixValue = filterArgs.value<DataPath>(ComputeArrayStatisticsFilter::k_DestinationAttributeMatrixPath_Key);
   DataType dataType = inputArray->getDataType();
 
-  size_t tupleSize = std::accumulate(tupleDims.begin(), tupleDims.end(), static_cast<usize>(1), std::multiplies<>());
-
   OutputActions actions;
 
   auto amAction = std::make_unique<CreateAttributeMatrixAction>(destinationAttributeMatrixValue, tupleDims);
@@ -123,7 +121,7 @@ OutputActions CreateCompatibleArrays(const DataStructure& dataStructure, const A
   if(findMode)
   {
     auto arrayPath = filterArgs.value<std::string>(ComputeArrayStatisticsFilter::k_ModeArrayName_Key);
-    auto action = std::make_unique<CreateNeighborListAction>(dataType, tupleSize, destinationAttributeMatrixValue.createChildPath(arrayPath));
+    auto action = std::make_unique<CreateNeighborListAction>(dataType, tupleDims, destinationAttributeMatrixValue.createChildPath(arrayPath));
     actions.appendAction(std::move(action));
   }
   if(findStdDeviation)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayStatisticsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayStatisticsFilter.cpp
@@ -36,7 +36,7 @@ struct IsIntegerType
   }
 };
 
-OutputActions CreateCompatibleArrays(const DataStructure& dataStructure, const Arguments& filterArgs, std::vector<usize> tupleDims)
+OutputActions CreateCompatibleArrays(const DataStructure& dataStructure, const Arguments& filterArgs, ShapeType tupleDims)
 {
   auto findLength = filterArgs.value<bool>(ComputeArrayStatisticsFilter::k_FindLength_Key);
   auto findMin = filterArgs.value<bool>(ComputeArrayStatisticsFilter::k_FindMin_Key);
@@ -358,7 +358,7 @@ IFilter::PreflightResult ComputeArrayStatisticsFilter::preflightImpl(const DataS
     return MakePreflightErrorResult(-57203, fmt::format("Input array must be a scalar array"));
   }
 
-  AttributeMatrix::ShapeType tupleDims = {1};
+  ShapeType tupleDims = {1};
   const Int32Array* featureIdsPtr = nullptr;
   if(pComputeByIndexValue)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundingBoxStatsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundingBoxStatsFilter.cpp
@@ -31,7 +31,7 @@ struct IsIntegerType
   }
 };
 
-void CreateCompatibleArrays(Result<OutputActions>& resultOutputActions, const DataStructure& dataStructure, const Arguments& filterArgs, std::vector<usize> tupleDims, const DataPath& outputAMPath)
+void CreateCompatibleArrays(Result<OutputActions>& resultOutputActions, const DataStructure& dataStructure, const Arguments& filterArgs, ShapeType tupleDims, const DataPath& outputAMPath)
 {
   auto calculateLength = filterArgs.value<bool>(ComputeBoundingBoxStatsFilter::k_CalculateLength_Key);
   auto calculateMin = filterArgs.value<bool>(ComputeBoundingBoxStatsFilter::k_CalculateMin_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundingBoxStatsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundingBoxStatsFilter.cpp
@@ -85,8 +85,7 @@ void CreateCompatibleArrays(Result<OutputActions>& resultOutputActions, const Da
   if(calculateMode)
   {
     auto arrayPath = filterArgs.value<std::string>(ComputeBoundingBoxStatsFilter::k_ModeName_Key);
-    usize tupleSize = std::accumulate(tupleDims.begin(), tupleDims.end(), static_cast<usize>(1), std::multiplies<>());
-    auto action = std::make_unique<CreateNeighborListAction>(dataType, tupleSize, outputAMPath.createChildPath(arrayPath));
+    auto action = std::make_unique<CreateNeighborListAction>(dataType, tupleDims, outputAMPath.createChildPath(arrayPath));
     resultOutputActions.value().appendAction(std::move(action));
   }
   if(calculateStdDeviation)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeEuclideanDistMapFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeEuclideanDistMapFilter.cpp
@@ -132,7 +132,7 @@ IFilter::PreflightResult ComputeEuclideanDistMapFilter::preflightImpl(const Data
     return {MakeErrorResult<OutputActions>(-12801, fmt::format("{} Data Array is not of the correct type. Select a DataArray object.", pFeatureIdsArrayPathValue.toString()))};
   }
 
-  IDataStore::ShapeType tupleShape = cellDataArray->getIDataStore()->getTupleShape();
+  ShapeType tupleShape = cellDataArray->getIDataStore()->getTupleShape();
   DataType outputDataType = DataType::int32;
   if(!pCalcManhattanDistValue)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureBoundsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureBoundsFilter.cpp
@@ -146,7 +146,7 @@ IFilter::PreflightResult ComputeFeatureBoundsFilter::preflightImpl(const DataStr
 
   nx::core::Result<OutputActions> resultOutputActions;
   const auto& featureAM = dataStructure.getDataRefAs<AttributeMatrix>(pFeatureAMPathValue);
-  AttributeMatrix::ShapeType tupleShape = featureAM.getShape();
+  ShapeType tupleShape = featureAM.getShape();
   switch(static_cast<ComputeFeatureBounds::OutputDataType>(pOutputTypeValue))
   {
   case ComputeFeatureBounds::OutputDataType::Split: {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureCentroidsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureCentroidsFilter.cpp
@@ -108,7 +108,7 @@ IFilter::PreflightResult ComputeFeatureCentroidsFilter::preflightImpl(const Data
   {
     return {MakeErrorResult<OutputActions>(-12700, fmt::format("Cannot find the selected feature Attribute Matrix at path '{}'", featureAttrMatrixPath.toString()))};
   }
-  IDataStore::ShapeType tupleShape = featureAttrMatrix->getShape();
+  ShapeType tupleShape = featureAttrMatrix->getShape();
 
   // Create the CreateArrayAction within a scope so that we do not accidentally use the variable is it is getting "moved"
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureClusteringFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureClusteringFilter.cpp
@@ -139,7 +139,7 @@ IFilter::PreflightResult ComputeFeatureClusteringFilter::preflightImpl(const Dat
   }
 
   const auto& cellEnsembleAM = dataStructure.getDataRefAs<AttributeMatrix>(pCellEnsembleAttributeMatrixNameValue);
-  const std::vector<usize>& tupleShape = cellEnsembleAM.getShape();
+  const ShapeType& tupleShape = cellEnsembleAM.getShape();
   {
     auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::float32, tupleShape, std::vector<usize>{static_cast<usize>(pNumberOfBinsValue)},
                                                                  pCellEnsembleAttributeMatrixNameValue.createChildPath(pRDFArrayNameValue));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureClusteringFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureClusteringFilter.cpp
@@ -152,7 +152,7 @@ IFilter::PreflightResult ComputeFeatureClusteringFilter::preflightImpl(const Dat
   {
     const DataPath featureAttributeMatrixPath = pFeaturePhasesArrayPathValue.getParent();
     const auto& cellFeatureAM = dataStructure.getDataRefAs<AttributeMatrix>(featureAttributeMatrixPath);
-    auto createArrayAction = std::make_unique<CreateNeighborListAction>(DataType::float32, cellFeatureAM.getNumTuples(), featureAttributeMatrixPath.createChildPath(pClusteringListArrayNameValue));
+    auto createArrayAction = std::make_unique<CreateNeighborListAction>(DataType::float32, cellFeatureAM.getShape(), featureAttributeMatrixPath.createChildPath(pClusteringListArrayNameValue));
     resultOutputActions.value().appendAction(std::move(createArrayAction));
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureNeighborsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureNeighborsFilter.cpp
@@ -126,9 +126,9 @@ IFilter::PreflightResult ComputeFeatureNeighborsFilter::preflightImpl(const Data
   OutputActions actions;
 
   auto& featureIdsArray = dataStructure.getDataRefAs<Int32Array>(featureIdsPath);
-  std::vector<usize> tupleShape = featureIdsArray.getIDataStore()->getTupleShape();
+  ShapeType tupleShape = featureIdsArray.getIDataStore()->getTupleShape();
 
-  const std::vector<usize> cDims{1};
+  const ShapeType cDims{1};
 
   // Create output Cell Data Arrays (if the user requested it)
   if(storeBoundaryCells)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureNeighborsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureNeighborsFilter.cpp
@@ -146,7 +146,6 @@ IFilter::PreflightResult ComputeFeatureNeighborsFilter::preflightImpl(const Data
     return {MakeErrorResult<OutputActions>(-12600, "Cell Feature AttributeMatrix Path is NOT an AttributeMatrix")};
   }
   tupleShape = featureAttrMatrix->getShape();
-  auto tupleCount = std::accumulate(tupleShape.begin(), tupleShape.end(), 1ULL, std::multiplies<>());
 
   // Create the NumNeighbors Output Data Array in the Feature Attribute Matrix
   {
@@ -155,12 +154,12 @@ IFilter::PreflightResult ComputeFeatureNeighborsFilter::preflightImpl(const Data
   }
   // Create the NeighborList Output NeighborList in the Feature Attribute Matrix
   {
-    auto action = std::make_unique<CreateNeighborListAction>(DataType::int32, tupleCount, neighborListPath);
+    auto action = std::make_unique<CreateNeighborListAction>(DataType::int32, tupleShape, neighborListPath);
     actions.appendAction(std::move(action));
   }
   // And we do the same for the SharedSurfaceArea list in the Feature Attribute Matrix
   {
-    auto action = std::make_unique<CreateNeighborListAction>(DataType::float32, tupleCount, sharedSurfaceAreaPath);
+    auto action = std::make_unique<CreateNeighborListAction>(DataType::float32, tupleShape, sharedSurfaceAreaPath);
     actions.appendAction(std::move(action));
   }
   // Create the SurfaceFeatures Output Data Array in the Feature Attribute Matrix

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureRectFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureRectFilter.cpp
@@ -84,7 +84,7 @@ IFilter::PreflightResult ComputeFeatureRectFilter::preflightImpl(const DataStruc
   DataPath featureRectArrayPath = pFeatureDataAttributeMatrixPathValue.createChildPath(pFeatureRectArrayNameValue);
 
   const auto& attrMatrix = dataStructure.getDataRefAs<AttributeMatrix>(pFeatureDataAttributeMatrixPathValue);
-  std::vector<usize> tDims = attrMatrix.getShape();
+  ShapeType tDims = attrMatrix.getShape();
 
   /*
    * This output Feature Rect array assumes that the original dataset has dimensions that are no larger than uint32.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
@@ -126,7 +126,7 @@ IFilter::PreflightResult ComputeFeatureSizesFilter::preflightImpl(const DataStru
         std::vector<Error>{Error{k_MissingFeatureAttributeMatrix, fmt::format("Could not find Feature Attribute Matrix at path '{}'", featureAttributeMatrixPath.toString())}})};
   }
 
-  std::vector<usize> tupleDimensions = featAttributeMatrix->getShape();
+  ShapeType tupleDimensions = featAttributeMatrix->getShape();
   uint64 numberOfComponents = 1;
 
   auto createVolumesAction = std::make_unique<CreateArrayAction>(DataType::float32, tupleDimensions, std::vector<usize>{numberOfComponents}, volumesPath, arrayDataFormat);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeMomentInvariants2DFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeMomentInvariants2DFilter.cpp
@@ -115,9 +115,9 @@ IFilter::PreflightResult ComputeMomentInvariants2DFilter::preflightImpl(const Da
                                                        pGeometryPathValue.toString()));
   }
 
-  std::vector<usize> componentDims(1, 1);
+  ShapeType componentDims(1, 1);
   const auto& cellFeatureAttributeMatrix = dataStructure.getDataRefAs<AttributeMatrix>(pFeatureAttributeMatrixPathValue);
-  const std::vector<usize>& tupleDims = cellFeatureAttributeMatrix.getShape();
+  const ShapeType& tupleDims = cellFeatureAttributeMatrix.getShape();
 
   {
     auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::float32, tupleDims, componentDims, omega1Path);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborListStatisticsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborListStatisticsFilter.cpp
@@ -31,7 +31,7 @@ OutputActions CreateCompatibleArrays(const DataStructure& dataStructure, const A
 
   auto inputArrayPath = filterArgs.value<DataPath>(ComputeNeighborListStatisticsFilter::k_InputNeighborListPath_Key);
   auto* inputArray = dataStructure.getDataAs<INeighborList>(inputArrayPath);
-  std::vector<usize> tupleDims{inputArray->getNumberOfTuples()};
+  ShapeType tupleDims{inputArray->getNumberOfTuples()};
   DataType dataType = inputArray->getDataType();
   const DataPath outputGroupPath = inputArrayPath.getParent();
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborhoodsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNeighborhoodsFilter.cpp
@@ -131,7 +131,7 @@ IFilter::PreflightResult ComputeNeighborhoodsFilter::preflightImpl(const DataStr
   }
   // Create the NeighborList Output NeighborList in the Feature Attribute Matrix
   {
-    auto action = std::make_unique<CreateNeighborListAction>(DataType::int32, cellFeatureData->getNumTuples(), pFeaturePhasesArrayPathValue.replaceName(pNeighborhoodListArrayNameValue));
+    auto action = std::make_unique<CreateNeighborListAction>(DataType::int32, cellFeatureData->getShape(), pFeaturePhasesArrayPathValue.replaceName(pNeighborhoodListArrayNameValue));
     resultOutputActions.value().appendAction(std::move(action));
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceAreaToVolumeFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceAreaToVolumeFilter.cpp
@@ -113,7 +113,7 @@ IFilter::PreflightResult ComputeSurfaceAreaToVolumeFilter::preflightImpl(const D
                                                         "located in the cell feature attribute matrix of the selected geometry",
                                                         pNumCellsArrayPathValue.toString()));
   }
-  IDataStore::ShapeType tupleShape = cellFeatureData->getShape();
+  ShapeType tupleShape = cellFeatureData->getShape();
   // Create the SurfaceAreaVolumeRatio
   {
     auto arrayPath = pNumCellsArrayPathValue.replaceName(filterArgs.value<std::string>(k_SurfaceAreaVolumeRatioArrayName_Key));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceFeaturesFilter.cpp
@@ -278,7 +278,7 @@ IFilter::PreflightResult ComputeSurfaceFeaturesFilter::preflightImpl(const DataS
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  std::vector<usize> tupleDims = std::vector<usize>{1};
+  ShapeType tupleDims = std::vector<usize>{1};
   if(const auto& surfaceFeaturesParent = dataStructure.getDataAs<AttributeMatrix>(pCellFeaturesAttributeMatrixPathValue); surfaceFeaturesParent != nullptr)
   {
     tupleDims = surfaceFeaturesParent->getShape();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConcatenateDataArraysFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConcatenateDataArraysFilter.cpp
@@ -147,7 +147,7 @@ IFilter::PreflightResult ConcatenateDataArraysFilter::preflightImpl(const DataSt
   }
   case IArray::ArrayType::NeighborListArray: {
     const auto& inputNeighborList = dataStructure.getDataRefAs<INeighborList>(inputArrayPaths[0]);
-    auto action = std::make_unique<CreateNeighborListAction>(inputNeighborList.getDataType(), numTuples, outputArrayPath);
+    auto action = std::make_unique<CreateNeighborListAction>(inputNeighborList.getDataType(), tDims, outputArrayPath);
     resultOutputActions.value().appendAction(std::move(action));
     break;
   }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConcatenateDataArraysFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConcatenateDataArraysFilter.cpp
@@ -92,7 +92,7 @@ IFilter::PreflightResult ConcatenateDataArraysFilter::preflightImpl(const DataSt
   }
 
   // Check for unequal array types, data types, and component dimensions
-  std::vector<usize> cDims;
+  ShapeType cDims;
   IArray::ArrayType arrayType;
   std::string arrayTypeName;
   usize numTuples = 0;
@@ -127,7 +127,7 @@ IFilter::PreflightResult ConcatenateDataArraysFilter::preflightImpl(const DataSt
     numTuples += std::accumulate(tupleShape.begin(), tupleShape.end(), static_cast<usize>(1), std::multiplies<>());
   }
 
-  std::vector<usize> tDims = {numTuples};
+  ShapeType tDims = {numTuples};
 
   // Create the output array
   nx::core::Result<OutputActions> resultOutputActions;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateAttributeMatrixFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateAttributeMatrixFilter.cpp
@@ -68,7 +68,7 @@ IFilter::PreflightResult CreateAttributeMatrixFilter::preflightImpl(const DataSt
   auto tableData = filterArgs.value<DynamicTableParameter::ValueType>(k_TupleDims_Key);
 
   const auto& rowData = tableData.at(0);
-  std::vector<usize> tupleDims;
+  ShapeType tupleDims;
   tupleDims.reserve(rowData.size());
   for(auto floatValue : rowData)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayAdvancedFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayAdvancedFilter.cpp
@@ -172,7 +172,7 @@ IFilter::PreflightResult CreateDataArrayAdvancedFilter::preflightImpl(const Data
 
   nx::core::Result<OutputActions> resultOutputActions;
 
-  std::vector<usize> compDims(compDimsData[0].size());
+  ShapeType compDims(compDimsData[0].size());
   std::transform(compDimsData[0].begin(), compDimsData[0].end(), compDims.begin(), [](double val) { return static_cast<usize>(val); });
   usize numComponents = std::accumulate(compDims.begin(), compDims.end(), static_cast<usize>(1), std::multiplies<>());
   if(numComponents <= 0)
@@ -183,7 +183,7 @@ IFilter::PreflightResult CreateDataArrayAdvancedFilter::preflightImpl(const Data
         fmt::format("The chosen component dimensions ({}) results in 0 total components.  Please choose component dimensions that result in a positive number of total components.", compDimsStr));
   }
 
-  std::vector<usize> tupleDims = {};
+  ShapeType tupleDims = {};
 
   auto* parentAM = dataStructure.getDataAs<AttributeMatrix>(dataArrayPath.getParent());
   if(parentAM == nullptr)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayFilter.cpp
@@ -119,8 +119,8 @@ IFilter::PreflightResult CreateDataArrayFilter::preflightImpl(const DataStructur
     return MakePreflightErrorResult(k_EmptyParameterError, fmt::format("{}: Init Value cannot be empty.{}({})", humanName(), __FILE__, __LINE__));
   }
 
-  std::vector<usize> compDims = std::vector<usize>{numComponents};
-  std::vector<usize> tupleDims = {};
+  ShapeType compDims = std::vector<usize>{numComponents};
+  ShapeType tupleDims = {};
 
   auto* parentAM = dataStructure.getDataAs<AttributeMatrix>(dataArrayPath.getParent());
   if(parentAM == nullptr)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropEdgeGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropEdgeGeometryFilter.cpp
@@ -209,7 +209,7 @@ IFilter::PreflightResult CropEdgeGeometryFilter::preflightImpl(const DataStructu
     {
       const auto& srcArray = dynamic_cast<const IDataArray&>(*object);
       DataType dataType = srcArray.getDataType();
-      IDataStore::ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
+      ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
       DataPath dataArrayPath = newEdgeAttributeMatrixPath.createChildPath(srcArray.getName());
       resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(dataType, std::vector<usize>{1}, std::move(componentShape), dataArrayPath));
     }
@@ -230,7 +230,7 @@ IFilter::PreflightResult CropEdgeGeometryFilter::preflightImpl(const DataStructu
     {
       const auto& srcArray = dynamic_cast<const IDataArray&>(*object);
       DataType dataType = srcArray.getDataType();
-      IDataStore::ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
+      ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
       DataPath dataArrayPath = newVertexAttributeMatrixPath.createChildPath(srcArray.getName());
       resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(dataType, std::vector<usize>{1}, std::move(componentShape), dataArrayPath));
     }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropImageGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropImageGeometryFilter.cpp
@@ -476,7 +476,7 @@ IFilter::PreflightResult CropImageGeometryFilter::preflightImpl(const DataStruct
     {
       const auto& srcArray = dynamic_cast<const IDataArray&>(*object);
       DataType dataType = srcArray.getDataType();
-      IDataStore::ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
+      ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
       DataPath dataArrayPath = newCellAttributeMatrixPath.createChildPath(srcArray.getName());
       resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(dataType, dataArrayShape, std::move(componentShape), dataArrayPath));
     }
@@ -506,7 +506,7 @@ IFilter::PreflightResult CropImageGeometryFilter::preflightImpl(const DataStruct
       if(const auto* srcArray = dynamic_cast<const IDataArray*>(object.get()); srcArray != nullptr)
       {
         DataType dataType = srcArray->getDataType();
-        IDataStore::ShapeType componentShape = srcArray->getIDataStoreRef().getComponentShape();
+        ShapeType componentShape = srcArray->getIDataStoreRef().getComponentShape();
         DataPath dataArrayPath = destCellFeatureAmPath.createChildPath(srcArray->getName());
         resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(dataType, tDims, std::move(componentShape), dataArrayPath));
       }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropVertexGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropVertexGeometryFilter.cpp
@@ -241,7 +241,7 @@ Result<> CropVertexGeometryFilter::executeImpl(DataStructure& dataStructure, con
   auto& crop = dataStructure.getDataRefAs<VertexGeom>(croppedGeomPath);
   usize numTuples = croppedPoints.size();
   crop.resizeVertexList(numTuples);
-  std::vector<usize> tDims = {numTuples};
+  ShapeType tDims = {numTuples};
 
   DataPath croppedVertexDataPath = croppedGeomPath.createChildPath(vertexDataName);
   auto& vertedDataAttMatrix = dataStructure.getDataRefAs<AttributeMatrix>(croppedVertexDataPath);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractInternalSurfacesFromTriangleGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractInternalSurfacesFromTriangleGeometryFilter.cpp
@@ -209,7 +209,7 @@ IFilter::PreflightResult ExtractInternalSurfacesFromTriangleGeometryFilter::pref
     return {MakeErrorResult<OutputActions>(k_MissingTriangleFacesArray, ss)};
   }
 
-  std::vector<usize> cDims(1, 1);
+  ShapeType cDims(1, 1);
 
   // Create Geometry
   usize numFaces = triangleGeom.getNumberOfFaces();
@@ -220,7 +220,7 @@ IFilter::PreflightResult ExtractInternalSurfacesFromTriangleGeometryFilter::pref
   DataPath internalFaceDataPath = createInternalTrianglesAction->getFaceDataPath();
   actions.appendAction(std::move(createInternalTrianglesAction));
 
-  std::vector<usize> tDims(1, 0);
+  ShapeType tDims(1, 0);
   std::list<std::string> tempDataArrayList;
 
   // Create arrays and check number of tuples match their respective face or vertex attribute matrix

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FeatureFaceCurvatureFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FeatureFaceCurvatureFilter.cpp
@@ -72,11 +72,11 @@ Parameters FeatureFaceCurvatureFilter::parameters() const
   params.insert(std::make_unique<ArraySelectionParameter>(k_FaceLabelsPath_Key, "Face Labels", "The DataPath to the 'Face Labels' DataArray", DataPath(),
                                                           ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{2}}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureFaceIdsPath_Key, "Feature Face Ids", "The DataPath to the 'FeatureIds' DataArray", DataPath(),
-                                                          ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{IArray::ShapeType{1}}));
+                                                          ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{ShapeType{1}}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_FaceNormalsPath_Key, "Face Normals", "The DataPath to the 'Feature Normals' DataArray", DataPath(),
-                                                          ArraySelectionParameter::AllowedTypes{DataType::float64}, ArraySelectionParameter::AllowedComponentShapes{IArray::ShapeType{3}}));
+                                                          ArraySelectionParameter::AllowedTypes{DataType::float64}, ArraySelectionParameter::AllowedComponentShapes{ShapeType{3}}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_FaceCentroidsPath_Key, "Face Centroids", "The DataPath to the 'Face Centroids' DataArray", DataPath(),
-                                                          ArraySelectionParameter::AllowedTypes{DataType::float64}, ArraySelectionParameter::AllowedComponentShapes{IArray::ShapeType{3}}));
+                                                          ArraySelectionParameter::AllowedTypes{DataType::float64}, ArraySelectionParameter::AllowedComponentShapes{ShapeType{3}}));
 
   params.insertSeparator(Parameters::Separator{"Output Face Data"});
   params.insert(std::make_unique<ArrayCreationParameter>(k_PrincipalCurvature1Path_Key, "Principal Curvature 1", "Output DataPath to hold the 'Principal Curvature 1' values",
@@ -156,7 +156,7 @@ IFilter::PreflightResult FeatureFaceCurvatureFilter::preflightImpl(const DataStr
   }
 
   // auto* dataArray = dataStructure.getDataAs<IDataArray>(triangles->getFaceAttributeMatrixDataPath());
-  IArray::ShapeType tupleShape = triangleMatrix->getShape();
+  ShapeType tupleShape = triangleMatrix->getShape();
 
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IdentifySampleFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IdentifySampleFilter.cpp
@@ -19,7 +19,7 @@ struct IdentifySampleFunctor
   template <typename T>
   void operator()(const ImageGeom* imageGeom, IDataArray* goodVoxelsPtr, bool fillHoles)
   {
-    std::vector<usize> cDims = {1};
+    ShapeType cDims = {1};
     auto& goodVoxels = goodVoxelsPtr->template getIDataStoreRefAs<AbstractDataStore<T>>();
 
     const auto totalPoints = static_cast<int64>(goodVoxelsPtr->getNumberOfTuples());

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeImageGeomCellDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InitializeImageGeomCellDataFilter.cpp
@@ -295,7 +295,7 @@ IFilter::PreflightResult InitializeImageGeomCellDataFilter::preflightImpl(const 
   for(const DataPath& path : cellArrayPaths)
   {
     const auto& dataArray = dataStructure.getDataRefAs<IDataArray>(path);
-    std::vector<usize> tupleShape = dataArray.getIDataStoreRef().getTupleShape();
+    ShapeType tupleShape = dataArray.getIDataStoreRef().getTupleShape();
 
     if(tupleShape.size() != reversedImageDims.size())
     {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
@@ -269,7 +269,7 @@ IFilter::PreflightResult InterpolatePointCloudToRegularGridFilter::preflightImpl
   auto vertexGeom = dataStructure.getDataAs<VertexGeom>(vertexGeomPath);
   auto image = dataStructure.getDataAs<ImageGeom>(imageGeomPath);
   const SizeVec3 imageDims = image->getDimensions();
-  std::vector<usize> tupleDims = {imageDims[2], imageDims[1], imageDims[0]};
+  ShapeType tupleDims = {imageDims[2], imageDims[1], imageDims[0]};
 
   // Create the attribute matrix for storing the interpolated/copied arrays
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
@@ -270,7 +270,6 @@ IFilter::PreflightResult InterpolatePointCloudToRegularGridFilter::preflightImpl
   auto image = dataStructure.getDataAs<ImageGeom>(imageGeomPath);
   const SizeVec3 imageDims = image->getDimensions();
   std::vector<usize> tupleDims = {imageDims[2], imageDims[1], imageDims[0]};
-  const usize numTuples = std::accumulate(tupleDims.cbegin(), tupleDims.cend(), static_cast<usize>(1), std::multiplies<>());
 
   // Create the attribute matrix for storing the interpolated/copied arrays
   {
@@ -295,7 +294,7 @@ IFilter::PreflightResult InterpolatePointCloudToRegularGridFilter::preflightImpl
     if(dataType != DataType::boolean)
     {
       auto neighborPath = interpolatedGroupPath.createChildPath(targetArray->getName());
-      auto neighborAction = std::make_unique<CreateNeighborListAction>(dataType, numTuples, neighborPath);
+      auto neighborAction = std::make_unique<CreateNeighborListAction>(dataType, tupleDims, neighborPath);
       actions.appendAction(std::move(neighborAction));
     }
   }
@@ -315,7 +314,7 @@ IFilter::PreflightResult InterpolatePointCloudToRegularGridFilter::preflightImpl
     if(dataType != DataType::boolean)
     {
       auto neighborPath = interpolatedGroupPath.createChildPath(targetArray->getName());
-      auto neighborAction = std::make_unique<CreateNeighborListAction>(dataType, numTuples, neighborPath);
+      auto neighborAction = std::make_unique<CreateNeighborListAction>(dataType, tupleDims, neighborPath);
       actions.appendAction(std::move(neighborAction));
     }
   }
@@ -335,7 +334,7 @@ IFilter::PreflightResult InterpolatePointCloudToRegularGridFilter::preflightImpl
   // Create the neighbor list array for storing the kernel distances
   if(storeKernelDistances)
   {
-    auto action = std::make_unique<CreateNeighborListAction>(DataType::float32, numTuples, interpolatedGroupPath.createChildPath(filterArgs.value<std::string>(k_KernelDistancesArrayName_Key)));
+    auto action = std::make_unique<CreateNeighborListAction>(DataType::float32, tupleDims, interpolatedGroupPath.createChildPath(filterArgs.value<std::string>(k_KernelDistancesArrayName_Key)));
     actions.appendAction(std::move(action));
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LabelTriangleGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/LabelTriangleGeometryFilter.cpp
@@ -105,7 +105,7 @@ IFilter::PreflightResult LabelTriangleGeometryFilter::preflightImpl(const DataSt
   }
 
   DataPath triAMPath = pTriangleGeomPathValue.createChildPath(pTriangleAMNameValue);
-  std::vector<usize> tDims(1, 1);
+  ShapeType tDims(1, 1);
   {
     auto createAMAction = std::make_unique<CreateAttributeMatrixAction>(triAMPath, tDims);
     resultOutputActions.value().appendAction(std::move(createAMAction));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PadImageGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PadImageGeometryFilter.cpp
@@ -230,7 +230,7 @@ IFilter::PreflightResult PadImageGeometryFilter::preflightImpl(const DataStructu
     {
       const auto& srcArray = dynamic_cast<const IDataArray&>(*object);
       DataType dataType = srcArray.getDataType();
-      IDataStore::ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
+      ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
       DataPath dataArrayPath = newCellAttributeMatrixPath.createChildPath(srcArray.getName());
       resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(dataType, destArrayDims, std::move(componentShape), dataArrayPath));
     }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadCSVFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadCSVFileFilter.cpp
@@ -407,7 +407,7 @@ IFilter::PreflightResult ReadCSVFileFilter::preflightImpl(const DataStructure& d
   }
 
   // Create the arrays
-  std::vector<usize> tupleDims(readCSVData.tupleDims.size());
+  ShapeType tupleDims(readCSVData.tupleDims.size());
   std::transform(readCSVData.tupleDims.begin(), readCSVData.tupleDims.end(), tupleDims.begin(), [](usize d) { return d; });
   if(useExistingGroupOrAM)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadRawBinaryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadRawBinaryFilter.cpp
@@ -111,7 +111,7 @@ IFilter::PreflightResult ReadRawBinaryFilter::preflightImpl(const DataStructure&
   }
 
   const auto& rowData = pTupleDimsValue.at(0);
-  std::vector<usize> tupleDims;
+  ShapeType tupleDims;
   for(auto floatValue : rowData)
   {
     tupleDims.push_back(static_cast<usize>(floatValue));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStringDataArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStringDataArrayFilter.cpp
@@ -102,7 +102,7 @@ IFilter::PreflightResult ReadStringDataArrayFilter::preflightImpl(const DataStru
 
   nx::core::Result<OutputActions> resultOutputActions;
 
-  std::vector<usize> tupleDims = {};
+  ShapeType tupleDims = {};
 
   auto* parentAM = dataStructure.getDataAs<AttributeMatrix>(arrayPath.getParent());
   if(parentAM == nullptr)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadTextDataArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadTextDataArrayFilter.cpp
@@ -119,7 +119,7 @@ IFilter::PreflightResult ReadTextDataArrayFilter::preflightImpl(const DataStruct
 
   nx::core::Result<OutputActions> resultOutputActions;
 
-  std::vector<usize> tupleDims = {};
+  ShapeType tupleDims = {};
 
   auto* parentAM = dataStructure.getDataAs<AttributeMatrix>(arrayPath.getParent());
   if(parentAM == nullptr)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RegularGridSampleSurfaceMeshFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RegularGridSampleSurfaceMeshFilter.cpp
@@ -152,7 +152,7 @@ IFilter::PreflightResult RegularGridSampleSurfaceMeshFilter::preflightImpl(const
   std::vector<PreflightValue> preflightUpdatedValues;
 
   DataPath cellAttributeMatrixPath;
-  std::vector<usize> tupleDims;
+  ShapeType tupleDims;
 
   if(geometryOption == GeometryOption::Create)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedVerticesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedVerticesFilter.cpp
@@ -177,8 +177,8 @@ IFilter::PreflightResult RemoveFlaggedVerticesFilter::preflightImpl(const DataSt
     {
       const auto& srcArray = dynamic_cast<const IDataArray&>(*object);
       const DataType dataType = srcArray.getDataType();
-      const IDataStore::ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
-      const IDataStore::ShapeType tupleShape = srcArray.getIDataStoreRef().getTupleShape();
+      const ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
+      const ShapeType tupleShape = srcArray.getIDataStoreRef().getTupleShape();
       const DataPath dataArrayPath = reducedVertGeomAttrMatPath.createChildPath(srcArray.getName());
       const std::string dataStoreFormat = srcArray.getDataFormat();
       resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(dataType, tupleShape, componentShape, dataArrayPath, dataStoreFormat));
@@ -253,7 +253,7 @@ Result<> RemoveFlaggedVerticesFilter::executeImpl(DataStructure& dataStructure, 
   const size_t numVerticesToKeep = maskCompare->getNumberOfTuples() - maskCompare->countTrueValues(); // We don't need component size since it must be 1
   const size_t numberOfVertices = vertexGeom.getNumberOfVertices();
 
-  const std::vector<usize> tDims = {numVerticesToKeep};
+  const ShapeType tDims = {numVerticesToKeep};
 
   // Resize the reduced vertex geometry object
   auto& reducedVertexGeom = dataStructure.getDataRefAs<VertexGeom>(reducedVertexPath);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinNumNeighborsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinNumNeighborsFilter.cpp
@@ -120,7 +120,7 @@ IFilter::PreflightResult RequireMinNumNeighborsFilter::preflightImpl(const DataS
 
   std::vector<DataPath> dataArrayPaths;
 
-  std::vector<usize> cDims = {1};
+  ShapeType cDims = {1};
   auto& featureIds = dataStructure.getDataRefAs<Int32Array>(featureIdsPath);
 
   auto& numNeighborsArray = dataStructure.getDataRefAs<Int32Array>(numNeighborsPath);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleImageGeomFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleImageGeomFilter.cpp
@@ -254,7 +254,7 @@ IFilter::PreflightResult ResampleImageGeomFilter::preflightImpl(const DataStruct
     {
       const auto& srcArray = dynamic_cast<const IDataArray&>(*object);
       DataType dataType = srcArray.getDataType();
-      IDataStore::ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
+      ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
       DataPath dataArrayPath = newCellAttributeMatrixPath.createChildPath(srcArray.getName());
       resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(dataType, dataArrayShape, std::move(componentShape), dataArrayPath));
     }
@@ -285,7 +285,7 @@ IFilter::PreflightResult ResampleImageGeomFilter::preflightImpl(const DataStruct
       if(const auto* srcArray = dynamic_cast<const IDataArray*>(object.get()); srcArray != nullptr)
       {
         DataType dataType = srcArray->getDataType();
-        IDataStore::ShapeType componentShape = srcArray->getIDataStoreRef().getComponentShape();
+        ShapeType componentShape = srcArray->getIDataStoreRef().getComponentShape();
         DataPath dataArrayPath = destCellFeatureAmPath.createChildPath(srcArray->getName());
         resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(dataType, tDims, std::move(componentShape), dataArrayPath));
       }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleRectGridToImageGeomFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ResampleRectGridToImageGeomFilter.cpp
@@ -136,7 +136,6 @@ IFilter::PreflightResult ResampleRectGridToImageGeomFilter::preflightImpl(const 
   const auto& rectGridGeom = dataStructure.getDataRefAs<RectGridGeom>(pRectilinearGridPathValue);
   const DataPath srcCellDataPath = pRectilinearGridPathValue.createChildPath(rectGridGeom.getCellData()->getName());
   const DataPath destCellDataPath = pImageGeometryPathValue.createChildPath(pImageGeomCellAttributeMatrixNameValue);
-  usize totalPoints = dims[0] * dims[1] * dims[2];
   for(const auto& path : pSelectedDataArrayPathsValue)
   {
     const DataPath destPath = destCellDataPath.createChildPath(path.getTargetName());
@@ -173,7 +172,7 @@ IFilter::PreflightResult ResampleRectGridToImageGeomFilter::preflightImpl(const 
     else if(arrayType == IArray::ArrayType::NeighborListArray)
     {
       const auto* srcDataArray = dataStructure.getDataAs<INeighborList>(path);
-      auto createArrayAction = std::make_unique<CreateNeighborListAction>(srcDataArray->getDataType(), totalPoints, destPath);
+      auto createArrayAction = std::make_unique<CreateNeighborListAction>(srcDataArray->getDataType(), dims, destPath);
       resultOutputActions.value().appendAction(std::move(createArrayAction));
     }
     else if(arrayType == IArray::ArrayType::StringArray)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReshapeDataArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReshapeDataArrayFilter.cpp
@@ -88,7 +88,7 @@ IFilter::PreflightResult ReshapeDataArrayFilter::preflightImpl(const DataStructu
 
   nx::core::Result<OutputActions> resultOutputActions;
 
-  std::vector<usize> tDims = {};
+  ShapeType tDims = {};
   const auto& rowData = tupleDimsData.at(0);
   tDims.reserve(rowData.size());
   for(usize i = 0; i < rowData.size(); ++i)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReshapeDataArrayFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReshapeDataArrayFilter.cpp
@@ -112,8 +112,6 @@ IFilter::PreflightResult ReshapeDataArrayFilter::preflightImpl(const DataStructu
                                                 fmt::join(inputArrayTupleShape, ",")));
   }
 
-  usize numTuples = std::accumulate(tDims.begin(), tDims.end(), static_cast<usize>(1), std::multiplies<>());
-
   // Reshape the array
   auto inputArrayType = inputArray.getArrayType();
   auto outputArrayPath = inputArrayPath.getParent().createChildPath(fmt::format(".{}", inputArrayPath.getTargetName()));
@@ -127,49 +125,10 @@ IFilter::PreflightResult ReshapeDataArrayFilter::preflightImpl(const DataStructu
   }
   case IArray::ArrayType::NeighborListArray: {
     auto& inputNeighborList = dataStructure.getDataRefAs<INeighborList>(inputArrayPath);
-    if(tDims.size() > 1)
-    {
-      if(numTuples == inputNeighborList.getNumberOfTuples())
-      {
-        return MakePreflightErrorResult(to_underlying(ReshapeDataArray::ErrorCodes::TupleShapesEqual),
-                                        fmt::format("The input array '{}' is a neighbor list, which does not support multiple tuple dimensions. "
-                                                    "The selected tuple shape [{}] cannot be converted to [{}] because it matches the neighbor list's tuple shape ([{}]). "
-                                                    "Please choose a tuple shape that results in a different number of tuples than the neighbor list.",
-                                                    inputArrayPath.toString(), fmt::join(tDims, ","), numTuples, numTuples));
-      }
-      else
-      {
-        resultOutputActions.warnings().push_back(
-            Warning{to_underlying(ReshapeDataArray::WarningCodes::NeighborListMultipleTupleDims),
-                    fmt::format("The input array '{}' is a neighbor list, and neighbor lists do not support multiple tuple dimensions.  The neighbor list will be reshaped to [{}] instead.",
-                                inputArrayPath.toString(), numTuples)});
-      }
-    }
-
-    resultOutputActions.value().appendAction(std::make_unique<CreateNeighborListAction>(inputNeighborList.getDataType(), numTuples, outputArrayPath));
+    resultOutputActions.value().appendAction(std::make_unique<CreateNeighborListAction>(inputNeighborList.getDataType(), tDims, outputArrayPath));
     break;
   }
   case IArray::ArrayType::StringArray: {
-    auto& inputStringArray = dataStructure.getDataRefAs<StringArray>(inputArrayPath);
-    if(tDims.size() > 1)
-    {
-      if(numTuples == inputStringArray.getNumberOfTuples())
-      {
-        return MakePreflightErrorResult(to_underlying(ReshapeDataArray::ErrorCodes::TupleShapesEqual),
-                                        fmt::format("The input array '{}' is a string array, which does not support multiple tuple dimensions. "
-                                                    "The selected tuple shape [{}] cannot be converted to [{}] because it matches the string array's tuple shape ([{}]). "
-                                                    "Please choose a tuple shape that results in a different number of tuples than the string array.",
-                                                    inputArrayPath.toString(), fmt::join(tDims, ","), numTuples, numTuples));
-      }
-      else
-      {
-        resultOutputActions.warnings().push_back(
-            Warning{to_underlying(ReshapeDataArray::WarningCodes::StringArrayMultipleTupleDims),
-                    fmt::format("The input array '{}' is a string array, and string arrays do not support multiple tuple dimensions.  The string array will be reshaped to [{}] instead.",
-                                inputArrayPath.toString(), numTuples)});
-      }
-    }
-
     resultOutputActions.value().appendAction(std::make_unique<CreateStringArrayAction>(tDims, outputArrayPath));
     break;
   }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RobustAutomaticThresholdFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RobustAutomaticThresholdFilter.cpp
@@ -131,7 +131,7 @@ IFilter::PreflightResult RobustAutomaticThresholdFilter::preflightImpl(const Dat
   }
   dataPaths.push_back(gradientArrayPath);
 
-  std::vector<usize> tupleDims = {inputArray.getTupleShape()};
+  ShapeType tupleDims = {inputArray.getTupleShape()};
   usize numComponents = inputArray.getNumberOfComponents();
 
   auto tupleValidityCheck = dataStructure.validateNumberOfTuples(dataPaths);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RotateSampleRefFrameFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RotateSampleRefFrameFilter.cpp
@@ -208,7 +208,7 @@ IFilter::PreflightResult RotateSampleRefFrameFilter::preflightImpl(const DataStr
     {
       const auto& srcArray = dynamic_cast<const IDataArray&>(*object);
       DataType dataType = srcArray.getDataType();
-      IDataStore::ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
+      ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
       DataPath dataArrayPath = newCellAttributeMatrixPath.createChildPath(srcArray.getName());
       resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(dataType, dataArrayShape, std::move(componentShape), dataArrayPath));
     }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitDataArrayByComponentFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitDataArrayByComponentFilter.cpp
@@ -104,8 +104,8 @@ IFilter::PreflightResult SplitDataArrayByComponentFilter::preflightImpl(const Da
     return {MakeErrorResult<OutputActions>(-65401, fmt::format("Selected Array '{}' must have more than 1 component", pInputArrayPath.toString()))};
   }
 
-  std::vector<usize> tdims = inputArray->getIDataStoreRef().getTupleShape();
-  std::vector<usize> cdims(1, 1);
+  ShapeType tDims = inputArray->getIDataStoreRef().getTupleShape();
+  ShapeType cDims(1, 1);
 
   if(pSelectComponents)
   {
@@ -121,7 +121,7 @@ IFilter::PreflightResult SplitDataArrayByComponentFilter::preflightImpl(const Da
       }
       std::string arrayName = pInputArrayPath.getTargetName() + pPostfix + StringUtilities::GenerateIndexString(compIndex, numComponents - 1);
       DataPath newArrayPath = pInputArrayPath.replaceName(arrayName);
-      resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(inputArray->getDataType(), tdims, cdims, newArrayPath));
+      resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(inputArray->getDataType(), tDims, cDims, newArrayPath));
     }
   }
   else
@@ -130,7 +130,7 @@ IFilter::PreflightResult SplitDataArrayByComponentFilter::preflightImpl(const Da
     {
       std::string arrayName = pInputArrayPath.getTargetName() + pPostfix + StringUtilities::GenerateIndexString(i, numComponents - 1);
       DataPath newArrayPath = pInputArrayPath.replaceName(arrayName);
-      resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(inputArray->getDataType(), tdims, cdims, newArrayPath));
+      resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(inputArray->getDataType(), tDims, cDims, newArrayPath));
     }
   }
 
@@ -152,7 +152,7 @@ Result<> SplitDataArrayByComponentFilter::executeImpl(DataStructure& dataStructu
   if(filterArgs.value<bool>(k_SelectComponents_Key))
   {
     auto pExtractComponents = filterArgs.value<DynamicTableParameter::ValueType>(k_ComponentsToExtract_Key)[0];
-    std::vector<usize> components;
+    ShapeType components;
     inputValues.ExtractComponents.reserve(pExtractComponents.size());
     for(auto floatValue : pExtractComponents)
     {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitDataArrayByTupleFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitDataArrayByTupleFilter.cpp
@@ -475,8 +475,7 @@ IFilter::PreflightResult SplitDataArrayByTupleFilter::preflightImpl(const DataSt
     }
     case IArray::ArrayType::NeighborListArray: {
       auto iInputNeighborList = dynamic_cast<const INeighborList*>(inputArray);
-      usize tupleCount = std::accumulate(tupleShapes[i].begin(), tupleShapes[i].end(), 1, std::multiplies<>());
-      resultOutputActions.value().appendAction(std::make_unique<CreateNeighborListAction>(iInputNeighborList->getDataType(), tupleCount, arrayPaths[i]));
+      resultOutputActions.value().appendAction(std::make_unique<CreateNeighborListAction>(iInputNeighborList->getDataType(), tupleShapes[i], arrayPaths[i]));
       break;
     }
     case IArray::ArrayType::StringArray: {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitDataArrayByTupleFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitDataArrayByTupleFilter.cpp
@@ -185,7 +185,7 @@ Result<> preflightDataGroupOutput(SplitDataArrayByTuple::OutputContainer outputC
   }
 
   arrayPaths.reserve(splitArrayTupleShapes.size());
-  std::vector<usize> tupleShapeColSums(splitArrayTupleShapes[0].size(), 0);
+  ShapeType tupleShapeColSums(splitArrayTupleShapes[0].size(), 0);
   std::string tupleShapesOutputStr;
   for(usize i = 0; i < splitArrayTupleShapes.size(); i++)
   {
@@ -218,7 +218,7 @@ Result<> preflightAttrMatrixOutput(SplitDataArrayByTuple::OutputContainer output
                                    const std::vector<usize>& inputArrayTupleShape, const std::vector<float64>& newAttrMatrixTupleShape, usize splitDimension, const DataStructure& dataStructure,
                                    std::vector<DataPath>& arrayPaths, std::vector<std::vector<usize>>& tupleShapes, std::vector<IFilter::PreflightValue>& preflightUpdatedValues)
 {
-  std::vector<usize> tupleShape;
+  ShapeType tupleShape;
   if(outputContainer == SplitDataArrayByTuple::OutputContainer::NewAttrMatrix)
   {
     for(usize j = 0; j < newAttrMatrixTupleShape.size(); ++j)
@@ -469,7 +469,7 @@ IFilter::PreflightResult SplitDataArrayByTupleFilter::preflightImpl(const DataSt
     {
     case IArray::ArrayType::DataArray: {
       auto iInputDataArray = dynamic_cast<const IDataArray*>(inputArray);
-      std::vector<usize> cDims = iInputDataArray->getComponentShape();
+      ShapeType cDims = iInputDataArray->getComponentShape();
       resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(iInputDataArray->getDataType(), tupleShapes[i], cDims, arrayPaths[i]));
       break;
     }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/UncertainRegularGridSampleSurfaceMeshFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/UncertainRegularGridSampleSurfaceMeshFilter.cpp
@@ -121,7 +121,7 @@ IFilter::PreflightResult UncertainRegularGridSampleSurfaceMeshFilter::preflightI
 
   nx::core::Result<OutputActions> resultOutputActions;
 
-  std::vector<usize> tupleDims = {static_cast<usize>(pDimensionsValue[0]), static_cast<usize>(pDimensionsValue[1]), static_cast<usize>(pDimensionsValue[2])};
+  ShapeType tupleDims = {static_cast<usize>(pDimensionsValue[0]), static_cast<usize>(pDimensionsValue[1]), static_cast<usize>(pDimensionsValue[2])};
 
   {
     auto createDataGroupAction =

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/SurfaceNets/MMCellMap.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/SurfaceNets/MMCellMap.cpp
@@ -205,7 +205,7 @@ bool MMCellMap::setCellVertices()
   // Create cell vertices. There are no vertices in right, front, top faces.
   try
   {
-    m_VerticesStoreRef.resizeTuples(IDataStore::ShapeType{numVertices});
+    m_VerticesStoreRef.resizeTuples(ShapeType{numVertices});
     m_VertexArray.resize(numVertices);
   } catch(std::bad_alloc& ba)
   {

--- a/src/Plugins/SimplnxCore/test/AlignSectionsListTest.cpp
+++ b/src/Plugins/SimplnxCore/test/AlignSectionsListTest.cpp
@@ -95,7 +95,7 @@ TEST_CASE("SimplnxCore::AlignSectionsListFilter: Relative Shifts execution", "[S
   UnitTest::WriteTestDataStructure(dataStructure, fmt::format("{}/align_sections_list/relative_align_sections_list.dream3d", unit_test::k_BinaryTestOutputDir));
 #endif
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, SmallIn100::k_TupleCheckIgnoredPaths);
 }
 
 TEST_CASE("SimplnxCore::AlignSectionsListFilter: Cumulative Shifts execution", "[SimplnxCore][AlignSectionsListFilter]")
@@ -164,5 +164,5 @@ TEST_CASE("SimplnxCore::AlignSectionsListFilter: Cumulative Shifts execution", "
   UnitTest::WriteTestDataStructure(dataStructure, fmt::format("{}/align_sections_list/cumulative_align_sections_list.dream3d", unit_test::k_BinaryTestOutputDir));
 #endif
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, SmallIn100::k_TupleCheckIgnoredPaths);
 }

--- a/src/Plugins/SimplnxCore/test/AppendImageGeometryTest.cpp
+++ b/src/Plugins/SimplnxCore/test/AppendImageGeometryTest.cpp
@@ -99,8 +99,7 @@ void createNeighborListsAndStringArrays(DataStructure& dataStructure, const std:
   const usize numTuples = cellDataAM.getNumTuples();
 
   std::vector<std::string> stringArrayValues(numTuples);
-  auto* neighborList = NeighborList<float32>::Create(dataStructure, "NeighborList", numTuples, cellDataAM.getId());
-  neighborList->resizeTotalElements(numTuples);
+  auto* neighborList = NeighborList<float32>::Create(dataStructure, "NeighborList", cellDataAM.getShape(), cellDataAM.getId());
   for(usize i = 0; i < numTuples; ++i)
   {
     const float32 factor = static_cast<float32>(i) * 0.001;
@@ -122,8 +121,7 @@ void createNeighborListsAndStringArrays(DataStructure& dataStructure, const std:
   usize xCount = maxTopVoxel[0] - minBottomVoxel[0] + 1;
   usize yCount = maxTopVoxel[1] - minBottomVoxel[1] + 1;
 
-  auto* neighborListBottom = NeighborList<float32>::Create(dataStructure, "NeighborList", numTuplesBottom, croppedBottomAM.getId());
-  neighborListBottom->resizeTotalElements(numTuplesBottom);
+  auto* neighborListBottom = NeighborList<float32>::Create(dataStructure, "NeighborList", croppedBottomAM.getShape(), croppedBottomAM.getId());
   std::vector<std::string> stringValuesBottom(numTuplesBottom);
   usize i = 0;
   for(usize z = minBottomVoxel[2]; z <= maxBottomVoxel[2]; ++z)
@@ -143,8 +141,7 @@ void createNeighborListsAndStringArrays(DataStructure& dataStructure, const std:
   }
   StringArray::CreateWithValues(dataStructure, "StringArray", stringValuesBottom, croppedBottomAM.getId());
 
-  auto* neighborListMiddle = NeighborList<float32>::Create(dataStructure, "NeighborList", numTuplesMiddle, croppedMiddleAM.getId());
-  neighborListMiddle->resizeTotalElements(numTuplesMiddle);
+  auto* neighborListMiddle = NeighborList<float32>::Create(dataStructure, "NeighborList", croppedMiddleAM.getShape(), croppedMiddleAM.getId());
   std::vector<std::string> stringValuesMiddle(numTuplesMiddle);
   i = 0;
   for(usize z = minMiddleVoxel[2]; z <= maxMiddleVoxel[2]; ++z)
@@ -164,8 +161,7 @@ void createNeighborListsAndStringArrays(DataStructure& dataStructure, const std:
   }
   StringArray::CreateWithValues(dataStructure, "StringArray", stringValuesMiddle, croppedMiddleAM.getId());
 
-  auto* neighborListTop = NeighborList<float32>::Create(dataStructure, "NeighborList", numTuplesTop, croppedTopAM.getId());
-  neighborListTop->resizeTotalElements(numTuplesTop);
+  auto* neighborListTop = NeighborList<float32>::Create(dataStructure, "NeighborList", croppedTopAM.getShape(), croppedTopAM.getId());
   std::vector<std::string> stringValueTop(numTuplesTop);
   i = 0;
   for(usize z = minTopVoxel[2]; z <= maxTopVoxel[2]; ++z)

--- a/src/Plugins/SimplnxCore/test/AppendImageGeometryTest.cpp
+++ b/src/Plugins/SimplnxCore/test/AppendImageGeometryTest.cpp
@@ -108,7 +108,7 @@ void createNeighborListsAndStringArrays(DataStructure& dataStructure, const std:
     stringArrayValues[i] = "String_" + StringUtilities::number(factor);
   }
 
-  const auto* stringArray = StringArray::CreateWithValues(dataStructure, "StringArray", stringArrayValues, cellDataAM.getId());
+  const auto* stringArray = StringArray::CreateWithValues(dataStructure, "StringArray", cellDataAM.getShape(), stringArrayValues, cellDataAM.getId());
 
   const auto& croppedTopAM = dataStructure.getDataRefAs<AttributeMatrix>(topPath.createChildPath(k_CellData));
   const auto& croppedMiddleAM = dataStructure.getDataRefAs<AttributeMatrix>(middlePath.createChildPath(k_CellData));
@@ -139,7 +139,7 @@ void createNeighborListsAndStringArrays(DataStructure& dataStructure, const std:
       }
     }
   }
-  StringArray::CreateWithValues(dataStructure, "StringArray", stringValuesBottom, croppedBottomAM.getId());
+  StringArray::CreateWithValues(dataStructure, "StringArray", croppedBottomAM.getShape(), stringValuesBottom, croppedBottomAM.getId());
 
   auto* neighborListMiddle = NeighborList<float32>::Create(dataStructure, "NeighborList", croppedMiddleAM.getShape(), croppedMiddleAM.getId());
   std::vector<std::string> stringValuesMiddle(numTuplesMiddle);
@@ -159,7 +159,7 @@ void createNeighborListsAndStringArrays(DataStructure& dataStructure, const std:
       }
     }
   }
-  StringArray::CreateWithValues(dataStructure, "StringArray", stringValuesMiddle, croppedMiddleAM.getId());
+  StringArray::CreateWithValues(dataStructure, "StringArray", croppedMiddleAM.getShape(), stringValuesMiddle, croppedMiddleAM.getId());
 
   auto* neighborListTop = NeighborList<float32>::Create(dataStructure, "NeighborList", croppedTopAM.getShape(), croppedTopAM.getId());
   std::vector<std::string> stringValueTop(numTuplesTop);
@@ -179,7 +179,7 @@ void createNeighborListsAndStringArrays(DataStructure& dataStructure, const std:
       }
     }
   }
-  StringArray::CreateWithValues(dataStructure, "StringArray", stringValueTop, croppedTopAM.getId());
+  StringArray::CreateWithValues(dataStructure, "StringArray", croppedTopAM.getShape(), stringValueTop, croppedTopAM.getId());
 }
 
 void appendGeometries(DataStructure& dataStructure, const DataPath& destinationPath, const std::vector<DataPath>& inputPaths, uint64 appendDimension, std::optional<const DataPath> newGeometryPathOpt,
@@ -318,7 +318,7 @@ TEST_CASE("SimplnxCore::AppendImageGeometryFilter: Valid Filter Execution", "[Si
     }
   }
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, SmallIn100::k_TupleCheckIgnoredPaths);
 }
 
 TEST_CASE("SimplnxCore::AppendImageGeometryFilter: Invalid Filter Execution", "[SimplnxCore][AppendImageGeometryFilter]")

--- a/src/Plugins/SimplnxCore/test/CombineNodeBasedGeometriesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/CombineNodeBasedGeometriesTest.cpp
@@ -88,7 +88,7 @@ void AddDataArray(AttributeMatrix& attrMatrix, DataStructure& dataStructure)
 
 StringArray* CreateStringArray(AttributeMatrix& attrMatrix, DataStructure& dataStructure, const std::string& arrayName)
 {
-  return StringArray::CreateWithValues(dataStructure, arrayName, std::vector<std::string>(attrMatrix.getNumTuples()), attrMatrix.getId());
+  return StringArray::CreateWithValues(dataStructure, arrayName, attrMatrix.getShape(), std::vector<std::string>(attrMatrix.getNumTuples()), attrMatrix.getId());
 }
 
 void AddStringArray(AttributeMatrix& attrMatrix, DataStructure& dataStructure)

--- a/src/Plugins/SimplnxCore/test/CombineNodeBasedGeometriesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/CombineNodeBasedGeometriesTest.cpp
@@ -101,7 +101,7 @@ void AddStringArray(AttributeMatrix& attrMatrix, DataStructure& dataStructure)
 template <typename T>
 NeighborList<T>* CreateNeighborList(AttributeMatrix& attrMatrix, DataStructure& dataStructure, const std::string& nlName)
 {
-  return NeighborList<T>::Create(dataStructure, nlName, attrMatrix.getNumTuples(), attrMatrix.getId());
+  return NeighborList<T>::Create(dataStructure, nlName, attrMatrix.getShape(), attrMatrix.getId());
 }
 
 template <typename T>

--- a/src/Plugins/SimplnxCore/test/ComputeBoundingBoxStatsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeBoundingBoxStatsTest.cpp
@@ -1049,7 +1049,7 @@ TEST_CASE("SimplnxCore::ComputeBoundingBoxStatsFilter: Attribute Matrix Handling
 
   constexpr StringLiteral k_NewAmName = "newAM";
 
-  AttributeMatrix* cellAm = AttributeMatrix::Create(dataStructure, k_NewAmName, AttributeMatrix::ShapeType(1, 1));
+  AttributeMatrix* cellAm = AttributeMatrix::Create(dataStructure, k_NewAmName, ShapeType(1, 1));
 
   {
     ComputeBoundingBoxStatsFilter filter;

--- a/src/Plugins/SimplnxCore/test/ComputeFeatureRectTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeFeatureRectTest.cpp
@@ -69,7 +69,7 @@ DataStructure CreateTestData()
 
   AttributeMatrix* featureAM = AttributeMatrix::Create(dataStructure, k_FeatureAttrMatrixName, {4}, iGeom->getId());
 
-  std::vector<usize> compDims = {6};
+  ShapeType compDims = {6};
   UInt32Array* rect = UInt32Array::CreateWithStore<UInt32DataStore>(dataStructure, k_RectCoordsExemplaryArrayName, {4}, {6}, featureAM->getId());
   auto& rectStore = rect->getDataStoreRef();
   rectStore.setComponent(1, 0, 1);

--- a/src/Plugins/SimplnxCore/test/ComputeNeighborListStatisticsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeNeighborListStatisticsTest.cpp
@@ -34,8 +34,7 @@ TEST_CASE("SimplnxCore::ComputeNeighborListStatisticsFilter: Test Algorithm", "[
   DataPath summationOutputPath = statsDataPath.createChildPath(summation);
 
   usize numTuples = 3;
-  auto* neighborList = NeighborList<float32>::Create(dataStructure, "Neighbor List", numTuples, topLevelGroup->getId());
-  neighborList->resizeTotalElements(numTuples);
+  auto* neighborList = NeighborList<float32>::Create(dataStructure, "Neighbor List", IListStore::ShapeType{numTuples}, topLevelGroup->getId());
   std::vector<float32> list1 = {117, 875, 1035, 3905, 4214};
   std::vector<float32> list2 = {750, 1905, 1912, 2015, 2586, 3180, 3592, 4041, 4772};
   std::vector<float32> list3 = {309, 775, 2625, 2818, 3061, 3751, 4235, 4817};

--- a/src/Plugins/SimplnxCore/test/ComputeNeighborListStatisticsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeNeighborListStatisticsTest.cpp
@@ -34,7 +34,7 @@ TEST_CASE("SimplnxCore::ComputeNeighborListStatisticsFilter: Test Algorithm", "[
   DataPath summationOutputPath = statsDataPath.createChildPath(summation);
 
   usize numTuples = 3;
-  auto* neighborList = NeighborList<float32>::Create(dataStructure, "Neighbor List", IListStore::ShapeType{numTuples}, topLevelGroup->getId());
+  auto* neighborList = NeighborList<float32>::Create(dataStructure, "Neighbor List", ShapeType{numTuples}, topLevelGroup->getId());
   std::vector<float32> list1 = {117, 875, 1035, 3905, 4214};
   std::vector<float32> list2 = {750, 1905, 1912, 2015, 2586, 3180, 3592, 4041, 4772};
   std::vector<float32> list3 = {309, 775, 2625, 2818, 3061, 3751, 4235, 4817};

--- a/src/Plugins/SimplnxCore/test/ConcatenateDataArraysTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ConcatenateDataArraysTest.cpp
@@ -322,8 +322,8 @@ TEST_CASE("SimplnxCore::ConcatenateDataArraysFilter: StringArray Valid - 1 Tuple
   std::string value1 = "Foo";
   std::string value2 = "Bar";
 
-  StringArray::CreateWithValues(dataStructure, k_TestArray1Name, {value1});
-  StringArray::CreateWithValues(dataStructure, k_TestArray2Name, {value2});
+  StringArray::CreateWithValues(dataStructure, k_TestArray1Name, StringArray::ShapeType{1}, {value1});
+  StringArray::CreateWithValues(dataStructure, k_TestArray2Name, StringArray::ShapeType{1}, {value2});
 
   args.insert(ConcatenateDataArraysFilter::k_InputArrays_Key, std::make_any<std::vector<DataPath>>(k_InputArrayPaths));
   args.insert(ConcatenateDataArraysFilter::k_OutputArray_Key, std::make_any<DataPath>(k_OutputArrayPath));
@@ -354,8 +354,8 @@ TEST_CASE("SimplnxCore::ConcatenateDataArraysFilter: StringArray Valid - 2 Tuple
   std::string value3 = "Baz";
   std::string value4 = "Fizzle";
 
-  StringArray::CreateWithValues(dataStructure, k_TestArray1Name, {value1, value2});
-  StringArray::CreateWithValues(dataStructure, k_TestArray2Name, {value3, value4});
+  StringArray::CreateWithValues(dataStructure, k_TestArray1Name, StringArray::ShapeType{2},{value1, value2});
+  StringArray::CreateWithValues(dataStructure, k_TestArray2Name, StringArray::ShapeType{2}, {value3, value4});
 
   args.insert(ConcatenateDataArraysFilter::k_InputArrays_Key, std::make_any<std::vector<DataPath>>(k_InputArrayPaths));
   args.insert(ConcatenateDataArraysFilter::k_OutputArray_Key, std::make_any<DataPath>(k_OutputArrayPath));
@@ -390,8 +390,8 @@ TEST_CASE("SimplnxCore::ConcatenateDataArraysFilter: StringArray Valid - 3 Tuple
   std::string value5 = "Sizzle";
   std::string value6 = "Twizzler";
 
-  StringArray::CreateWithValues(dataStructure, k_TestArray1Name, {value1, value2, value3});
-  StringArray::CreateWithValues(dataStructure, k_TestArray2Name, {value4, value5, value6});
+  StringArray::CreateWithValues(dataStructure, k_TestArray1Name, StringArray::ShapeType{3}, {value1, value2, value3});
+  StringArray::CreateWithValues(dataStructure, k_TestArray2Name, StringArray::ShapeType{3}, {value4, value5, value6});
 
   args.insert(ConcatenateDataArraysFilter::k_InputArrays_Key, std::make_any<std::vector<DataPath>>(k_InputArrayPaths));
   args.insert(ConcatenateDataArraysFilter::k_OutputArray_Key, std::make_any<DataPath>(k_OutputArrayPath));
@@ -464,7 +464,7 @@ TEST_CASE("SimplnxCore::ConcatenateDataArraysFilter: Invalid Parameters", "[Simp
   SECTION("Mismatching Type Names 2")
   {
     Int8Array::CreateWithStore<Int8DataStore>(dataStructure, k_TestArray1Name, std::vector<usize>{1}, std::vector<usize>{3});
-    StringArray::CreateWithValues(dataStructure, k_TestArray2Name, {"Foo"});
+    StringArray::CreateWithValues(dataStructure, k_TestArray2Name, StringArray::ShapeType{1}, {"Foo"});
 
     args.insert(ConcatenateDataArraysFilter::k_InputArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{k_InputArrayPaths}));
     args.insert(ConcatenateDataArraysFilter::k_OutputArray_Key, std::make_any<DataPath>(k_OutputArrayPath));

--- a/src/Plugins/SimplnxCore/test/ConcatenateDataArraysTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ConcatenateDataArraysTest.cpp
@@ -193,10 +193,10 @@ TEMPLATE_TEST_CASE("SimplnxCore::ConcatenateDataArraysFilter: NeighborLists Vali
   DataStructure dataStructure;
   Arguments args;
 
-  auto inputNeighborList1 = NeighborList<T>::Create(dataStructure, k_TestArray1Name, 1);
+  auto inputNeighborList1 = NeighborList<T>::Create(dataStructure, k_TestArray1Name, IListStore::ShapeType{1});
   typename NeighborList<T>::VectorType inputList1({0, 1, 0});
   inputNeighborList1->setList(0, inputList1);
-  auto inputNeighborList2 = NeighborList<T>::Create(dataStructure, k_TestArray2Name, 1);
+  auto inputNeighborList2 = NeighborList<T>::Create(dataStructure, k_TestArray2Name, IListStore::ShapeType{1});
   typename NeighborList<T>::VectorType inputList2({1, 1, 1});
   inputNeighborList2->setList(0, inputList2);
 
@@ -228,12 +228,12 @@ TEMPLATE_TEST_CASE("SimplnxCore::ConcatenateDataArraysFilter: NeighborLists Vali
   DataStructure dataStructure;
   Arguments args;
 
-  auto inputNeighborList1 = NeighborList<T>::Create(dataStructure, k_TestArray1Name, 2);
+  auto inputNeighborList1 = NeighborList<T>::Create(dataStructure, k_TestArray1Name, IListStore::ShapeType{2});
   typename NeighborList<T>::VectorType inputList1({0, 1, 0});
   inputNeighborList1->setList(0, inputList1);
   typename NeighborList<T>::VectorType inputList2({1, 0, 0});
   inputNeighborList1->setList(1, inputList2);
-  auto inputNeighborList2 = NeighborList<T>::Create(dataStructure, k_TestArray2Name, 2);
+  auto inputNeighborList2 = NeighborList<T>::Create(dataStructure, k_TestArray2Name, IListStore::ShapeType{2});
   typename NeighborList<T>::VectorType inputList3({1, 1, 1});
   inputNeighborList2->setList(0, inputList3);
   typename NeighborList<T>::VectorType inputList4({0, 0, 1});
@@ -271,14 +271,14 @@ TEMPLATE_TEST_CASE("SimplnxCore::ConcatenateDataArraysFilter: NeighborLists Vali
   DataStructure dataStructure;
   Arguments args;
 
-  auto inputNeighborList1 = NeighborList<T>::Create(dataStructure, k_TestArray1Name, 3);
+  auto inputNeighborList1 = NeighborList<T>::Create(dataStructure, k_TestArray1Name, IListStore::ShapeType{3});
   typename NeighborList<T>::VectorType inputList1({0, 1, 0});
   inputNeighborList1->setList(0, inputList1);
   typename NeighborList<T>::VectorType inputList2({1, 0, 0});
   inputNeighborList1->setList(1, inputList2);
   typename NeighborList<T>::VectorType inputList3({2, 2, 1});
   inputNeighborList1->setList(2, inputList3);
-  auto inputNeighborList2 = NeighborList<T>::Create(dataStructure, k_TestArray2Name, 3);
+  auto inputNeighborList2 = NeighborList<T>::Create(dataStructure, k_TestArray2Name, IListStore::ShapeType{3});
   typename NeighborList<T>::VectorType inputList4({1, 1, 1});
   inputNeighborList2->setList(0, inputList4);
   typename NeighborList<T>::VectorType inputList5({0, 0, 1});

--- a/src/Plugins/SimplnxCore/test/ConcatenateDataArraysTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ConcatenateDataArraysTest.cpp
@@ -193,10 +193,10 @@ TEMPLATE_TEST_CASE("SimplnxCore::ConcatenateDataArraysFilter: NeighborLists Vali
   DataStructure dataStructure;
   Arguments args;
 
-  auto inputNeighborList1 = NeighborList<T>::Create(dataStructure, k_TestArray1Name, IListStore::ShapeType{1});
+  auto inputNeighborList1 = NeighborList<T>::Create(dataStructure, k_TestArray1Name, ShapeType{1});
   typename NeighborList<T>::VectorType inputList1({0, 1, 0});
   inputNeighborList1->setList(0, inputList1);
-  auto inputNeighborList2 = NeighborList<T>::Create(dataStructure, k_TestArray2Name, IListStore::ShapeType{1});
+  auto inputNeighborList2 = NeighborList<T>::Create(dataStructure, k_TestArray2Name, ShapeType{1});
   typename NeighborList<T>::VectorType inputList2({1, 1, 1});
   inputNeighborList2->setList(0, inputList2);
 
@@ -228,12 +228,12 @@ TEMPLATE_TEST_CASE("SimplnxCore::ConcatenateDataArraysFilter: NeighborLists Vali
   DataStructure dataStructure;
   Arguments args;
 
-  auto inputNeighborList1 = NeighborList<T>::Create(dataStructure, k_TestArray1Name, IListStore::ShapeType{2});
+  auto inputNeighborList1 = NeighborList<T>::Create(dataStructure, k_TestArray1Name, ShapeType{2});
   typename NeighborList<T>::VectorType inputList1({0, 1, 0});
   inputNeighborList1->setList(0, inputList1);
   typename NeighborList<T>::VectorType inputList2({1, 0, 0});
   inputNeighborList1->setList(1, inputList2);
-  auto inputNeighborList2 = NeighborList<T>::Create(dataStructure, k_TestArray2Name, IListStore::ShapeType{2});
+  auto inputNeighborList2 = NeighborList<T>::Create(dataStructure, k_TestArray2Name, ShapeType{2});
   typename NeighborList<T>::VectorType inputList3({1, 1, 1});
   inputNeighborList2->setList(0, inputList3);
   typename NeighborList<T>::VectorType inputList4({0, 0, 1});
@@ -271,14 +271,14 @@ TEMPLATE_TEST_CASE("SimplnxCore::ConcatenateDataArraysFilter: NeighborLists Vali
   DataStructure dataStructure;
   Arguments args;
 
-  auto inputNeighborList1 = NeighborList<T>::Create(dataStructure, k_TestArray1Name, IListStore::ShapeType{3});
+  auto inputNeighborList1 = NeighborList<T>::Create(dataStructure, k_TestArray1Name, ShapeType{3});
   typename NeighborList<T>::VectorType inputList1({0, 1, 0});
   inputNeighborList1->setList(0, inputList1);
   typename NeighborList<T>::VectorType inputList2({1, 0, 0});
   inputNeighborList1->setList(1, inputList2);
   typename NeighborList<T>::VectorType inputList3({2, 2, 1});
   inputNeighborList1->setList(2, inputList3);
-  auto inputNeighborList2 = NeighborList<T>::Create(dataStructure, k_TestArray2Name, IListStore::ShapeType{3});
+  auto inputNeighborList2 = NeighborList<T>::Create(dataStructure, k_TestArray2Name, ShapeType{3});
   typename NeighborList<T>::VectorType inputList4({1, 1, 1});
   inputNeighborList2->setList(0, inputList4);
   typename NeighborList<T>::VectorType inputList5({0, 0, 1});
@@ -322,8 +322,8 @@ TEST_CASE("SimplnxCore::ConcatenateDataArraysFilter: StringArray Valid - 1 Tuple
   std::string value1 = "Foo";
   std::string value2 = "Bar";
 
-  StringArray::CreateWithValues(dataStructure, k_TestArray1Name, StringArray::ShapeType{1}, {value1});
-  StringArray::CreateWithValues(dataStructure, k_TestArray2Name, StringArray::ShapeType{1}, {value2});
+  StringArray::CreateWithValues(dataStructure, k_TestArray1Name, ShapeType{1}, {value1});
+  StringArray::CreateWithValues(dataStructure, k_TestArray2Name, ShapeType{1}, {value2});
 
   args.insert(ConcatenateDataArraysFilter::k_InputArrays_Key, std::make_any<std::vector<DataPath>>(k_InputArrayPaths));
   args.insert(ConcatenateDataArraysFilter::k_OutputArray_Key, std::make_any<DataPath>(k_OutputArrayPath));
@@ -354,8 +354,8 @@ TEST_CASE("SimplnxCore::ConcatenateDataArraysFilter: StringArray Valid - 2 Tuple
   std::string value3 = "Baz";
   std::string value4 = "Fizzle";
 
-  StringArray::CreateWithValues(dataStructure, k_TestArray1Name, StringArray::ShapeType{2},{value1, value2});
-  StringArray::CreateWithValues(dataStructure, k_TestArray2Name, StringArray::ShapeType{2}, {value3, value4});
+  StringArray::CreateWithValues(dataStructure, k_TestArray1Name, ShapeType{2}, {value1, value2});
+  StringArray::CreateWithValues(dataStructure, k_TestArray2Name, ShapeType{2}, {value3, value4});
 
   args.insert(ConcatenateDataArraysFilter::k_InputArrays_Key, std::make_any<std::vector<DataPath>>(k_InputArrayPaths));
   args.insert(ConcatenateDataArraysFilter::k_OutputArray_Key, std::make_any<DataPath>(k_OutputArrayPath));
@@ -390,8 +390,8 @@ TEST_CASE("SimplnxCore::ConcatenateDataArraysFilter: StringArray Valid - 3 Tuple
   std::string value5 = "Sizzle";
   std::string value6 = "Twizzler";
 
-  StringArray::CreateWithValues(dataStructure, k_TestArray1Name, StringArray::ShapeType{3}, {value1, value2, value3});
-  StringArray::CreateWithValues(dataStructure, k_TestArray2Name, StringArray::ShapeType{3}, {value4, value5, value6});
+  StringArray::CreateWithValues(dataStructure, k_TestArray1Name, ShapeType{3}, {value1, value2, value3});
+  StringArray::CreateWithValues(dataStructure, k_TestArray2Name, ShapeType{3}, {value4, value5, value6});
 
   args.insert(ConcatenateDataArraysFilter::k_InputArrays_Key, std::make_any<std::vector<DataPath>>(k_InputArrayPaths));
   args.insert(ConcatenateDataArraysFilter::k_OutputArray_Key, std::make_any<DataPath>(k_OutputArrayPath));
@@ -464,7 +464,7 @@ TEST_CASE("SimplnxCore::ConcatenateDataArraysFilter: Invalid Parameters", "[Simp
   SECTION("Mismatching Type Names 2")
   {
     Int8Array::CreateWithStore<Int8DataStore>(dataStructure, k_TestArray1Name, std::vector<usize>{1}, std::vector<usize>{3});
-    StringArray::CreateWithValues(dataStructure, k_TestArray2Name, StringArray::ShapeType{1}, {"Foo"});
+    StringArray::CreateWithValues(dataStructure, k_TestArray2Name, ShapeType{1}, {"Foo"});
 
     args.insert(ConcatenateDataArraysFilter::k_InputArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{k_InputArrayPaths}));
     args.insert(ConcatenateDataArraysFilter::k_OutputArray_Key, std::make_any<DataPath>(k_OutputArrayPath));

--- a/src/Plugins/SimplnxCore/test/ConditionalSetValueTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ConditionalSetValueTest.cpp
@@ -103,7 +103,7 @@ TEST_CASE("SimplnxCore::ConditionalSetValueFilter: Test Algorithm Bool", "[Condi
   ciDataArray->fill(10.0);
 
   // Create a bool array where every value is TRUE
-  std::vector<usize> tupleShape = {imageGeomDims[2], imageGeomDims[1], imageGeomDims[0]};
+  ShapeType tupleShape = {imageGeomDims[2], imageGeomDims[1], imageGeomDims[0]};
 
   BoolArray& conditionalArray = dataStructure.getDataRefAs<BoolArray>(DataPath({k_SmallIN100, k_EbsdScanData, k_ConditionalArray}));
   conditionalArray.fill(true);
@@ -150,7 +150,7 @@ TEST_CASE("SimplnxCore::ConditionalSetValueFilter: Test Algorithm UInt8", "[Cond
   float32DataArray.fill(10.0);
 
   // Create a bool array where every value is TRUE
-  std::vector<usize> tupleShape = {imageGeomDims[2], imageGeomDims[1], imageGeomDims[0]};
+  ShapeType tupleShape = {imageGeomDims[2], imageGeomDims[1], imageGeomDims[0]};
   BoolArray& conditionalArray = dataStructure.getDataRefAs<BoolArray>(DataPath({k_SmallIN100, k_EbsdScanData, k_ConditionalArray}));
   conditionalArray.fill(true);
 
@@ -191,7 +191,7 @@ TEST_CASE("SimplnxCore::ConditionalSetValueFilter: Test Algorithm Int8", "[Condi
   float32DataArray.fill(10.0);
 
   // Create a bool array where every value is TRUE
-  std::vector<usize> tupleShape = {imageGeomDims[2], imageGeomDims[1], imageGeomDims[0]};
+  ShapeType tupleShape = {imageGeomDims[2], imageGeomDims[1], imageGeomDims[0]};
   BoolArray& conditionalArray = dataStructure.getDataRefAs<BoolArray>(DataPath({k_SmallIN100, k_EbsdScanData, k_ConditionalArray}));
   conditionalArray.fill(true);
 
@@ -240,7 +240,7 @@ TEST_CASE("SimplnxCore::ConditionalSetValueFilter: Overflow/Underflow", "[Condit
   UnitTest::AddImageGeometry(dataStructure, imageDims, imageSpacing, imageOrigin, *levelTwoGroup);
 
   // Create a bool array where every value is TRUE
-  std::vector<usize> tupleShape = {imageDims[2], imageDims[1], imageDims[0]};
+  ShapeType tupleShape = {imageDims[2], imageDims[1], imageDims[0]};
   BoolArray* conditionalArray1 = UnitTest::CreateTestDataArray<bool>(dataStructure, k_ConditionalArray, tupleShape, {1}, levelOneGroup->getId());
   conditionalArray1->fill(true);
   BoolArray* conditionalArray2 = UnitTest::CreateTestDataArray<bool>(dataStructure, k_ConditionalArray, tupleShape, {1}, levelTwoGroup->getId());
@@ -372,7 +372,7 @@ TEST_CASE("SimplnxCore::ConditionalSetValueFilter: Test Inverted Mask Algorithm 
   float32DataArray.fill(10.0);
 
   // Create a bool array where every value is TRUE
-  std::vector<usize> tupleShape = {imageGeomDims[2], imageGeomDims[1], imageGeomDims[0]};
+  ShapeType tupleShape = {imageGeomDims[2], imageGeomDims[1], imageGeomDims[0]};
   BoolArray& conditionalArray = dataStructure.getDataRefAs<BoolArray>(DataPath({k_SmallIN100, k_EbsdScanData, k_ConditionalArray}));
   conditionalArray.fill(false);
 

--- a/src/Plugins/SimplnxCore/test/CropImageGeometryTest.cpp
+++ b/src/Plugins/SimplnxCore/test/CropImageGeometryTest.cpp
@@ -40,7 +40,7 @@ DataStructure CreateDataStructure()
   imageGeom->setDimensions(imageGeomDims); // Listed from slowest to fastest (Z, Y, X)
 
   auto imageDimsArray = imageGeomDims.toArray();
-  AttributeMatrix::ShapeType cellDataDims{imageDimsArray.crbegin(), imageDimsArray.crend()};
+  ShapeType cellDataDims{imageDimsArray.crbegin(), imageDimsArray.crend()};
   auto* cellDataPtr = AttributeMatrix::Create(dataStructure, ImageGeom::k_CellAttributeMatrixName, cellDataDims, imageGeom->getId());
   imageGeom->setCellData(*cellDataPtr);
 

--- a/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
@@ -141,7 +141,7 @@ DataStructure CreateTestDataStructure()
   auto group2 = DataGroup::Create(dataStructure, DataNames::k_Group2Name, group1->getId());
   auto group3 = DataGroup::Create(dataStructure, DataNames::k_Group3Name, group2->getId());
 
-  std::vector<usize> tupleShape = {10};
+  ShapeType tupleShape = {10};
   auto* attributeMatrix = AttributeMatrix::Create(dataStructure, DataNames::k_AttributeMatrixName, tupleShape, group1->getId());
 
   Result<> arrayCreationResults =
@@ -294,7 +294,7 @@ TEST_CASE("DREAM3DFileTest:DREAM3D File IO Test")
     REQUIRE(dataStructure.getData(DataPath({DataNames::k_Group1Name, DataNames::k_Group2Name, DataNames::k_Group3Name})) != nullptr);
     auto attMatrix = dataStructure.getDataAs<AttributeMatrix>(DataPath({DataNames::k_Group1Name, DataNames::k_AttributeMatrixName}));
     REQUIRE(attMatrix != nullptr);
-    REQUIRE(attMatrix->getShape() == AttributeMatrix::ShapeType{10});
+    REQUIRE(attMatrix->getShape() == ShapeType{10});
     REQUIRE(dataStructure.getData(DataPath({DataNames::k_Group1Name, DataNames::k_AttributeMatrixName, DataNames::k_Array2Name})) != nullptr);
 
     // Test reading the Pipeline

--- a/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
@@ -447,7 +447,7 @@ TEST_CASE("DREAM3DFileTest: Existing Data Objects Test")
     SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
 
-  UnitTest::CheckArraysInheritTupleDims(ds);
+  UnitTest::CheckArraysInheritTupleDims(ds, SmallIn100::k_TupleCheckIgnoredPaths);
 }
 
 TEST_CASE("DREAM3DFileTest: Path Import Policy Tests")
@@ -553,5 +553,5 @@ TEST_CASE("DREAM3DFileTest: Path Import Policy Tests")
     REQUIRE(dataStructure.containsData(DataPath({"DataContainer", "CellEnsembleData", "CrystalStructures"})));
   }
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, SmallIn100::k_TupleCheckIgnoredPaths);
 }

--- a/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
@@ -318,7 +318,7 @@ TEST_CASE("DREAM3DFileTest::StringArray")
 
   std::vector<std::string> values = {"foo", "bar", "baz"};
 
-  REQUIRE(StringArray::CreateWithValues(exportDataStructure, stringArrayPath.getTargetName(), values) != nullptr);
+  REQUIRE(StringArray::CreateWithValues(exportDataStructure, stringArrayPath.getTargetName(), ShapeType{3}, values) != nullptr);
 
   WriteDREAM3DFilter writeDream3dFilter;
   Arguments writeArgs;

--- a/src/Plugins/SimplnxCore/test/InterpolatePointCloudToRegularGridTest.cpp
+++ b/src/Plugins/SimplnxCore/test/InterpolatePointCloudToRegularGridTest.cpp
@@ -43,6 +43,13 @@ const DataPath k_GaussianKernalDistancesExemplar = k_GaussianInterpolatedDataExe
 const DataPath k_GaussianFaceAreasComputed = k_GaussianInterpolatedDataComputed.createChildPath(k_FaceAreas);
 const DataPath k_GaussianVoxelIndicesComputed = k_GaussianInterpolatedDataComputed.createChildPath(k_VoxelIndices);
 const DataPath k_GaussianKernalDistancesComputed = k_GaussianInterpolatedDataComputed.createChildPath(k_KernalDistances);
+
+// These paths are excluded because they come from a version prior to
+// NeighborList and StringArray having multidimensional tuple capability
+// (Only exemplars not checked, GENERATED/COMPUTED VALIDATED)
+const std::vector<DataPath> k_ExemplarTupleCheckIgnoredPaths{{{"Image Geometry", "GaussianInterpolatedData", "FaceAreas"}},      {{"Image Geometry", "GaussianInterpolatedData", "KernelDistances"}},
+                                                             {{"Image Geometry", "GaussianInterpolatedData", "VoxelIndices"}},   {{"Image Geometry", "UniformInterpolatedData", "FaceAreas"}},
+                                                             {{"Image Geometry", "UniformInterpolatedData", "KernelDistances"}}, {{"Image Geometry", "UniformInterpolatedData", "VoxelIndices"}}};
 } // namespace
 
 TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Valid Filter Execution - Uniform Inpterpolation with Mask", "[SimplnxCore][InterpolatePointCloudToRegularGridFilter]")
@@ -84,7 +91,7 @@ TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Valid Filter E
   UnitTest::CompareNeighborLists<uint64>(dataStructure, k_UniformVoxelIndicesExemplar, k_UniformVoxelIndicesComputed);
   UnitTest::CompareNeighborLists<float32>(dataStructure, k_UniformKernalDistancesExemplar, k_UniformKernalDistancesComputed);
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, k_ExemplarTupleCheckIgnoredPaths);
 }
 
 TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Valid Filter Execution - Gaussian Inpterpolation", "[SimplnxCore][InterpolatePointCloudToRegularGridFilter]")
@@ -126,7 +133,7 @@ TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Valid Filter E
   UnitTest::CompareNeighborLists<uint64>(dataStructure, k_GaussianVoxelIndicesExemplar, k_GaussianVoxelIndicesComputed);
   UnitTest::CompareNeighborLists<float32>(dataStructure, k_GaussianKernalDistancesExemplar, k_GaussianKernalDistancesComputed);
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, k_ExemplarTupleCheckIgnoredPaths);
 }
 
 TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Invalid Filter Execution", "[SimplnxCore][InterpolatePointCloudToRegularGridFilter]")
@@ -180,5 +187,5 @@ TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Invalid Filter
   auto executeResult = filter.execute(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result)
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, k_ExemplarTupleCheckIgnoredPaths);
 }

--- a/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
@@ -34,9 +34,9 @@ DataStructure CreateTestDataStructure()
   std::vector<usize> dims = {20, 1, 1};
   image->setDimensions(dims);
 
-  std::vector<usize> tDims = {20};
-  std::vector<usize> cDims = {1};
-  std::vector<usize> cDimsMulti = {3};
+  ShapeType tDims = {20};
+  ShapeType cDims = {1};
+  ShapeType cDimsMulti = {3};
   float fnum = 0.0f;
   int inum = 0;
   AttributeMatrix* am = AttributeMatrix::Create(dataStructure, k_CellData, tDims, image->getId());

--- a/src/Plugins/SimplnxCore/test/PointSampleTriangleGeometryFilterTest.cpp
+++ b/src/Plugins/SimplnxCore/test/PointSampleTriangleGeometryFilterTest.cpp
@@ -189,8 +189,8 @@ TEST_CASE("SimplnxCore::PointSampleTriangleGeometryFilter", "[DREAM3DReview][Poi
     // We need to insert this small data set for the XDMF to work correctly.
     DataPath xdmfVertsDataPath = vertGeometryDataPath.createChildPath("Verts");
     DataObject::IdType parentId = dataStructure.getId(vertGeometryDataPath).value();
-    std::vector<usize> tupleShape = {vertGeom.getNumberOfVertices()};
-    std::vector<usize> componentShape = {1};
+    ShapeType tupleShape = {vertGeom.getNumberOfVertices()};
+    ShapeType componentShape = {1};
     DataArray<int64_t>* vertsArray = DataArray<int64_t>::CreateWithStore<DataStore<int64_t>>(dataStructure, "Verts", tupleShape, componentShape, parentId);
     for(int64_t i = 0; i < tupleShape[0]; i++)
     {

--- a/src/Plugins/SimplnxCore/test/ReadCSVFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReadCSVFileTest.cpp
@@ -96,7 +96,7 @@ void CreateTestDataFile(const fs::path& inputFilePath, nonstd::span<std::string>
  * @return
  */
 Arguments createArguments(const std::string& inputFilePath, usize startImportRow, ReadCSVData::HeaderMode headerMode, usize headersLine, const std::vector<char>& delimiters,
-                          const std::vector<std::string>& customHeaders, const std::vector<CSVType>& dataTypes, const std::vector<bool>& skippedArrayMask, const std::vector<usize>& tupleDims,
+                          const std::vector<std::string>& customHeaders, const std::vector<CSVType>& dataTypes, const std::vector<bool>& skippedArrayMask, const ShapeType& tupleDims,
                           nonstd::span<std::string> values, const std::string& newGroupName)
 {
   Arguments args;
@@ -199,7 +199,7 @@ void TestCase_TestPrimitives_Error(nonstd::span<std::string> values, int32 expec
 
 // -----------------------------------------------------------------------------
 void TestCase_TestImporterData_Error(const std::string& inputFilePath, usize startImportRow, ReadCSVData::HeaderMode headerMode, usize headersLine, const std::vector<char>& delimiters,
-                                     const std::vector<std::string>& headers, const std::vector<CSVType>& dataTypes, const std::vector<bool>& skippedArrayMask, const std::vector<usize>& tupleDims,
+                                     const std::vector<std::string>& headers, const std::vector<CSVType>& dataTypes, const std::vector<bool>& skippedArrayMask, const ShapeType& tupleDims,
                                      nonstd::span<std::string> values, int32 expectedErrorCode)
 {
   std::string newGroupName = "New Group";
@@ -423,7 +423,7 @@ TEST_CASE("SimplnxCore::ReadCSVFileFilter (Case 5): Invalid filter execution - I
   std::vector<std::string> v = {std::to_string(std::numeric_limits<int8>::min()), std::to_string(std::numeric_limits<int8>::max())};
   fs::create_directories(k_TestInput.parent_path());
   CreateTestDataFile(k_TestInput, v, {"Array"});
-  std::vector<usize> tupleDims = {static_cast<usize>(v.size())};
+  ShapeType tupleDims = {static_cast<usize>(v.size())};
 
   // Empty input file path
   TestCase_TestImporterData_Error("", 2, ReadCSVData::HeaderMode::LINE, 1, {','}, {}, {CSVType::int8}, {false}, tupleDims, v, k_EmptyFile);

--- a/src/Plugins/SimplnxCore/test/ReadTextDataArrayTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReadTextDataArrayTest.cpp
@@ -79,7 +79,7 @@ template <typename T>
 void RunInvalidTest()
 {
   const std::string inputFilePath = fmt::format("{}/TestFile1.txt", unit_test::k_BinaryTestOutputDir);
-  std::vector<usize> tupleDims = {10};
+  ShapeType tupleDims = {10};
   char delimiter = '\t';
   const DataPath createdArrayPath({k_GroupAName, k_DataArrayName});
 
@@ -201,7 +201,7 @@ void RunTest(char sep, int delimiter)
 
   DataStructure dataStructure;
   auto* imageGeom = ImageGeom::Create(dataStructure, "ImageDataContainer");
-  const std::vector<usize> tDims = {xDim, yDim, zDim};
+  const ShapeType tDims = {xDim, yDim, zDim};
   imageGeom->setDimensions(tDims);
   AttributeMatrix* attrMat = AttributeMatrix::Create(dataStructure, "AttributeMatrix", std::vector<usize>{zDim, yDim, xDim}, imageGeom->getId());
 

--- a/src/Plugins/SimplnxCore/test/ResampleRectGridToImageGeomTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ResampleRectGridToImageGeomTest.cpp
@@ -51,7 +51,7 @@ TEST_CASE("SimplnxCore::ResampleRectGridToImageGeomFilter: Valid Filter Executio
       stringArrayValues[i] = "String_" + StringUtilities::number(factor);
     }
 
-    const auto* stringArray = StringArray::CreateWithValues(dataStructure, k_StringArrayName, stringArrayValues, cellDataAM.getId());
+    const auto* stringArray = StringArray::CreateWithValues(dataStructure, k_StringArrayName, cellDataAM.getShape(), stringArrayValues, cellDataAM.getId());
   }
 
   // Create default Parameters for the filter.

--- a/src/Plugins/SimplnxCore/test/ResampleRectGridToImageGeomTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ResampleRectGridToImageGeomTest.cpp
@@ -42,8 +42,7 @@ TEST_CASE("SimplnxCore::ResampleRectGridToImageGeomFilter: Valid Filter Executio
     const usize numTuples = cellDataAM.getNumTuples();
 
     std::vector<std::string> stringArrayValues(numTuples);
-    auto* neighborList = NeighborList<float32>::Create(dataStructure, k_NeighborListArrayName, numTuples, cellDataAM.getId());
-    neighborList->resizeTotalElements(numTuples);
+    auto* neighborList = NeighborList<float32>::Create(dataStructure, k_NeighborListArrayName, cellDataAM.getShape(), cellDataAM.getId());
     for(usize i = 0; i < numTuples; ++i)
     {
       const float32 factor = static_cast<float32>(i) * 0.001;

--- a/src/Plugins/SimplnxCore/test/ReshapeDataArrayTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReshapeDataArrayTest.cpp
@@ -151,7 +151,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: Valid NeighborLists - 
   DataStructure dataStructure;
   Arguments args;
 
-  auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, 2);
+  auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, IListStore::ShapeType{2});
   typename NeighborList<T>::VectorType inputList({0, 1, 0});
   inputNeighborList->setList(0, inputList);
   typename NeighborList<T>::VectorType inputList2({1, 0, 0});
@@ -183,7 +183,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: Valid NeighborLists - 
   DataStructure dataStructure;
   Arguments args;
 
-  auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, 1);
+  auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, IListStore::ShapeType{1});
   typename NeighborList<T>::VectorType inputList({0, 1, 0});
   inputNeighborList->setList(0, inputList);
 
@@ -294,7 +294,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: Invalid - Same Size", 
   }
   SECTION("NeighborLists")
   {
-    auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, 1);
+    auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, IListStore::ShapeType{1});
     typename NeighborList<T>::VectorType inputList({0, 1, 0});
     inputNeighborList->setList(0, inputList);
 
@@ -329,7 +329,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: NeighborList Warning -
   DataStructure dataStructure;
   Arguments args;
 
-  auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, 1);
+  auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, IListStore::ShapeType{1});
   typename NeighborList<T>::VectorType inputList({0, 1, 0});
   inputNeighborList->setList(0, inputList);
 

--- a/src/Plugins/SimplnxCore/test/ReshapeDataArrayTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReshapeDataArrayTest.cpp
@@ -219,7 +219,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: Valid StringArrays - S
   std::string value5 = "Buzz";
   std::string value6 = "FizzBuzz";
 
-  StringArray::CreateWithValues(dataStructure, k_TestArrayName, {value1, value2, value3, value4, value5, value6});
+  StringArray::CreateWithValues(dataStructure, k_TestArrayName, StringArray::ShapeType{6}, {value1, value2, value3, value4, value5, value6});
 
   args.insert(ReshapeDataArrayFilter::k_Input_Array_Key, std::make_any<DataPath>(k_InputArrayPath));
   args.insert(ReshapeDataArrayFilter::k_TupleDims_Key, std::make_any<DynamicTableParameter::ValueType>(DynamicTableInfo::TableDataType{{4.0}}));
@@ -248,7 +248,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: Valid StringArrays - E
   std::string value1 = "Foo";
   std::string value2 = "Bar";
 
-  StringArray::CreateWithValues(dataStructure, k_TestArrayName, {value1, value2});
+  StringArray::CreateWithValues(dataStructure, k_TestArrayName, StringArray::ShapeType{2}, {value1, value2});
 
   args.insert(ReshapeDataArrayFilter::k_Input_Array_Key, std::make_any<DataPath>(k_InputArrayPath));
   args.insert(ReshapeDataArrayFilter::k_TupleDims_Key, std::make_any<DynamicTableParameter::ValueType>(DynamicTableInfo::TableDataType{{4.0}}));
@@ -306,7 +306,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: Invalid - Same Size", 
     std::string value1 = "Foo";
     std::string value2 = "Bar";
 
-    StringArray::CreateWithValues(dataStructure, k_TestArrayName, {value1, value2});
+    StringArray::CreateWithValues(dataStructure, k_TestArrayName, StringArray::ShapeType{2}, {value1, value2});
 
     args.insert(ReshapeDataArrayFilter::k_Input_Array_Key, std::make_any<DataPath>(k_InputArrayPath));
     args.insert(ReshapeDataArrayFilter::k_TupleDims_Key, std::make_any<DynamicTableParameter::ValueType>(DynamicTableInfo::TableDataType{{2.0}}));
@@ -338,13 +338,11 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: NeighborList Warning -
 
   auto result = filter.execute(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(result.result);
-  REQUIRE(result.result.warnings().size() == 1);
-  REQUIRE(result.result.warnings()[0].code == to_underlying(ReshapeDataArray::WarningCodes::NeighborListMultipleTupleDims));
 
   REQUIRE_NOTHROW(dataStructure.getDataRefAs<NeighborList<T>>(k_InputArrayPath));
   auto reshapedNeighborList = dataStructure.getDataRefAs<NeighborList<T>>(k_InputArrayPath);
 
-  REQUIRE(reshapedNeighborList.getTupleShape() == std::vector<usize>{4});
+  REQUIRE(reshapedNeighborList.getTupleShape() == std::vector<usize>{2, 2});
   auto reshapedList1 = reshapedNeighborList.getList(0);
   auto reshapedList2 = reshapedNeighborList.getList(1);
   auto reshapedList3 = reshapedNeighborList.getList(2);
@@ -367,20 +365,18 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: StringArray Warning - 
   std::string value1 = "Foo";
   std::string value2 = "Bar";
 
-  StringArray::CreateWithValues(dataStructure, k_TestArrayName, {value1, value2});
+  StringArray::CreateWithValues(dataStructure, k_TestArrayName, StringArray::ShapeType{2}, {value1, value2});
 
   args.insert(ReshapeDataArrayFilter::k_Input_Array_Key, std::make_any<DataPath>(k_InputArrayPath));
   args.insert(ReshapeDataArrayFilter::k_TupleDims_Key, std::make_any<DynamicTableParameter::ValueType>(DynamicTableInfo::TableDataType{{2.0, 3.0}}));
 
   auto result = filter.execute(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(result.result);
-  REQUIRE(result.result.warnings().size() == 1);
-  REQUIRE(result.result.warnings()[0].code == to_underlying(ReshapeDataArray::WarningCodes::StringArrayMultipleTupleDims));
 
   REQUIRE_NOTHROW(dataStructure.getDataRefAs<StringArray>(k_InputArrayPath));
   auto reshapedArray = dataStructure.getDataRefAs<StringArray>(k_InputArrayPath);
 
-  REQUIRE(reshapedArray.getTupleShape() == std::vector<usize>{6});
+  REQUIRE(reshapedArray.getTupleShape() == std::vector<usize>{2, 3});
   REQUIRE(reshapedArray[0] == value1);
   REQUIRE(reshapedArray[1] == value2);
   REQUIRE(reshapedArray[2].empty());
@@ -400,7 +396,7 @@ TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: Invalid Tuple Dimensions", "[Si
   std::string value1 = "Foo";
   std::string value2 = "Bar";
 
-  StringArray::CreateWithValues(dataStructure, k_TestArrayName, {value1, value2});
+  StringArray::CreateWithValues(dataStructure, k_TestArrayName, StringArray::ShapeType{2}, {value1, value2});
 
   args.insert(ReshapeDataArrayFilter::k_Input_Array_Key, std::make_any<DataPath>(k_InputArrayPath));
   args.insert(ReshapeDataArrayFilter::k_TupleDims_Key, std::make_any<DynamicTableParameter::ValueType>(DynamicTableInfo::TableDataType{{0.0, 3.0}}));

--- a/src/Plugins/SimplnxCore/test/ReshapeDataArrayTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReshapeDataArrayTest.cpp
@@ -151,7 +151,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: Valid NeighborLists - 
   DataStructure dataStructure;
   Arguments args;
 
-  auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, IListStore::ShapeType{2});
+  auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, ShapeType{2});
   typename NeighborList<T>::VectorType inputList({0, 1, 0});
   inputNeighborList->setList(0, inputList);
   typename NeighborList<T>::VectorType inputList2({1, 0, 0});
@@ -183,7 +183,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: Valid NeighborLists - 
   DataStructure dataStructure;
   Arguments args;
 
-  auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, IListStore::ShapeType{1});
+  auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, ShapeType{1});
   typename NeighborList<T>::VectorType inputList({0, 1, 0});
   inputNeighborList->setList(0, inputList);
 
@@ -219,7 +219,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: Valid StringArrays - S
   std::string value5 = "Buzz";
   std::string value6 = "FizzBuzz";
 
-  StringArray::CreateWithValues(dataStructure, k_TestArrayName, StringArray::ShapeType{6}, {value1, value2, value3, value4, value5, value6});
+  StringArray::CreateWithValues(dataStructure, k_TestArrayName, ShapeType{6}, {value1, value2, value3, value4, value5, value6});
 
   args.insert(ReshapeDataArrayFilter::k_Input_Array_Key, std::make_any<DataPath>(k_InputArrayPath));
   args.insert(ReshapeDataArrayFilter::k_TupleDims_Key, std::make_any<DynamicTableParameter::ValueType>(DynamicTableInfo::TableDataType{{4.0}}));
@@ -248,7 +248,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: Valid StringArrays - E
   std::string value1 = "Foo";
   std::string value2 = "Bar";
 
-  StringArray::CreateWithValues(dataStructure, k_TestArrayName, StringArray::ShapeType{2}, {value1, value2});
+  StringArray::CreateWithValues(dataStructure, k_TestArrayName, ShapeType{2}, {value1, value2});
 
   args.insert(ReshapeDataArrayFilter::k_Input_Array_Key, std::make_any<DataPath>(k_InputArrayPath));
   args.insert(ReshapeDataArrayFilter::k_TupleDims_Key, std::make_any<DynamicTableParameter::ValueType>(DynamicTableInfo::TableDataType{{4.0}}));
@@ -294,7 +294,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: Invalid - Same Size", 
   }
   SECTION("NeighborLists")
   {
-    auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, IListStore::ShapeType{1});
+    auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, ShapeType{1});
     typename NeighborList<T>::VectorType inputList({0, 1, 0});
     inputNeighborList->setList(0, inputList);
 
@@ -306,7 +306,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: Invalid - Same Size", 
     std::string value1 = "Foo";
     std::string value2 = "Bar";
 
-    StringArray::CreateWithValues(dataStructure, k_TestArrayName, StringArray::ShapeType{2}, {value1, value2});
+    StringArray::CreateWithValues(dataStructure, k_TestArrayName, ShapeType{2}, {value1, value2});
 
     args.insert(ReshapeDataArrayFilter::k_Input_Array_Key, std::make_any<DataPath>(k_InputArrayPath));
     args.insert(ReshapeDataArrayFilter::k_TupleDims_Key, std::make_any<DynamicTableParameter::ValueType>(DynamicTableInfo::TableDataType{{2.0}}));
@@ -329,7 +329,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: NeighborList Warning -
   DataStructure dataStructure;
   Arguments args;
 
-  auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, IListStore::ShapeType{1});
+  auto inputNeighborList = NeighborList<T>::Create(dataStructure, k_TestArrayName, ShapeType{1});
   typename NeighborList<T>::VectorType inputList({0, 1, 0});
   inputNeighborList->setList(0, inputList);
 
@@ -365,7 +365,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: StringArray Warning - 
   std::string value1 = "Foo";
   std::string value2 = "Bar";
 
-  StringArray::CreateWithValues(dataStructure, k_TestArrayName, StringArray::ShapeType{2}, {value1, value2});
+  StringArray::CreateWithValues(dataStructure, k_TestArrayName, ShapeType{2}, {value1, value2});
 
   args.insert(ReshapeDataArrayFilter::k_Input_Array_Key, std::make_any<DataPath>(k_InputArrayPath));
   args.insert(ReshapeDataArrayFilter::k_TupleDims_Key, std::make_any<DynamicTableParameter::ValueType>(DynamicTableInfo::TableDataType{{2.0, 3.0}}));
@@ -396,7 +396,7 @@ TEST_CASE("SimplnxCore::ReshapeDataArraysFilter: Invalid Tuple Dimensions", "[Si
   std::string value1 = "Foo";
   std::string value2 = "Bar";
 
-  StringArray::CreateWithValues(dataStructure, k_TestArrayName, StringArray::ShapeType{2}, {value1, value2});
+  StringArray::CreateWithValues(dataStructure, k_TestArrayName, ShapeType{2}, {value1, value2});
 
   args.insert(ReshapeDataArrayFilter::k_Input_Array_Key, std::make_any<DataPath>(k_InputArrayPath));
   args.insert(ReshapeDataArrayFilter::k_TupleDims_Key, std::make_any<DynamicTableParameter::ValueType>(DynamicTableInfo::TableDataType{{0.0, 3.0}}));

--- a/src/Plugins/SimplnxCore/test/SplitDataArrayByComponentTest.cpp
+++ b/src/Plugins/SimplnxCore/test/SplitDataArrayByComponentTest.cpp
@@ -102,7 +102,7 @@ void TestSplitByType(DataStructure& dataStructure, const std::string& dataType, 
   SplitDataArrayByComponentFilter filter;
 
   DataPath arrayPath({"AttributeMatrix", "MultiComponent Array " + dataType});
-  std::vector<usize> compsToCheck;
+  ShapeType compsToCheck;
 
   Arguments args;
   // read in the exemplar shift data file

--- a/src/Plugins/SimplnxCore/test/SplitDataArrayByTupleTest.cpp
+++ b/src/Plugins/SimplnxCore/test/SplitDataArrayByTupleTest.cpp
@@ -88,7 +88,7 @@ void fillDataArray(DataArray<T>& inputArray)
 }
 
 template <typename T>
-DataStructure createDataStructure(const std::vector<usize>& tupleShape, const std::vector<usize>& compShape)
+DataStructure createDataStructure(const ShapeType& tupleShape, const ShapeType& compShape)
 {
   DataStructure ds;
 

--- a/src/Plugins/SimplnxCore/test/SplitDataArrayByTupleTest.cpp
+++ b/src/Plugins/SimplnxCore/test/SplitDataArrayByTupleTest.cpp
@@ -404,7 +404,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::SplitDataArrayByTupleFilter - Valid Execution",
   {
     DataStructure ds;
     auto* am = AttributeMatrix::Create(ds, k_AttributeMatrixName, {10});
-    auto* nl = NeighborList<T>::Create(ds, "Input NL", 10, am->getId());
+    auto* nl = NeighborList<T>::Create(ds, "Input NL", am->getShape(), am->getId());
     for(usize i = 0; i < 10; ++i)
     {
       nl->setList(i, std::vector<T>{static_cast<T>(i), static_cast<T>(i + 1)});

--- a/src/Plugins/SimplnxCore/test/SplitDataArrayByTupleTest.cpp
+++ b/src/Plugins/SimplnxCore/test/SplitDataArrayByTupleTest.cpp
@@ -461,7 +461,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::SplitDataArrayByTupleFilter - Valid Execution",
     {
       strings.push_back(fmt::format("str{}", i));
     }
-    auto* strArray = StringArray::CreateWithValues(ds, "Input Strings", strings, am->getId());
+    auto* strArray = StringArray::CreateWithValues(ds, "Input Strings", am->getShape(), strings, am->getId());
 
     // Execute filter
     args.insertOrAssign(SplitDataArrayByTupleFilter::k_DataArrayPath_Key, std::make_any<DataPath>(DataPath({k_AttributeMatrixName, "Input Strings"})));

--- a/src/Plugins/SimplnxCore/test/WriteFeatureDataCSVTest.cpp
+++ b/src/Plugins/SimplnxCore/test/WriteFeatureDataCSVTest.cpp
@@ -56,8 +56,7 @@ TEST_CASE("SimplnxCore::WriteFeatureDataCSVFilter: Test Algorithm", "[WriteFeatu
   AttributeMatrix& topLevelGroup = *AttributeMatrix::Create(dataStructure, "TestData", k_VertexTupleDims);
   auto path = dataStructure.getAllDataPaths()[0];
 
-  auto* neighborList = NeighborList<float32>::Create(dataStructure, "Neighbor List", k_NumTuples, topLevelGroup.getId());
-  neighborList->resizeTotalElements(k_NumTuples);
+  auto* neighborList = NeighborList<float32>::Create(dataStructure, "Neighbor List", topLevelGroup.getShape(), topLevelGroup.getId());
   std::vector<float32> list1 = {117, 875, 1035, 3905, 4214};
   std::vector<float32> list2 = {750, 1905, 1912, 2015, 2586, 3180, 3592, 4041, 4772};
   std::vector<float32> list3 = {309, 775, 2625, 2818, 3061, 3751, 4235, 4817};

--- a/src/Plugins/SimplnxCore/test/WriteVtkRectilinearGridTest.cpp
+++ b/src/Plugins/SimplnxCore/test/WriteVtkRectilinearGridTest.cpp
@@ -70,7 +70,7 @@ TEST_CASE("SimplnxCore::WriteVtkRectilinearGridFilter: Valid Filter Execution", 
   std::error_code errorCode;
   std::filesystem::remove_all(fmt::format("{}/vtk_rectilinear_grid_writer", unit_test::k_BinaryTestOutputDir), errorCode);
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, SmallIn100::k_TupleCheckIgnoredPaths);
 }
 
 TEST_CASE("SimplnxCore::WriteVtkRectilinearGridFilter: InValid Filter Execution", "[SimplnxCore][WriteVtkRectilinearGridFilter]")
@@ -115,5 +115,5 @@ TEST_CASE("SimplnxCore::WriteVtkRectilinearGridFilter: InValid Filter Execution"
   auto executeResult = filter.execute(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result)
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, SmallIn100::k_TupleCheckIgnoredPaths);
 }

--- a/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
+++ b/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
@@ -1162,7 +1162,7 @@ PYBIND11_MODULE(simplnx, mod)
       "path"_a, "dims"_a, "origin"_a, "spacing"_a, "cell_attribute_matrix_name"_a);
 
   auto createNeighborListAction = SIMPLNX_PY_BIND_CLASS_VARIADIC(mod, CreateNeighborListAction, IDataCreationAction);
-  createNeighborListAction.def(py::init<DataType, usize, const DataPath&>(), "type"_a, "tuple_count"_a, "path"_a);
+  createNeighborListAction.def(py::init<DataType, const ShapeType&, const DataPath&>(), "type"_a, "tuple_count"_a, "path"_a);
 
   auto createRectGridGeometryAction = SIMPLNX_PY_BIND_CLASS_VARIADIC(mod, CreateRectGridGeometryAction, IDataCreationAction);
   createRectGridGeometryAction.def(py::init<const DataPath&, usize, usize, usize, const std::string&, const std::string&, const std::string&, const std::string&>(), "path"_a, "x_bounds_dim"_a,
@@ -1171,7 +1171,7 @@ PYBIND11_MODULE(simplnx, mod)
                                    "input_y_bounds_path"_a, "input_z_bounds_path"_a, "cell_attribute_matrix_name"_a, "array_type"_a);
 
   auto createStringArrayAction = SIMPLNX_PY_BIND_CLASS_VARIADIC(mod, CreateStringArrayAction, IDataCreationAction);
-  createStringArrayAction.def(py::init<const std::vector<usize>&, const DataPath&, const std::string&>(), "t_dims"_a, "path"_a, "initialize_value"_a = std::string(""));
+  createStringArrayAction.def(py::init<const ShapeType&, const DataPath&, const std::string&>(), "t_dims"_a, "path"_a, "initialize_value"_a = std::string(""));
 
   auto createVertexGeometryAction = SIMPLNX_PY_BIND_CLASS_VARIADIC(mod, CreateVertexGeometryAction, IDataCreationAction);
   createVertexGeometryAction.def(py::init<const DataPath&, IGeometry::MeshIndexType, const std::string&, const std::string&>(), "geometry_path"_a, "num_vertices"_a, "vertex_attribute_matrix_name"_a,

--- a/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
+++ b/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
@@ -169,13 +169,13 @@ template <class T>
 auto BindDataStore(py::handle scope, const char* name)
 {
   py::class_<DataStore<T>, AbstractDataStore<T>, std::shared_ptr<DataStore<T>>> dataStore(scope, name);
-  dataStore.def(py::init<const IDataStore::ShapeType&, const IDataStore::ShapeType&, std::optional<T>>(), "tuple_shape"_a, "component_shape"_a, "init_value"_a = std::optional<T>{});
+  dataStore.def(py::init<const ShapeType&, const ShapeType&, std::optional<T>>(), "tuple_shape"_a, "component_shape"_a, "init_value"_a = std::optional<T>{});
   dataStore.def_property_readonly_static("dtype", []([[maybe_unused]] py::object self) { return py::dtype::of<T>(); });
   dataStore.def(
       "npview",
       [](DataStore<T>& dataStore) {
-        IDataStore::ShapeType shape = dataStore.getTupleShape();
-        IDataStore::ShapeType componentShape = dataStore.getComponentShape();
+        ShapeType shape = dataStore.getTupleShape();
+        ShapeType componentShape = dataStore.getComponentShape();
         shape.insert(shape.end(), componentShape.cbegin(), componentShape.cend());
         return py::array_t<T, py::array::c_style>(shape, dataStore.data(), py::cast(dataStore));
       },
@@ -198,8 +198,8 @@ auto BindDataArray(py::handle scope, const char* name)
         using DataStoreType = DataStore<T>;
         const typename DataArrayType::store_type& abstractDataStore = dataArray.getDataStoreRef();
         const DataStoreType& dataStore = dynamic_cast<const DataStoreType&>(abstractDataStore);
-        IDataStore::ShapeType shape = dataStore.getTupleShape();
-        IDataStore::ShapeType componentShape = dataStore.getComponentShape();
+        ShapeType shape = dataStore.getTupleShape();
+        ShapeType componentShape = dataStore.getComponentShape();
         shape.insert(shape.end(), componentShape.cbegin(), componentShape.cend());
         return py::array_t<T, py::array::c_style>(shape, dataStore.data(), py::cast(dataStore));
       },
@@ -1139,7 +1139,7 @@ PYBIND11_MODULE(simplnx, mod)
                         "data_format"_a = std::string(""));
 
   auto createAttributeMatrixAction = SIMPLNX_PY_BIND_CLASS_VARIADIC(mod, CreateAttributeMatrixAction, IDataCreationAction);
-  createAttributeMatrixAction.def(py::init<const DataPath&, const AttributeMatrix::ShapeType&>(), "path"_a, "shape"_a);
+  createAttributeMatrixAction.def(py::init<const DataPath&, const ShapeType&>(), "path"_a, "shape"_a);
 
   auto createDataGroupAction = SIMPLNX_PY_BIND_CLASS_VARIADIC(mod, CreateDataGroupAction, IDataCreationAction);
   createDataGroupAction.def(py::init<const DataPath&>(), "path"_a);

--- a/src/simplnx/Common/Aliases.hpp
+++ b/src/simplnx/Common/Aliases.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "simplnx/Common/Types.hpp"
+
+#include <vector>
+
+namespace nx::core
+{
+using ShapeType = typename std::vector<usize>;
+}

--- a/src/simplnx/DataStructure/AbstractDataStore.hpp
+++ b/src/simplnx/DataStructure/AbstractDataStore.hpp
@@ -32,7 +32,6 @@ class AbstractDataStore : public IDataStore
 {
 public:
   using value_type = T;
-  using ShapeType = typename IDataStore::ShapeType;
   using index_type = uint64;
 
   /**
@@ -841,17 +840,17 @@ public:
    * @brief Returns the Smallest N-Dimensional tuple position included in the
    * specified chunk.
    * @param flatChunkIndex
-   * @return IDataStore::ShapeType
+   * @return ShapeType
    */
-  virtual IDataStore::ShapeType getChunkLowerBounds(uint64 flatChunkIndex) const = 0;
+  virtual ShapeType getChunkLowerBounds(uint64 flatChunkIndex) const = 0;
 
   /**
    * @brief Returns the largest N-Dimensional tuple position included in the
    * specified chunk.
    * @param flatChunkIndex
-   * @return IDataStore::ShapeType
+   * @return ShapeType
    */
-  virtual IDataStore::ShapeType getChunkUpperBounds(uint64 flatChunkIndex) const = 0;
+  virtual ShapeType getChunkUpperBounds(uint64 flatChunkIndex) const = 0;
 
   /**
    * @brief Returns the tuple shape for the specified chunk.
@@ -859,17 +858,17 @@ public:
    * @param flatChunkIndex
    * @return std::vector<uint64> chunk tuple shape
    */
-  virtual IDataStore::ShapeType getChunkTupleShape(uint64 flatChunkIndex) const
+  virtual ShapeType getChunkTupleShape(uint64 flatChunkIndex) const
   {
     if(flatChunkIndex >= getNumberOfChunks())
     {
-      return IDataStore::ShapeType();
+      return ShapeType();
     }
     auto lowerBounds = getChunkLowerBounds(flatChunkIndex);
     auto upperBounds = getChunkUpperBounds(flatChunkIndex);
 
     const usize tupleCount = lowerBounds.size();
-    IDataStore::ShapeType chunkTupleShape(tupleCount);
+    ShapeType chunkTupleShape(tupleCount);
     for(usize i = 0; i < tupleCount; i++)
     {
       chunkTupleShape[i] = upperBounds[i] - lowerBounds[i] + 1;

--- a/src/simplnx/DataStructure/AbstractListStore.hpp
+++ b/src/simplnx/DataStructure/AbstractListStore.hpp
@@ -22,7 +22,6 @@ public:
   {
   public:
     using vector_type = std::vector<T>;
-    using ShapeType = typename IListStore::ShapeType;
     using const_iterator = typename vector_type::const_iterator;
 
     ConstReferenceList(const AbstractListStore<T>& store, usize tupleIndex)

--- a/src/simplnx/DataStructure/AbstractListStore.hpp
+++ b/src/simplnx/DataStructure/AbstractListStore.hpp
@@ -22,6 +22,7 @@ public:
   {
   public:
     using vector_type = std::vector<T>;
+    using ShapeType = typename IListStore::ShapeType;
     using const_iterator = typename vector_type::const_iterator;
 
     ConstReferenceList(const AbstractListStore<T>& store, usize tupleIndex)
@@ -30,9 +31,7 @@ public:
     , m_Index(tupleIndex)
     {
     }
-    ~ConstReferenceList()
-    {
-    }
+    ~ConstReferenceList() = default;
 
     const T& operator[](usize i) const
     {
@@ -154,9 +153,9 @@ public:
     }
     ReferenceList& operator=(ReferenceList&& rhs)
     {
-      m_Edited = std::move(rhs.m_Edited);
+      m_Edited = rhs.m_Edited;
       m_List = std::move(rhs.m_List);
-      m_Index = std::move(rhs.m_Index);
+      m_Index = rhs.m_Index;
       return *this;
     }
     constexpr void swap(ReferenceList& rhs) noexcept

--- a/src/simplnx/DataStructure/AbstractStringStore.hpp
+++ b/src/simplnx/DataStructure/AbstractStringStore.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "simplnx/Common/Aliases.hpp"
 #include "simplnx/Common/Types.hpp"
 
 #include <memory>
@@ -14,8 +15,6 @@ public:
   using value_type = std::string;
   using reference = value_type&;
   using const_reference = const value_type&;
-  using ShapeValueType = usize;
-  using ShapeType = typename std::vector<ShapeValueType>;
 
   class Iterator
   {

--- a/src/simplnx/DataStructure/AbstractStringStore.hpp
+++ b/src/simplnx/DataStructure/AbstractStringStore.hpp
@@ -14,6 +14,8 @@ public:
   using value_type = std::string;
   using reference = value_type&;
   using const_reference = const value_type&;
+  using ShapeValueType = usize;
+  using ShapeType = typename std::vector<ShapeValueType>;
 
   class Iterator
   {
@@ -328,7 +330,24 @@ public:
 
   virtual usize size() const = 0;
   virtual bool empty() const = 0;
-  virtual void resize(usize count) = 0;
+
+  /**
+   * @brief Returns the number of tuples in the StringStore.
+   * @return usize
+   */
+  virtual usize getNumberOfTuples() const = 0;
+  /**
+   * @brief Returns the dimensions of the Tuples
+   * @return
+   */
+  virtual const ShapeType& getTupleShape() const = 0;
+
+  /**
+   * @brief This method sets the shape of the dimensions to `tupleShape`.
+   * @param tupleShape The new shape of the data where the dimensions are "C" ordered
+   * from *slowest* to *fastest*.
+   */
+  virtual void resizeTuples(const ShapeType& tupleShape) = 0;
 
   virtual reference operator[](usize index) = 0;
   virtual const_reference operator[](usize index) const = 0;

--- a/src/simplnx/DataStructure/AttributeMatrix.cpp
+++ b/src/simplnx/DataStructure/AttributeMatrix.cpp
@@ -1,5 +1,6 @@
 #include "AttributeMatrix.hpp"
 
+#include "simplnx/Common/Aliases.hpp"
 #include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/DataStructure/IArray.hpp"
 
@@ -92,7 +93,7 @@ bool AttributeMatrix::canInsert(const DataObject* obj) const
     return false;
   }
 
-  const IArray::ShapeType arrayTupleShape = arrayObjectPtr->getTupleShape();
+  const ShapeType arrayTupleShape = arrayObjectPtr->getTupleShape();
 
   const usize totalTuples = std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
   const usize incomingTupleCount = std::accumulate(arrayTupleShape.cbegin(), arrayTupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
@@ -100,7 +101,7 @@ bool AttributeMatrix::canInsert(const DataObject* obj) const
   return (totalTuples == incomingTupleCount);
 }
 
-const AttributeMatrix::ShapeType& AttributeMatrix::getShape() const
+const ShapeType& AttributeMatrix::getShape() const
 {
   return m_TupleShape;
 }

--- a/src/simplnx/DataStructure/AttributeMatrix.hpp
+++ b/src/simplnx/DataStructure/AttributeMatrix.hpp
@@ -14,8 +14,6 @@ namespace nx::core
 class SIMPLNX_EXPORT AttributeMatrix : public BaseGroup
 {
 public:
-  using ShapeType = std::vector<usize>;
-
   static inline constexpr StringLiteral k_TypeName = "AttributeMatrix";
 
   /**

--- a/src/simplnx/DataStructure/DataArray.hpp
+++ b/src/simplnx/DataStructure/DataArray.hpp
@@ -85,8 +85,7 @@ public:
    * @return DataArray<T>* Instance of the DataArray object that is owned and managed by the DataStructure
    */
   template <typename DataStoreType>
-  static DataArray* CreateWithStore(DataStructure& dataStructure, const std::string& name, const std::vector<usize>& tupleShape, const std::vector<usize>& componentShape,
-                                    const std::optional<IdType>& parentId = {})
+  static DataArray* CreateWithStore(DataStructure& dataStructure, const std::string& name, const ShapeType& tupleShape, const ShapeType& componentShape, const std::optional<IdType>& parentId = {})
   {
     static_assert(std::is_base_of_v<AbstractDataStore<T>, DataStoreType>);
 

--- a/src/simplnx/DataStructure/DataStore.hpp
+++ b/src/simplnx/DataStructure/DataStore.hpp
@@ -32,7 +32,6 @@ public:
   using parent_type = AbstractDataStore<T>;
   using value_type = typename AbstractDataStore<T>::value_type;
   using reference = typename AbstractDataStore<T>::reference;
-  using ShapeType = typename IDataStore::ShapeType;
 
   static constexpr const char k_DataStore[] = "DataStore";
   static constexpr const char k_DataObjectId[] = "DataObjectId";
@@ -236,7 +235,7 @@ public:
    * @param tupleShape The new shape of the data where the dimensions are "C" ordered
    * from *slowest* to *fastest*.
    */
-  void resizeTuples(const std::vector<usize>& tupleShape) override
+  void resizeTuples(const ShapeType& tupleShape) override
   {
     auto oldSize = this->getSize();
     // Calculate the total number of values in the new array
@@ -599,17 +598,17 @@ public:
    * @brief Returns the Smallest N-Dimensional tuple position included in the
    * specified chunk.
    * @param flatChunkIndex
-   * @return IDataStore::ShapeType
+   * @return ShapeType
    */
-  IDataStore::ShapeType getChunkLowerBounds(uint64 flatChunkIndex) const override
+  ShapeType getChunkLowerBounds(uint64 flatChunkIndex) const override
   {
     if(flatChunkIndex >= getNumberOfChunks())
     {
-      return IDataStore::ShapeType();
+      return ShapeType();
     }
     usize tupleDims = getTupleShape().size();
 
-    IDataStore::ShapeType lowerBounds(tupleDims);
+    ShapeType lowerBounds(tupleDims);
     std::fill(lowerBounds.begin(), lowerBounds.end(), 0);
     return lowerBounds;
   }
@@ -618,16 +617,16 @@ public:
    * @brief Returns the largest N-Dimensional tuple position included in the
    * specified chunk.
    * @param flatChunkIndex
-   * @return IDataStore::ShapeType
+   * @return ShapeType
    */
-  IDataStore::ShapeType getChunkUpperBounds(uint64 flatChunkIndex) const override
+  ShapeType getChunkUpperBounds(uint64 flatChunkIndex) const override
   {
     if(flatChunkIndex >= getNumberOfChunks())
     {
-      return IDataStore::ShapeType();
+      return ShapeType();
     }
 
-    IDataStore::ShapeType upperBounds(getTupleShape());
+    ShapeType upperBounds(getTupleShape());
     for(auto& value : upperBounds)
     {
       value -= 1;

--- a/src/simplnx/DataStructure/EmptyDataStore.hpp
+++ b/src/simplnx/DataStructure/EmptyDataStore.hpp
@@ -23,7 +23,6 @@ class EmptyDataStore : public AbstractDataStore<T>
 public:
   using value_type = typename AbstractDataStore<T>::value_type;
   using reference = typename AbstractDataStore<T>::reference;
-  using ShapeType = typename IDataStore::ShapeType;
 
   /**
    * @brief Constructs an empty data store with a tuple getSize and count of 0.
@@ -336,11 +335,11 @@ public:
     return nullptr;
   }
 
-  IDataStore::ShapeType getChunkLowerBounds(uint64 flatChunkIndex) const override
+  ShapeType getChunkLowerBounds(uint64 flatChunkIndex) const override
   {
     return {};
   }
-  IDataStore::ShapeType getChunkUpperBounds(uint64 flatChunkIndex) const override
+  ShapeType getChunkUpperBounds(uint64 flatChunkIndex) const override
   {
     return {};
   }

--- a/src/simplnx/DataStructure/EmptyListStore.hpp
+++ b/src/simplnx/DataStructure/EmptyListStore.hpp
@@ -209,7 +209,7 @@ public:
 
   void readHdf5(const HDF5::DatasetIO& datasetReader) override
   {
-    auto tupleDimsResult = datasetReader.readVectorAttribute<uint64>("TupleDimensions");
+    auto tupleDimsResult = datasetReader.readVectorAttribute<usize>("TupleDimensions");
     if(tupleDimsResult.invalid())
     {
       clear();

--- a/src/simplnx/DataStructure/EmptyListStore.hpp
+++ b/src/simplnx/DataStructure/EmptyListStore.hpp
@@ -10,7 +10,7 @@ template <class T>
 class EmptyListStore : public AbstractListStore<T>
 {
 public:
-  using shape_type = typename std::vector<usize>;
+  using ShapeType = typename std::vector<usize>;
   using value_type = T;
   using parent_type = AbstractListStore<T>;
   using vector_type = typename parent_type::vector_type;
@@ -22,9 +22,10 @@ public:
    * @param tupleShape
    * @param listSize
    */
-  EmptyListStore(usize numTuples)
+  EmptyListStore(const ShapeType& tupleShape)
   : AbstractListStore<T>()
-  , m_NumTuples(numTuples)
+  , m_TupleShape(tupleShape.cbegin(), tupleShape.cend())
+  , m_NumTuples(std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
   {
   }
 
@@ -32,6 +33,24 @@ public:
   EmptyListStore(EmptyListStore&& rhs) = default;
 
   ~EmptyListStore() override = default;
+
+  /**
+   * @brief Returns the number of tuples in the EmptyListStore.
+   * @return usize
+   */
+  usize getNumberOfTuples() const override
+  {
+    return m_NumTuples;
+  }
+
+  /**
+   * @brief Returns the dimensions of the Tuples
+   * @return
+   */
+  const ShapeType& getTupleShape() const override
+  {
+    return m_TupleShape;
+  }
 
   /**
    * @brief Returns a copy of the current list store.
@@ -52,9 +71,10 @@ public:
     throw std::runtime_error("EmptyListStore cannot add values to list");
   }
 
-  void resizeTuples(usize tupleCount) override
+  void resizeTuples(const ShapeType& tupleShape) override
   {
-    m_NumTuples = tupleCount;
+    m_TupleShape = tupleShape;
+    m_NumTuples = std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>());
   }
 
   void clear() override
@@ -67,6 +87,7 @@ public:
    */
   void clearAllLists() override
   {
+    m_TupleShape = ShapeType{0};
     m_NumTuples = 0;
   }
 
@@ -196,9 +217,7 @@ public:
     }
     else
     {
-      std::vector<uint64> tupleDims = tupleDimsResult.value();
-      uint64 numTuples = std::accumulate(tupleDims.begin(), tupleDims.end(), static_cast<uint64>(1), std::multiplies<>());
-      resizeTuples(numTuples);
+      resizeTuples(tupleDimsResult.value());
     }
   }
 
@@ -208,6 +227,7 @@ public:
   }
 
 private:
+  ShapeType m_TupleShape;
   usize m_NumTuples = 0;
 };
 } // namespace nx::core

--- a/src/simplnx/DataStructure/EmptyListStore.hpp
+++ b/src/simplnx/DataStructure/EmptyListStore.hpp
@@ -10,7 +10,6 @@ template <class T>
 class EmptyListStore : public AbstractListStore<T>
 {
 public:
-  using ShapeType = typename std::vector<usize>;
   using value_type = T;
   using parent_type = AbstractListStore<T>;
   using vector_type = typename parent_type::vector_type;

--- a/src/simplnx/DataStructure/IArray.hpp
+++ b/src/simplnx/DataStructure/IArray.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "simplnx/Common/Aliases.hpp"
 #include "simplnx/DataStructure/DataObject.hpp"
 
 namespace nx::core
@@ -7,8 +8,6 @@ namespace nx::core
 class SIMPLNX_EXPORT IArray : public DataObject
 {
 public:
-  using ShapeType = std::vector<usize>;
-
   static inline constexpr StringLiteral k_TypeName = "IArray";
 
   enum class ArrayType : EnumType
@@ -102,7 +101,7 @@ public:
    * @param tupleShape The new shape of the data where the dimensions are "C" ordered
    * from *slowest* to *fastest*.
    */
-  virtual void resizeTuples(const std::vector<usize>& tupleShape) = 0;
+  virtual void resizeTuples(const ShapeType& tupleShape) = 0;
 
   static std::set<std::string> StringListFromArrayType(const std::set<ArrayType>& arrayTypes)
   {

--- a/src/simplnx/DataStructure/IDataArray.hpp
+++ b/src/simplnx/DataStructure/IDataArray.hpp
@@ -137,7 +137,7 @@ public:
   /**
    * @brief Resizes the internal array to accomondate
    */
-  void resizeTuples(const std::vector<usize>& tupleShape) override
+  void resizeTuples(const ShapeType& tupleShape) override
   {
     getIDataStoreRef().resizeTuples(tupleShape);
   }

--- a/src/simplnx/DataStructure/IDataStore.hpp
+++ b/src/simplnx/DataStructure/IDataStore.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "simplnx/Common/Aliases.hpp"
 #include "simplnx/Common/Types.hpp"
 #include "simplnx/simplnx_export.hpp"
 
@@ -22,9 +23,6 @@ namespace nx::core
 class SIMPLNX_EXPORT IDataStore
 {
 public:
-  using ShapeValueType = usize;
-  using ShapeType = typename std::vector<ShapeValueType>;
-
   enum class StoreType : int32
   {
     InMemory = 0,

--- a/src/simplnx/DataStructure/IListStore.hpp
+++ b/src/simplnx/DataStructure/IListStore.hpp
@@ -32,20 +32,6 @@ public:
 
   /**
    * @brief This method sets the shape of the dimensions to `tupleShape`.
-   *
-   * There are 3 possibilities when using this function:
-   * [1] The number of tuples of the new shape is *LESS* than the original. In this
-   * case a memory allocation will take place and the first 'N' elements of data
-   * will be copied into the new array. The remaining data is *LOST*
-   *
-   * [2] The number of tuples of the new shape is *EQUAL* to the original. In this
-   * case the shape is set and the function returns.
-   *
-   * [3] The number of tuples of the new shape is *GREATER* than the original. In
-   * this case a new array is allocated and all the data from the original array
-   * is copied into the new array and the remaining elements are initialized to
-   * the default initialization value.
-   *
    * @param tupleShape The new shape of the data where the dimensions are "C" ordered
    * from *slowest* to *fastest*.
    */

--- a/src/simplnx/DataStructure/IListStore.hpp
+++ b/src/simplnx/DataStructure/IListStore.hpp
@@ -2,6 +2,8 @@
 
 #include "simplnx/Common/Types.hpp"
 
+#include <vector>
+
 namespace nx::core
 {
 namespace HDF5
@@ -12,7 +14,21 @@ class DatasetIO;
 class IListStore
 {
 public:
+  using ShapeValueType = usize;
+  using ShapeType = typename std::vector<ShapeValueType>;
+
   virtual ~IListStore() = default;
+
+  /**
+   * @brief Returns the number of tuples in the DataStore.
+   * @return usize
+   */
+  virtual usize getNumberOfTuples() const = 0;
+  /**
+   * @brief Returns the dimensions of the Tuples
+   * @return
+   */
+  virtual const ShapeType& getTupleShape() const = 0;
 
   /**
    * @brief This method sets the shape of the dimensions to `tupleShape`.
@@ -33,7 +49,7 @@ public:
    * @param tupleShape The new shape of the data where the dimensions are "C" ordered
    * from *slowest* to *fastest*.
    */
-  virtual void resizeTuples(usize tupleCount) = 0;
+  virtual void resizeTuples(const ShapeType& tupleShape) = 0;
 
   /**
    * @brief Clear All Lists

--- a/src/simplnx/DataStructure/IListStore.hpp
+++ b/src/simplnx/DataStructure/IListStore.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "simplnx/Common/Aliases.hpp"
 #include "simplnx/Common/Types.hpp"
 
 #include <vector>
@@ -14,9 +15,6 @@ class DatasetIO;
 class IListStore
 {
 public:
-  using ShapeValueType = usize;
-  using ShapeType = typename std::vector<ShapeValueType>;
-
   virtual ~IListStore() = default;
 
   /**

--- a/src/simplnx/DataStructure/INeighborList.cpp
+++ b/src/simplnx/DataStructure/INeighborList.cpp
@@ -64,7 +64,7 @@ usize INeighborList::getNumberOfTuples() const
   return getIListStoreRef().getNumberOfTuples();
 }
 
-void INeighborList::resizeTuples(const std::vector<usize>& tupleShape)
+void INeighborList::resizeTuples(const ShapeType& tupleShape)
 {
   getIListStoreRef().resizeTuples(tupleShape);
 }
@@ -74,12 +74,12 @@ usize INeighborList::getNumberOfComponents() const
   return 1;
 }
 
-IArray::ShapeType INeighborList::getTupleShape() const
+ShapeType INeighborList::getTupleShape() const
 {
   return getIListStoreRef().getTupleShape();
 }
 
-IArray::ShapeType INeighborList::getComponentShape() const
+ShapeType INeighborList::getComponentShape() const
 {
   return {1};
 }

--- a/src/simplnx/DataStructure/INeighborList.cpp
+++ b/src/simplnx/DataStructure/INeighborList.cpp
@@ -1,18 +1,14 @@
 #include "INeighborList.hpp"
 
-#include "simplnx/DataStructure/NeighborList.hpp"
-
 namespace nx::core
 {
-INeighborList::INeighborList(DataStructure& dataStructure, const std::string& name, usize numTuples)
+INeighborList::INeighborList(DataStructure& dataStructure, const std::string& name)
 : IArray(dataStructure, name)
-, m_NumTuples(numTuples)
 {
 }
 
-INeighborList::INeighborList(DataStructure& dataStructure, const std::string& name, usize numTuples, IdType importId)
+INeighborList::INeighborList(DataStructure& dataStructure, const std::string& name, IdType importId)
 : IArray(dataStructure, name, importId)
-, m_NumTuples(numTuples)
 {
 }
 
@@ -21,6 +17,11 @@ INeighborList::~INeighborList() noexcept = default;
 std::string INeighborList::getTypeName() const
 {
   return NeighborListConstants::k_TypeName;
+}
+
+DataObject::Type INeighborList::getDataObjectType() const
+{
+  return Type::INeighborList;
 }
 
 void INeighborList::setNumNeighborsArrayName(const std::string& name)
@@ -38,14 +39,34 @@ std::string INeighborList::getNumNeighborsArrayName() const
   return arrayName;
 }
 
-usize INeighborList::getNumberOfTuples() const
+IListStore& INeighborList::getIListStoreRef()
 {
-  return m_NumTuples;
+  IListStore* store = getIListStore();
+  if(store == nullptr)
+  {
+    throw std::runtime_error("INeighborList: Null IListStore");
+  }
+  return *store;
 }
 
-void INeighborList::setNumberOfTuples(usize numTuples)
+const IListStore& INeighborList::getIListStoreRef() const
 {
-  m_NumTuples = numTuples;
+  const IListStore* store = getIListStore();
+  if(store == nullptr)
+  {
+    throw std::runtime_error("INeighborList: Null IListStore");
+  }
+  return *store;
+}
+
+usize INeighborList::getNumberOfTuples() const
+{
+  return getIListStoreRef().getNumberOfTuples();
+}
+
+void INeighborList::resizeTuples(const std::vector<usize>& tupleShape)
+{
+  getIListStoreRef().resizeTuples(tupleShape);
 }
 
 usize INeighborList::getNumberOfComponents() const
@@ -55,7 +76,7 @@ usize INeighborList::getNumberOfComponents() const
 
 IArray::ShapeType INeighborList::getTupleShape() const
 {
-  return {m_NumTuples};
+  return getIListStoreRef().getTupleShape();
 }
 
 IArray::ShapeType INeighborList::getComponentShape() const

--- a/src/simplnx/DataStructure/INeighborList.hpp
+++ b/src/simplnx/DataStructure/INeighborList.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "simplnx/Common/Aliases.hpp"
 #include "simplnx/DataStructure/IArray.hpp"
 #include "simplnx/DataStructure/IListStore.hpp"
 
@@ -152,7 +153,7 @@ public:
   /**
    * @brief Resizes the internal array to accommodate
    */
-  void resizeTuples(const std::vector<usize>& tupleShape) override;
+  void resizeTuples(const ShapeType& tupleShape) override;
 
 protected:
   /**

--- a/src/simplnx/DataStructure/INeighborList.hpp
+++ b/src/simplnx/DataStructure/INeighborList.hpp
@@ -1,9 +1,15 @@
 #pragma once
 
 #include "simplnx/DataStructure/IArray.hpp"
+#include "simplnx/DataStructure/IListStore.hpp"
 
 namespace nx::core
 {
+namespace NeighborListConstants
+{
+inline constexpr StringLiteral k_TypeName = "NeighborList<T>";
+}
+
 /**
  * @brief Non-templated base class for NeighborList class.
  */
@@ -13,6 +19,74 @@ public:
   static inline constexpr StringLiteral k_TypeName = "INeighborList";
 
   ~INeighborList() noexcept override;
+
+  /**
+   * @brief Returns a pointer to the array's IListStore.
+   * @return IListStore*
+   */
+  virtual IListStore* getIListStore() = 0;
+
+  /**
+   * @brief Returns a pointer to the array's IListStore.
+   * @return const IListStore*
+   */
+  virtual const IListStore* getIListStore() const = 0;
+
+  /**
+   * @brief Returns a reference to the array's IListStore.
+   * @return IListStore&
+   */
+  IListStore& getIListStoreRef();
+
+  /**
+   * @brief Returns a reference to the array's IListStore.
+   * @return const IListStore&
+   */
+  const IListStore& getIListStoreRef() const;
+
+  /**
+   * @brief Returns a pointer to the DataStore cast as type StoreT.
+   * @return const StoreT*
+   */
+  template <class StoreT>
+  const StoreT* getIListStoreAs() const
+  {
+    static_assert(std::is_base_of_v<IListStore, StoreT>);
+    return dynamic_cast<const StoreT*>(getIListStore());
+  }
+
+  /**
+   * @brief Returns a pointer to the DataStore cast as type StoreT.
+   * @return StoreT*
+   */
+  template <class StoreT>
+  StoreT* getIListStoreAs()
+  {
+    static_assert(std::is_base_of_v<IListStore, StoreT>);
+    return dynamic_cast<StoreT*>(getIListStore());
+  }
+
+  /**
+   * @brief Returns a reference to the DataStore cast as type StoreT.
+   * @return const StoreT&
+   */
+  template <class StoreT>
+  const StoreT& getIListStoreRefAs() const
+  {
+    static_assert(std::is_base_of_v<IListStore, StoreT>);
+    return dynamic_cast<const StoreT&>(getIListStoreRef());
+  }
+
+  /**
+   * @brief Returns a reference to the DataStore cast as type StoreT.
+   * @return StoreT&
+   */
+  template <class StoreT>
+  StoreT& getIListStoreRefAs()
+  {
+    static_assert(std::is_base_of_v<IListStore, StoreT>);
+    return dynamic_cast<StoreT&>(getIListStoreRef());
+  }
 
   /**
    * @brief Returns typename of the DataObject as a std::string.
@@ -73,10 +147,12 @@ public:
    * @brief Returns an enumeration of the class or subclass. Used for quick comparison or type deduction
    * @return
    */
-  DataObject::Type getDataObjectType() const override
-  {
-    return Type::INeighborList;
-  }
+  DataObject::Type getDataObjectType() const override;
+
+  /**
+   * @brief Resizes the internal array to accommodate
+   */
+  void resizeTuples(const std::vector<usize>& tupleShape) override;
 
 protected:
   /**
@@ -85,7 +161,7 @@ protected:
    * @param name
    * @param numTuples
    */
-  INeighborList(DataStructure& dataStructure, const std::string& name, usize numTuples);
+  INeighborList(DataStructure& dataStructure, const std::string& name);
 
   /**
    * @brief Constructor for use when importing INeighborLists
@@ -94,16 +170,9 @@ protected:
    * @param numTuples
    * @param importId
    */
-  INeighborList(DataStructure& dataStructure, const std::string& name, usize numTuples, IdType importId);
-
-  /**
-   * @brief Sets the number of tuples.
-   * @param numTuples
-   */
-  void setNumberOfTuples(usize numTuples);
+  INeighborList(DataStructure& dataStructure, const std::string& name, IdType importId);
 
 private:
   std::string m_NumNeighborsArrayName;
-  usize m_NumTuples;
 };
 } // namespace nx::core

--- a/src/simplnx/DataStructure/IO/Generic/CoreDataIOManager.cpp
+++ b/src/simplnx/DataStructure/IO/Generic/CoreDataIOManager.cpp
@@ -26,8 +26,7 @@ void CoreDataIOManager::addCoreFactories()
 
 void CoreDataIOManager::addDataStoreFnc()
 {
-  DataStoreCreateFnc dataStoreFnc = [](nx::core::DataType numericType, const typename IDataStore::ShapeType& tupleShape, const typename IDataStore::ShapeType& componentShape,
-                                       const std::optional<IDataStore::ShapeType>& chunkShape) {
+  DataStoreCreateFnc dataStoreFnc = [](nx::core::DataType numericType, const ShapeType& tupleShape, const ShapeType& componentShape, const std::optional<ShapeType>& chunkShape) {
     std::unique_ptr<IDataStore> dataStore = nullptr;
     switch(numericType)
     {
@@ -72,7 +71,7 @@ void CoreDataIOManager::addDataStoreFnc()
 
 void CoreDataIOManager::addListStoreFnc()
 {
-  ListStoreCreateFnc listStoreFnc = [](nx::core::DataType numericType, const IListStore::ShapeType& tupleShape) {
+  ListStoreCreateFnc listStoreFnc = [](nx::core::DataType numericType, const ShapeType& tupleShape) {
     std::unique_ptr<IListStore> listStore = nullptr;
     switch(numericType)
     {

--- a/src/simplnx/DataStructure/IO/Generic/CoreDataIOManager.cpp
+++ b/src/simplnx/DataStructure/IO/Generic/CoreDataIOManager.cpp
@@ -72,39 +72,39 @@ void CoreDataIOManager::addDataStoreFnc()
 
 void CoreDataIOManager::addListStoreFnc()
 {
-  ListStoreCreateFnc listStoreFnc = [](nx::core::DataType numericType, usize tupleCount) {
+  ListStoreCreateFnc listStoreFnc = [](nx::core::DataType numericType, const IListStore::ShapeType& tupleShape) {
     std::unique_ptr<IListStore> listStore = nullptr;
     switch(numericType)
     {
     case DataType::int8:
-      listStore = std::make_unique<Int8ListStore>(tupleCount);
+      listStore = std::make_unique<Int8ListStore>(tupleShape);
       break;
     case DataType::int16:
-      listStore = std::make_unique<Int16ListStore>(tupleCount);
+      listStore = std::make_unique<Int16ListStore>(tupleShape);
       break;
     case DataType::int32:
-      listStore = std::make_unique<Int32ListStore>(tupleCount);
+      listStore = std::make_unique<Int32ListStore>(tupleShape);
       break;
     case DataType::int64:
-      listStore = std::make_unique<Int64ListStore>(tupleCount);
+      listStore = std::make_unique<Int64ListStore>(tupleShape);
       break;
     case DataType::uint8:
-      listStore = std::make_unique<UInt8ListStore>(tupleCount);
+      listStore = std::make_unique<UInt8ListStore>(tupleShape);
       break;
     case DataType::uint16:
-      listStore = std::make_unique<UInt16ListStore>(tupleCount);
+      listStore = std::make_unique<UInt16ListStore>(tupleShape);
       break;
     case DataType::uint32:
-      listStore = std::make_unique<UInt32ListStore>(tupleCount);
+      listStore = std::make_unique<UInt32ListStore>(tupleShape);
       break;
     case DataType::uint64:
-      listStore = std::make_unique<UInt64ListStore>(tupleCount);
+      listStore = std::make_unique<UInt64ListStore>(tupleShape);
       break;
     case DataType::float32:
-      listStore = std::make_unique<Float32ListStore>(tupleCount);
+      listStore = std::make_unique<Float32ListStore>(tupleShape);
       break;
     case DataType::float64:
-      listStore = std::make_unique<Float64ListStore>(tupleCount);
+      listStore = std::make_unique<Float64ListStore>(tupleShape);
       break;
     case DataType::boolean:
       listStore = nullptr;

--- a/src/simplnx/DataStructure/IO/Generic/DataIOCollection.cpp
+++ b/src/simplnx/DataStructure/IO/Generic/DataIOCollection.cpp
@@ -45,8 +45,7 @@ bool DataIOCollection::hasDataStoreCreationFunction(const std::string& type) con
   }
   return false;
 }
-std::unique_ptr<IDataStore> DataIOCollection::createDataStore(const std::string& type, DataType dataType, const typename IDataStore::ShapeType& tupleShape,
-                                                              const typename IDataStore::ShapeType& componentShape)
+std::unique_ptr<IDataStore> DataIOCollection::createDataStore(const std::string& type, DataType dataType, const ShapeType& tupleShape, const ShapeType& componentShape)
 {
   for(const auto& [ioType, ioManager] : m_ManagerMap)
   {
@@ -60,7 +59,7 @@ std::unique_ptr<IDataStore> DataIOCollection::createDataStore(const std::string&
   return coreManager.dataStoreCreationFnc(coreManager.formatName())(dataType, tupleShape, componentShape, {});
 }
 
-std::unique_ptr<IListStore> DataIOCollection::createListStore(const std::string& type, DataType dataType, const IListStore::ShapeType& tupleShape) const
+std::unique_ptr<IListStore> DataIOCollection::createListStore(const std::string& type, DataType dataType, const ShapeType& tupleShape) const
 {
   for(const auto& [ioType, ioManager] : m_ManagerMap)
   {

--- a/src/simplnx/DataStructure/IO/Generic/DataIOCollection.cpp
+++ b/src/simplnx/DataStructure/IO/Generic/DataIOCollection.cpp
@@ -60,18 +60,18 @@ std::unique_ptr<IDataStore> DataIOCollection::createDataStore(const std::string&
   return coreManager.dataStoreCreationFnc(coreManager.formatName())(dataType, tupleShape, componentShape, {});
 }
 
-std::unique_ptr<IListStore> DataIOCollection::createListStore(const std::string& type, DataType dataType, usize tupleCount) const
+std::unique_ptr<IListStore> DataIOCollection::createListStore(const std::string& type, DataType dataType, const IListStore::ShapeType& tupleShape) const
 {
   for(const auto& [ioType, ioManager] : m_ManagerMap)
   {
     if(ioManager->hasListStoreCreationFnc(type))
     {
-      return ioManager->listStoreCreationFnc(type)(dataType, tupleCount);
+      return ioManager->listStoreCreationFnc(type)(dataType, tupleShape);
     }
   }
 
   nx::core::Generic::CoreDataIOManager coreManager;
-  return coreManager.listStoreCreationFnc(coreManager.formatName())(dataType, tupleCount);
+  return coreManager.listStoreCreationFnc(coreManager.formatName())(dataType, tupleShape);
 }
 
 void DataIOCollection::checkStoreDataFormat(uint64 dataSize, std::string& dataFormat) const

--- a/src/simplnx/DataStructure/IO/Generic/DataIOCollection.hpp
+++ b/src/simplnx/DataStructure/IO/Generic/DataIOCollection.hpp
@@ -61,12 +61,12 @@ public:
     return std::dynamic_pointer_cast<AbstractDataStore<T>>(dataStore);
   }
 
-  std::unique_ptr<IListStore> createListStore(const std::string& type, DataType numericType, usize tupleCount) const;
+  std::unique_ptr<IListStore> createListStore(const std::string& type, DataType numericType, const IListStore::ShapeType& tupleShape) const;
   template <typename T>
-  std::shared_ptr<AbstractListStore<T>> createListStoreWithType(const std::string& dataFormat, usize tupleCount) const
+  std::shared_ptr<AbstractListStore<T>> createListStoreWithType(const std::string& dataFormat, const IListStore::ShapeType& tupleShape) const
   {
     DataType numericType = GetDataType<T>();
-    std::shared_ptr<IListStore> listStore = createListStore(dataFormat, numericType, tupleCount);
+    std::shared_ptr<IListStore> listStore = createListStore(dataFormat, numericType, tupleShape);
     return std::dynamic_pointer_cast<AbstractListStore<T>>(listStore);
   }
 

--- a/src/simplnx/DataStructure/IO/Generic/DataIOCollection.hpp
+++ b/src/simplnx/DataStructure/IO/Generic/DataIOCollection.hpp
@@ -52,18 +52,18 @@ public:
   std::vector<std::string> getFormatNames() const;
 
   bool hasDataStoreCreationFunction(const std::string& type) const;
-  std::unique_ptr<IDataStore> createDataStore(const std::string& type, DataType numericType, const typename IDataStore::ShapeType& tupleShape, const typename IDataStore::ShapeType& componentShape);
+  std::unique_ptr<IDataStore> createDataStore(const std::string& type, DataType numericType, const ShapeType& tupleShape, const ShapeType& componentShape);
   template <typename T>
-  std::shared_ptr<AbstractDataStore<T>> createDataStoreWithType(const std::string& type, const typename IDataStore::ShapeType& tupleShape, const typename IDataStore::ShapeType& componentShape)
+  std::shared_ptr<AbstractDataStore<T>> createDataStoreWithType(const std::string& type, const ShapeType& tupleShape, const ShapeType& componentShape)
   {
     DataType numericType = GetDataType<T>();
     std::shared_ptr<IDataStore> dataStore = createDataStore(type, numericType, tupleShape, componentShape);
     return std::dynamic_pointer_cast<AbstractDataStore<T>>(dataStore);
   }
 
-  std::unique_ptr<IListStore> createListStore(const std::string& type, DataType numericType, const IListStore::ShapeType& tupleShape) const;
+  std::unique_ptr<IListStore> createListStore(const std::string& type, DataType numericType, const ShapeType& tupleShape) const;
   template <typename T>
-  std::shared_ptr<AbstractListStore<T>> createListStoreWithType(const std::string& dataFormat, const IListStore::ShapeType& tupleShape) const
+  std::shared_ptr<AbstractListStore<T>> createListStoreWithType(const std::string& dataFormat, const ShapeType& tupleShape) const
   {
     DataType numericType = GetDataType<T>();
     std::shared_ptr<IListStore> listStore = createListStore(dataFormat, numericType, tupleShape);

--- a/src/simplnx/DataStructure/IO/Generic/IDataIOManager.hpp
+++ b/src/simplnx/DataStructure/IO/Generic/IDataIOManager.hpp
@@ -29,7 +29,7 @@ public:
   using factory_collection = std::map<factory_id_type, factory_ptr>;
   using DataStoreCreateFnc =
       std::function<std::unique_ptr<IDataStore>(DataType, const typename IDataStore::ShapeType&, const typename IDataStore::ShapeType&, const std::optional<IDataStore::ShapeType>&)>;
-  using ListStoreCreateFnc = std::function<std::unique_ptr<IListStore>(DataType, usize)>;
+  using ListStoreCreateFnc = std::function<std::unique_ptr<IListStore>(DataType, const IListStore::ShapeType&)>;
   using DataStoreCreationMap = std::map<std::string, DataStoreCreateFnc>;
   using ListStoreCreationMap = std::map<std::string, ListStoreCreateFnc>;
 

--- a/src/simplnx/DataStructure/IO/Generic/IDataIOManager.hpp
+++ b/src/simplnx/DataStructure/IO/Generic/IDataIOManager.hpp
@@ -27,9 +27,8 @@ public:
   using factory_id_type = std::string;
   using factory_ptr = std::shared_ptr<IDataFactory>;
   using factory_collection = std::map<factory_id_type, factory_ptr>;
-  using DataStoreCreateFnc =
-      std::function<std::unique_ptr<IDataStore>(DataType, const typename IDataStore::ShapeType&, const typename IDataStore::ShapeType&, const std::optional<IDataStore::ShapeType>&)>;
-  using ListStoreCreateFnc = std::function<std::unique_ptr<IListStore>(DataType, const IListStore::ShapeType&)>;
+  using DataStoreCreateFnc = std::function<std::unique_ptr<IDataStore>(DataType, const ShapeType&, const ShapeType&, const std::optional<ShapeType>&)>;
+  using ListStoreCreateFnc = std::function<std::unique_ptr<IListStore>(DataType, const ShapeType&)>;
   using DataStoreCreationMap = std::map<std::string, DataStoreCreateFnc>;
   using ListStoreCreationMap = std::map<std::string, ListStoreCreateFnc>;
 

--- a/src/simplnx/DataStructure/IO/HDF5/AttributeMatrixIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/AttributeMatrixIO.cpp
@@ -27,7 +27,7 @@ Result<> AttributeMatrixIO::readData(DataStructureReader& structureReader, const
 
   auto groupReader = parentGroup.openGroup(objectName);
 
-  std::vector<usize> tupleShape;
+  ShapeType tupleShape;
   auto tupleShapeResult = groupReader.readVectorAttribute<usize>(IOConstants::k_TupleDims);
   if(tupleShapeResult.invalid())
   {

--- a/src/simplnx/DataStructure/IO/HDF5/DataArrayIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataArrayIO.hpp
@@ -139,19 +139,19 @@ public:
     auto datasetReader = parentGroup.openDataset(dataArrayName);
 
     auto typeResult = datasetReader.getDataType();
-    const auto type = std::move(typeResult.value());
+    const auto type = typeResult.value();
 
     std::string dataTypeStr;
     auto dataTypeStrResult = datasetReader.readStringAttribute(Constants::k_ObjectTypeTag);
     dataTypeStr = std::move(dataTypeStrResult.value());
-    const bool isBoolArray = (dataTypeStr.compare("DataArray<bool>") == 0);
+    const bool isBoolArray = (dataTypeStr == "DataArray<bool>");
 
     // Check ability to import the data
     int32 importable = 0;
     auto importableResult = datasetReader.readScalarAttribute<int32>(Constants::k_ImportableTag);
     if(importableResult.valid())
     {
-      importable = std::move(importableResult.value());
+      importable = importableResult.value();
     }
     if(importable == 0)
     {

--- a/src/simplnx/DataStructure/IO/HDF5/DataStructureWriter.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataStructureWriter.cpp
@@ -137,7 +137,7 @@ Result<> DataStructureWriter::writeDataObject(const DataObject* dataObject, nx::
 
 Result<> DataStructureWriter::writeDataMap(const DataMap& dataMap, nx::core::HDF5::GroupIO& parentGroup)
 {
-  for(auto [key, object] : dataMap)
+  for(const auto& [key, object] : dataMap)
   {
     Result<> result = writeDataObject(object.get(), parentGroup);
     if(result.invalid())

--- a/src/simplnx/DataStructure/IO/HDF5/IDataStoreIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/IDataStoreIO.cpp
@@ -10,9 +10,9 @@
 
 using namespace nx::core;
 
-typename nx::core::IDataStore::ShapeType nx::core::HDF5::IDataStoreIO::ReadTupleShape(const nx::core::HDF5::DatasetIO& datasetReader)
+ShapeType nx::core::HDF5::IDataStoreIO::ReadTupleShape(const nx::core::HDF5::DatasetIO& datasetReader)
 {
-  std::vector<usize> tupleShape;
+  ShapeType tupleShape;
   auto tupleShapeResult = datasetReader.readVectorAttribute<usize>(IOConstants::k_TupleShapeTag);
   if(tupleShapeResult.valid())
   {
@@ -21,9 +21,9 @@ typename nx::core::IDataStore::ShapeType nx::core::HDF5::IDataStoreIO::ReadTuple
   return tupleShape;
 }
 
-typename nx::core::IDataStore::ShapeType nx::core::HDF5::IDataStoreIO::ReadComponentShape(const nx::core::HDF5::DatasetIO& datasetReader)
+ShapeType nx::core::HDF5::IDataStoreIO::ReadComponentShape(const nx::core::HDF5::DatasetIO& datasetReader)
 {
-  std::vector<usize> compShape;
+  ShapeType compShape;
   auto compShapeResult = datasetReader.readVectorAttribute<usize>(IOConstants::k_ComponentShapeTag);
   if(compShapeResult.valid())
   {

--- a/src/simplnx/DataStructure/IO/HDF5/IDataStoreIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/IDataStoreIO.hpp
@@ -16,7 +16,7 @@ namespace IDataStoreIO
  * @param datasetReader
  * @return Result<>
  */
-typename IDataStore::ShapeType SIMPLNX_EXPORT ReadTupleShape(const nx::core::HDF5::DatasetIO& datasetReader);
+ShapeType SIMPLNX_EXPORT ReadTupleShape(const nx::core::HDF5::DatasetIO& datasetReader);
 
 /**
  * @brief Attempts to read the DataStore component shape from HDF5.
@@ -24,7 +24,7 @@ typename IDataStore::ShapeType SIMPLNX_EXPORT ReadTupleShape(const nx::core::HDF
  * @param datasetReader
  * @return Result<>
  */
-typename IDataStore::ShapeType SIMPLNX_EXPORT ReadComponentShape(const nx::core::HDF5::DatasetIO& datasetReader);
+ShapeType SIMPLNX_EXPORT ReadComponentShape(const nx::core::HDF5::DatasetIO& datasetReader);
 } // namespace IDataStoreIO
 } // namespace HDF5
 } // namespace nx::core

--- a/src/simplnx/DataStructure/IO/HDF5/NeighborListIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/NeighborListIO.hpp
@@ -49,7 +49,7 @@ public:
 
       if(useEmptyDataStore)
       {
-        auto tupleDimsResult = numNeighborsReader.readVectorAttribute<uint64>("TupleDimensions");
+        auto tupleDimsResult = numNeighborsReader.readVectorAttribute<usize>("TupleDimensions");
         if(tupleDimsResult.invalid())
         {
           return nullptr;

--- a/src/simplnx/DataStructure/IO/HDF5/NeighborListIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/NeighborListIO.hpp
@@ -54,9 +54,8 @@ public:
         {
           return nullptr;
         }
-        std::vector<uint64> tupleDims = tupleDimsResult.value();
-        uint64 numTuples = std::accumulate(tupleDims.begin(), tupleDims.end(), static_cast<uint64>(1), std::multiplies<>());
-        return std::make_shared<EmptyListStore<T>>(numTuples);
+
+        return std::make_shared<EmptyListStore<T>>(tupleDimsResult.value());
       }
 
       auto numNeighborsPtr = DataStoreIO::ReadDataStore<int32>(numNeighborsReader);
@@ -76,7 +75,7 @@ public:
 
       usize offset = 0;
       const auto numTuples = numNeighborsStore.getNumberOfTuples();
-      auto listStorePtr = DataStoreUtilities::CreateListStore<T>(numTuples);
+      auto listStorePtr = DataStoreUtilities::CreateListStore<T>(numNeighborsStore.getTupleShape());
       AbstractListStore<T>& listStore = *listStorePtr.get();
       for(usize i = 0; i < numTuples; i++)
       {
@@ -165,7 +164,7 @@ public:
 
     usize offset = 0;
     const auto numTuples = numNeighborsStore.getNumberOfTuples();
-    auto listStorePtr = DataStoreUtilities::CreateListStore<T>(numTuples);
+    auto listStorePtr = DataStoreUtilities::CreateListStore<T>(numNeighborsStore.getTupleShape());
     AbstractListStore<T>& listStore = *listStorePtr.get();
     for(usize i = 0; i < numTuples; i++)
     {

--- a/src/simplnx/DataStructure/IO/HDF5/StringArrayIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/StringArrayIO.cpp
@@ -46,7 +46,7 @@ Result<> StringArrayIO::readData(DataStructureReader& dataStructureReader, const
     return {};
   }
 
-  std::vector<usize> tupleShape;
+  ShapeType tupleShape;
   auto tupleShapeResult = datasetReader.readVectorAttribute<usize>(k_TupleDimsAttrName);
   if(tupleShapeResult.valid())
   {

--- a/src/simplnx/DataStructure/IO/HDF5/StringArrayIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/StringArrayIO.cpp
@@ -104,7 +104,7 @@ Result<> StringArrayIO::finishImportingData(DataStructure& dataStructure, const 
 
   auto datasetReader = parentGroupReader.openDataset(dataPath.getTargetName());
   std::vector<std::string> strings = datasetReader.readAsVectorOfStrings();
-  auto stringStore = std::make_shared<StringStore>(std::move(strings));
+  auto stringStore = std::make_shared<StringStore>(std::move(strings), stringArray->getTupleShape());
   stringArray->setStore(stringStore);
   return {};
 }

--- a/src/simplnx/DataStructure/IO/HDF5/StringArrayIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/StringArrayIO.cpp
@@ -1,4 +1,5 @@
 #include "StringArrayIO.hpp"
+#include <numeric>
 
 #include "DataStructureReader.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
@@ -39,21 +40,22 @@ Result<> StringArrayIO::readData(DataStructureReader& dataStructureReader, const
   {
     return ConvertResult(std::move(importableResult));
   }
-  int32 importable = std::move(importableResult.value());
+  int32 importable = importableResult.value();
   if(importable == 0)
   {
     return {};
   }
 
-  auto numValuesResult = datasetReader.readScalarAttribute<uint64>(k_TupleDimsAttrName);
-  if(numValuesResult.invalid())
+  std::vector<usize> tupleShape;
+  auto tupleShapeResult = datasetReader.readVectorAttribute<usize>(k_TupleDimsAttrName);
+  if(tupleShapeResult.valid())
   {
-    return ConvertResult(std::move(numValuesResult));
+    tupleShape = std::move(tupleShapeResult.value());
   }
-  uint64 numValues = std::move(numValuesResult.value());
+  usize numValues = std::accumulate(tupleShape.cbegin(), tupleShape.cend(), 1, std::multiplies<>());
 
   std::vector<std::string> strings = useEmptyDataStore ? std::vector<std::string>(numValues) : datasetReader.readAsVectorOfStrings();
-  const auto* data = StringArray::Import(dataStructureReader.getDataStructure(), dataArrayName, importId, std::move(strings), parentId);
+  const auto* data = StringArray::Import(dataStructureReader.getDataStructure(), dataArrayName, tupleShape, importId, std::move(strings), parentId);
 
   if(data == nullptr)
   {
@@ -63,12 +65,12 @@ Result<> StringArrayIO::readData(DataStructureReader& dataStructureReader, const
   return {};
 }
 
-Result<> StringArrayIO::writeData(DataStructureWriter& dataStructureWriter, const data_type& dataArray, group_writer_type& parentGroup, bool importable) const
+Result<> StringArrayIO::writeData(DataStructureWriter& dataStructureWriter, const data_type& stringArray, group_writer_type& parentGroup, bool importable) const
 {
-  auto datasetWriter = parentGroup.createDataset(dataArray.getName());
+  auto datasetWriter = parentGroup.createDataset(stringArray.getName());
 
   // writeVectorOfStrings may resize the collection
-  data_type::collection_type strings = dataArray.values();
+  data_type::collection_type strings = stringArray.values();
   auto result = datasetWriter.writeVectorOfStrings(strings);
   if(result.invalid())
   {
@@ -77,15 +79,14 @@ Result<> StringArrayIO::writeData(DataStructureWriter& dataStructureWriter, cons
 
   // Write the number of values as an attribute for quicker preflight times
   {
-    const uint64 value = dataArray.size();
-    result = datasetWriter.writeScalarAttribute(k_TupleDimsAttrName, value);
+    result = datasetWriter.writeVectorAttribute<usize>(k_TupleDimsAttrName, stringArray.getTupleShape());
     if(result.invalid())
     {
       return result;
     }
   }
 
-  return WriteObjectAttributes(dataStructureWriter, dataArray, datasetWriter, importable);
+  return WriteObjectAttributes(dataStructureWriter, stringArray, datasetWriter, importable);
 }
 
 Result<> StringArrayIO::finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& parentGroupReader) const

--- a/src/simplnx/DataStructure/ListStore.hpp
+++ b/src/simplnx/DataStructure/ListStore.hpp
@@ -20,16 +20,18 @@ public:
   using const_reference = typename parent_type::const_reference;
   using iterator = typename parent_type::iterator;
   using const_iterator = typename parent_type::const_iterator;
-  using shape_type = typename std::vector<usize>;
+  using ShapeType = typename std::vector<usize>;
 
   /**
    * @brief Constructs a ListStore using the specified tuple shape and list size.
    * @param tupleShape
    * @param listSize
    */
-  ListStore(usize numTuples)
+  explicit ListStore(const ShapeType& tupleShape)
   : parent_type()
-  , m_Array(numTuples)
+  , m_TupleShape(tupleShape.cbegin(), tupleShape.cend())
+  , m_NumTuples(std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
+  , m_Array(m_NumTuples)
   {
   }
 
@@ -37,7 +39,7 @@ public:
    * @brief Creates a ListStore from a vector of vectors.
    * @param vectors
    */
-  ListStore(const typename std::vector<shared_vector_type>& vectors)
+  explicit ListStore(const typename std::vector<shared_vector_type>& vectors)
   : parent_type()
   {
     setData(vectors);
@@ -49,6 +51,8 @@ public:
   ListStore(const ListStore& other)
   : parent_type(other)
   , m_Array(other.m_Array)
+  , m_TupleShape(other.m_TupleShape)
+  , m_NumTuples(other.m_NumTuples)
   {
   }
 
@@ -58,6 +62,8 @@ public:
   ListStore(ListStore&& copy) noexcept
   : parent_type(std::move(copy))
   , m_Array(std::move(copy.m_Array))
+  , m_TupleShape(std::move(copy.m_TupleShape))
+  , m_NumTuples(copy.m_NumTuples)
   {
   }
 
@@ -70,6 +76,24 @@ public:
   std::unique_ptr<parent_type> deepCopy() const override
   {
     return std::make_unique<ListStore>(*this);
+  }
+
+  /**
+   * @brief Returns the number of tuples in the ListStore.
+   * @return usize
+   */
+  usize getNumberOfTuples() const override
+  {
+    return m_NumTuples;
+  }
+
+  /**
+   * @brief Returns the dimensions of the Tuples
+   * @return
+   */
+  const ShapeType& getTupleShape() const override
+  {
+    return m_TupleShape;
   }
 
   /**
@@ -91,9 +115,11 @@ public:
    * @param tupleShape The new shape of the data where the dimensions are "C" ordered
    * from *slowest* to *fastest*.
    */
-  void resizeTuples(usize tupleCount) override
+  void resizeTuples(const ShapeType& tupleShape) override
   {
-    m_Array.resize(tupleCount);
+    m_TupleShape = tupleShape;
+    m_NumTuples = std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>());
+    m_Array.resize(m_NumTuples);
   }
 
   /**
@@ -168,36 +194,27 @@ public:
    */
   T getValue(int32 grainId, int32 index, bool& ok) const override
   {
-    if(grainId >= this->getNumberOfLists() || grainId < 0 || index < 0)
+    if(grainId < this->getNumberOfLists() && grainId >= 0 && index >= 0 && index < m_Array[grainId].size())
     {
-      ok = false;
-      return {};
+      ok = true;
+      return m_Array[grainId][index];
     }
 
-    auto& list = m_Array[grainId];
-    if(index > list.size())
-    {
-      ok = false;
-      return {};
-    }
-
-    ok = true;
-    return list[index];
+    ok = false;
+    return {};
   }
 
   void setValue(int32 grainId, usize index, T value) override
   {
-    if(grainId >= this->getNumberOfLists())
+    if(grainId < this->getNumberOfLists() && grainId >= 0 && index < m_Array[grainId].size())
     {
-      return;
+      m_Array[grainId][index] = value;
     }
-
-    m_Array[grainId][index] = value;
   }
 
   uint64 getNumberOfLists() const override
   {
-    return m_Array.size();
+    return m_NumTuples;
   }
 
   /**
@@ -247,7 +264,9 @@ public:
 
   void setData(const std::vector<shared_vector_type>& lists) override
   {
-    m_Array.resize(lists.size());
+    m_NumTuples = lists.size();
+    m_TupleShape = ShapeType{m_NumTuples};
+    m_Array.resize(m_NumTuples);
     for(usize i = 0; i < m_Array.size(); i++)
     {
       m_Array[i] = *lists[i];
@@ -257,6 +276,8 @@ public:
   void setData(const std::vector<vector_type>& lists) override
   {
     m_Array = lists;
+    m_NumTuples = m_Array.size();
+    m_TupleShape = ShapeType{m_NumTuples};
   }
 
   void readHdf5(const HDF5::DatasetIO& datasetReader) override
@@ -270,6 +291,8 @@ public:
   }
 
 private:
+  ShapeType m_TupleShape;
+  ShapeType::value_type m_NumTuples;
   std::vector<std::vector<T>> m_Array;
 };
 

--- a/src/simplnx/DataStructure/ListStore.hpp
+++ b/src/simplnx/DataStructure/ListStore.hpp
@@ -20,7 +20,6 @@ public:
   using const_reference = typename parent_type::const_reference;
   using iterator = typename parent_type::iterator;
   using const_iterator = typename parent_type::const_iterator;
-  using ShapeType = typename std::vector<usize>;
 
   /**
    * @brief Constructs a ListStore using the specified tuple shape and list size.

--- a/src/simplnx/DataStructure/ListStore.hpp
+++ b/src/simplnx/DataStructure/ListStore.hpp
@@ -98,20 +98,6 @@ public:
 
   /**
    * @brief This method sets the shape of the dimensions to `tupleShape`.
-   *
-   * There are 3 possibilities when using this function:
-   * [1] The number of tuples of the new shape is *LESS* than the original. In this
-   * case a memory allocation will take place and the first 'N' elements of data
-   * will be copied into the new array. The remaining data is *LOST*
-   *
-   * [2] The number of tuples of the new shape is *EQUAL* to the original. In this
-   * case the shape is set and the function returns.
-   *
-   * [3] The number of tuples of the new shape is *GREATER* than the original. In
-   * this case a new array is allocated and all the data from the original array
-   * is copied into the new array and the remaining elements are initialized to
-   * the default initialization value.
-   *
    * @param tupleShape The new shape of the data where the dimensions are "C" ordered
    * from *slowest* to *fastest*.
    */

--- a/src/simplnx/DataStructure/NeighborList.cpp
+++ b/src/simplnx/DataStructure/NeighborList.cpp
@@ -8,9 +8,9 @@
 namespace nx::core
 {
 template <typename T>
-NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& name, usize numTuples)
-: INeighborList(dataStructure, name, numTuples)
-, m_Store(std::make_shared<ListStore<T>>(numTuples))
+NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& name, const std::vector<usize>& tupleShape)
+: INeighborList(dataStructure, name)
+, m_Store(std::make_shared<ListStore<T>>(tupleShape))
 , m_IsAllocated(false)
 , m_InitValue(static_cast<T>(0.0))
 {
@@ -18,7 +18,7 @@ NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& n
 
 template <typename T>
 NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& name, const std::vector<SharedVectorType>& dataVector, IdType importId)
-: INeighborList(dataStructure, name, dataVector.size(), importId)
+: INeighborList(dataStructure, name, importId)
 , m_Store(std::make_shared<ListStore<T>>(dataVector))
 , m_IsAllocated(true)
 , m_InitValue(static_cast<T>(0.0))
@@ -27,7 +27,7 @@ NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& n
 
 template <typename T>
 NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& name, const std::shared_ptr<store_type>& dataStore, IdType importId)
-: INeighborList(dataStructure, name, dataStore->size(), importId)
+: INeighborList(dataStructure, name, importId)
 , m_Store(dataStore)
 , m_IsAllocated(true)
 , m_InitValue(static_cast<T>(0.0))
@@ -36,7 +36,7 @@ NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& n
 
 template <typename T>
 NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& name, const std::shared_ptr<store_type>& dataStore)
-: INeighborList(dataStructure, name, dataStore->size())
+: INeighborList(dataStructure, name)
 , m_Store(dataStore)
 , m_IsAllocated(true)
 , m_InitValue(static_cast<T>(0.0))
@@ -44,9 +44,9 @@ NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& n
 }
 
 template <typename T>
-NeighborList<T>* NeighborList<T>::Create(DataStructure& dataStructure, const std::string& name, usize numTuples, const std::optional<IdType>& parentId)
+NeighborList<T>* NeighborList<T>::Create(DataStructure& dataStructure, const std::string& name, const std::vector<usize>& tupleShape, const std::optional<IdType>& parentId)
 {
-  auto data = std::shared_ptr<NeighborList>(new NeighborList(dataStructure, name, numTuples));
+  auto data = std::shared_ptr<NeighborList>(new NeighborList(dataStructure, name, tupleShape));
   if(!AttemptToAddObject(dataStructure, data, parentId))
   {
     return nullptr;
@@ -117,10 +117,10 @@ NeighborList<T>& NeighborList<T>::operator=(const NeighborList<T>& rhs)
 }
 
 template <typename T>
-NeighborList<T>& NeighborList<T>::operator=(NeighborList<T>&& rhs)
+NeighborList<T>& NeighborList<T>::operator=(NeighborList<T>&& rhs) noexcept
 {
   m_Store = std::move(rhs.m_Store);
-  m_IsAllocated = std::move(rhs.m_IsAllocated);
+  m_IsAllocated = rhs.m_IsAllocated; // trivially copyable, move does nothing
   m_InitValue = std::move(rhs.m_InitValue);
 
   return *this;
@@ -141,7 +141,7 @@ std::shared_ptr<DataObject> NeighborList<T>::deepCopy(const DataPath& copyPath)
     return nullptr;
   }
   // Don't construct with identifier since it will get created when inserting into data structure
-  auto copy = std::shared_ptr<NeighborList<T>>(new NeighborList<T>(dataStruct, copyPath.getTargetName(), getNumberOfTuples()));
+  auto copy = std::shared_ptr<NeighborList<T>>(new NeighborList<T>(dataStruct, copyPath.getTargetName(), getTupleShape()));
   copy->setNumNeighborsArrayName(getNumNeighborsArrayName());
   copy->m_Store = m_Store->deepCopy();
   if(dataStruct.insert(copy, copyPath.getParent()))
@@ -167,10 +167,10 @@ int32 NeighborList<T>::eraseTuples(const std::vector<usize>& idxs)
     return 0;
   }
 
-  usize idxsSize = static_cast<usize>(idxs.size());
-  if(idxsSize >= getNumberOfTuples())
+  auto indicesSize = static_cast<usize>(idxs.size());
+  if(indicesSize >= getNumberOfTuples())
   {
-    resizeTuples(0);
+    resizeTuples(ShapeType{0});
     return 0;
   }
 
@@ -186,7 +186,7 @@ int32 NeighborList<T>::eraseTuples(const std::vector<usize>& idxs)
   }
 
   auto copy = m_Store->deepCopy();
-  copy->resizeTuples(arraySize - idxsSize);
+  copy->resizeTuples(ShapeType{static_cast<ShapeType::value_type>(arraySize - indicesSize)});
 
   usize idxsIndex = 0;
   usize rIdx = 0;
@@ -200,14 +200,13 @@ int32 NeighborList<T>::eraseTuples(const std::vector<usize>& idxs)
     else
     {
       ++idxsIndex;
-      if(idxsIndex == idxsSize)
+      if(idxsIndex == indicesSize)
       {
         idxsIndex--;
       }
     }
   }
   m_Store = std::move(copy);
-  setNumberOfTuples(m_Store->size());
   return err;
 }
 
@@ -277,36 +276,12 @@ void NeighborList<T>::initializeWithZeros()
 }
 
 template <typename T>
-int32 NeighborList<T>::resizeTotalElements(usize size)
-{
-  usize old = m_Store->size();
-  m_Store->resizeTuples(size);
-  setNumberOfTuples(size);
-
-  if(size == 0)
-  {
-    m_IsAllocated = false;
-  }
-  else
-  {
-    m_IsAllocated = true;
-  }
-  return 1;
-}
-
-template <typename T>
-void NeighborList<T>::resizeTuples(usize numTuples)
-{
-  resizeTotalElements(numTuples);
-}
-
-template <typename T>
 void NeighborList<T>::addEntry(int32 grainId, value_type value)
 {
   if(grainId >= static_cast<int32>(m_Store->size()))
   {
     usize old = m_Store->size();
-    m_Store->resizeTuples(grainId + 1);
+    m_Store->resizeTuples(ShapeType{static_cast<ShapeType::value_type>(grainId + 1)});
     m_IsAllocated = true;
     // Initialize with zero length Vectors
     for(usize i = old; i < m_Store->size(); ++i)
@@ -315,7 +290,6 @@ void NeighborList<T>::addEntry(int32 grainId, value_type value)
     }
   }
   m_Store->addEntry(grainId, value);
-  setNumberOfTuples(m_Store->size());
 }
 
 template <typename T>
@@ -330,8 +304,7 @@ void NeighborList<T>::setList(int32 grainId, const SharedVectorType& neighborLis
 {
   if(grainId >= static_cast<int32>(m_Store->size()))
   {
-    usize old = m_Store->size();
-    m_Store->resizeTuples(grainId + 1);
+    m_Store->resizeTuples(ShapeType{static_cast<ShapeType::value_type>(grainId + 1)});
     m_IsAllocated = true;
   }
   m_Store->setList(grainId, neighborList);
@@ -342,8 +315,7 @@ void NeighborList<T>::setList(int32 grainId, const VectorType& neighborList)
 {
   if(grainId >= static_cast<int32>(m_Store->size()))
   {
-    usize old = m_Store->size();
-    m_Store->resizeTuples(grainId + 1);
+    m_Store->resizeTuples(ShapeType{static_cast<ShapeType::value_type>(grainId + 1)});
     m_IsAllocated = true;
   }
   m_Store->setList(grainId, neighborList);
@@ -358,13 +330,7 @@ void NeighborList<T>::setLists(const std::vector<std::vector<T>>& neighborLists)
 template <typename T>
 T NeighborList<T>::getValue(int32 grainId, int32 index, bool& ok) const
 {
-  VectorType vec = m_Store->at(grainId);
-  if(index < 0 || static_cast<usize>(index) >= vec.size())
-  {
-    ok = false;
-    return static_cast<T>(-1);
-  }
-  return vec[index];
+  return m_Store->getValue(grainId, index, ok);
 }
 
 template <typename T>
@@ -428,11 +394,16 @@ DataObject::Type NeighborList<T>::getDataObjectType() const
   return Type::NeighborList;
 }
 
-template <typename T>
-void NeighborList<T>::resizeTuples(const std::vector<usize>& tupleShape)
+template<typename T>
+IListStore* NeighborList<T>::getIListStore()
 {
-  auto numTuples = std::accumulate(tupleShape.cbegin(), tupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
-  resizeTotalElements(numTuples);
+  return m_Store.get();
+}
+
+template<typename T>
+const IListStore* NeighborList<T>::getIListStore() const
+{
+  return m_Store.get();
 }
 
 template <typename T>

--- a/src/simplnx/DataStructure/NeighborList.cpp
+++ b/src/simplnx/DataStructure/NeighborList.cpp
@@ -8,7 +8,7 @@
 namespace nx::core
 {
 template <typename T>
-NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& name, const std::vector<usize>& tupleShape)
+NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& name, const ShapeType& tupleShape)
 : INeighborList(dataStructure, name)
 , m_Store(std::make_shared<ListStore<T>>(tupleShape))
 , m_IsAllocated(false)
@@ -44,7 +44,7 @@ NeighborList<T>::NeighborList(DataStructure& dataStructure, const std::string& n
 }
 
 template <typename T>
-NeighborList<T>* NeighborList<T>::Create(DataStructure& dataStructure, const std::string& name, const std::vector<usize>& tupleShape, const std::optional<IdType>& parentId)
+NeighborList<T>* NeighborList<T>::Create(DataStructure& dataStructure, const std::string& name, const ShapeType& tupleShape, const std::optional<IdType>& parentId)
 {
   auto data = std::shared_ptr<NeighborList>(new NeighborList(dataStructure, name, tupleShape));
   if(!AttemptToAddObject(dataStructure, data, parentId))
@@ -401,13 +401,13 @@ DataObject::Type NeighborList<T>::getDataObjectType() const
   return Type::NeighborList;
 }
 
-template<typename T>
+template <typename T>
 IListStore* NeighborList<T>::getIListStore()
 {
   return m_Store.get();
 }
 
-template<typename T>
+template <typename T>
 const IListStore* NeighborList<T>::getIListStore() const
 {
   return m_Store.get();

--- a/src/simplnx/DataStructure/NeighborList.cpp
+++ b/src/simplnx/DataStructure/NeighborList.cpp
@@ -293,6 +293,13 @@ void NeighborList<T>::addEntry(int32 grainId, value_type value)
 }
 
 template <typename T>
+void NeighborList<T>::updateListEntry(int32 grainId, usize elementPosition, value_type value)
+{
+  // The store does bound checking
+  m_Store->setValue(grainId, elementPosition, value);
+}
+
+template <typename T>
 void NeighborList<T>::clearAllLists()
 {
   m_Store->clear();

--- a/src/simplnx/DataStructure/NeighborList.hpp
+++ b/src/simplnx/DataStructure/NeighborList.hpp
@@ -36,7 +36,7 @@ public:
    * @tparam T
    * @return NeighborList<T>*
    */
-  static NeighborList* Create(DataStructure& dataStructure, const std::string& name, const std::vector<usize>& tupleShape, const std::optional<IdType>& parentId = {});
+  static NeighborList* Create(DataStructure& dataStructure, const std::string& name, const ShapeType& tupleShape, const std::optional<IdType>& parentId = {});
 
   /**
    * @brief
@@ -393,7 +393,7 @@ protected:
   /**
    * @brief NeighborList
    */
-  NeighborList(DataStructure& dataStructure, const std::string& name, const std::vector<usize>& tupleShape);
+  NeighborList(DataStructure& dataStructure, const std::string& name, const ShapeType& tupleShape);
 
   /**
    * @brief NeighborList

--- a/src/simplnx/DataStructure/NeighborList.hpp
+++ b/src/simplnx/DataStructure/NeighborList.hpp
@@ -7,11 +7,6 @@
 
 namespace nx::core
 {
-namespace NeighborListConstants
-{
-inline constexpr StringLiteral k_TypeName = "NeighborList<T>";
-}
-
 /**
  * @class NeighborList
  * @brief
@@ -41,7 +36,7 @@ public:
    * @tparam T
    * @return NeighborList<T>*
    */
-  static NeighborList* Create(DataStructure& dataStructure, const std::string& name, usize numTuples, const std::optional<IdType>& parentId = {});
+  static NeighborList* Create(DataStructure& dataStructure, const std::string& name, const std::vector<usize>& tupleShape, const std::optional<IdType>& parentId = {});
 
   /**
    * @brief
@@ -160,34 +155,6 @@ public:
    * This is the same as calling ```clearAllLists()```
    */
   void initializeWithZeros();
-
-  /**
-   * @brief resizeTotalElements
-   * @param size
-   * @return int32
-   */
-  int32 resizeTotalElements(usize size);
-
-  /**
-   * @brief This method sets the shape of the dimensions to `tupleShape`.
-   *
-   * There are 3 possibilities when using this function:
-   * [1] The number of tuples of the new shape is *LESS* than the original. In this
-   * case a memory allocation will take place and the first 'N' elements of data
-   * will be copied into the new array. The remaining data is *LOST*
-   *
-   * [2] The number of tuples of the new shape is *EQUAL* to the original. In this
-   * case the shape is set and the function returns.
-   *
-   * [3] The number of tuples of the new shape is *GREATER* than the original. In
-   * this case a new array is allocated and all the data from the original array
-   * is copied into the new array and the remaining elements are initialized to
-   * the default initialization value.
-   *
-   * @param tupleShape The new shape of the data where the dimensions are "C" ordered
-   * from *slowest* to *fastest*.
-   */
-  void resizeTuples(usize numTuples);
 
   /**
    * @brief addEntry
@@ -375,9 +342,16 @@ public:
   DataObject::Type getDataObjectType() const override;
 
   /**
-   * @brief Resizes the internal array to accomondate
+   * @brief Returns a pointer to the underlying IListStore.
+   * @return const IListStore*
    */
-  void resizeTuples(const std::vector<usize>& tupleShape) override;
+  IListStore* getIListStore() override;
+
+  /**
+   * @brief Returns a pointer to the underlying IListStore.
+   * @return const IListStore*
+   */
+  const IListStore* getIListStore() const override;
 
   /**
    * @brief Returns a shared_ptr to the underlying list store.
@@ -404,13 +378,13 @@ public:
   const_iterator cend() const;
 
   NeighborList& operator=(const NeighborList& rhs);
-  NeighborList& operator=(NeighborList&& rhs);
+  NeighborList& operator=(NeighborList&& rhs) noexcept;
 
 protected:
   /**
    * @brief NeighborList
    */
-  NeighborList(DataStructure& dataStructure, const std::string& name, usize numTuples);
+  NeighborList(DataStructure& dataStructure, const std::string& name, const std::vector<usize>& tupleShape);
 
   /**
    * @brief NeighborList

--- a/src/simplnx/DataStructure/NeighborList.hpp
+++ b/src/simplnx/DataStructure/NeighborList.hpp
@@ -164,6 +164,15 @@ public:
   void addEntry(int32 grainId, value_type value);
 
   /**
+   * @brief updateListEntry changes the value in supplied element position in the supplied grain to the supplied value,
+   * This is a bounds checked function
+   * @param grainId the list to access
+   * @param elementPosition the position in the grain to be updated
+   * @param value the new value
+   */
+  void updateListEntry(int32 grainId, usize elementPosition, value_type value);
+
+  /**
    * @brief Clear All Lists
    */
   void clearAllLists();

--- a/src/simplnx/DataStructure/StringArray.cpp
+++ b/src/simplnx/DataStructure/StringArray.cpp
@@ -9,7 +9,7 @@ namespace nx::core
 {
 StringArray* StringArray::Create(DataStructure& dataStructure, const std::string_view& name, const std::optional<IdType>& parentId)
 {
-  return CreateWithValues(dataStructure, name,{0}, {}, parentId);
+  return CreateWithValues(dataStructure, name, {0}, {}, parentId);
 }
 
 StringArray* StringArray::CreateWithValues(DataStructure& dataStructure, const std::string_view& name, const ShapeType& tupleShape, collection_type strings, const std::optional<IdType>& parentId)
@@ -23,7 +23,8 @@ StringArray* StringArray::CreateWithValues(DataStructure& dataStructure, const s
   return data.get();
 }
 
-StringArray* StringArray::Import(DataStructure& dataStructure, const std::string_view& name, const ShapeType& tupleShape, IdType importId, collection_type strings, const std::optional<IdType>& parentId)
+StringArray* StringArray::Import(DataStructure& dataStructure, const std::string_view& name, const ShapeType& tupleShape, IdType importId, collection_type strings,
+                                 const std::optional<IdType>& parentId)
 {
   auto data = std::shared_ptr<StringArray>(new StringArray(dataStructure, name.data(), tupleShape, importId, std::move(strings)));
   if(!AttemptToAddObject(dataStructure, data, parentId))
@@ -208,12 +209,12 @@ bool StringArray::empty() const
   return m_Strings->empty();
 }
 
-IArray::ShapeType StringArray::getTupleShape() const
+ShapeType StringArray::getTupleShape() const
 {
   return m_Strings->getTupleShape();
 }
 
-IArray::ShapeType StringArray::getComponentShape() const
+ShapeType StringArray::getComponentShape() const
 {
   return {1};
 }
@@ -228,7 +229,7 @@ usize StringArray::getNumberOfComponents() const
   return 1;
 }
 
-void StringArray::resizeTuples(const std::vector<usize>& tupleShape)
+void StringArray::resizeTuples(const ShapeType& tupleShape)
 {
   m_Strings->resizeTuples(tupleShape);
 }

--- a/src/simplnx/DataStructure/StringArray.cpp
+++ b/src/simplnx/DataStructure/StringArray.cpp
@@ -2,8 +2,6 @@
 #include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/DataStructure/StringStore.hpp"
 
-#include <fmt/format.h>
-
 #include <numeric>
 #include <stdexcept>
 
@@ -64,8 +62,28 @@ StringArray::StringArray(const StringArray& other)
 {
 }
 
+/*
+ * In a non-delegating constructor, initialization proceeds in the following order:
+ * (13.1) — First, and only for the constructor of the most derived class (1.8), virtual base classes are initialized in the order they appear on
+ * a depth-first left-to-right traversal of the directed acyclic graph of base classes, where “left-to-right” is the order of appearance of the base
+ * classes in the derived class base-specifier-list.
+ * (13.2) — Then, direct base classes are initialized in declaration order as they appear in the base-specifier-list
+ * (regardless of the order of the mem-initializers).
+ * (13.3) — Then, non-static data members are initialized in the order they were declared in the class definition
+ * (again regardless of the order of the mem-initializers).
+ * (13.4) — Finally, the compound-statement of the constructor body is executed.
+ * [ Note: The declaration order is mandated to ensure that base and member subobjects are destroyed in the reverse order of initialization. —end note ]
+ *
+ * The initialization performed by each mem-initializer constitutes a full-expression.
+ * Any expression in a mem-initializer is evaluated as part of the full-expression that performs the initialization.
+ *
+ * Thus, disregard clang-tidy, the second move here is still a valid one because the IArray portion of the object will
+ * be moved first leaving the derived class member variables (m_Strings) in a valid state as only
+ * the base (IArray) has been marked-to-be/or-is destroyed, however, `other` should not be used after ctor initializer list as
+ * it will no longer be in a valid state.
+ */
 StringArray::StringArray(StringArray&& other) noexcept
-: IArray(other)
+: IArray(std::move(other))
 , m_Strings(std::move(other.m_Strings))
 {
 }
@@ -112,33 +130,29 @@ size_t StringArray::size() const
   return m_Strings->size();
 }
 
-const StringArray::collection_type StringArray::values() const
+StringArray::collection_type StringArray::values() const
 {
-  return collection_type(begin(), end());
+  return {begin(), end()};
 }
 
 StringArray::reference StringArray::operator[](usize index)
 {
-  return (*m_Strings)[index];
+  return m_Strings->operator[](index);
 }
 
 StringArray::const_reference StringArray::operator[](usize index) const
 {
-  return (*m_Strings)[index];
+  return m_Strings->operator[](index);
 }
 
 void StringArray::setValue(usize index, const std::string& value)
 {
-  (*m_Strings)[index] = value;
+  m_Strings->setValue(index, value);
 }
 
 StringArray::const_reference StringArray::at(usize index) const
 {
-  if(index >= size())
-  {
-    throw std::out_of_range(fmt::format("Attempting to access string at index {} out of {}", index, size()));
-  }
-  return (*m_Strings)[index];
+  return m_Strings->at(index);
 }
 
 StringArray::iterator StringArray::begin()
@@ -216,11 +230,7 @@ usize StringArray::getNumberOfComponents() const
 
 void StringArray::resizeTuples(const std::vector<usize>& tupleShape)
 {
-  auto numTuples = std::accumulate(tupleShape.cbegin(), tupleShape.cend(), static_cast<usize>(1), std::multiplies<>());
-  if(numTuples != size())
-  {
-    m_Strings->resize(numTuples);
-  }
+  m_Strings->resizeTuples(tupleShape);
 }
 
 void StringArray::swapTuples(usize index0, usize index1)

--- a/src/simplnx/DataStructure/StringArray.cpp
+++ b/src/simplnx/DataStructure/StringArray.cpp
@@ -9,13 +9,13 @@ namespace nx::core
 {
 StringArray* StringArray::Create(DataStructure& dataStructure, const std::string_view& name, const std::optional<IdType>& parentId)
 {
-  return CreateWithValues(dataStructure, name, {}, parentId);
+  return CreateWithValues(dataStructure, name,{0}, {}, parentId);
 }
 
-StringArray* StringArray::CreateWithValues(DataStructure& dataStructure, const std::string_view& name, collection_type strings, const std::optional<IdType>& parentId)
+StringArray* StringArray::CreateWithValues(DataStructure& dataStructure, const std::string_view& name, const ShapeType& tupleShape, collection_type strings, const std::optional<IdType>& parentId)
 {
   auto data = std::shared_ptr<StringArray>(new StringArray(dataStructure, name.data()));
-  data->m_Strings = std::make_shared<StringStore>(strings);
+  data->m_Strings = std::make_shared<StringStore>(strings, tupleShape);
   if(!AttemptToAddObject(dataStructure, data, parentId))
   {
     return nullptr;
@@ -23,9 +23,9 @@ StringArray* StringArray::CreateWithValues(DataStructure& dataStructure, const s
   return data.get();
 }
 
-StringArray* StringArray::Import(DataStructure& dataStructure, const std::string_view& name, IdType importId, collection_type strings, const std::optional<IdType>& parentId)
+StringArray* StringArray::Import(DataStructure& dataStructure, const std::string_view& name, const ShapeType& tupleShape, IdType importId, collection_type strings, const std::optional<IdType>& parentId)
 {
-  auto data = std::shared_ptr<StringArray>(new StringArray(dataStructure, name.data(), importId, std::move(strings)));
+  auto data = std::shared_ptr<StringArray>(new StringArray(dataStructure, name.data(), tupleShape, importId, std::move(strings)));
   if(!AttemptToAddObject(dataStructure, data, parentId))
   {
     return nullptr;
@@ -38,10 +38,10 @@ StringArray::StringArray(DataStructure& dataStructure, std::string name)
 {
 }
 
-StringArray::StringArray(DataStructure& dataStructure, std::string name, collection_type strings)
+StringArray::StringArray(DataStructure& dataStructure, std::string name, const ShapeType& tupleShape, collection_type strings)
 : IArray(dataStructure, std::move(name))
 {
-  m_Strings = std::make_shared<StringStore>(strings);
+  m_Strings = std::make_shared<StringStore>(strings, tupleShape);
 }
 
 StringArray::StringArray(DataStructure& dataStructure, std::string name, std::shared_ptr<store_type>& store)
@@ -50,10 +50,10 @@ StringArray::StringArray(DataStructure& dataStructure, std::string name, std::sh
 {
 }
 
-StringArray::StringArray(DataStructure& dataStructure, std::string name, IdType importId, collection_type strings)
+StringArray::StringArray(DataStructure& dataStructure, std::string name, const ShapeType& tupleShape, IdType importId, collection_type strings)
 : IArray(dataStructure, std::move(name), importId)
 {
-  m_Strings = std::make_shared<StringStore>(strings);
+  m_Strings = std::make_shared<StringStore>(strings, tupleShape);
 }
 
 StringArray::StringArray(const StringArray& other)
@@ -210,7 +210,7 @@ bool StringArray::empty() const
 
 IArray::ShapeType StringArray::getTupleShape() const
 {
-  return {size()};
+  return m_Strings->getTupleShape();
 }
 
 IArray::ShapeType StringArray::getComponentShape() const

--- a/src/simplnx/DataStructure/StringArray.hpp
+++ b/src/simplnx/DataStructure/StringArray.hpp
@@ -21,9 +21,9 @@ public:
   static inline constexpr StringLiteral k_TypeName = "StringArray";
 
   static StringArray* Create(DataStructure& dataStructure, const std::string_view& name, const std::optional<IdType>& parentId = {});
-  static StringArray* CreateWithValues(DataStructure& dataStructure, const std::string_view& name, collection_type strings, const std::optional<IdType>& parentId = {});
+  static StringArray* CreateWithValues(DataStructure& dataStructure, const std::string_view& name, const ShapeType& tupleShape, collection_type strings, const std::optional<IdType>& parentId = {});
 
-  static StringArray* Import(DataStructure& dataStructure, const std::string_view& name, IdType importId, collection_type strings, const std::optional<IdType>& parentId = {});
+  static StringArray* Import(DataStructure& dataStructure, const std::string_view& name, const ShapeType& tupleShape, IdType importId, collection_type strings, const std::optional<IdType>& parentId = {});
 
   StringArray(const StringArray& other);
   StringArray(StringArray&& other) noexcept;
@@ -114,9 +114,9 @@ public:
 
 protected:
   StringArray(DataStructure& dataStructure, std::string name);
-  StringArray(DataStructure& dataStructure, std::string name, collection_type strings);
+  StringArray(DataStructure& dataStructure, std::string name, const ShapeType& tupleShape, collection_type strings);
   StringArray(DataStructure& dataStructure, std::string name, std::shared_ptr<store_type>& store);
-  StringArray(DataStructure& dataStructure, std::string name, IdType importId, collection_type strings);
+  StringArray(DataStructure& dataStructure, std::string name, const ShapeType& tupleShape, IdType importId, collection_type strings);
 
 private:
   std::shared_ptr<AbstractStringStore> m_Strings = nullptr;

--- a/src/simplnx/DataStructure/StringArray.hpp
+++ b/src/simplnx/DataStructure/StringArray.hpp
@@ -23,7 +23,8 @@ public:
   static StringArray* Create(DataStructure& dataStructure, const std::string_view& name, const std::optional<IdType>& parentId = {});
   static StringArray* CreateWithValues(DataStructure& dataStructure, const std::string_view& name, const ShapeType& tupleShape, collection_type strings, const std::optional<IdType>& parentId = {});
 
-  static StringArray* Import(DataStructure& dataStructure, const std::string_view& name, const ShapeType& tupleShape, IdType importId, collection_type strings, const std::optional<IdType>& parentId = {});
+  static StringArray* Import(DataStructure& dataStructure, const std::string_view& name, const ShapeType& tupleShape, IdType importId, collection_type strings,
+                             const std::optional<IdType>& parentId = {});
 
   StringArray(const StringArray& other);
   StringArray(StringArray&& other) noexcept;
@@ -108,7 +109,7 @@ public:
    * @param tupleShape The new shape of the data where the dimensions are "C" ordered
    * from *slowest* to *fastest*.
    */
-  void resizeTuples(const std::vector<usize>& tupleShape) override;
+  void resizeTuples(const ShapeType& tupleShape) override;
 
   void setStore(const std::shared_ptr<AbstractStringStore>& newStore);
 

--- a/src/simplnx/DataStructure/StringArray.hpp
+++ b/src/simplnx/DataStructure/StringArray.hpp
@@ -43,7 +43,7 @@ public:
   std::shared_ptr<DataObject> deepCopy(const DataPath& copyPath) override;
 
   size_t size() const override;
-  const collection_type values() const;
+  collection_type values() const;
 
   reference operator[](usize index);
   const_reference operator[](usize index) const;
@@ -105,20 +105,6 @@ public:
 
   /**
    * @brief This method sets the shape of the dimensions to `tupleShape`.
-   *
-   * There are 3 possibilities when using this function:
-   * [1] The number of tuples of the new shape is *LESS* than the original. In this
-   * case a memory allocation will take place and the first 'N' elements of data
-   * will be copied into the new array. The remaining data is *LOST*
-   *
-   * [2] The number of tuples of the new shape is *EQUAL* to the original. In this
-   * case the shape is set and the function returns.
-   *
-   * [3] The number of tuples of the new shape is *GREATER* than the original. In
-   * this case a new array is allocated and all the data from the original array
-   * is copied into the new array and the remaining elements are initialized to
-   * the default initialization value.
-   *
    * @param tupleShape The new shape of the data where the dimensions are "C" ordered
    * from *slowest* to *fastest*.
    */

--- a/src/simplnx/DataStructure/StringStore.cpp
+++ b/src/simplnx/DataStructure/StringStore.cpp
@@ -1,29 +1,52 @@
 #include "StringStore.hpp"
 
+#include <numeric>
+
 namespace nx::core
 {
-StringStore::StringStore(uint64 size)
+StringStore::StringStore(const ShapeType& tupleShape)
 : AbstractStringStore()
-, m_Data(size)
+, m_TupleShape(tupleShape.cbegin(), tupleShape.cend())
+, m_NumTuples(std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>()))
+, m_Data(m_NumTuples)
 {
 }
 
 StringStore::StringStore(std::vector<std::string> strings)
 : AbstractStringStore()
+, m_TupleShape(ShapeType{strings.size()})
+, m_NumTuples(strings.size())
 , m_Data(std::move(strings))
 {
 }
 
 StringStore::~StringStore() = default;
 
+usize StringStore::getNumberOfTuples() const
+{
+  return m_NumTuples;
+}
+
+const StringStore::ShapeType& StringStore::getTupleShape() const
+{
+  return m_TupleShape;
+}
+
+void StringStore::resizeTuples(const ShapeType& tupleShape)
+{
+  m_TupleShape = tupleShape;
+  m_NumTuples = std::accumulate(m_TupleShape.cbegin(), m_TupleShape.cend(), static_cast<size_t>(1), std::multiplies<>());
+  m_Data.resize(m_NumTuples);
+}
+
 usize StringStore::size() const
 {
-  return m_Data.size();
+  return m_NumTuples;
 }
 
 bool StringStore::empty() const
 {
-  return m_Data.size() == 0;
+  return m_NumTuples == 0;
 }
 
 StringStore::reference StringStore::operator[](usize index)
@@ -47,11 +70,6 @@ StringStore::const_reference StringStore::getValue(usize index) const
 void StringStore::setValue(usize index, const value_type& value)
 {
   m_Data.at(index) = value;
-}
-
-void StringStore::resize(usize count)
-{
-  m_Data.resize(count);
 }
 
 std::unique_ptr<AbstractStringStore> StringStore::deepCopy() const

--- a/src/simplnx/DataStructure/StringStore.cpp
+++ b/src/simplnx/DataStructure/StringStore.cpp
@@ -12,9 +12,9 @@ StringStore::StringStore(const ShapeType& tupleShape)
 {
 }
 
-StringStore::StringStore(std::vector<std::string> strings)
+StringStore::StringStore(std::vector<std::string> strings, const ShapeType& tupleShape)
 : AbstractStringStore()
-, m_TupleShape(ShapeType{strings.size()})
+, m_TupleShape(tupleShape.cbegin(), tupleShape.cend())
 , m_NumTuples(strings.size())
 , m_Data(std::move(strings))
 {
@@ -74,12 +74,13 @@ void StringStore::setValue(usize index, const value_type& value)
 
 std::unique_ptr<AbstractStringStore> StringStore::deepCopy() const
 {
-  return std::make_unique<StringStore>(m_Data);
+  return std::make_unique<StringStore>(m_Data, m_TupleShape);
 }
 
 AbstractStringStore& StringStore::operator=(const std::vector<std::string>& values)
 {
   m_Data = values;
+  m_TupleShape = ShapeType{values.size()};
   return *this;
 }
 } // namespace nx::core

--- a/src/simplnx/DataStructure/StringStore.cpp
+++ b/src/simplnx/DataStructure/StringStore.cpp
@@ -27,7 +27,7 @@ usize StringStore::getNumberOfTuples() const
   return m_NumTuples;
 }
 
-const StringStore::ShapeType& StringStore::getTupleShape() const
+const ShapeType& StringStore::getTupleShape() const
 {
   return m_TupleShape;
 }

--- a/src/simplnx/DataStructure/StringStore.hpp
+++ b/src/simplnx/DataStructure/StringStore.hpp
@@ -10,8 +10,6 @@ namespace nx::core
 class StringStore : public AbstractStringStore
 {
 public:
-  using ShapeType = typename std::vector<usize>;
-
   explicit StringStore(const ShapeType& tupleShape);
   explicit StringStore(std::vector<std::string> strings, const ShapeType& tupleShape);
   ~StringStore();

--- a/src/simplnx/DataStructure/StringStore.hpp
+++ b/src/simplnx/DataStructure/StringStore.hpp
@@ -10,15 +10,10 @@ namespace nx::core
 class StringStore : public AbstractStringStore
 {
 public:
-<<<<<<< refs/remotes/upstream/develop
-  StringStore(uint64 count = 0);
-  StringStore(std::vector<std::string> strings);
-=======
   using ShapeType = typename std::vector<usize>;
 
   explicit StringStore(const ShapeType& tupleShape);
-  explicit StringStore(const std::vector<std::string>& strings);
->>>>>>> Rework StringArray to work from multidimensional tuples
+  explicit StringStore(std::vector<std::string> strings, const ShapeType& tupleShape);
   ~StringStore();
 
   std::unique_ptr<AbstractStringStore> deepCopy() const override;

--- a/src/simplnx/DataStructure/StringStore.hpp
+++ b/src/simplnx/DataStructure/StringStore.hpp
@@ -10,15 +10,40 @@ namespace nx::core
 class StringStore : public AbstractStringStore
 {
 public:
+<<<<<<< refs/remotes/upstream/develop
   StringStore(uint64 count = 0);
   StringStore(std::vector<std::string> strings);
+=======
+  using ShapeType = typename std::vector<usize>;
+
+  explicit StringStore(const ShapeType& tupleShape);
+  explicit StringStore(const std::vector<std::string>& strings);
+>>>>>>> Rework StringArray to work from multidimensional tuples
   ~StringStore();
 
   std::unique_ptr<AbstractStringStore> deepCopy() const override;
 
+  /**
+   * @brief Returns the number of tuples in the ListStore.
+   * @return usize
+   */
+  usize getNumberOfTuples() const override;
+
+  /**
+   * @brief Returns the dimensions of the Tuples
+   * @return
+   */
+  const ShapeType& getTupleShape() const override;
+
+  /**
+   * @brief This method sets the shape of the dimensions to `tupleShape`.
+   * @param tupleShape The new shape of the data where the dimensions are "C" ordered
+   * from *slowest* to *fastest*.
+   */
+  void resizeTuples(const ShapeType& tupleShape) override;
+
   usize size() const override;
   bool empty() const override;
-  void resize(usize count) override;
 
   reference operator[](usize index) override;
   const_reference operator[](usize index) const override;
@@ -30,6 +55,8 @@ public:
   AbstractStringStore& operator=(const std::vector<std::string>& values) override;
 
 private:
+  ShapeType m_TupleShape;
+  ShapeType::value_type m_NumTuples;
   std::vector<std::string> m_Data;
 };
 } // namespace nx::core

--- a/src/simplnx/Filter/Actions/CopyArrayInstanceAction.cpp
+++ b/src/simplnx/Filter/Actions/CopyArrayInstanceAction.cpp
@@ -17,8 +17,8 @@ template <typename T>
 Result<> DoCopy(IDataArray* inputDataArray, DataStructure& dataStructure, DataPath&& path, IDataAction::Mode mode)
 {
   auto* castInputArray = dynamic_cast<DataArray<T>*>(inputDataArray);
-  IDataStore::ShapeType tupleShape = castInputArray->getDataStore()->getTupleShape();
-  IDataStore::ShapeType componentShape = castInputArray->getDataStore()->getComponentShape();
+  ShapeType tupleShape = castInputArray->getDataStore()->getTupleShape();
+  ShapeType componentShape = castInputArray->getDataStore()->getComponentShape();
   return ArrayCreationUtilities::CreateArray<T>(dataStructure, tupleShape, componentShape, path, mode);
 }
 } // namespace

--- a/src/simplnx/Filter/Actions/CreateArrayAction.hpp
+++ b/src/simplnx/Filter/Actions/CreateArrayAction.hpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/simplnx_export.hpp"
 
+#include "simplnx/Common/Aliases.hpp"
 #include "simplnx/Common/Types.hpp"
 #include "simplnx/DataStructure/DataPath.hpp"
 #include "simplnx/Filter/Output.hpp"
@@ -60,7 +61,7 @@ public:
    * @brief Returns the component dimensions of the DataArray to be created.
    * @return const std::vector<usize>&
    */
-  const std::vector<usize>& componentDims() const;
+  const ShapeType& componentDims() const;
 
   /**
    * @brief Returns the path of the DataArray to be created.

--- a/src/simplnx/Filter/Actions/CreateAttributeMatrixAction.cpp
+++ b/src/simplnx/Filter/Actions/CreateAttributeMatrixAction.cpp
@@ -8,7 +8,7 @@
 namespace nx::core
 {
 //------------------------------------------------------------------------------
-CreateAttributeMatrixAction::CreateAttributeMatrixAction(const DataPath& path, const AttributeMatrix::ShapeType& shape)
+CreateAttributeMatrixAction::CreateAttributeMatrixAction(const DataPath& path, const ShapeType& shape)
 : IDataCreationAction(path)
 , m_TupleShape(shape)
 {

--- a/src/simplnx/Filter/Actions/CreateAttributeMatrixAction.hpp
+++ b/src/simplnx/Filter/Actions/CreateAttributeMatrixAction.hpp
@@ -15,7 +15,7 @@ class SIMPLNX_EXPORT CreateAttributeMatrixAction : public IDataCreationAction
 public:
   CreateAttributeMatrixAction() = delete;
 
-  CreateAttributeMatrixAction(const DataPath& path, const AttributeMatrix::ShapeType& shape);
+  CreateAttributeMatrixAction(const DataPath& path, const ShapeType& shape);
 
   ~CreateAttributeMatrixAction() noexcept override;
 
@@ -45,6 +45,6 @@ public:
   std::vector<DataPath> getAllCreatedPaths() const override;
 
 private:
-  AttributeMatrix::ShapeType m_TupleShape;
+  ShapeType m_TupleShape;
 };
 } // namespace nx::core

--- a/src/simplnx/Filter/Actions/CreateNeighborListAction.cpp
+++ b/src/simplnx/Filter/Actions/CreateNeighborListAction.cpp
@@ -9,7 +9,7 @@ using namespace nx::core;
 
 namespace nx::core
 {
-CreateNeighborListAction::CreateNeighborListAction(DataType type, const INeighborList::ShapeType& tupleShape, const DataPath& path)
+CreateNeighborListAction::CreateNeighborListAction(DataType type, const ShapeType& tupleShape, const DataPath& path)
 : IDataCreationAction(path)
 , m_Type(type)
 , m_TupleShape(tupleShape.cbegin(), tupleShape.cend())
@@ -68,7 +68,7 @@ DataType CreateNeighborListAction::type() const
   return m_Type;
 }
 
-const INeighborList::ShapeType& CreateNeighborListAction::tupleShape() const
+const ShapeType& CreateNeighborListAction::tupleShape() const
 {
   return m_TupleShape;
 }

--- a/src/simplnx/Filter/Actions/CreateNeighborListAction.cpp
+++ b/src/simplnx/Filter/Actions/CreateNeighborListAction.cpp
@@ -9,10 +9,10 @@ using namespace nx::core;
 
 namespace nx::core
 {
-CreateNeighborListAction::CreateNeighborListAction(DataType type, usize tupleCount, const DataPath& path)
+CreateNeighborListAction::CreateNeighborListAction(DataType type, const INeighborList::ShapeType& tupleShape, const DataPath& path)
 : IDataCreationAction(path)
 , m_Type(type)
-, m_TupleCount(tupleCount)
+, m_TupleShape(tupleShape.cbegin(), tupleShape.cend())
 {
 }
 
@@ -24,34 +24,34 @@ Result<> CreateNeighborListAction::apply(DataStructure& dataStructure, Mode mode
   switch(m_Type)
   {
   case DataType::int8: {
-    return CreateNeighbors<int8>(dataStructure, m_TupleCount, getCreatedPath(), mode);
+    return CreateNeighbors<int8>(dataStructure, m_TupleShape, getCreatedPath(), mode);
   }
   case DataType::uint8: {
-    return CreateNeighbors<uint8>(dataStructure, m_TupleCount, getCreatedPath(), mode);
+    return CreateNeighbors<uint8>(dataStructure, m_TupleShape, getCreatedPath(), mode);
   }
   case DataType::int16: {
-    return CreateNeighbors<int16>(dataStructure, m_TupleCount, getCreatedPath(), mode);
+    return CreateNeighbors<int16>(dataStructure, m_TupleShape, getCreatedPath(), mode);
   }
   case DataType::uint16: {
-    return CreateNeighbors<uint16>(dataStructure, m_TupleCount, getCreatedPath(), mode);
+    return CreateNeighbors<uint16>(dataStructure, m_TupleShape, getCreatedPath(), mode);
   }
   case DataType::int32: {
-    return CreateNeighbors<int32>(dataStructure, m_TupleCount, getCreatedPath(), mode);
+    return CreateNeighbors<int32>(dataStructure, m_TupleShape, getCreatedPath(), mode);
   }
   case DataType::uint32: {
-    return CreateNeighbors<uint32>(dataStructure, m_TupleCount, getCreatedPath(), mode);
+    return CreateNeighbors<uint32>(dataStructure, m_TupleShape, getCreatedPath(), mode);
   }
   case DataType::int64: {
-    return CreateNeighbors<int64>(dataStructure, m_TupleCount, getCreatedPath(), mode);
+    return CreateNeighbors<int64>(dataStructure, m_TupleShape, getCreatedPath(), mode);
   }
   case DataType::uint64: {
-    return CreateNeighbors<uint64>(dataStructure, m_TupleCount, getCreatedPath(), mode);
+    return CreateNeighbors<uint64>(dataStructure, m_TupleShape, getCreatedPath(), mode);
   }
   case DataType::float32: {
-    return CreateNeighbors<float32>(dataStructure, m_TupleCount, getCreatedPath(), mode);
+    return CreateNeighbors<float32>(dataStructure, m_TupleShape, getCreatedPath(), mode);
   }
   case DataType::float64: {
-    return CreateNeighbors<float64>(dataStructure, m_TupleCount, getCreatedPath(), mode);
+    return CreateNeighbors<float64>(dataStructure, m_TupleShape, getCreatedPath(), mode);
   }
   default:
     throw std::runtime_error(fmt::format("CreateNeighborListAction: Invalid Numeric Type '{}'", to_underlying(m_Type)));
@@ -60,7 +60,7 @@ Result<> CreateNeighborListAction::apply(DataStructure& dataStructure, Mode mode
 
 IDataAction::UniquePointer CreateNeighborListAction::clone() const
 {
-  return std::make_unique<CreateNeighborListAction>(m_Type, m_TupleCount, getCreatedPath());
+  return std::make_unique<CreateNeighborListAction>(m_Type, m_TupleShape, getCreatedPath());
 }
 
 DataType CreateNeighborListAction::type() const
@@ -68,9 +68,9 @@ DataType CreateNeighborListAction::type() const
   return m_Type;
 }
 
-usize CreateNeighborListAction::tupleCount() const
+const INeighborList::ShapeType& CreateNeighborListAction::tupleShape() const
 {
-  return m_TupleCount;
+  return m_TupleShape;
 }
 
 DataPath CreateNeighborListAction::path() const

--- a/src/simplnx/Filter/Actions/CreateNeighborListAction.hpp
+++ b/src/simplnx/Filter/Actions/CreateNeighborListAction.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "simplnx/DataStructure/NeighborList.hpp"
 #include "simplnx/Filter/Output.hpp"
+
 #include "simplnx/simplnx_export.hpp"
 
 namespace nx::core
@@ -14,7 +16,7 @@ class SIMPLNX_EXPORT CreateNeighborListAction : public IDataCreationAction
 public:
   CreateNeighborListAction() = delete;
 
-  CreateNeighborListAction(DataType type, usize tupleCount, const DataPath& path);
+  CreateNeighborListAction(DataType type, const INeighborList::ShapeType& tupleShape, const DataPath& path);
 
   ~CreateNeighborListAction() noexcept override;
 
@@ -44,10 +46,10 @@ public:
   DataType type() const;
 
   /**
-   * @brief Returns the number of tuples for the NeighborList to be created.
+   * @brief Returns the shape of tuples for the NeighborList to be created.
    * @return usize
    */
-  usize tupleCount() const;
+  const INeighborList::ShapeType& tupleShape() const;
 
   /**
    * @brief Returns the path of the DataArray to be created.
@@ -63,6 +65,6 @@ public:
 
 private:
   DataType m_Type;
-  usize m_TupleCount;
+  INeighborList::ShapeType m_TupleShape;
 };
 } // namespace nx::core

--- a/src/simplnx/Filter/Actions/CreateNeighborListAction.hpp
+++ b/src/simplnx/Filter/Actions/CreateNeighborListAction.hpp
@@ -16,7 +16,7 @@ class SIMPLNX_EXPORT CreateNeighborListAction : public IDataCreationAction
 public:
   CreateNeighborListAction() = delete;
 
-  CreateNeighborListAction(DataType type, const INeighborList::ShapeType& tupleShape, const DataPath& path);
+  CreateNeighborListAction(DataType type, const ShapeType& tupleShape, const DataPath& path);
 
   ~CreateNeighborListAction() noexcept override;
 
@@ -49,7 +49,7 @@ public:
    * @brief Returns the shape of tuples for the NeighborList to be created.
    * @return usize
    */
-  const INeighborList::ShapeType& tupleShape() const;
+  const ShapeType& tupleShape() const;
 
   /**
    * @brief Returns the path of the DataArray to be created.
@@ -65,6 +65,6 @@ public:
 
 private:
   DataType m_Type;
-  INeighborList::ShapeType m_TupleShape;
+  ShapeType m_TupleShape;
 };
 } // namespace nx::core

--- a/src/simplnx/Filter/Actions/CreateStringArrayAction.cpp
+++ b/src/simplnx/Filter/Actions/CreateStringArrayAction.cpp
@@ -48,7 +48,7 @@ Result<> CreateStringArrayAction::apply(DataStructure& dataStructure, Mode mode)
   usize totalTuples = std::accumulate(m_Dims.cbegin(), m_Dims.cend(), static_cast<usize>(1), std::multiplies<>());
 
   std::vector<std::string> values(totalTuples, m_InitializeValue);
-  StringArray* array = StringArray::CreateWithValues(dataStructure, name, values, dataObjectId);
+  StringArray* array = StringArray::CreateWithValues(dataStructure, name, m_Dims, values, dataObjectId);
   if(array == nullptr)
   {
     if(parentObject != nullptr && parentObject->getDataObjectType() == DataObject::Type::AttributeMatrix)

--- a/src/simplnx/Filter/Actions/CreateVertexGeometryAction.hpp
+++ b/src/simplnx/Filter/Actions/CreateVertexGeometryAction.hpp
@@ -111,7 +111,7 @@ public:
     // Create the VertexGeom
     VertexGeom* vertexGeom = VertexGeom::Create(dataStructure, getCreatedPath().getTargetName(), dataStructure.getId(parentPath).value());
 
-    std::vector<usize> tupleShape = {m_NumVertices}; // We don't probably know how many Vertices there are but take what ever the developer sends us
+    ShapeType tupleShape = {m_NumVertices}; // We don't probably know how many Vertices there are but take what ever the developer sends us
 
     // Create the Vertex Array with a component size of 3
     if(m_ArrayHandlingType == ArrayHandlingType::Copy)
@@ -147,7 +147,7 @@ public:
     else
     {
       const DataPath vertexPath = getCreatedPath().createChildPath(m_SharedVertexListName);
-      const std::vector<usize> componentShape = {3};
+      const ShapeType componentShape = {3};
 
       Result<> result = ArrayCreationUtilities::CreateArray<float32>(dataStructure, tupleShape, componentShape, vertexPath, mode, m_CreatedDataStoreFormat);
       if(result.invalid())

--- a/src/simplnx/Parameters/ArraySelectionParameter.hpp
+++ b/src/simplnx/Parameters/ArraySelectionParameter.hpp
@@ -20,7 +20,7 @@ class SIMPLNX_EXPORT ArraySelectionParameter : public MutableDataParameter
 public:
   using ValueType = DataPath;
   using AllowedTypes = nx::core::DataTypeSetType;
-  using AllowedComponentShapes = std::vector<IArray::ShapeType>;
+  using AllowedComponentShapes = std::vector<ShapeType>;
 
   enum class DataLocation : uint8
   {

--- a/src/simplnx/Parameters/ArrayThresholdsParameter.hpp
+++ b/src/simplnx/Parameters/ArrayThresholdsParameter.hpp
@@ -14,7 +14,7 @@ class SIMPLNX_EXPORT ArrayThresholdsParameter : public MutableDataParameter
 {
 public:
   using ValueType = ArrayThresholdSet;
-  using AllowedComponentShapes = std::vector<IArray::ShapeType>;
+  using AllowedComponentShapes = std::vector<ShapeType>;
 
   ArrayThresholdsParameter() = delete;
   ArrayThresholdsParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, AllowedComponentShapes requiredComps = {});

--- a/src/simplnx/Parameters/MultiArraySelectionParameter.hpp
+++ b/src/simplnx/Parameters/MultiArraySelectionParameter.hpp
@@ -16,7 +16,7 @@ public:
   using ValueType = std::vector<DataPath>;
   using AllowedTypes = std::set<IArray::ArrayType>;
   using AllowedDataTypes = nx::core::DataTypeSetType;
-  using AllowedComponentShapes = std::vector<IArray::ShapeType>;
+  using AllowedComponentShapes = std::vector<ShapeType>;
 
   MultiArraySelectionParameter() = delete;
   MultiArraySelectionParameter(const std::string& name, const std::string& humanName, const std::string& helpText, const ValueType& defaultValue, const AllowedTypes& allowedTypes,

--- a/src/simplnx/Parameters/util/ReadCSVData.hpp
+++ b/src/simplnx/Parameters/util/ReadCSVData.hpp
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "simplnx/Common/Aliases.hpp"
 #include "simplnx/Common/Result.hpp"
 #include "simplnx/Common/StringLiteral.hpp"
 #include "simplnx/Common/TypeTraits.hpp"
@@ -387,7 +388,7 @@ public:
   std::vector<bool> skippedArrayMask;
   usize headersLine = 1;
   HeaderMode headerMode = HeaderMode::CUSTOM;
-  std::vector<usize> tupleDims = {1};
+  ShapeType tupleDims = {1};
   std::vector<char> delimiters = {};
   bool consecutiveDelimiters = false;
 };

--- a/src/simplnx/Utilities/ArrayCreationUtilities.hpp
+++ b/src/simplnx/Utilities/ArrayCreationUtilities.hpp
@@ -33,7 +33,7 @@ SIMPLNX_EXPORT bool CheckMemoryRequirement(DataStructure& dataStructure, uint64 
  * @return
  */
 template <class T>
-Result<> CreateArray(DataStructure& dataStructure, const std::vector<usize>& tupleShape, const std::vector<usize>& compShape, const DataPath& path, IDataAction::Mode mode, std::string dataFormat = "",
+Result<> CreateArray(DataStructure& dataStructure, const ShapeType& tupleShape, const ShapeType& compShape, const DataPath& path, IDataAction::Mode mode, std::string dataFormat = "",
                      std::string fillValue = "")
 {
   auto parentPath = path.getParent();

--- a/src/simplnx/Utilities/DataArrayUtilities.cpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.cpp
@@ -17,10 +17,10 @@ using namespace nx::core;
 namespace
 {
 template <class T>
-Result<> ReplaceArray(DataStructure& dataStructure, const DataPath& dataPath, const std::vector<usize>& tupleShape, IDataAction::Mode mode, const IDataArray& inputDataArray)
+Result<> ReplaceArray(DataStructure& dataStructure, const DataPath& dataPath, const ShapeType& tupleShape, IDataAction::Mode mode, const IDataArray& inputDataArray)
 {
   auto& castInputArray = dynamic_cast<const DataArray<T>&>(inputDataArray);
-  const IDataStore::ShapeType componentShape = castInputArray.getDataStoreRef().getComponentShape();
+  const ShapeType componentShape = castInputArray.getDataStoreRef().getComponentShape();
   dataStructure.removeData(dataPath);
   return ArrayCreationUtilities::CreateArray<T>(dataStructure, tupleShape, componentShape, dataPath, mode);
 }
@@ -41,7 +41,7 @@ struct InitializeNeighborListFunctor
 struct CreateDefaultValueDataArrayFunctor
 {
   template <typename T>
-  Result<IArray*> operator()(DataStructure& destDataStructure, const std::string& name, const std::vector<usize>& tupleShape, const std::vector<usize>& componentShape, const std::string& defaultValue,
+  Result<IArray*> operator()(DataStructure& destDataStructure, const std::string& name, const ShapeType& tupleShape, const ShapeType& componentShape, const std::string& defaultValue,
                              const std::optional<DataObject::IdType> parentId)
   {
     auto newDataArray = DataArray<T>::template CreateWithStore<DataStore<T>>(destDataStructure, name, tupleShape, componentShape, parentId);
@@ -61,7 +61,7 @@ struct CreateDefaultValueDataArrayFunctor
 struct CreateDefaultValueNeighborListFunctor
 {
   template <typename T>
-  Result<IArray*> operator()(DataStructure& destDataStructure, const std::string& name, const std::vector<usize>& tupleShape, const std::optional<DataObject::IdType> parentId)
+  Result<IArray*> operator()(DataStructure& destDataStructure, const std::string& name, const ShapeType& tupleShape, const std::optional<DataObject::IdType> parentId)
   {
     auto newNeighborList = NeighborList<T>::Create(destDataStructure, name, tupleShape, parentId);
     return {newNeighborList};
@@ -104,7 +104,7 @@ Result<> ConditionalReplaceValueInArray(const std::string& valueAsStr, DataObjec
 }
 
 //-----------------------------------------------------------------------------
-Result<> ResizeAndReplaceDataArray(DataStructure& dataStructure, const DataPath& dataPath, std::vector<usize>& tupleShape, IDataAction::Mode mode)
+Result<> ResizeAndReplaceDataArray(DataStructure& dataStructure, const DataPath& dataPath, ShapeType& tupleShape, IDataAction::Mode mode)
 {
   auto* inputDataArrayPtr = dataStructure.getDataAs<IDataArray>(dataPath);
 
@@ -237,8 +237,8 @@ bool ConvertIDataArray(const std::shared_ptr<IDataArray>& dataArray, const std::
   }
 }
 
-Result<IArray*> CreateDefaultValueArrayFromArray(DataStructure& destDataStructure, IArray* array, const std::string& newArrayName, const std::vector<usize>& tupleShape,
-                                                 const std::string& defaultValue, const std::optional<DataObject::IdType> parentId)
+Result<IArray*> CreateDefaultValueArrayFromArray(DataStructure& destDataStructure, IArray* array, const std::string& newArrayName, const ShapeType& tupleShape, const std::string& defaultValue,
+                                                 const std::optional<DataObject::IdType> parentId)
 {
   switch(array->getArrayType())
   {
@@ -309,7 +309,7 @@ void CreateDataArrayActions(const DataStructure& dataStructure, const AttributeM
   {
     const auto& srcArray = dataStructure.getDataRefAs<IDataArray>(dataPath);
     DataType dataType = srcArray.getDataType();
-    IDataStore::ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
+    ShapeType componentShape = srcArray.getIDataStoreRef().getComponentShape();
     DataPath dataArrayPath = reducedGeometryPathAttrMatPath.createChildPath(srcArray.getName());
     resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(dataType, sourceAttrMatPtr->getShape(), std::move(componentShape), dataArrayPath));
   }

--- a/src/simplnx/Utilities/DataArrayUtilities.cpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.cpp
@@ -63,8 +63,7 @@ struct CreateDefaultValueNeighborListFunctor
   template <typename T>
   Result<IArray*> operator()(DataStructure& destDataStructure, const std::string& name, const std::vector<usize>& tupleShape, const std::optional<DataObject::IdType> parentId)
   {
-    auto numTuples = std::accumulate(tupleShape.begin(), tupleShape.end(), static_cast<usize>(1), std::multiplies<>());
-    auto newNeighborList = NeighborList<T>::Create(destDataStructure, name, numTuples, parentId);
+    auto newNeighborList = NeighborList<T>::Create(destDataStructure, name, tupleShape, parentId);
     return {newNeighborList};
   }
 };

--- a/src/simplnx/Utilities/DataArrayUtilities.hpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.hpp
@@ -149,7 +149,7 @@ bool ConvertIDataArray(const std::shared_ptr<IDataArray>& dataArray, const std::
  * @return
  */
 template <class T>
-Result<> CreateNeighbors(DataStructure& dataStructure, usize numTuples, const DataPath& path, IDataAction::Mode mode)
+Result<> CreateNeighbors(DataStructure& dataStructure, const INeighborList::ShapeType& tupleShape, const DataPath& path, IDataAction::Mode mode)
 {
   static constexpr StringLiteral prefix = "CreateNeighborListAction: ";
   auto parentPath = path.getParent();
@@ -171,7 +171,7 @@ Result<> CreateNeighbors(DataStructure& dataStructure, usize numTuples, const Da
 
   std::string name = path[last];
 
-  auto neighborList = NeighborList<T>::Create(dataStructure, name, INeighborList::ShapeType{numTuples}, dataObjectId);
+  auto neighborList = NeighborList<T>::Create(dataStructure, name, tupleShape, dataObjectId);
   if(neighborList == nullptr)
   {
     return MakeErrorResult(-5802, fmt::format("{}Unable to create NeighborList at \"{}\"", prefix, path.toString()));

--- a/src/simplnx/Utilities/DataArrayUtilities.hpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.hpp
@@ -149,7 +149,7 @@ bool ConvertIDataArray(const std::shared_ptr<IDataArray>& dataArray, const std::
  * @return
  */
 template <class T>
-Result<> CreateNeighbors(DataStructure& dataStructure, const INeighborList::ShapeType& tupleShape, const DataPath& path, IDataAction::Mode mode)
+Result<> CreateNeighbors(DataStructure& dataStructure, const ShapeType& tupleShape, const DataPath& path, IDataAction::Mode mode)
 {
   static constexpr StringLiteral prefix = "CreateNeighborListAction: ";
   auto parentPath = path.getParent();
@@ -265,7 +265,7 @@ Result<> ImportFromBinaryFile(const std::filesystem::path& binaryFilePath, DataA
  * @return
  */
 template <typename T>
-DataArray<T>* ImportFromBinaryFile(const std::string& filename, const std::string& name, DataStructure& dataStructure, const std::vector<usize>& tupleShape, const std::vector<usize>& componentShape,
+DataArray<T>* ImportFromBinaryFile(const std::string& filename, const std::string& name, DataStructure& dataStructure, const ShapeType& tupleShape, const ShapeType& componentShape,
                                    DataObject::IdType parentId = {})
 {
   // std::cout << "  Reading file " << filename << std::endl;
@@ -332,7 +332,7 @@ Result<> DeepCopy(DataStructure& dataStructure, const DataPath& sourceDataPath, 
  * @param mode The mode: Preflight or Execute
  * @return
  */
-SIMPLNX_EXPORT Result<> ResizeAndReplaceDataArray(DataStructure& dataStructure, const DataPath& dataPath, std::vector<usize>& tupleShape, IDataAction::Mode mode);
+SIMPLNX_EXPORT Result<> ResizeAndReplaceDataArray(DataStructure& dataStructure, const DataPath& dataPath, ShapeType& tupleShape, IDataAction::Mode mode);
 
 /**
  * @brief This method will ensure that all the arrays are of the same type
@@ -513,7 +513,7 @@ inline void IncrementLikeOdometer(std::vector<usize>& idx, const std::vector<usi
  * can be converted to the proper type needed for the new array, and an error result is returned otherwise.
  * @return
  */
-SIMPLNX_EXPORT Result<IArray*> CreateDefaultValueArrayFromArray(DataStructure& destDataStructure, IArray* array, const std::string& newArrayName, const std::vector<usize>& tupleShape,
+SIMPLNX_EXPORT Result<IArray*> CreateDefaultValueArrayFromArray(DataStructure& destDataStructure, IArray* array, const std::string& newArrayName, const ShapeType& tupleShape,
                                                                 const std::string& defaultValue, const std::optional<DataObject::IdType> parentId = {});
 
 template <typename T>

--- a/src/simplnx/Utilities/DataArrayUtilities.hpp
+++ b/src/simplnx/Utilities/DataArrayUtilities.hpp
@@ -171,7 +171,7 @@ Result<> CreateNeighbors(DataStructure& dataStructure, usize numTuples, const Da
 
   std::string name = path[last];
 
-  auto neighborList = NeighborList<T>::Create(dataStructure, name, numTuples, dataObjectId);
+  auto neighborList = NeighborList<T>::Create(dataStructure, name, INeighborList::ShapeType{numTuples}, dataObjectId);
   if(neighborList == nullptr)
   {
     return MakeErrorResult(-5802, fmt::format("{}Unable to create NeighborList at \"{}\"", prefix, path.toString()));

--- a/src/simplnx/Utilities/DataStoreUtilities.hpp
+++ b/src/simplnx/Utilities/DataStoreUtilities.hpp
@@ -64,19 +64,19 @@ std::shared_ptr<AbstractDataStore<T>> CreateDataStore(const typename IDataStore:
 }
 
 template <class T>
-std::shared_ptr<AbstractListStore<T>> CreateListStore(usize tupleCount, IDataAction::Mode mode = IDataAction::Mode::Execute, std::string dataFormat = "")
+std::shared_ptr<AbstractListStore<T>> CreateListStore(const IListStore::ShapeType& tupleShape, IDataAction::Mode mode = IDataAction::Mode::Execute, std::string dataFormat = "")
 {
   switch(mode)
   {
   case IDataAction::Mode::Preflight: {
-    return std::make_unique<EmptyListStore<T>>(tupleCount);
+    return std::make_unique<EmptyListStore<T>>(tupleShape);
   }
   case IDataAction::Mode::Execute: {
-    uint64 dataSize = CalculateDataSize<T>({tupleCount}, {10});
+    uint64 dataSize = CalculateDataSize<T>(tupleShape, {10});
     TryForceLargeDataFormatFromPrefs(dataFormat);
     auto ioCollection = GetIOCollection();
     ioCollection->checkStoreDataFormat(dataSize, dataFormat);
-    return ioCollection->createListStoreWithType<T>(dataFormat, tupleCount);
+    return ioCollection->createListStoreWithType<T>(dataFormat, tupleShape);
   }
   default: {
     throw std::runtime_error("Invalid mode");

--- a/src/simplnx/Utilities/DataStoreUtilities.hpp
+++ b/src/simplnx/Utilities/DataStoreUtilities.hpp
@@ -26,7 +26,7 @@ SIMPLNX_EXPORT void TryForceLargeDataFormatFromPrefs(std::string& dataFormat);
 SIMPLNX_EXPORT std::shared_ptr<DataIOCollection> GetIOCollection();
 
 template <class T>
-uint64 CalculateDataSize(const IDataStore::ShapeType& tupleShape, const IDataStore::ShapeType& componentShape)
+uint64 CalculateDataSize(const ShapeType& tupleShape, const ShapeType& componentShape)
 {
   uint64 numValues = std::accumulate(tupleShape.begin(), tupleShape.end(), 1ULL, std::multiplies<>());
   uint64 numComponents = std::accumulate(componentShape.begin(), componentShape.end(), 1ULL, std::multiplies<>());
@@ -42,8 +42,7 @@ uint64 CalculateDataSize(const IDataStore::ShapeType& tupleShape, const IDataSto
  * @return
  */
 template <class T>
-std::shared_ptr<AbstractDataStore<T>> CreateDataStore(const typename IDataStore::ShapeType& tupleShape, const typename IDataStore::ShapeType& componentShape, IDataAction::Mode mode,
-                                                      std::string dataFormat = "")
+std::shared_ptr<AbstractDataStore<T>> CreateDataStore(const ShapeType& tupleShape, const ShapeType& componentShape, IDataAction::Mode mode, std::string dataFormat = "")
 {
   switch(mode)
   {
@@ -64,7 +63,7 @@ std::shared_ptr<AbstractDataStore<T>> CreateDataStore(const typename IDataStore:
 }
 
 template <class T>
-std::shared_ptr<AbstractListStore<T>> CreateListStore(const IListStore::ShapeType& tupleShape, IDataAction::Mode mode = IDataAction::Mode::Execute, std::string dataFormat = "")
+std::shared_ptr<AbstractListStore<T>> CreateListStore(const ShapeType& tupleShape, IDataAction::Mode mode = IDataAction::Mode::Execute, std::string dataFormat = "")
 {
   switch(mode)
   {

--- a/src/simplnx/Utilities/FileUtilities.cpp
+++ b/src/simplnx/Utilities/FileUtilities.cpp
@@ -428,7 +428,7 @@ Result<> ParseLine(std::fstream& inStream, const ParsersVector& dataParsers, con
   return {};
 }
 
-std::string TupleDimsToString(const std::vector<usize>& tupleDims)
+std::string TupleDimsToString(const ShapeType& tupleDims)
 {
   std::string tupleDimsStr;
   for(usize i = 0; i < tupleDims.size(); ++i)

--- a/src/simplnx/Utilities/FileUtilities.hpp
+++ b/src/simplnx/Utilities/FileUtilities.hpp
@@ -200,7 +200,7 @@ SIMPLNX_EXPORT Result<> ParseLine(std::fstream& inStream, const ParsersVector& d
  * @param tupleDims
  * @return
  */
-SIMPLNX_EXPORT std::string TupleDimsToString(const std::vector<usize>& tupleDims);
+SIMPLNX_EXPORT std::string TupleDimsToString(const ShapeType& tupleDims);
 
 /**
  *

--- a/src/simplnx/Utilities/GeometryUtilities.hpp
+++ b/src/simplnx/Utilities/GeometryUtilities.hpp
@@ -185,7 +185,7 @@ Result<> EliminateDuplicateNodes(GeometryType& geom, std::optional<float32> scal
   }
 
   // Create array to hold unique node numbers
-  Int64DataStore uniqueIds(IDataStore::ShapeType{nNodes}, IDataStore::ShapeType{1}, {});
+  Int64DataStore uniqueIds(ShapeType{nNodes}, ShapeType{1}, {});
   for(IGeometry::MeshIndexType i = 0; i < nNodesAll; i++)
   {
     uniqueIds[i] = static_cast<int64>(i);

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -1,5 +1,6 @@
 #include "Dream3dIO.hpp"
 
+#include "simplnx/Common/Aliases.hpp"
 #include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
@@ -1286,12 +1287,12 @@ Result<> readLegacyAttributeMatrix(DataStructure& dataStructure, const nx::core:
   DataObject::IdType parentId = parent.getId();
   const std::string amName = amGroupReader.getName();
 
-  auto tDimsResult = amGroupReader.readVectorAttribute<uint64>("TupleDimensions");
+  auto tDimsResult = amGroupReader.readVectorAttribute<usize>("TupleDimensions");
   if(tDimsResult.invalid())
   {
     return ConvertResult(std::move(tDimsResult));
   }
-  std::vector<uint64> tDims = std::move(tDimsResult.value());
+  ShapeType tDims = std::move(tDimsResult.value());
   auto reversedTDims = ShapeType(tDims.crbegin(), tDims.crend());
 
   auto* attributeMatrix = AttributeMatrix::Create(dataStructure, amName, reversedTDims, parentId);

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -483,7 +483,7 @@ std::string GetXdmfArrayType(usize numComp)
 void WriteXdmfAttributeDataHelper(std::ostream& out, usize numComp, std::string_view attrType, std::string_view dataContainerName, const IDataArray& array, std::string_view centering, usize precision,
                                   std::string_view xdmfTypeName, std::string_view hdf5FilePath)
 {
-  IDataStore::ShapeType tupleDims = array.getTupleShape();
+  ShapeType tupleDims = array.getTupleShape();
 
   std::string tupleStr = fmt::format("{}", fmt::join(tupleDims.crbegin(), tupleDims.crend(), " "));
 
@@ -865,8 +865,8 @@ Result<> readLegacyStringArray(DataStructure& dataStructure, const nx::core::HDF
 
   if(preflight)
   {
-    std::vector<usize> tDims;
-    std::vector<usize> cDims;
+    ShapeType tDims;
+    ShapeType cDims;
     auto result = readLegacyDataArrayDims(dataArrayReader, tDims, cDims);
     if(result.invalid())
     {
@@ -881,7 +881,7 @@ Result<> readLegacyStringArray(DataStructure& dataStructure, const nx::core::HDF
   else
   {
     const std::vector<std::string> strings = dataArrayReader.readAsVectorOfStrings();
-    StringArray::CreateWithValues(dataStructure, daName, StringArray::ShapeType{strings.size()}, strings, parentId);
+    StringArray::CreateWithValues(dataStructure, daName, ShapeType{strings.size()}, strings, parentId);
   }
   return {};
 }
@@ -895,10 +895,10 @@ Result<> finishImportingLegacyStringArray(DataStructure& dataStructure, const nx
   }
 
   const std::vector<std::string> strings = dataArrayReader.readAsVectorOfStrings();
-  StringArray::ShapeType tupShape = existingArray->getTupleShape();
+  ShapeType tupShape = existingArray->getTupleShape();
   if(existingArray->getNumberOfTuples() != strings.size())
   {
-    tupShape = StringArray::ShapeType{strings.size()};
+    tupShape = ShapeType{strings.size()};
   }
 
   existingArray->setStore(std::make_shared<StringStore>(strings, tupShape));
@@ -916,8 +916,8 @@ Result<IDataArray*> readLegacyDataArray(DataStructure& dataStructure, const nx::
   }
   auto dataType = std::move(dataTypeResult.value());
 
-  std::vector<usize> tDims;
-  std::vector<usize> cDims;
+  ShapeType tDims;
+  ShapeType cDims;
   Result<> dimsResult = readLegacyDataArrayDims(dataArrayReader, tDims, cDims);
   if(dimsResult.invalid())
   {
@@ -1072,8 +1072,8 @@ Result<UInt64Array*> readLegacyNodeConnectivityList(DataStructure& dataStructure
   HDF5::DatasetIO dataArrayReader = geomGroup.openDataset(arrayName);
   DataObject::IdType parentId = geometry->getId();
 
-  std::vector<usize> tDims;
-  std::vector<usize> cDims;
+  ShapeType tDims;
+  ShapeType cDims;
   Result<> result = readLegacyDataArrayDims(dataArrayReader, tDims, cDims);
   if(result.invalid())
   {
@@ -1094,7 +1094,7 @@ Result<UInt64Array*> readLegacyNodeConnectivityList(DataStructure& dataStructure
 
 template <typename T>
 Result<> createLegacyNeighborList(DataStructure& dataStructure, DataObject ::IdType parentId, const nx::core::HDF5::GroupIO& parentReader, const nx::core::HDF5::DatasetIO& datasetReader,
-                                  const std::vector<usize>& tupleDims)
+                                  const ShapeType& tupleDims)
 {
   auto listStore = HDF5::NeighborListIO<T>::ReadHdf5Data(parentReader, datasetReader);
   auto* neighborList = NeighborList<T>::Create(dataStructure, datasetReader.getName(), listStore, parentId);
@@ -1115,7 +1115,7 @@ Result<> readLegacyNeighborList(DataStructure& dataStructure, const nx::core::HD
   }
   auto dataType = dataTypeResult.value();
 
-  std::vector<usize> tDims;
+  ShapeType tDims;
   auto tDimsResult = datasetReader.readVectorAttribute<usize>(Legacy::TupleDims);
   tDims = std::move(tDimsResult.value());
 
@@ -1292,7 +1292,7 @@ Result<> readLegacyAttributeMatrix(DataStructure& dataStructure, const nx::core:
     return ConvertResult(std::move(tDimsResult));
   }
   std::vector<uint64> tDims = std::move(tDimsResult.value());
-  auto reversedTDims = AttributeMatrix::ShapeType(tDims.crbegin(), tDims.crend());
+  auto reversedTDims = ShapeType(tDims.crbegin(), tDims.crend());
 
   auto* attributeMatrix = AttributeMatrix::Create(dataStructure, amName, reversedTDims, parentId);
 

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -876,12 +876,12 @@ Result<> readLegacyStringArray(DataStructure& dataStructure, const nx::core::HDF
     auto numElements =
         std::accumulate(tDims.cbegin(), tDims.cend(), static_cast<usize>(1), std::multiplies<>()) * std::accumulate(cDims.cbegin(), cDims.cend(), static_cast<usize>(1), std::multiplies<>());
     const std::vector<std::string> strings(numElements);
-    StringArray::CreateWithValues(dataStructure, daName, strings, parentId);
+    StringArray::CreateWithValues(dataStructure, daName, tDims, strings, parentId);
   }
   else
   {
     const std::vector<std::string> strings = dataArrayReader.readAsVectorOfStrings();
-    StringArray::CreateWithValues(dataStructure, daName, strings, parentId);
+    StringArray::CreateWithValues(dataStructure, daName, StringArray::ShapeType{strings.size()}, strings, parentId);
   }
   return {};
 }
@@ -895,7 +895,14 @@ Result<> finishImportingLegacyStringArray(DataStructure& dataStructure, const nx
   }
 
   const std::vector<std::string> strings = dataArrayReader.readAsVectorOfStrings();
-  existingArray->setStore(std::make_shared<StringStore>(strings));
+  StringArray::ShapeType tupShape = existingArray->getTupleShape();
+  if(existingArray->getNumberOfTuples() != strings.size())
+  {
+    tupShape = StringArray::ShapeType{strings.size()};
+  }
+
+  existingArray->setStore(std::make_shared<StringStore>(strings, tupShape));
+
   return {};
 }
 

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
@@ -463,8 +463,6 @@ std::vector<std::string> DatasetIO::readAsVectorOfStrings() const
 template <typename T>
 std::shared_ptr<AbstractDataStore<T>> DatasetIO::readAsDataStore() const
 {
-  using ShapeType = typename IDataStore::ShapeType;
-
   auto dataset = open();
   size_t numElements = getNumElements();
 
@@ -477,10 +475,8 @@ std::shared_ptr<AbstractDataStore<T>> DatasetIO::readAsDataStore() const
 }
 
 template <typename T>
-std::shared_ptr<AbstractDataStore<T>> DatasetIO::readAsDataStore(const IDataStore::ShapeType& tupleShape, const IDataStore::ShapeType& componentShape) const
+std::shared_ptr<AbstractDataStore<T>> DatasetIO::readAsDataStore(const ShapeType& tupleShape, const ShapeType& componentShape) const
 {
-  using ShapeType = typename IDataStore::ShapeType;
-
   auto dataset = open();
   size_t numElements = getNumElements();
 
@@ -1471,20 +1467,20 @@ template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<bool>> DatasetIO::read
 template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataStore<float>() const;
 template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<double>> DatasetIO::readAsDataStore<double>() const;
 
-template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int8_t>> DatasetIO::readAsDataStore<int8_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int16_t>> DatasetIO::readAsDataStore<int16_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int32_t>> DatasetIO::readAsDataStore<int32_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int64_t>> DatasetIO::readAsDataStore<int64_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint8_t>> DatasetIO::readAsDataStore<uint8_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint16_t>> DatasetIO::readAsDataStore<uint16_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint32_t>> DatasetIO::readAsDataStore<uint32_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint64_t>> DatasetIO::readAsDataStore<uint64_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int8_t>> DatasetIO::readAsDataStore<int8_t>(const ShapeType&, const ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int16_t>> DatasetIO::readAsDataStore<int16_t>(const ShapeType&, const ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int32_t>> DatasetIO::readAsDataStore<int32_t>(const ShapeType&, const ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<int64_t>> DatasetIO::readAsDataStore<int64_t>(const ShapeType&, const ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint8_t>> DatasetIO::readAsDataStore<uint8_t>(const ShapeType&, const ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint16_t>> DatasetIO::readAsDataStore<uint16_t>(const ShapeType&, const ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint32_t>> DatasetIO::readAsDataStore<uint32_t>(const ShapeType&, const ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<uint64_t>> DatasetIO::readAsDataStore<uint64_t>(const ShapeType&, const ShapeType&) const;
 #ifdef __APPLE__
-// template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<size_t>> DatasetIO::readAsDataStore<size_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+// template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<size_t>> DatasetIO::readAsDataStore<size_t>(const ShapeType&, const ShapeType&) const;
 #endif
-template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<bool>> DatasetIO::readAsDataStore<bool>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataStore<float>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<double>> DatasetIO::readAsDataStore<double>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<bool>> DatasetIO::readAsDataStore<bool>(const ShapeType&, const ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataStore<float>(const ShapeType&, const ShapeType&) const;
+template SIMPLNX_EXPORT std::shared_ptr<AbstractDataStore<double>> DatasetIO::readAsDataStore<double>(const ShapeType&, const ShapeType&) const;
 
 template SIMPLNX_EXPORT Result<> DatasetIO::readIntoSpan<int8_t>(nonstd::span<int8_t>) const;
 template SIMPLNX_EXPORT Result<> DatasetIO::readIntoSpan<int16_t>(nonstd::span<int16_t>) const;

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp
@@ -132,7 +132,7 @@ public:
    * @return std::shared_ptr<AbstractDataStore<T>>
    */
   template <typename T>
-  std::shared_ptr<AbstractDataStore<T>> readAsDataStore(const IDataStore::ShapeType& tupleDims, const IDataStore::ShapeType& componentDims) const;
+  std::shared_ptr<AbstractDataStore<T>> readAsDataStore(const ShapeType& tupleDims, const ShapeType& componentDims) const;
 
   /**
    * @brief Reads the dataset into the given span. Requires the span to be the
@@ -539,20 +539,20 @@ extern template std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataS
 extern template std::shared_ptr<AbstractDataStore<double>> DatasetIO::readAsDataStore<double>() const;
 extern template std::shared_ptr<AbstractDataStore<bool>> DatasetIO::readAsDataStore<bool>() const;
 
-extern template std::shared_ptr<AbstractDataStore<int8_t>> DatasetIO::readAsDataStore<int8_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-extern template std::shared_ptr<AbstractDataStore<int16_t>> DatasetIO::readAsDataStore<int16_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-extern template std::shared_ptr<AbstractDataStore<int32_t>> DatasetIO::readAsDataStore<int32_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-extern template std::shared_ptr<AbstractDataStore<int64_t>> DatasetIO::readAsDataStore<int64_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-extern template std::shared_ptr<AbstractDataStore<uint8_t>> DatasetIO::readAsDataStore<uint8_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-extern template std::shared_ptr<AbstractDataStore<uint16_t>> DatasetIO::readAsDataStore<uint16_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-extern template std::shared_ptr<AbstractDataStore<uint32_t>> DatasetIO::readAsDataStore<uint32_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-extern template std::shared_ptr<AbstractDataStore<uint64_t>> DatasetIO::readAsDataStore<uint64_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<int8_t>> DatasetIO::readAsDataStore<int8_t>(const ShapeType&, const ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<int16_t>> DatasetIO::readAsDataStore<int16_t>(const ShapeType&, const ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<int32_t>> DatasetIO::readAsDataStore<int32_t>(const ShapeType&, const ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<int64_t>> DatasetIO::readAsDataStore<int64_t>(const ShapeType&, const ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<uint8_t>> DatasetIO::readAsDataStore<uint8_t>(const ShapeType&, const ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<uint16_t>> DatasetIO::readAsDataStore<uint16_t>(const ShapeType&, const ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<uint32_t>> DatasetIO::readAsDataStore<uint32_t>(const ShapeType&, const ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<uint64_t>> DatasetIO::readAsDataStore<uint64_t>(const ShapeType&, const ShapeType&) const;
 #ifdef __APPLE__
-// extern template std::shared_ptr<AbstractDataStore<size_t>> DatasetIO::readAsDataStore<size_t>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+// extern template std::shared_ptr<AbstractDataStore<size_t>> DatasetIO::readAsDataStore<size_t>(const ShapeType&, const ShapeType&) const;
 #endif
-extern template std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataStore<float>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-extern template std::shared_ptr<AbstractDataStore<double>> DatasetIO::readAsDataStore<double>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
-extern template std::shared_ptr<AbstractDataStore<bool>> DatasetIO::readAsDataStore<bool>(const IDataStore::ShapeType&, const IDataStore::ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<float>> DatasetIO::readAsDataStore<float>(const ShapeType&, const ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<double>> DatasetIO::readAsDataStore<double>(const ShapeType&, const ShapeType&) const;
+extern template std::shared_ptr<AbstractDataStore<bool>> DatasetIO::readAsDataStore<bool>(const ShapeType&, const ShapeType&) const;
 
 extern template nx::core::Result<> DatasetIO::readIntoSpan<int8_t>(nonstd::span<int8_t>) const;
 extern template nx::core::Result<> DatasetIO::readIntoSpan<int16_t>(nonstd::span<int16_t>) const;

--- a/test/DataArrayTest.cpp
+++ b/test/DataArrayTest.cpp
@@ -50,7 +50,7 @@ TEST_CASE("DataArrayCreation")
   nx::core::DataStructure dataStructure;
 
   using DataStoreType = nx::core::DataStore<int32_t>;
-  DataStoreType data_array = DataStoreType(nx::core::IDataStore::ShapeType{0}, nx::core::IDataStore::ShapeType{2}, 0);
+  DataStoreType data_array = DataStoreType(nx::core::ShapeType{0}, nx::core::ShapeType{2}, 0);
   size_t numTuples = data_array.getNumberOfTuples();
   REQUIRE(numTuples == 0);
 
@@ -67,8 +67,8 @@ TEST_CASE("nx::core::DataArray Copy TupleTest", "[simplnx][DataArray]")
   const usize k_NumComponents = 3;
 
   DataStructure dataStructure;
-  IDataStore::ShapeType tupleShape{k_NumTuples};
-  IDataStore::ShapeType componentShape{k_NumComponents};
+  ShapeType tupleShape{k_NumTuples};
+  ShapeType componentShape{k_NumComponents};
   Result<> result = ArrayCreationUtilities::CreateArray<int32>(dataStructure, tupleShape, componentShape, k_DataPath, IDataAction::Mode::Execute);
   REQUIRE(result.valid() == true);
 
@@ -103,8 +103,8 @@ TEST_CASE("nx::core::DataArray Copy TupleTest", "[simplnx][DataArray]")
 
 TEST_CASE("DataStore Test")
 {
-  IDataStore::ShapeType tupleShape{5};
-  IDataStore::ShapeType componentShape{3};
+  ShapeType tupleShape{5};
+  ShapeType componentShape{3};
   DataStore<int32> dataStore(tupleShape, componentShape, 5);
 
   REQUIRE(dataStore.getSize() == 15);
@@ -138,8 +138,8 @@ TEST_CASE("DataStore Test")
 
 TEST_CASE("Copy DataStore", "DataArray")
 {
-  IDataStore::ShapeType tupleShape{5};
-  IDataStore::ShapeType componentShape{3};
+  ShapeType tupleShape{5};
+  ShapeType componentShape{3};
   DataStore<int32> dataStore(tupleShape, componentShape, 5);
   usize size = dataStore.getSize();
   for(usize i = 0; i < size; i++)

--- a/test/DataStructTest.cpp
+++ b/test/DataStructTest.cpp
@@ -107,8 +107,7 @@ DataStructure createTestDataStructure()
     const DataGroup* levelOneGroup = DataGroup::Create(dataStruct, Constants::k_LevelOne, imageGeom->getId());
 
     const DataGroup* levelTwoGroup = DataGroup::Create(dataStruct, Constants::k_LevelTwo, levelOneGroup->getId());
-    auto* neighborList = NeighborList<int16>::Create(dataStruct, Constants::k_Int16DataSet, 3, levelOneGroup->getId());
-    neighborList->resizeTotalElements(3);
+    auto* neighborList = NeighborList<int16>::Create(dataStruct, Constants::k_Int16DataSet, IListStore::ShapeType{3}, levelOneGroup->getId());
     std::vector<int16> list1 = {117, 875, 1035, 3905, 4214};
     std::vector<int16> list2 = {750, 1905, 1912, 2015, 2586, 3180, 3592, 4041, 4772};
     std::vector<int16> list3 = {309, 775, 2625, 2818, 3061, 3751, 4235, 4817};

--- a/test/DataStructTest.cpp
+++ b/test/DataStructTest.cpp
@@ -107,7 +107,7 @@ DataStructure createTestDataStructure()
     const DataGroup* levelOneGroup = DataGroup::Create(dataStruct, Constants::k_LevelOne, imageGeom->getId());
 
     const DataGroup* levelTwoGroup = DataGroup::Create(dataStruct, Constants::k_LevelTwo, levelOneGroup->getId());
-    auto* neighborList = NeighborList<int16>::Create(dataStruct, Constants::k_Int16DataSet, IListStore::ShapeType{3}, levelOneGroup->getId());
+    auto* neighborList = NeighborList<int16>::Create(dataStruct, Constants::k_Int16DataSet, ShapeType{3}, levelOneGroup->getId());
     std::vector<int16> list1 = {117, 875, 1035, 3905, 4214};
     std::vector<int16> list2 = {750, 1905, 1912, 2015, 2586, 3180, 3592, 4041, 4772};
     std::vector<int16> list3 = {309, 775, 2625, 2818, 3061, 3751, 4235, 4817};

--- a/test/DataStructTest.cpp
+++ b/test/DataStructTest.cpp
@@ -198,7 +198,7 @@ DataStructure createTestDataStructure()
     std::vector<usize> vertTupleShape = {4};
     AttributeMatrix* vertAttMatrix = AttributeMatrix::Create(dataStruct, Constants::k_VertexDataGroupName, vertTupleShape, vertexGeom->getId());
     vertexGeom->setVertexAttributeMatrix(*vertAttMatrix);
-    StringArray* testStringArray = StringArray::CreateWithValues(dataStruct, k_StringArray, {"stringone", "stringtwo", "stringthree", "stringfour"}, vertAttMatrix->getId());
+    StringArray* testStringArray = StringArray::CreateWithValues(dataStruct, k_StringArray, vertAttMatrix->getShape(), {"stringone", "stringtwo", "stringthree", "stringfour"}, vertAttMatrix->getId());
     Float32Array* vertListArray = UnitTest::CreateTestDataArray<float32>(dataStruct, Constants::k_Float32DataSet, vertTupleShape, {3}, vertexGeom->getId());
     (*vertListArray)[0] = 0;
     (*vertListArray)[1] = 0;

--- a/test/H5Test.cpp
+++ b/test/H5Test.cpp
@@ -419,10 +419,11 @@ void CreateHexahedralGeometry(DataStructure& dataStructure)
 void CreateNeighborList(DataStructure& dataStructure)
 {
   const usize numItems = 50;
+  const std::vector<usize> tupleShape = {numItems};
 
   auto* neighborGroup = DataGroup::Create(dataStructure, k_NeighborGroupName);
   auto* neighborGroup2 = DataGroup::Create(dataStructure, k_NeighborGroupName + "2");
-  auto* neighborList = NeighborList<int64>::Create(dataStructure, "NeighborList", numItems, neighborGroup->getId());
+  auto* neighborList = NeighborList<int64>::Create(dataStructure, "NeighborList", tupleShape, neighborGroup->getId());
   for(usize i = 0; i < numItems; i++)
   {
     for(usize j = 0; j < i + 1; j++)

--- a/test/H5Test.cpp
+++ b/test/H5Test.cpp
@@ -104,8 +104,7 @@ DataStructure GetTestDataStructure()
 }
 
 template <typename T>
-DataArray<T>* CreateTestDataArray(const std::string& name, DataStructure& dataStructure, typename DataStore<T>::ShapeType tupleShape, typename DataStore<T>::ShapeType componentShape,
-                                  DataObject::IdType parentId)
+DataArray<T>* CreateTestDataArray(const std::string& name, DataStructure& dataStructure, ShapeType tupleShape, ShapeType componentShape, DataObject::IdType parentId)
 {
   using DataStoreType = DataStore<T>;
   using ArrayType = DataArray<T>;
@@ -132,7 +131,7 @@ DataStructure CreateDataStructure()
   // Create some DataArrays; The DataStructure keeps a shared_ptr<> to the DataArray so DO NOT put
   // it into another shared_ptr<>
   usize numComponents = 1;
-  std::vector<usize> tupleShape = {imageGeomDims[0], imageGeomDims[1], imageGeomDims[2]};
+  ShapeType tupleShape = {imageGeomDims[0], imageGeomDims[1], imageGeomDims[2]};
 
   Float32Array* ci_data = CreateTestDataArray<float>("Confidence Index", dataStructure, tupleShape, {numComponents}, scanData->getId());
   Int32Array* feature_ids_data = CreateTestDataArray<int32>("FeatureIds", dataStructure, tupleShape, {numComponents}, scanData->getId());
@@ -193,7 +192,7 @@ void CreateVertexGeometry(DataStructure& dataStructure)
   REQUIRE(vertexGeometry->getNumberOfVertices() == 144);
 
   // Now create some "Cell" data for the Vertex Geometry
-  std::vector<usize> tupleShape = {vertexGeometry->getNumberOfVertices()};
+  ShapeType tupleShape = {vertexGeometry->getNumberOfVertices()};
   usize numComponents = 1;
   Int16Array* ci_data = CreateTestDataArray<int16_t>("Area", dataStructure, tupleShape, {numComponents}, geometryGroup->getId());
   Float32Array* power_data = CreateTestDataArray<float>("Power", dataStructure, tupleShape, {numComponents}, geometryGroup->getId());
@@ -419,7 +418,7 @@ void CreateHexahedralGeometry(DataStructure& dataStructure)
 void CreateNeighborList(DataStructure& dataStructure)
 {
   const usize numItems = 50;
-  const std::vector<usize> tupleShape = {numItems};
+  const ShapeType tupleShape = {numItems};
 
   auto* neighborGroup = DataGroup::Create(dataStructure, k_NeighborGroupName);
   auto* neighborGroup2 = DataGroup::Create(dataStructure, k_NeighborGroupName + "2");
@@ -436,8 +435,8 @@ void CreateNeighborList(DataStructure& dataStructure)
 
 void CreateArrayTypes(DataStructure& dataStructure)
 {
-  const std::vector<usize> tupleShape = {2};
-  const std::vector<usize> componentShape = {1};
+  const ShapeType tupleShape = {2};
+  const ShapeType componentShape = {1};
 
   auto* boolArray = DataArray<bool>::CreateWithStore<DataStore<bool>>(dataStructure, "BoolArray", tupleShape, componentShape);
   AbstractDataStore<bool>& boolStore = boolArray->getDataStoreRef();
@@ -457,7 +456,7 @@ void CreateArrayTypes(DataStructure& dataStructure)
   DataArray<float32>::CreateWithStore<DataStore<float32>>(dataStructure, "Float32Array", tupleShape, componentShape);
   DataArray<float64>::CreateWithStore<DataStore<float64>>(dataStructure, "Float64Array", tupleShape, componentShape);
 
-  StringArray::CreateWithValues(dataStructure, "StringArray", StringArray::ShapeType{3}, {"Foo", "Bar", "Bazz"});
+  StringArray::CreateWithValues(dataStructure, "StringArray", ShapeType{3}, {"Foo", "Bar", "Bazz"});
 }
 
 //------------------------------------------------------------------------------
@@ -903,7 +902,7 @@ TEST_CASE("xdmf")
   std::mt19937 generator(randomDevice());
   std::uniform_int_distribution<> intDistribution(0, 100);
   std::uniform_real_distribution<> realDistribution(-10.0f, 10.0f);
-  auto vertsDataStore = std::make_unique<DataStore<float32>>(IDataStore::ShapeType{numVerts}, IDataStore::ShapeType{3}, 0.0f);
+  auto vertsDataStore = std::make_unique<DataStore<float32>>(ShapeType{numVerts}, ShapeType{3}, 0.0f);
   for(auto& item : vertsDataStore->createSpan())
   {
     item = realDistribution(generator);

--- a/test/H5Test.cpp
+++ b/test/H5Test.cpp
@@ -457,7 +457,7 @@ void CreateArrayTypes(DataStructure& dataStructure)
   DataArray<float32>::CreateWithStore<DataStore<float32>>(dataStructure, "Float32Array", tupleShape, componentShape);
   DataArray<float64>::CreateWithStore<DataStore<float64>>(dataStructure, "Float64Array", tupleShape, componentShape);
 
-  StringArray::CreateWithValues(dataStructure, "StringArray", {"Foo", "Bar", "Bazz"});
+  StringArray::CreateWithValues(dataStructure, "StringArray", StringArray::ShapeType{3}, {"Foo", "Bar", "Bazz"});
 }
 
 //------------------------------------------------------------------------------

--- a/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.hpp
+++ b/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.hpp
@@ -895,8 +895,7 @@ void CompareArrays(const IArray* generatedArray, const IArray* exemplarArray)
  * @return
  */
 template <typename T>
-DataArray<T>* CreateTestDataArray(DataStructure& dataStructure, const std::string& name, typename DataStore<T>::ShapeType tupleShape, typename DataStore<T>::ShapeType componentShape,
-                                  DataObject::IdType parentId = {})
+DataArray<T>* CreateTestDataArray(DataStructure& dataStructure, const std::string& name, ShapeType tupleShape, ShapeType componentShape, DataObject::IdType parentId = {})
 {
   using DataStoreType = DataStore<T>;
   using ArrayType = DataArray<T>;
@@ -935,7 +934,7 @@ inline DataStructure CreateDataStructure()
   // Create some DataArrays; The DataStructure keeps a shared_ptr<> to the DataArray so DO NOT put
   // it into another shared_ptr<>
   usize numComponents = 1;
-  std::vector<usize> tupleShape = {imageGeomDims[2], imageGeomDims[1], imageGeomDims[0]};
+  ShapeType tupleShape = {imageGeomDims[2], imageGeomDims[1], imageGeomDims[0]};
 
   Float32Array* ci_data = CreateTestDataArray<float>(dataStructure, Constants::k_ConfidenceIndex, tupleShape, {numComponents}, scanData->getId());
   Int32Array* feature_ids_data = CreateTestDataArray<int32>(dataStructure, Constants::k_FeatureIds, tupleShape, {numComponents}, scanData->getId());
@@ -969,7 +968,7 @@ inline DataStructure CreateDataStructure()
  * other group has a DataArray of each primitive type with 3 components.
  * @return
  */
-inline DataStructure CreateAllPrimitiveTypes(const std::vector<usize>& tupleShape)
+inline DataStructure CreateAllPrimitiveTypes(const ShapeType& tupleShape)
 {
   DataStructure dataStructure;
   DataGroup* levelZeroGroup = DataGroup::Create(dataStructure, Constants::k_LevelZero);
@@ -988,7 +987,7 @@ inline DataStructure CreateAllPrimitiveTypes(const std::vector<usize>& tupleShap
 
   // DataStore<usize>::ShapeType tupleShape = {imageGeomDims[2], imageGeomDims[1], imageGeomDims[0]};
   // Create Scalar type data
-  DataStore<uint64>::ShapeType componentShape = {1ULL};
+  ShapeType componentShape = {1ULL};
 
   CreateTestDataArray<int8>(dataStructure, Constants::k_Int8DataSet, tupleShape, componentShape, levelOneId);
   CreateTestDataArray<uint8>(dataStructure, Constants::k_Uint8DataSet, tupleShape, componentShape, levelOneId);

--- a/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.hpp
+++ b/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.hpp
@@ -1338,14 +1338,14 @@ inline DataStructure CreateComplexMultiLevelDataGraph()
   return dataStructure;
 }
 
-inline void CheckArraysInheritTupleDims(const DataStructure& dataStructure)
+inline void CheckArraysInheritTupleDims(const DataStructure& dataStructure, std::vector<DataPath> ignoredPaths = {})
 {
   std::optional<std::vector<DataPath>> amPathsOpt = GetAllChildDataPathsRecursive(dataStructure, {}, DataObject::Type::AttributeMatrix);
   REQUIRE(amPathsOpt.has_value());
   for(const auto& amPath : amPathsOpt.value())
   {
     const auto& attrMatrix = dataStructure.getDataRefAs<AttributeMatrix>(amPath);
-    std::optional<std::vector<DataPath>> daPathsOpt = GetAllChildDataPaths(dataStructure, amPath, DataObject::Type::DataArray);
+    std::optional<std::vector<DataPath>> daPathsOpt = GetAllChildArrayDataPaths(dataStructure, amPath, ignoredPaths);
     REQUIRE(daPathsOpt.has_value());
     for(const auto& daPath : daPathsOpt.value())
     {
@@ -1370,6 +1370,33 @@ const FilterHandle k_IdentifySampleFilterHandle(k_IdentifySampleFilterId, k_Simp
 
 namespace SmallIn100
 {
+// These paths are excluded because they come from a version prior to
+// NeighborList and StringArray having multidimensional tuple capability
+const std::vector<DataPath> k_TupleCheckIgnoredPaths{{{"MirroredXDataContainer", "CellData", "NeighborList"}},
+                                                     {{"MirroredXDataContainer", "CellData", "StringArray"}},
+                                                     {{"MirroredXInconsistentArrays", "CellData", "NeighborList"}},
+                                                     {{"MirroredXInconsistentArrays", "CellData", "StringArray"}},
+                                                     {{"MirroredYDataContainer", "CellData", "NeighborList"}},
+                                                     {{"MirroredYDataContainer", "CellData", "StringArray"}},
+                                                     {{"MirroredYInconsistentArrays", "CellData", "NeighborList"}},
+                                                     {{"MirroredYInconsistentArrays", "CellData", "StringArray"}},
+                                                     {{"MirroredZDataContainer", "CellData", "NeighborList"}},
+                                                     {{"MirroredZDataContainer", "CellData", "StringArray"}},
+                                                     {{"MirroredZInconsistentArrays", "CellData", "NeighborList"}},
+                                                     {{"MirroredZInconsistentArrays", "CellData", "StringArray"}},
+                                                     {{"XDataContainer", "CellData", "NeighborList"}},
+                                                     {{"XDataContainer", "CellData", "StringArray"}},
+                                                     {{"XInconsistentArrays", "CellData", "NeighborList"}},
+                                                     {{"XInconsistentArrays", "CellData", "StringArray"}},
+                                                     {{"YDataContainer", "CellData", "NeighborList"}},
+                                                     {{"YDataContainer", "CellData", "StringArray"}},
+                                                     {{"YInconsistentArrays", "CellData", "NeighborList"}},
+                                                     {{"YInconsistentArrays", "CellData", "StringArray"}},
+                                                     {{"ZDataContainer", "CellData", "NeighborList"}},
+                                                     {{"ZDataContainer", "CellData", "StringArray"}},
+                                                     {{"ZInconsistentArrays", "CellData", "NeighborList"}},
+                                                     {{"ZInconsistentArrays", "CellData", "StringArray"}}};
+
 //------------------------------------------------------------------------------
 inline void ExecuteMultiThresholdObjects(DataStructure& dataStructure, const FilterList& filterList)
 {
@@ -1409,7 +1436,8 @@ inline void ExecuteMultiThresholdObjects(DataStructure& dataStructure, const Fil
   // Execute the filter and check the result
   auto executeResult = filter->execute(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, k_TupleCheckIgnoredPaths);
 }
 
 //------------------------------------------------------------------------------
@@ -1436,6 +1464,7 @@ inline void ExecuteIdentifySample(DataStructure& dataStructure, const FilterList
   // Execute the filter and check the result
   auto executeResult = filter->execute(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure, k_TupleCheckIgnoredPaths);
 }
 } // namespace SmallIn100

--- a/wrapping/python/examples/scripts/neighbor_list.py
+++ b/wrapping/python/examples/scripts/neighbor_list.py
@@ -3,9 +3,10 @@ import simplnx as nx
 ds = nx.DataStructure()
 
 SIZE = 42
+tuple_dims = [[SIZE]]
 PATH = nx.DataPath(['foo'])
 
-action = nx.CreateNeighborListAction(nx.DataType.int32, SIZE, PATH)
+action = nx.CreateNeighborListAction(nx.DataType.int32, tuple_dims, PATH)
 
 assert action.apply(ds, nx.IDataAction.Mode.Execute)
 

--- a/wrapping/python/examples/scripts/neighbor_list.py
+++ b/wrapping/python/examples/scripts/neighbor_list.py
@@ -3,10 +3,9 @@ import simplnx as nx
 ds = nx.DataStructure()
 
 SIZE = 42
-tuple_dims = [[SIZE]]
 PATH = nx.DataPath(['foo'])
 
-action = nx.CreateNeighborListAction(nx.DataType.int32, tuple_dims, PATH)
+action = nx.CreateNeighborListAction(nx.DataType.int32, [SIZE], PATH)
 
 assert action.apply(ds, nx.IDataAction.Mode.Execute)
 


### PR DESCRIPTION
Fixes: #1359 
Fixes: #1260 

Has a NX counterpart.

This PR makes several changes to the backend in one fell swoop, including:
- Multidimensional Tuple support for `NeighborList` and `StringArray`
- `NeighborList` and `StringArray` modernization (information about underlying data is now held in Stores)
- `ShapeType` alias has been centralized and usages have been updated
- API cleanup for `NeighborList` and `StringArray` and all relevant abstract interfaces and stores
- `UnitTest::CheckArraysInheritTupleDims` now validates all objects in an `AttributeMatrix`
