### PR TITLE
ENH: Modernize ComputeFZQuaternions

### DIFF
--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFZQuaternionsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFZQuaternionsFilter.cpp
@@ -6,6 +6,7 @@
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/DataObjectNameParameter.hpp"
+#include "simplnx/Utilities/MaskCompareUtilities.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
 
@@ -21,12 +22,11 @@ namespace
  * @brief The GenerateFZQuatsImpl class implements a threaded algorithm that computes the Fundamental Zone Quaternion
  * for a given Quaternion and Laue Class (which is based from the crystalStructures array
  */
-template <typename MaskArrayType>
-class GenerateFZQuatsImpl
+class GenerateMaskedFZQuatsImpl
 {
 public:
-  GenerateFZQuatsImpl(Float32Array& quats, Int32Array& phases, UInt32Array& crystalStructures, int32_t numPhases, MaskArrayType* goodVoxels, Float32Array& fzQuats,
-                      const std::atomic_bool& shouldCancel, std::atomic_int32_t& warningCount)
+  GenerateMaskedFZQuatsImpl(const Float32AbstractDataStore& quats, const Int32AbstractDataStore& phases, const UInt32AbstractDataStore& crystalStructures, const int32 numPhases,
+                            std::unique_ptr<MaskCompareUtilities::MaskCompare>& goodVoxels, Float32AbstractDataStore& fzQuats, const std::atomic_bool& shouldCancel, std::atomic_int32_t& warningCount)
   : m_Quats(quats)
   , m_CellPhases(phases)
   , m_CrystalStructures(crystalStructures)
@@ -38,7 +38,7 @@ public:
   {
   }
 
-  virtual ~GenerateFZQuatsImpl() = default;
+  ~GenerateMaskedFZQuatsImpl() = default;
 
   /**
    * @brief convert
@@ -48,8 +48,7 @@ public:
   void convert(size_t start, size_t end) const
   {
     std::vector<LaueOps::Pointer> ops = LaueOps::GetAllOrientationOps();
-    int32_t phase = 0;
-    bool generateFZQuat = false;
+    int32 phase = 0;
     size_t index = 0;
 
     for(size_t i = start; i < end; i++)
@@ -58,13 +57,7 @@ public:
       {
         break;
       }
-      phase = m_CellPhases[i];
-
-      generateFZQuat = true;
-      if(nullptr != m_GoodVoxels)
-      {
-        generateFZQuat = static_cast<bool>((*m_GoodVoxels)[i]);
-      }
+      phase = m_CellPhases.getValue(i);
 
       // Sanity check the phase data to make sure we do not walk off the end of the array
       if(phase >= m_NumPhases)
@@ -72,22 +65,17 @@ public:
         m_WarningCount++;
       }
 
-      // Initialize the output to zero. There really isn't a good value to use.
+      // Output initialized to zero by default
       index = i * 4;
-      m_FZQuats[index] = 0.0f;
-      m_FZQuats[index + 1] = 0.0f;
-      m_FZQuats[index + 2] = 0.0f;
-      m_FZQuats[index + 3] = 0.0f;
-
-      if(phase < m_NumPhases && generateFZQuat && m_CrystalStructures[phase] < EbsdLib::CrystalStructure::LaueGroupEnd)
+      if(phase < m_NumPhases && m_GoodVoxels->isTrue(i) && m_CrystalStructures.getValue(phase) < EbsdLib::CrystalStructure::LaueGroupEnd)
       {
-        QuatD quatD = QuatD(m_Quats[index], m_Quats[index + 1], m_Quats[index + 2], m_Quats[index + 3]); // Makes a copy into q
-        int32_t xtal = static_cast<int32_t>(m_CrystalStructures[phase]);                                 // get the Laue Group
+        QuatD quatD = QuatD(m_Quats.getValue(index), m_Quats.getValue(index + 1), m_Quats.getValue(index + 2), m_Quats.getValue(index + 3)); // Makes a copy into q
+        auto xtal = static_cast<int32_t>(m_CrystalStructures.getValue(phase));                                                               // get the Laue Group
         quatD = ops[xtal]->getFZQuat(quatD);
-        m_FZQuats[index] = quatD.x();
-        m_FZQuats[index + 1] = quatD.y();
-        m_FZQuats[index + 2] = quatD.z();
-        m_FZQuats[index + 3] = quatD.w();
+        m_FZQuats.setValue(index, static_cast<float32>(quatD.x()));
+        m_FZQuats.setValue(index + 1, static_cast<float32>(quatD.y()));
+        m_FZQuats.setValue(index + 2, static_cast<float32>(quatD.z()));
+        m_FZQuats.setValue(index + 3, static_cast<float32>(quatD.w()));
       }
     }
   }
@@ -98,12 +86,84 @@ public:
   }
 
 private:
-  Float32Array& m_Quats;
-  Int32Array& m_CellPhases;
-  UInt32Array& m_CrystalStructures;
-  int32_t m_NumPhases = 0;
-  MaskArrayType* m_GoodVoxels;
-  Float32Array& m_FZQuats;
+  const Float32AbstractDataStore& m_Quats;
+  const Int32AbstractDataStore& m_CellPhases;
+  const UInt32AbstractDataStore& m_CrystalStructures;
+  const int32 m_NumPhases = 0;
+  std::unique_ptr<MaskCompareUtilities::MaskCompare>& m_GoodVoxels;
+  Float32AbstractDataStore& m_FZQuats;
+  const std::atomic_bool& m_ShouldCancel;
+  std::atomic_int32_t& m_WarningCount;
+};
+
+class GenerateFZQuatsImpl
+{
+public:
+  GenerateFZQuatsImpl(const Float32AbstractDataStore& quats, const Int32AbstractDataStore& phases, const UInt32AbstractDataStore& crystalStructures, const int32 numPhases,
+                      Float32AbstractDataStore& fzQuats, const std::atomic_bool& shouldCancel, std::atomic_int32_t& warningCount)
+  : m_Quats(quats)
+  , m_CellPhases(phases)
+  , m_CrystalStructures(crystalStructures)
+  , m_NumPhases(numPhases)
+  , m_FZQuats(fzQuats)
+  , m_ShouldCancel(shouldCancel)
+  , m_WarningCount(warningCount)
+  {
+  }
+
+  ~GenerateFZQuatsImpl() = default;
+
+  /**
+   * @brief convert
+   * @param start
+   * @param end
+   */
+  void convert(size_t start, size_t end) const
+  {
+    std::vector<LaueOps::Pointer> ops = LaueOps::GetAllOrientationOps();
+    int32 phase = 0;
+    size_t index = 0;
+
+    for(size_t i = start; i < end; i++)
+    {
+      if(m_ShouldCancel)
+      {
+        break;
+      }
+      phase = m_CellPhases.getValue(i);
+
+      // Sanity check the phase data to make sure we do not walk off the end of the array
+      if(phase >= m_NumPhases)
+      {
+        m_WarningCount++;
+      }
+
+      // Output initialized to zero by default
+      index = i * 4;
+      if(phase < m_NumPhases && m_CrystalStructures.getValue(phase) < EbsdLib::CrystalStructure::LaueGroupEnd)
+      {
+        QuatD quatD = QuatD(m_Quats.getValue(index), m_Quats.getValue(index + 1), m_Quats.getValue(index + 2), m_Quats.getValue(index + 3)); // Makes a copy into q
+        auto xtal = static_cast<int32_t>(m_CrystalStructures.getValue(phase));                                                               // get the Laue Group
+        quatD = ops[xtal]->getFZQuat(quatD);
+        m_FZQuats.setValue(index, static_cast<float32>(quatD.x()));
+        m_FZQuats.setValue(index + 1, static_cast<float32>(quatD.y()));
+        m_FZQuats.setValue(index + 2, static_cast<float32>(quatD.z()));
+        m_FZQuats.setValue(index + 3, static_cast<float32>(quatD.w()));
+      }
+    }
+  }
+
+  void operator()(const Range& range) const
+  {
+    convert(range.min(), range.max());
+  }
+
+private:
+  const Float32AbstractDataStore& m_Quats;
+  const Int32AbstractDataStore& m_CellPhases;
+  const UInt32AbstractDataStore& m_CrystalStructures;
+  const int32 m_NumPhases = 0;
+  Float32AbstractDataStore& m_FZQuats;
   const std::atomic_bool& m_ShouldCancel;
   std::atomic_int32_t& m_WarningCount;
 };
@@ -158,9 +218,8 @@ Parameters ComputeFZQuaternionsFilter::parameters() const
   params.insertSeparator(Parameters::Separator{"Optional Data Mask"});
   params.insertLinkableParameter(
       std::make_unique<BoolParameter>(k_UseMask_Key, "Apply to Good Elements Only (Bad Elements Will Be Black)", "Whether to assign a black color to 'bad' Elements", false));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_MaskArrayPath_Key, "Input Mask [Optional]", "Optional Mask array where valid data is TRUE or 1.", DataPath{},
-                                                          ArraySelectionParameter::AllowedTypes{DataType::int8, DataType::uint8, DataType::boolean},
-                                                          ArraySelectionParameter::AllowedComponentShapes{{1}}));
+  params.insert(std::make_unique<ArraySelectionParameter>(k_MaskArrayPath_Key, "Input Element Mask", "Optional Mask array where valid data is TRUE or 1.", DataPath{},
+                                                          ArraySelectionParameter::AllowedTypes{DataType::uint8, DataType::boolean}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insertSeparator(Parameters::Separator{"Input Ensemble Data"});
   params.insert(std::make_unique<ArraySelectionParameter>(k_CrystalStructuresArrayPath_Key, "Crystal Structures", "Enumeration representing the crystal structure for each Ensemble",
                                                           DataPath({"Ensemble Data", "CrystalStructures"}), ArraySelectionParameter::AllowedTypes{DataType::uint32},
@@ -189,68 +248,38 @@ IFilter::UniquePointer ComputeFZQuaternionsFilter::clone() const
 IFilter::PreflightResult ComputeFZQuaternionsFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                                    const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
-
   auto pUseGoodVoxelsValue = filterArgs.value<bool>(k_UseMask_Key);
   auto pQuatsArrayPathValue = filterArgs.value<DataPath>(k_QuatsArrayPath_Key);
   auto pCellPhasesArrayPathValue = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
   auto pGoodVoxelsArrayPathValue = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
-  auto pCrystalStructuresArrayPathValue = filterArgs.value<DataPath>(k_CrystalStructuresArrayPath_Key);
   auto pFZQuatsArrayPathValue = pQuatsArrayPathValue.replaceName(filterArgs.value<std::string>(k_FZQuatsArrayName_Key));
 
-  const Int32Array& phaseData = dataStructure.getDataRefAs<Int32Array>(pCellPhasesArrayPathValue);
-
-  if(phaseData.getNumberOfComponents() != 1)
-  {
-    return {MakeErrorResult<OutputActions>(-49000, fmt::format("Phase Array number of components is not 1: '{}'", phaseData.getNumberOfComponents()))};
-  }
-
-  const Float32Array& quatArray = dataStructure.getDataRefAs<Float32Array>(pQuatsArrayPathValue);
-  if(quatArray.getNumberOfComponents() != 4)
-  {
-    return {MakeErrorResult<OutputActions>(-49001, fmt::format("Quaternion Array number of components is not 4: '{}'", quatArray.getNumberOfComponents()))};
-  }
-
+  const auto& phaseData = dataStructure.getDataRefAs<Int32Array>(pCellPhasesArrayPathValue);
+  const auto& quatArray = dataStructure.getDataRefAs<Float32Array>(pQuatsArrayPathValue);
   if(phaseData.getNumberOfTuples() != quatArray.getNumberOfTuples())
   {
-    return {MakeErrorResult<OutputActions>(-49002,
+    return {MakeErrorResult<OutputActions>(-49001,
                                            fmt::format("Quaternion and Phase Arrays must have the same number of tuples. '{} != {}'", quatArray.getNumberOfTuples(), phaseData.getNumberOfTuples()))};
-  }
-
-  const UInt32Array& xtalArray = dataStructure.getDataRefAs<UInt32Array>(pCrystalStructuresArrayPathValue);
-  if(xtalArray.getNumberOfComponents() != 1)
-  {
-    return {MakeErrorResult<OutputActions>(-49003, fmt::format("Crystal Structure Array number of components is not 1: '{}'", xtalArray.getNumberOfComponents()))};
   }
 
   if(pUseGoodVoxelsValue)
   {
-    const IDataArray& maskArray = dataStructure.getDataRefAs<IDataArray>(pGoodVoxelsArrayPathValue);
-    if(maskArray.getNumberOfComponents() != 1)
-    {
-      return {MakeErrorResult<OutputActions>(-49004, fmt::format("Mask Array number of components is not 1: '{}'", maskArray.getNumberOfComponents()))};
-    }
-    if(maskArray.getDataType() != nx::core::DataType::boolean && maskArray.getDataType() != nx::core::DataType::uint8 && maskArray.getDataType() != nx::core::DataType::int8)
-    {
-      return {MakeErrorResult<OutputActions>(-49005, fmt::format("Mask Array is not [BOOL (10) | UINT8 (2) | INT8 (1)]: '{}'", fmt::underlying(maskArray.getDataType())))};
-    }
-
+    const auto& maskArray = dataStructure.getDataRefAs<IDataArray>(pGoodVoxelsArrayPathValue);
     if(maskArray.getNumberOfTuples() != quatArray.getNumberOfTuples())
     {
-      return {MakeErrorResult<OutputActions>(-49006,
+      return {MakeErrorResult<OutputActions>(-49002,
                                              fmt::format("Quaternion and Mask arrays must have the same number of tuples. '{} != {}'", quatArray.getNumberOfTuples(), maskArray.getNumberOfTuples()))};
     }
   }
 
   nx::core::Result<OutputActions> resultOutputActions;
 
-  std::vector<PreflightValue> preflightUpdatedValues;
-
-  auto createArrayAction =
-      std::make_unique<CreateArrayAction>(nx::core::DataType::float32, quatArray.getDataStore()->getTupleShape(), quatArray.getDataStore()->getComponentShape(), pFZQuatsArrayPathValue);
+  auto createArrayAction = std::make_unique<CreateArrayAction>(nx::core::DataType::float32, quatArray.getDataStore()->getTupleShape(), quatArray.getDataStore()->getComponentShape(),
+                                                               pFZQuatsArrayPathValue, CreateArrayAction::k_DefaultDataFormat, "0.0");
   resultOutputActions.value().appendAction(std::move(createArrayAction));
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()
-  return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
+  return {std::move(resultOutputActions)};
 }
 
 //------------------------------------------------------------------------------
@@ -264,14 +293,14 @@ Result<> ComputeFZQuaternionsFilter::executeImpl(DataStructure& dataStructure, c
   auto pCrystalStructuresArrayPathValue = filterArgs.value<DataPath>(k_CrystalStructuresArrayPath_Key);
   auto pFZQuatsArrayPathValue = pQuatsArrayPathValue.replaceName(filterArgs.value<std::string>(k_FZQuatsArrayName_Key));
 
-  Int32Array& phaseArray = dataStructure.getDataRefAs<Int32Array>(pCellPhasesArrayPathValue);
-  Float32Array& quatArray = dataStructure.getDataRefAs<Float32Array>(pQuatsArrayPathValue);
-  UInt32Array& xtalArray = dataStructure.getDataRefAs<UInt32Array>(pCrystalStructuresArrayPathValue);
-  IDataArray* maskArray = dataStructure.getDataAs<IDataArray>(pGoodVoxelsArrayPathValue);
-  Float32Array& fzQuatArray = dataStructure.getDataRefAs<Float32Array>(pFZQuatsArrayPathValue);
+  auto& phaseArray = dataStructure.getDataRefAs<Int32Array>(pCellPhasesArrayPathValue);
+  auto& quatArray = dataStructure.getDataRefAs<Float32Array>(pQuatsArrayPathValue);
+  auto& xtalArray = dataStructure.getDataRefAs<UInt32Array>(pCrystalStructuresArrayPathValue);
+  auto* maskArray = dataStructure.getDataAs<IDataArray>(pGoodVoxelsArrayPathValue);
+  auto& fzQuatArray = dataStructure.getDataRefAs<Float32Array>(pFZQuatsArrayPathValue);
 
   std::atomic_int32_t warningCount = 0;
-  int32_t numPhases = static_cast<int32_t>(xtalArray.getNumberOfTuples());
+  auto numPhases = static_cast<int32>(xtalArray.getNumberOfTuples());
 
   typename IParallelAlgorithm::AlgorithmArrays algArrays;
   algArrays.push_back(&phaseArray);
@@ -293,38 +322,37 @@ Result<> ComputeFZQuaternionsFilter::executeImpl(DataStructure& dataStructure, c
 
     if(pUseGoodVoxelsValue)
     {
-      if(maskArray->getDataType() == DataType::boolean)
+      std::unique_ptr<MaskCompareUtilities::MaskCompare> maskArrayPtr = nullptr;
+      try
       {
-        BoolArray* goodVoxelsArray = dataStructure.getDataAs<BoolArray>(pGoodVoxelsArrayPathValue);
-        dataAlg.execute(::GenerateFZQuatsImpl<BoolArray>(quatArray, phaseArray, xtalArray, numPhases, goodVoxelsArray, fzQuatArray, shouldCancel, warningCount));
-      }
-      else if(maskArray->getDataType() == DataType::uint8)
+        maskArrayPtr = MaskCompareUtilities::InstantiateMaskCompare(dataStructure, pGoodVoxelsArrayPathValue);
+      } catch(const std::out_of_range& exception)
       {
-        UInt32Array* goodVoxelsArray = dataStructure.getDataAs<UInt32Array>(pGoodVoxelsArrayPathValue);
-        dataAlg.execute(::GenerateFZQuatsImpl<UInt32Array>(quatArray, phaseArray, xtalArray, numPhases, goodVoxelsArray, fzQuatArray, shouldCancel, warningCount));
+        // This really should NOT be happening as the path was verified during preflight BUT we may be calling this from
+        // some other context that is NOT going through the normal nx::core::IFilter API of Preflight and Execute
+        return MakeErrorResult(-49003, fmt::format("Mask Array DataPath does not exist or is not of the correct type (Bool | UInt8) {}", pGoodVoxelsArrayPathValue.toString()));
       }
-      else if(maskArray->getDataType() == DataType::int8)
-      {
-        Int8Array* goodVoxelsArray = dataStructure.getDataAs<Int8Array>(pGoodVoxelsArrayPathValue);
-        dataAlg.execute(::GenerateFZQuatsImpl<Int8Array>(quatArray, phaseArray, xtalArray, numPhases, goodVoxelsArray, fzQuatArray, shouldCancel, warningCount));
-      }
+
+      dataAlg.execute(::GenerateMaskedFZQuatsImpl(quatArray.getDataStoreRef(), phaseArray.getDataStoreRef(), xtalArray.getDataStoreRef(), numPhases, maskArrayPtr, fzQuatArray.getDataStoreRef(),
+                                                  shouldCancel, warningCount));
     }
     else
     {
-      dataAlg.execute(::GenerateFZQuatsImpl<Int8Array>(quatArray, phaseArray, xtalArray, numPhases, nullptr, fzQuatArray, shouldCancel, warningCount));
+      dataAlg.execute(
+          ::GenerateFZQuatsImpl(quatArray.getDataStoreRef(), phaseArray.getDataStoreRef(), xtalArray.getDataStoreRef(), numPhases, fzQuatArray.getDataStoreRef(), shouldCancel, warningCount));
     }
 
     if(warningCount > 0)
     {
-      std::string errorMessage = fmt::format("The Ensemble Phase information only references {} phase(s) but {} cell(s) had a phase value greater than {}. \
-This indicates a problem with the input cell phase data. DREAM3D-NX may have given INCORRECT RESULTS.",
+      std::string errorMessage = fmt::format("The Ensemble Phase information only references {} phase(s) but {} cell(s) had a phase value greater than {}. This indicates a problem with the input "
+                                             "cell phase data. DREAM3D-NX may have given INCORRECT RESULTS.",
                                              numPhases - 1, warningCount.load(), numPhases - 1);
 
-      return {MakeErrorResult<>(-49008, errorMessage)};
+      return {MakeErrorResult<>(-49004, errorMessage)};
     }
   } catch(const EbsdLib::method_not_implemented& e)
   {
-    return {MakeErrorResult<>(-49008, fmt::format("EbsdLib threw an exception when computing the fundamental zone data. {}", e.what()))};
+    return {MakeErrorResult<>(-49005, fmt::format("EbsdLib threw an exception when computing the fundamental zone data. {}", e.what()))};
   }
 
   return {};


### PR DESCRIPTION
Update Compute FZQuaternions to:
- use MaskCompare
- use proper DataStore access patterns
- remove preflight checks done by parameter
- cut accesses to output datastore by initializing to 0 by default
- general code cleanup
