### PR TITLE
BUG: When reading a legacy NeighborList, the incorrect group was passed to the reader

### DIFF
--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -1270,7 +1270,7 @@ Result<> finishImportingLegacyArray(DataStructure& dataStructure, const nx::core
   auto dataArraySet = amGroup.openDataset(dataPath.getTargetName());
   if(isLegacyNeighborList(dataArraySet))
   {
-    return finishImportingLegacyNeighborList(dataStructure, parentReader, dataArraySet, dataPath);
+    return finishImportingLegacyNeighborList(dataStructure, amGroup, dataArraySet, dataPath);
   }
   else if(isLegacyStringArray(dataArraySet))
   {


### PR DESCRIPTION
Reading a 6.5.171 .dream3d file with neighbor lists would give warnings to the console about not being able to read the data sets with the number of neighbors. This will fix that. But I am wondering how reading the neighborlist actually has been working.
