### PR TITLE
BUG: Fixed reading StringArray data

### DIFF
--- a/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
@@ -1,6 +1,8 @@
 #include "SimplnxCore/Filters/CreateDataArrayFilter.hpp"
 #include "SimplnxCore/Filters/CreateImageGeometryFilter.hpp"
 #include "SimplnxCore/Filters/ReadDREAM3DFilter.hpp"
+#include "SimplnxCore/Filters/WriteDREAM3DFilter.hpp"
+
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
 
 #include "simplnx/Core/Application.hpp"
@@ -302,6 +304,41 @@ TEST_CASE("DREAM3DFileTest:DREAM3D File IO Test")
 
     UnitTest::CheckArraysInheritTupleDims(dataStructure);
   }
+}
+
+TEST_CASE("DREAM3DFileTest::StringArray")
+{
+  auto app = Application::GetOrCreateInstance();
+
+  fs::path path = GetDataDir(*app) / "StringArray.dream3d";
+
+  DataStructure exportDataStructure;
+
+  DataPath stringArrayPath({"StringArray"});
+
+  std::vector<std::string> values = {"foo", "bar", "baz"};
+
+  REQUIRE(StringArray::CreateWithValues(exportDataStructure, stringArrayPath.getTargetName(), values) != nullptr);
+
+  WriteDREAM3DFilter writeDream3dFilter;
+  Arguments writeArgs;
+  writeArgs.insertOrAssign(WriteDREAM3DFilter::k_ExportFilePath, path);
+  writeArgs.insertOrAssign(WriteDREAM3DFilter::k_WriteXdmf, false);
+  Result<> writeResult = writeDream3dFilter.execute(exportDataStructure, writeArgs).result;
+  SIMPLNX_RESULT_REQUIRE_VALID(writeResult);
+
+  DataStructure importDataStructure;
+
+  ReadDREAM3DFilter readDream3dFilter;
+  Arguments readArgs;
+  Dream3dImportParameter::ImportData importData(path);
+  readArgs.insertOrAssign(ReadDREAM3DFilter::k_ImportFileData, importData);
+  Result<> readResult = readDream3dFilter.execute(importDataStructure, readArgs).result;
+  SIMPLNX_RESULT_REQUIRE_VALID(readResult);
+
+  const StringArray* stringArray = importDataStructure.getDataAs<StringArray>(stringArrayPath);
+  REQUIRE(stringArray != nullptr);
+  REQUIRE(std::equal(stringArray->begin(), stringArray->end(), values.begin(), values.end()));
 }
 
 TEST_CASE("DREAM3DFileTest:Import/Export DREAM3D Filter Test")

--- a/src/simplnx/DataStructure/IO/HDF5/StringArrayIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/StringArrayIO.cpp
@@ -2,6 +2,7 @@
 
 #include "DataStructureReader.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
+#include "simplnx/DataStructure/StringStore.hpp"
 
 #include "simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/GroupIO.hpp"
@@ -85,6 +86,26 @@ Result<> StringArrayIO::writeData(DataStructureWriter& dataStructureWriter, cons
   }
 
   return WriteObjectAttributes(dataStructureWriter, dataArray, datasetWriter, importable);
+}
+
+Result<> StringArrayIO::finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& parentGroupReader) const
+{
+  if(!dataStructure.containsData(dataPath))
+  {
+    return MakeErrorResult(-151200, fmt::format("Imported DataStructure Object at path '{}' does not exist.", dataPath.toString()));
+  }
+
+  auto* stringArray = dataStructure.getDataAs<data_type>(dataPath);
+  if(stringArray == nullptr)
+  {
+    return MakeErrorResult(-151201, fmt::format("Imported DataStructure Object at path '{}' is not of the expected type.", dataPath.toString()));
+  }
+
+  auto datasetReader = parentGroupReader.openDataset(dataPath.getTargetName());
+  std::vector<std::string> strings = datasetReader.readAsVectorOfStrings();
+  auto stringStore = std::make_shared<StringStore>(std::move(strings));
+  stringArray->setStore(stringStore);
+  return {};
 }
 
 Result<> StringArrayIO::writeDataObject(DataStructureWriter& dataStructureWriter, const DataObject* dataObject, group_writer_type& parentWriter) const

--- a/src/simplnx/DataStructure/IO/HDF5/StringArrayIO.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/StringArrayIO.hpp
@@ -49,6 +49,15 @@ public:
   Result<> writeData(DataStructureWriter& dataStructureWriter, const data_type& stringArray, group_writer_type& parentGroup, bool importable) const;
 
   /**
+   * @brief Replaces the AbstractDataStore using data from the HDF5 dataset.
+   * @param dataStructure
+   * @param dataPath
+   * @param dataStructureReader
+   * @return Result<>
+   */
+  Result<> finishImportingData(DataStructure& dataStructure, const DataPath& dataPath, const group_reader_type& parentGroupReader) const override;
+
+  /**
    * @brief Attempts to write the DataObject to HDF5.
    * Returns an error if the DataObject cannot be cast to a StringArray.
    * Otherwise, this method returns writeData(...)

--- a/src/simplnx/DataStructure/StringStore.cpp
+++ b/src/simplnx/DataStructure/StringStore.cpp
@@ -8,9 +8,9 @@ StringStore::StringStore(uint64 size)
 {
 }
 
-StringStore::StringStore(const std::vector<std::string>& strings)
+StringStore::StringStore(std::vector<std::string> strings)
 : AbstractStringStore()
-, m_Data(strings)
+, m_Data(std::move(strings))
 {
 }
 

--- a/src/simplnx/DataStructure/StringStore.hpp
+++ b/src/simplnx/DataStructure/StringStore.hpp
@@ -11,7 +11,7 @@ class StringStore : public AbstractStringStore
 {
 public:
   StringStore(uint64 count = 0);
-  StringStore(const std::vector<std::string>& strings);
+  StringStore(std::vector<std::string> strings);
   ~StringStore();
 
   std::unique_ptr<AbstractStringStore> deepCopy() const override;

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.cpp
@@ -382,6 +382,7 @@ std::string DatasetIO::readAsString() const
 
 std::vector<std::string> DatasetIO::readAsVectorOfStrings() const
 {
+  auto datasetId = open();
   if(!isValid())
   {
     return {};
@@ -389,7 +390,6 @@ std::vector<std::string> DatasetIO::readAsVectorOfStrings() const
   // auto dataset = openH5Dataset();
 
   std::vector<std::string> strings;
-  auto datasetId = open();
 
   hid_t typeID = H5Dget_type(datasetId);
 


### PR DESCRIPTION
`StringArrayIO` did not implement `finishImportingData` so the values were imported as empty strings as if it had been preflight.

- Added a unit test to check this failure
- DatasetIO::readAsVectorOfStrings now ensures the dataset is open before reading
- StringStore now takes a vector by value in its constructor to allow it to move temporaries into itself to avoid a copy