### PR TITLE
COMP: Fix MSVC template warnings

### DIFF
--- a/src/Plugins/OrientationAnalysis/docs/ComputeShapesTriangleGeomFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ComputeShapesTriangleGeomFilter.md
@@ -4,7 +4,7 @@
 
 Statistics (Morphological)
 
-## Warning
+## Caveats
 
 This filter has two caveats.
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureNeighborCAxisMisalignments.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureNeighborCAxisMisalignments.cpp
@@ -71,7 +71,7 @@ Result<> ComputeFeatureNeighborCAxisMisalignments::operator()()
   const usize totalFeatures = featurePhases.getNumberOfTuples();
   const usize numQuatComps = featureAvgQuat.getNumberOfComponents();
 
-  std::vector<std::vector<double>> misalignmentLists(totalFeatures);
+  std::vector<std::vector<float32>> misalignmentLists(totalFeatures);
 
   const Eigen::Vector3d cAxis{0.0, 0.0, 1.0};
   usize hexNeighborListSize = 0;
@@ -129,7 +129,7 @@ Result<> ComputeFeatureNeighborCAxisMisalignments::operator()()
         }
 
         // Convert the misorientation to Degrees and store the value
-        currentMisalignmentList[j] = w * Constants::k_180OverPiD;
+        currentMisalignmentList[j] = static_cast<float32>(w * Constants::k_180OverPiD);
 
         // If we are finding the average misorientation, then start accumulating those values
         if(m_InputValues->FindAvgMisals)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertOrientationsToVertexGeometry.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertOrientationsToVertexGeometry.cpp
@@ -44,9 +44,12 @@ Result<> ConvertOrientationsToVertexGeometry::operator()()
   }
   else
   {
-    auto inputArrayF64 = m_DataStructure.getDataAs<Float64Array>(m_InputValues->InputOrientationArrayPath);
+    auto* inputArrayF64 = m_DataStructure.getDataAs<Float64Array>(m_InputValues->InputOrientationArrayPath);
     auto tmpArray = Float32Array::CreateWithStore<Float32DataStore>(tmpDs, inputArrayF64->getName(), inputArrayF64->getTupleShape(), inputArrayF64->getComponentShape());
-    std::copy(inputArrayF64->begin(), inputArrayF64->begin() + inputArrayF64->getSize(), tmpArray->begin());
+    for(usize i = 0; i < inputArrayF64->size(); i++)
+    {
+      tmpArray->setValue(i, static_cast<float32>(inputArrayF64->getValue(i)));
+    }
   }
 
   DataPath quatsArrayPath;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeArrayStatistics.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeArrayStatistics.cpp
@@ -542,11 +542,11 @@ public:
         {
           if(m_FindMedian)
           {
-            values.push_back(m_Source[i]);
+            values.push_back(static_cast<float>(m_Source[i]));
           }
           if(m_FindNumUniqueValues)
           {
-            valuesSet.emplace(m_Source[i]);
+            valuesSet.emplace(static_cast<int32>(m_Source[i]));
           }
         }
       }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBoundingBoxStats.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBoundingBoxStats.cpp
@@ -19,6 +19,9 @@ constexpr usize k_MaxXIndex = 3;
 constexpr usize k_MaxYIndex = 4;
 constexpr usize k_MaxZIndex = 5;
 
+template <class T>
+concept ArithmeticNotBool = std::is_arithmetic_v<T> && !std::is_same_v<T, bool>;
+
 std::array<usize, 6> GetVoxelIndices(const Float32AbstractDataStore& unifiedBounds, usize targetBoundsIndex, const ImageGeom& image)
 {
   std::array<usize, 6> voxelIndices = {};
@@ -373,7 +376,6 @@ public:
             minValue = std::min(minValue, value);
             maxValue = std::max(maxValue, value);
             summationValue += value;
-
             // modes
             frequencyMap[value]++;
           }
@@ -490,7 +492,8 @@ public:
 
       // We are working with primitives here for their trivially copyable nature, this lets us cut accesses to output vector
       float64 sumOfDiffs = 0.0f;
