### PR TITLE
BUG: Adds more checks to the HDFType of a data set and returns better error messages

### DIFF
--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadHDF5DatasetFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadHDF5DatasetFilter.cpp
@@ -291,13 +291,13 @@ IFilter::PreflightResult ReadHDF5DatasetFilter::preflightImpl(const DataStructur
     Result<DataType> typeResult = datasetReader.getDataType();
     if(typeResult.invalid())
     {
-      return {nonstd::make_unexpected(typeResult.errors())};
+      return {ConvertInvalidResult<OutputActions>(std::move(typeResult))};
     }
-    DataType dataType = std::move(typeResult.value());
+    DataType dataType = typeResult.value();
     auto action = std::make_unique<CreateArrayAction>(dataType, tDims, cDims, dataArrayPath);
     resultOutputActions.value().appendAction(std::move(action));
 
-  } // End For Loop over dataset imoprt info list
+  } // End For Loop over dataset import info list
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadHDF5DatasetFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadHDF5DatasetFilter.cpp
@@ -287,13 +287,16 @@ IFilter::PreflightResult ReadHDF5DatasetFilter::preflightImpl(const DataStructur
       stream << "The selected dataset '" << pSelectedAttributeMatrixValue.value().toString() << "/" << objectName << "' already exists.";
       return MakePreflightErrorResult(-20014, stream.str());
     }
-    else
+
+    Result<DataType> typeResult = datasetReader.getDataType();
+    if(typeResult.invalid())
     {
-      Result<DataType> typeResult = datasetReader.getDataType();
-      DataType dataType = std::move(typeResult.value());
-      auto action = std::make_unique<CreateArrayAction>(dataType, tDims, cDims, dataArrayPath);
-      resultOutputActions.value().appendAction(std::move(action));
+      return {nonstd::make_unexpected(typeResult.errors())};
     }
+    DataType dataType = std::move(typeResult.value());
+    auto action = std::make_unique<CreateArrayAction>(dataType, tDims, cDims, dataArrayPath);
+    resultOutputActions.value().appendAction(std::move(action));
+
   } // End For Loop over dataset imoprt info list
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
@@ -261,6 +261,12 @@ Result<nx::core::DataType> DatasetIO::getDataType() const
     return MakeErrorResult<nx::core::DataType>(-20013, fmt::format("The selected data set '{}' could not be opened.", getNamePath()));
   }
   hid_t typeId = H5Dget_type(datasetId);
+
+  H5T_class_t classType = H5Tget_class(typeId);
+  if(classType == H5T_COMPOUND)
+  {
+    return MakeErrorResult<nx::core::DataType>(-20016, fmt::format("H5T_COMPOUND data type is not supported for importing.", getNamePath()));
+  }
   auto type = getTypeFromId(typeId);
   if(type == Type::unknown)
   {


### PR DESCRIPTION
When attempting to read HDF5 H5T_COMPOUND types no error was thrown leaving the user to wonder what was happening. We now return an error message indicating that simplnx does not import H5T_COMPOUND datasets. Currently.
