### PR TITLE
BUG: Fixes issue when segmenting features with a +1 feature count

### DIFF
--- a/src/Plugins/OrientationAnalysis/test/EBSDSegmentFeaturesFilterTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/EBSDSegmentFeaturesFilterTest.cpp
@@ -1,5 +1,25 @@
 #include <catch2/catch.hpp>
 
+/**
+* this unit test needs a complete rewrite.
+*
+* There are 4 exemplar ANG files that are specifically crafted with 51 clusters of orientations
+* that are all 6 degrees apart. Each cluster has a spread of 3 degrees. We should be able to
+* use these files to perform the segmentation and know exactly what the output should be.
+*
+* Here is a checklist of TEST_CASE() that should be written:
+*
+* For each exemplar Image Geometry, the data is ready for segmentation. Segment the data
+* using the filter, check the results against the exemplar data from the test data archive.
+*
+* NOTE: The exemplar data files were hand validated before being used in this unit test.
+*
+* We should also include a version that uses a Mask and one that possibly randomizes the featureIds.
+*
+* I am not sure about testing negative misorientations. Not sure that matters.
+*/
+
+
 #include "OrientationAnalysis/Filters/EBSDSegmentFeaturesFilter.hpp"
 #include "OrientationAnalysis/OrientationAnalysis_test_dirs.hpp"
 #include "OrientationAnalysisTestUtils.hpp"
@@ -18,6 +38,8 @@ using namespace nx::core::Constants;
 
 TEST_CASE("OrientationAnalysis::EBSDSegmentFeatures: Valid Execution", "[OrientationAnalysis][EBSDSegmentFeatures]")
 {
+  REQUIRE(true == false);
+
   UnitTest::LoadPlugins();
 
   const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_CMakeExecutable, nx::core::unit_test::k_TestFilesDir, "6_6_ebsd_segment_features.tar.gz",

--- a/src/simplnx/Utilities/SegmentFeatures.cpp
+++ b/src/simplnx/Utilities/SegmentFeatures.cpp
@@ -148,7 +148,7 @@ Result<> SegmentFeatures::execute(IGridGeometry* gridGeom)
   // Initialize a sequence of execution modifiers
   int32 gnum = 1;
   int64 nextSeed = 0;
-  int64 seed = getSeed(gnum, nextSeed);
+  int64 seed = 0; // Always use the very first value of the array that we are using to segment
   usize size = 0;
 
   // Initialize containers
@@ -205,18 +205,18 @@ Result<> SegmentFeatures::execute(IGridGeometry* gridGeom)
       totalVoxelsSegmented += size;
     }
 
+    // Send a progress message
+    throttledMessenger.sendThrottledMessage([&]() { return fmt::format("{:.2f}% - Features Found: {}", 100.0f * static_cast<float>(totalVoxelsSegmented) / static_cast<float>(totalVoxels), gnum); });
+    // Increment or set values for the next iteration
     voxelsList.assign(size + 1, -1);
     gnum++;
-
-    throttledMessenger.sendThrottledMessage([&]() { return fmt::format("{:.2f}% - Features Found: {}", 100.0f * static_cast<float>(totalVoxelsSegmented) / static_cast<float>(totalVoxels), gnum); });
-
+    // Get the next seed value
+    seed = getSeed(gnum, nextSeed); // If seed ends up being -1, then we will exit the loop.
     nextSeed = seed + 1;
-    seed = getSeed(gnum, nextSeed);
   }
 
-  m_MessageHelper.sendMessage(fmt::format("Total Features Found: {}", gnum));
-
-  m_FoundFeatures = gnum;
+  m_FoundFeatures = gnum - 1; // Decrement the gnum because it will end up 1 larger than it should have been.
+  m_MessageHelper.sendMessage(fmt::format("Total Features Found: {}", m_FoundFeatures));
   return {};
 }
 


### PR DESCRIPTION
This will affect the final feature level Attribute Matrix. The previous algorithm probably ran fine, one would just end up with 1 additional row in the Attribute Matrix which is inconsistent.

The unit test also needs significant rework.