-      float32 meanValue = m_StatsVector[targetBoundsIndex].summationValue / static_cast<float32>(m_StatsVector[targetBoundsIndex].count);
+      float32 meanValue = 0.0f;
+      meanValue = m_StatsVector[targetBoundsIndex].summationValue / static_cast<float32>(m_StatsVector[targetBoundsIndex].count);
 
       usize zStride = 0, yStride = 0;
       for(usize zIndex = voxelIndices[k_MinZIndex]; zIndex < voxelIndices[k_MaxZIndex]; zIndex++)
@@ -628,14 +631,7 @@ Result<> FillStatsArrays(const std::vector<StatsCacheT>& statsVector, DataStruct
       if(meanArray != nullptr)
       {
         float32 meanValue = 0.0f;
-        if constexpr(std::is_same_v<T, bool>)
-        {
-          meanValue = static_cast<float32>(statsVector[i].summationValue >= (statsVector.size() - statsVector[i].summationValue));
-        }
-        else
-        {
-          meanValue = statsVector[i].summationValue / static_cast<float32>(statsVector[i].count);
-        }
+        meanValue = statsVector[i].summationValue / static_cast<float32>(statsVector[i].count);
         meanArray->setValue(i, meanValue);
       }
       if constexpr(std::is_same_v<StatsCacheT, CompleteStatsCache<typename StatsCacheT::value_type>>)
@@ -735,12 +731,14 @@ Result<> ComputeBoundingBoxStats::operator()()
   const auto& geom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->GeometryPath);
   auto& unifiedArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->UnifiedPath).getDataStoreRef();
   auto& inputArray = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->InputPath);
+  if(inputArray.getDataType() == DataType::boolean)
+  {
+    return MakeErrorResult(-98500, "Boolean arrays cannot be used as inputs to this filter.");
+  }
   if(m_InputValues->CalculateMode)
   {
     return ExecuteNeighborFunction(ExecuteBoundsStatsCalculations<true>{}, inputArray.getDataType(), m_DataStructure, m_InputValues, geom, unifiedArray, inputArray);
   }
-  else
-  {
-    return ExecuteDataFunction(ExecuteBoundsStatsCalculations<false>{}, inputArray.getDataType(), m_DataStructure, m_InputValues, geom, unifiedArray, inputArray);
-  }
+
+  return ExecuteDataFunctionNoBool(ExecuteBoundsStatsCalculations<false>{}, inputArray.getDataType(), m_DataStructure, m_InputValues, geom, unifiedArray, inputArray);
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundingBoxStatsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeBoundingBoxStatsFilter.cpp
@@ -150,7 +150,7 @@ Parameters ComputeBoundingBoxStatsFilter::parameters() const
   params.insert(std::make_unique<GeometrySelectionParameter>(k_GeometryPath_Key, "Selected Image Geometry", "The DataPath to the Geometry that contains the points/edges/faces for the geometry",
                                                              DataPath{}, GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_InputArrayPath_Key, "Attribute Array to Compute Statistics", "Input Attribute Array for which to compute statistics", DataPath{},
-                                                          nx::core::GetAllDataTypes(), ArraySelectionParameter::AllowedComponentShapes{{1}}));
+                                                          nx::core::GetAllNumericTypes(), ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_UnifiedBoundsPath_Key, "Unified Bounding Boxes Array",
                                                           "The array containing the min and max point of the bounding box for each feature | tuple ordering {Min-X,Min-Y,Min-Z,Max-X,Max-Y,Max-Z}",
                                                           DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::float32}, ArraySelectionParameter::AllowedComponentShapes{{6}}));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayAdvancedFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateDataArrayAdvancedFilter.cpp
