### PR TITLE
ENH: Update UnitTestCommon to have a .cpp file for implementations

### DIFF
--- a/test/UnitTestCommon/CMakeLists.txt
+++ b/test/UnitTestCommon/CMakeLists.txt
@@ -1,22 +1,24 @@
 find_package(Catch2 CONFIG REQUIRED)
 find_package(reproc++ CONFIG REQUIRED)
 
-add_library(ComplexUnitTestCommon INTERFACE)
-add_library(simplnx::UnitTestCommon ALIAS ComplexUnitTestCommon)
+add_library(SimplnxUnitTestCommon INTERFACE)
+add_library(simplnx::UnitTestCommon ALIAS SimplnxUnitTestCommon)
 
-target_include_directories(ComplexUnitTestCommon
+target_include_directories(SimplnxUnitTestCommon
   INTERFACE
     ${PROJECT_SOURCE_DIR}/test/UnitTestCommon/include
 )
 
-target_link_libraries(ComplexUnitTestCommon
+target_link_libraries(SimplnxUnitTestCommon
   INTERFACE
     simplnx
     Catch2::Catch2
     reproc++
 )
 
-target_sources(ComplexUnitTestCommon
+target_sources(SimplnxUnitTestCommon
+  PUBLIC
+    ${PROJECT_SOURCE_DIR}/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.cpp
   INTERFACE
     ${PROJECT_SOURCE_DIR}/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.hpp
     ${PROJECT_SOURCE_DIR}/test/UnitTestCommon/include/simplnx/UnitTest/DataObjectComparison.hpp

--- a/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.cpp
+++ b/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.cpp
@@ -1,0 +1,50 @@
+#include "UnitTestCommon.hpp"
+
+using namespace nx::core::UnitTest;
+
+TestFileSentinel::TestFileSentinel(std::string cmakeExecutable, std::string testFilesDir, std::string inputArchiveName, std::string expectedTopLevelOutput, bool decompressFiles, bool removeTemp)
+: m_CMakeExecutable(std::move(cmakeExecutable))
+, m_TestFilesDir(std::move(testFilesDir))
+, m_InputArchiveName(std::move(inputArchiveName))
+, m_ExpectedTopLevelOutput(std::move(expectedTopLevelOutput))
+, m_Decompress(decompressFiles)
+, m_RemoveTemp(removeTemp)
+{
+  if(m_Decompress)
+  {
+    const auto errorCode = decompress();
+    if(errorCode)
+    {
+      std::cout << "std::error_code.value(): " << errorCode.value() << std::endl;
+      std::cout << "std::error_code.message(): " << errorCode.message() << std::endl;
+      //        REQUIRE(errorCode.value() == 0);
+    }
+  }
+}
+
+TestFileSentinel::~TestFileSentinel()
+{
+  if(m_RemoveTemp)
+  {
+    std::error_code errorCode;
+    std::filesystem::remove_all(fmt::format("{}/{}", m_TestFilesDir, m_ExpectedTopLevelOutput), errorCode);
+    if(errorCode)
+    {
+      std::cout << "Removing decompressed data failed: " << errorCode.message() << std::endl;
+    }
+  }
+}
+
+std::error_code TestFileSentinel::decompress()
+{
+  reproc::options options;
+  options.redirect.parent = true;
+  options.deadline = reproc::milliseconds(600000);
+  options.working_directory = m_TestFilesDir.c_str();
+  options.nonblocking = false;
+
+  std::vector<std::string> args = {m_CMakeExecutable, "-E", "tar", "xvzf", fmt::format("{}/{}", m_TestFilesDir, m_InputArchiveName)};
+
+  auto resultPair = reproc::run(args, options);
+  return resultPair.second;
+}

--- a/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.hpp
+++ b/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.hpp
@@ -249,38 +249,9 @@ public:
    * @param decompressFiles Decompress the archive
    * @param removeTemp delete files that were decompressed
    */
-  TestFileSentinel(std::string cmakeExecutable, std::string testFilesDir, std::string inputArchiveName, std::string expectedTopLevelOutput, bool decompressFiles = true, bool removeTemp = true)
-  : m_CMakeExecutable(std::move(cmakeExecutable))
-  , m_TestFilesDir(std::move(testFilesDir))
-  , m_InputArchiveName(std::move(inputArchiveName))
-  , m_ExpectedTopLevelOutput(std::move(expectedTopLevelOutput))
-  , m_Decompress(decompressFiles)
-  , m_RemoveTemp(removeTemp)
-  {
-    if(m_Decompress)
-    {
-      const auto errorCode = decompress();
-      if(errorCode)
-      {
-        std::cout << "std::error_code.value(): " << errorCode.value() << std::endl;
-        std::cout << "std::error_code.message(): " << errorCode.message() << std::endl;
-        REQUIRE(errorCode.value() == 0);
-      }
-    }
-  }
+  TestFileSentinel(std::string cmakeExecutable, std::string testFilesDir, std::string inputArchiveName, std::string expectedTopLevelOutput, bool decompressFiles = true, bool removeTemp = true);
 
-  ~TestFileSentinel()
-  {
-    if(m_RemoveTemp)
-    {
-      std::error_code errorCode;
-      std::filesystem::remove_all(fmt::format("{}/{}", m_TestFilesDir, m_ExpectedTopLevelOutput), errorCode);
-      if(errorCode)
-      {
-        std::cout << "Removing decompressed data failed: " << errorCode.message() << std::endl;
-      }
-    }
-  }
+  ~TestFileSentinel();
 
   TestFileSentinel(const TestFileSentinel&) = delete;            // Copy Constructor Not Implemented
   TestFileSentinel(TestFileSentinel&&) = delete;                 // Move Constructor Not Implemented
@@ -291,19 +262,7 @@ public:
    * @brief Does the actual decompression of the archive.
    * @return
    */
-  std::error_code decompress()
-  {
-    reproc::options options;
-    options.redirect.parent = true;
-    options.deadline = reproc::milliseconds(600000);
-    options.working_directory = m_TestFilesDir.c_str();
-    options.nonblocking = false;
-
-    std::vector<std::string> args = {m_CMakeExecutable, "-E", "tar", "xvzf", fmt::format("{}/{}", m_TestFilesDir, m_InputArchiveName)};
-
-    auto resultPair = reproc::run(args, options);
-    return resultPair.second;
-  }
+  std::error_code decompress();
 
 private:
   std::string m_CMakeExecutable;


### PR DESCRIPTION
This is handy because on macOS when debugging the requirements for the decompression never passes even though it actually does work. This allows the developer to quickly comment out that line in order to debug.