@@ -177,7 +177,7 @@ IFilter::PreflightResult CreateDataArrayAdvancedFilter::preflightImpl(const Data
   usize numComponents = std::accumulate(compDims.begin(), compDims.end(), static_cast<usize>(1), std::multiplies<>());
   if(numComponents <= 0)
   {
-    std::string compDimsStr = std::accumulate(compDims.begin() + 1ULL, compDims.end(), std::to_string(compDims[0]), [](const std::string& a, int b) { return a + " x " + std::to_string(b); });
+    std::string compDimsStr = std::accumulate(compDims.begin() + 1ULL, compDims.end(), std::to_string(compDims[0]), [](const std::string& a, usize b) { return a + " x " + std::to_string(b); });
     return MakePreflightErrorResult(
         -78601,
         fmt::format("The chosen component dimensions ({}) results in 0 total components.  Please choose component dimensions that result in a positive number of total components.", compDimsStr));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitDataArrayByTupleFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitDataArrayByTupleFilter.cpp
@@ -51,7 +51,7 @@ template <typename T>
 std::string valuesToString(const std::vector<T>& values, const std::string& token = " x ")
 {
   std::vector<std::string> shapeStrs;
-  std::transform(values.cbegin(), values.cend(), std::back_inserter(shapeStrs), [](usize val) { return std::to_string(val); });
+  std::transform(values.cbegin(), values.cend(), std::back_inserter(shapeStrs), [](T val) { return std::to_string(val); });
   std::vector<std::string_view> shapeStrViews(shapeStrs.begin(), shapeStrs.end());
   return StringUtilities::join(shapeStrViews, token);
 }
@@ -229,8 +229,11 @@ Result<> preflightAttrMatrixOutput(SplitDataArrayByTuple::OutputContainer output
                                 fmt::format("Attribute matrix tuple shape contains \"{}\" at Tuple Dim {}.  All tuple shape values must be >= 1.", newAttrMatrixTupleShape[j], j))};
       }
     }
-
-    tupleShape = std::vector<usize>(newAttrMatrixTupleShape.begin(), newAttrMatrixTupleShape.end());
+    tupleShape.resize(newAttrMatrixTupleShape.size());
+    for(size_t i = 0; i < newAttrMatrixTupleShape.size(); i++)
+    {
+      tupleShape[i] = static_cast<usize>(newAttrMatrixTupleShape[i]);
+    }
   }
   else
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteLAMMPSFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/WriteLAMMPSFileFilter.cpp
@@ -91,8 +91,8 @@ IFilter::PreflightResult WriteLAMMPSFileFilter::preflightImpl(const DataStructur
   if(vertsCount != atomLabelsCount)
   {
     return MakePreflightErrorResult(-77460, fmt::format("Tuple Dimensions don't match: Number of Vertices - {} || Number of Atom Labels - {}",
-                                                        std::accumulate(vertsCount.begin(), vertsCount.end(), 1, std::multiplies<>()),
-                                                        std::accumulate(atomLabelsCount.begin(), atomLabelsCount.end(), 1, std::multiplies<>())));
+                                                        std::accumulate(vertsCount.begin(), vertsCount.end(), 1ULL, std::multiplies<>()),
+                                                        std::accumulate(atomLabelsCount.begin(), atomLabelsCount.end(), 1ULL, std::multiplies<>())));
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/test/CombineNodeBasedGeometriesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/CombineNodeBasedGeometriesTest.cpp
@@ -113,7 +113,7 @@ void AddNeighborList(AttributeMatrix& attrMatrix, DataStructure& dataStructure)
   for(usize i = 0; i < attrMatrix.getNumTuples(); i++)
   {
     typename NeighborList<T>::SharedVectorType inputList(new std::vector<T>(k_NeighborListListSize));
-    std::iota(inputList->begin(), inputList->end(), 0);
+    std::iota(inputList->begin(), inputList->end(), static_cast<T>(0));
     nl->setList(i, inputList);
   }
 }
@@ -175,7 +175,7 @@ template <typename TGeom, typename TNode, typename TGetNumPerElement, typename T
 void CreateNodeArray(TGeom& geom, DataStructure& dataStructure, const std::string& sharedListName, usize numElements, TGetNumPerElement getNumPerElement, TSetNodeArray setNodeArray)
 {
   auto arr = CreateNodeArray<TNode>(geom, dataStructure, sharedListName, numElements, getNumPerElement(geom));
-  std::iota(arr->begin(), arr->end(), 0);
+  std::iota(arr->begin(), arr->end(), static_cast<TNode>(0));
   setNodeArray(geom, *arr);
 }
 

--- a/src/Plugins/SimplnxCore/test/CombineTransformationMatricesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/CombineTransformationMatricesTest.cpp
@@ -84,8 +84,8 @@ void CreateTestImageGeometry(DataStructure& dataStructure, const std::string& ge
   geom->setCellData(*am);
   UInt32Array* testArray = UInt32Array::CreateWithStore<UInt32DataStore>(dataStructure, k_CellArrayName, amDims, cDims, am->getId());
 
-  auto numComps = std::accumulate(cDims.begin(), cDims.end(), 1, std::multiplies<>());
-  std::generate(testArray->begin(), testArray->end(), [n = 0, numComps]() mutable { return 1 + (n++ / numComps); });
+  usize numComps = std::accumulate(cDims.begin(), cDims.end(), 1ULL, std::multiplies<>());
+  std::generate(testArray->begin(), testArray->end(), [n = 0, numComps]() mutable { return static_cast<uint32>(1 + (n++ / numComps)); });
 }
 
 void CreateTestVertexGeometry(DataStructure& dataStructure, const std::string& geomName)
@@ -97,7 +97,7 @@ void CreateTestVertexGeometry(DataStructure& dataStructure, const std::string& g
   AttributeMatrix* am = AttributeMatrix::Create(dataStructure, VertexGeom::k_VertexAttributeMatrixName, {16}, geom->getId());
   geom->setVertexAttributeMatrix(*am);
   Int64Array* testArray = Int64Array::CreateWithStore<Int64DataStore>(dataStructure, k_CellArrayName, {16}, {2}, am->getId());
-  std::iota(testArray->begin(), testArray->end(), 0.0f);
+  std::iota(testArray->begin(), testArray->end(), static_cast<int64_t>(0));
 }
 
 void CompareGeometries(const DataStructure& dataStructure, const DataPath& exemplaryGeomPath, const DataPath& resultGeomPath)

--- a/src/Plugins/SimplnxCore/test/ComputeSurfaceFeaturesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeSurfaceFeaturesTest.cpp
@@ -10,6 +10,7 @@
 
 namespace fs = std::filesystem;
 using namespace nx::core;
+using namespace nx::core::UnitTest;
 
 namespace
 {
@@ -22,6 +23,18 @@ const DataPath k_SurfaceFeaturesExemplaryPath = k_CellFeatureAMPath.createChildP
 const DataPath k_SurfaceFeaturesArrayPath = k_CellFeatureAMPath.createChildPath(k_SurfaceFeatures);
 const std::string k_FeatureIds2DFileName = "FindSurfaceFeaturesTest/FeatureIds_2D.raw";
 const std::string k_SurfaceFeatures2DExemplaryFileName = "FindSurfaceFeaturesTest/SurfaceFeatures2D.raw";
+
+template <typename T, typename K>
+std::vector<K> ConvertVectorReverse(const std::vector<T>& input)
+{
+  std::vector<K> result;
+  result.reserve(input.size());
+  for(auto it = input.rbegin(); it != input.rend(); ++it)
+  {
+    result.emplace_back(static_cast<K>(*it));
+  }
+  return result;
+}
 
 void test_impl(const std::vector<uint64>& geometryDims, const std::string& featureIdsFileName, const std::string& exemplaryFileName)
 {
@@ -43,9 +56,9 @@ void test_impl(const std::vector<uint64>& geometryDims, const std::string& featu
   ReadRawBinaryFilter rbrFilter;
   Arguments rbrArgs;
   rbrArgs.insertOrAssign(ReadRawBinaryFilter::k_InputFile_Key, fs::path(unit_test::k_TestFilesDir.str()).append(featureIdsFileName));
-  rbrArgs.insertOrAssign(ReadRawBinaryFilter::k_NumberOfComponents_Key, std::make_any<uint64>(1));
+  rbrArgs.insertOrAssign(ReadRawBinaryFilter::k_NumberOfComponents_Key, std::make_any<uint64>(1ULL));
   rbrArgs.insertOrAssign(ReadRawBinaryFilter::k_ScalarType_Key, NumericType::int32);
-  rbrArgs.insertOrAssign(ReadRawBinaryFilter::k_TupleDims_Key, DynamicTableParameter::ValueType({std::vector<float64>(geometryDims.rbegin(), geometryDims.rend())}));
+  rbrArgs.insertOrAssign(ReadRawBinaryFilter::k_TupleDims_Key, DynamicTableParameter::ValueType({ConvertVectorReverse<uint64, double>(geometryDims)}));
   rbrArgs.insertOrAssign(ReadRawBinaryFilter::k_CreatedAttributeArrayPath_Key, std::make_any<DataPath>(k_FeatureIDsPath));
 
   result = rbrFilter.execute(dataStructure, rbrArgs);
@@ -65,7 +78,7 @@ void test_impl(const std::vector<uint64>& geometryDims, const std::string& featu
 
   rbrArgs.insertOrAssign(ReadRawBinaryFilter::k_InputFile_Key, fs::path(unit_test::k_TestFilesDir.str()).append(exemplaryFileName));
   rbrArgs.insertOrAssign(ReadRawBinaryFilter::k_ScalarType_Key, NumericType::int8);
-  rbrArgs.insertOrAssign(ReadRawBinaryFilter::k_TupleDims_Key, DynamicTableParameter::ValueType({{796}}));
+  rbrArgs.insertOrAssign(ReadRawBinaryFilter::k_TupleDims_Key, DynamicTableParameter::ValueType({{796.0}}));
   rbrArgs.insertOrAssign(ReadRawBinaryFilter::k_CreatedAttributeArrayPath_Key, std::make_any<DataPath>(k_SurfaceFeaturesExemplaryPath));
 
   result = rbrFilter.execute(dataStructure, rbrArgs);

--- a/src/Plugins/SimplnxCore/test/DBSCANTest.cpp
+++ b/src/Plugins/SimplnxCore/test/DBSCANTest.cpp
@@ -269,7 +269,7 @@ TEST_CASE("SimplnxCore::DBSCAN: 3D Test (LowDensityFirst)", "[SimplnxCore][DBSCA
 
     // Create default Parameters for the filter.
     args.insertOrAssign(DBSCANFilter::k_ParseOrderIndex_Key, std::make_any<ChoicesParameter::ValueType>(to_underlying(DBSCAN::ParseOrder::LowDensityFirst)));
-    args.insertOrAssign(DBSCANFilter::k_Epsilon_Key, std::make_any<float32>(0.0099999998));
+    args.insertOrAssign(DBSCANFilter::k_Epsilon_Key, std::make_any<float32>(0.0099999998f));
     args.insertOrAssign(DBSCANFilter::k_MinPoints_Key, std::make_any<int32>(5));
     args.insertOrAssign(DBSCANFilter::k_UseMask_Key, std::make_any<bool>(false));
     args.insertOrAssign(DBSCANFilter::k_SelectedArrayPath_Key, std::make_any<DataPath>(targetPath));

--- a/src/Plugins/SimplnxCore/test/WriteNodesAndElementsFilesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/WriteNodesAndElementsFilesTest.cpp
@@ -51,12 +51,12 @@ void CreateEdgeGeometry(DataStructure& ds)
   auto vertexAttrMatrix = AttributeMatrix::Create(ds, "Vertex Data", {2}, geom->getId());
   geom->setVertexAttributeMatrix(*vertexAttrMatrix);
   Float32Array* vertices = UnitTest::CreateTestDataArray<float32>(ds, "Vertices Store", {2}, {3}, geom->getId());
-  std::vector<float32> verticesVec = {1, 1.5, 1.75, 2, 3, 4};
+  std::vector<float32> verticesVec = {1.0f, 1.5f, 1.75f, 2.0f, 3.0f, 4.0f};
   std::copy(verticesVec.begin(), verticesVec.end(), vertices->begin());
   geom->setVertices(*vertices);
   DataArray<IGeometry::MeshIndexType>* cells = UnitTest::CreateTestDataArray<IGeometry::MeshIndexType>(ds, "Cells Store", {1}, {2}, geom->getId());
-  std::vector<float32> cellsVec = {0, 1};
-  std::copy(cellsVec.begin(), cellsVec.end(), cells->begin());
+  cells->setValue(0, 0ULL);
+  cells->setValue(1, 1ULL);
   geom->setEdgeList(*cells);
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/StringArrayIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/StringArrayIO.cpp
@@ -52,7 +52,7 @@ Result<> StringArrayIO::readData(DataStructureReader& dataStructureReader, const
   {
     tupleShape = std::move(tupleShapeResult.value());
   }
-  usize numValues = std::accumulate(tupleShape.cbegin(), tupleShape.cend(), 1, std::multiplies<>());
+  usize numValues = std::accumulate(tupleShape.cbegin(), tupleShape.cend(), 1ULL, std::multiplies<>());
 
   std::vector<std::string> strings = useEmptyDataStore ? std::vector<std::string>(numValues) : datasetReader.readAsVectorOfStrings();
   const auto* data = StringArray::Import(dataStructureReader.getDataStructure(), dataArrayName, tupleShape, importId, std::move(strings), parentId);

--- a/src/simplnx/Utilities/FilterUtilities.hpp
+++ b/src/simplnx/Utilities/FilterUtilities.hpp
@@ -98,6 +98,15 @@ auto RunTemplateClass(DataType dataType, ArgsT&&... args)
   throw std::runtime_error(fmt::format("FilterUtilities::RunTemplateClass<> Error: dataType did not match any known type. DataType was {}", DataTypeToString(dataType)));
 }
 
+/**
+ * @brief
+ * @tparam FuncT
+ * @tparam ArgsT
+ * @param func
+ * @param dataType
+ * @param args
+ * @return
+ */
 template <class FuncT, class... ArgsT>
 auto ExecuteDataFunction(FuncT&& func, DataType dataType, ArgsT&&... args)
 {
@@ -142,6 +151,65 @@ auto ExecuteDataFunction(FuncT&& func, DataType dataType, ArgsT&&... args)
   }
 }
 
+/**
+ * @brief Will execute a function depending on the type of data. This version does not handle booleans
+ * @tparam FuncT
+ * @tparam ArgsT
+ * @param func
+ * @param dataType
+ * @param args
+ * @return
+ */
+template <class FuncT, class... ArgsT>
+auto ExecuteDataFunctionNoBool(FuncT&& func, DataType dataType, ArgsT&&... args)
+{
+  switch(dataType)
+  {
+  case DataType::int8: {
+    return func.template operator()<int8>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::int16: {
+    return func.template operator()<int16>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::int32: {
+    return func.template operator()<int32>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::int64: {
+    return func.template operator()<int64>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::uint8: {
+    return func.template operator()<uint8>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::uint16: {
+    return func.template operator()<uint16>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::uint32: {
+    return func.template operator()<uint32>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::uint64: {
+    return func.template operator()<uint64>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::float32: {
+    return func.template operator()<float32>(std::forward<ArgsT>(args)...);
+  }
+  case DataType::float64: {
+    return func.template operator()<float64>(std::forward<ArgsT>(args)...);
+  }
+  default: {
+    throw std::runtime_error("nx::core::ExecuteDataFunction<...>(FuncT&& func, DataType dataType, ArgsT&&... args). Error: Invalid DataType");
+  }
+  }
+}
+
+/**
+ *
+ * @tparam FuncT
+ * @tparam ArgsT
+ * @param func
+ * @param dataType
+ * @param args
+ * @return
+ */
 template <class FuncT, class... ArgsT>
 auto ExecuteNeighborFunction(FuncT&& func, DataType dataType, ArgsT&&... args)
 {


### PR DESCRIPTION
MSVC Compiler warnings due to possible template type usage and converting between them. This PR attempts to fix the warnings by fixing the code.