### PR TITLE
STY: Fix warnings about unintended slicing of object

### DIFF
--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImageWriterFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKImageWriterFilter.cpp
@@ -242,7 +242,7 @@ Result<> SaveImageData(const fs::path& filePath, IDataStore& sliceData, const IT
   {
     if(!fs::create_directories(fs::absolute(filePath).parent_path()))
     {
-      return {MakeErrorResult(-19000, fmt::format("Error Creating output path for image '{}'", fs::absolute(filePath).string()))};
+      return MakeErrorResult(-19000, fmt::format("Error Creating output path for image '{}'", fs::absolute(filePath).string()));
     }
   }
 

--- a/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMhaFileReaderFilter.cpp
+++ b/src/Plugins/ITKImageProcessing/src/ITKImageProcessing/Filters/ITKMhaFileReaderFilter.cpp
@@ -479,7 +479,7 @@ Result<> ITKMhaFileReaderFilter::executeImpl(DataStructure& dataStructure, const
       auto applyTransformationToGeometryFilter = filterListPtr->createFilter(k_ApplyTransformationToGeometryFilterHandle);
       if(applyTransformationToGeometryFilter == nullptr)
       {
-        return {MakeErrorResult(-5001, fmt::format("Error applying transformation to geometry - Unable to instantiate filter 'Apply Transformation To Geometry'."))};
+        return MakeErrorResult(-5001, fmt::format("Error applying transformation to geometry - Unable to instantiate filter 'Apply Transformation To Geometry'."));
       }
 
       Arguments args;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.cpp
@@ -12,6 +12,8 @@
 #include <EbsdLib/Orientation/OrientationMatrix.hpp>
 #include <EbsdLib/Orientation/Quaternion.hpp>
 
+#include <cmath>
+
 using namespace nx::core;
 using namespace nx::core::OrientationUtilities;
 
@@ -72,7 +74,7 @@ Result<> CAxisSegmentFeatures::operator()()
   // Sanity check the result.
   if(this->m_FoundFeatures < 1)
   {
-    return {MakeErrorResult(-87000, fmt::format("The number of Features is '{}' which means no Features were detected. A threshold value may be set incorrectly", this->m_FoundFeatures))};
+    return MakeErrorResult(-87000, fmt::format("The number of Features is '{}' which means no Features were detected. A threshold value may be set incorrectly", this->m_FoundFeatures));
   }
 
   // Resize the Feature Attribute Matrix
@@ -138,19 +140,18 @@ int64 CAxisSegmentFeatures::getSeed(int32 gnum, int64 nextSeed) const
 bool CAxisSegmentFeatures::determineGrouping(int64 referencepoint, int64 neighborpoint, int32 gnum) const
 {
   bool group = false;
-  float32 w = std::numeric_limits<float32>::max();
 
   const Eigen::Vector3f cAxis{0.0f, 0.0f, 1.0f};
-  Eigen::Vector3f c1{0.0f, 0.0f, 0.0f};
-  Eigen::Vector3f c2{0.0f, 0.0f, 0.0f};
   Float32Array& currentQuat = *m_QuatsArray;
   Int32Array& featureIds = *m_FeatureIdsArray;
   Int32Array& cellPhases = *m_CellPhases;
+
   bool neighborPointIsGood = false;
   if(m_GoodVoxelsArray != nullptr)
   {
     neighborPointIsGood = m_GoodVoxelsArray->isTrue(neighborpoint);
   }
+
   if(featureIds[neighborpoint] == 0 && (!m_InputValues->UseMask || neighborPointIsGood))
   {
     if(cellPhases[referencepoint] == cellPhases[neighborpoint])
@@ -162,8 +163,8 @@ bool CAxisSegmentFeatures::determineGrouping(int64 referencepoint, int64 neighbo
       const ebsdlib::OrientationMatrixFType oMatrix2 = q2.toOrientationMatrix();
 
       // Convert the quaternion matrices to transposed g matrices so when caxis is multiplied by it, it will give the sample direction that the caxis is along
-      c1 = oMatrix1.transpose() * cAxis;
-      c2 = oMatrix2.transpose() * cAxis;
+      Eigen::Vector3f c1 = oMatrix1.transpose() * cAxis;
+      Eigen::Vector3f c2 = oMatrix2.transpose() * cAxis;
 
       // normalize so that the dot product can be taken below without
       // dividing by the magnitudes (they would be 1)
@@ -171,8 +172,8 @@ bool CAxisSegmentFeatures::determineGrouping(int64 referencepoint, int64 neighbo
       c2.normalize();
 
       // Validate value of w falls between [-1, 1] to ensure that acos returns a valid value
-      w = std::clamp(((c1[0] * c2[0]) + (c1[1] * c2[1]) + (c1[2] * c2[2])), -1.0F, 1.0F);
-      w = acosf(w);
+      float32 w = std::clamp(((c1[0] * c2[0]) + (c1[1] * c2[1]) + (c1[2] * c2[2])), -1.0F, 1.0F);
+      w = std::acos(w);
       if(w <= m_InputValues->MisorientationTolerance || (Constants::k_PiD - w) <= m_InputValues->MisorientationTolerance)
       {
         group = true;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertQuaternion.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertQuaternion.cpp
@@ -113,7 +113,7 @@ Result<> ConvertQuaternion::operator()()
   }
   else
   {
-    return {MakeErrorResult(-74836, fmt::format("The input and output arrays must be either Float32 or Float64 type"))};
+    return MakeErrorResult(-74836, fmt::format("The input and output arrays must be either Float32 or Float64 type"));
   }
   return {};
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
@@ -48,7 +48,7 @@ Result<> EBSDSegmentFeatures::operator()()
   // Sanity check the result.
   if(this->m_FoundFeatures < 1)
   {
-    return {MakeErrorResult(-87000, fmt::format("The number of Features is '{}' which means no Features were detected. A threshold value may be set incorrectly", this->m_FoundFeatures))};
+    return MakeErrorResult(-87000, fmt::format("The number of Features is '{}' which means no Features were detected. A threshold value may be set incorrectly", this->m_FoundFeatures));
   }
 
   // Resize the Feature Attribute Matrix

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadH5Ebsd.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadH5Ebsd.cpp
@@ -272,7 +272,7 @@ Result<> ReadH5Ebsd::operator()()
   int err = volumeInfoReader->readVolumeInfo();
   if(err < 0)
   {
-    return {MakeErrorResult(-50000, fmt::format("Could not read H5EbsdVolumeInfo from file '{}", m_InputValues->inputFilePath))};
+    return MakeErrorResult(-50000, fmt::format("Could not read H5EbsdVolumeInfo from file '{}", m_InputValues->inputFilePath));
   }
   std::array<int64_t, 3> dims = {0, 0, 0};
   std::array<float, 3> res = {0.0f, 0.0f, 0.0f};
@@ -326,8 +326,8 @@ Result<> ReadH5Ebsd::operator()()
   }
   else
   {
-    return {MakeErrorResult(-50001, fmt::format("Could not determine or match a supported manufacturer from the data file. Supported manufacturer codes are: '{}' and '{}'", ebsdlib::Ctf::Manufacturer,
-                                                ebsdlib::Ang::Manufacturer))};
+    return MakeErrorResult(-50001, fmt::format("Could not determine or match a supported manufacturer from the data file. Supported manufacturer codes are: '{}' and '{}'", ebsdlib::Ctf::Manufacturer,
+                                               ebsdlib::Ang::Manufacturer));
   }
   // Sanity Check the Error Condition or the state of the EBSD Reader Object.
   if(m_InputValues->useRecommendedTransform)
@@ -359,7 +359,7 @@ Result<> ReadH5Ebsd::operator()()
       auto executeResult = rotEuler.execute(m_DataStructure, args, nullptr, m_MessageHandler, m_ShouldCancel);
       if(executeResult.result.invalid())
       {
-        return {MakeErrorResult(-50011, fmt::format("Error executing {}", rotEuler.humanName()))};
+        return MakeErrorResult(-50011, fmt::format("Error executing {}", rotEuler.humanName()));
       }
     }
 
@@ -377,7 +377,7 @@ Result<> ReadH5Ebsd::operator()()
       auto filter = filterList->createFilter(k_RotateSampleRefFrameFilterHandle);
       if(nullptr == filter)
       {
-        return {MakeErrorResult(-50010, fmt::format("Error creating RotateSampleRefFrame filter"))};
+        return MakeErrorResult(-50010, fmt::format("Error creating RotateSampleRefFrame filter"));
       }
       Arguments args;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/PartitionGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/PartitionGeometry.cpp
@@ -209,7 +209,7 @@ Result<> PartitionGeometry::operator()()
     break;
   }
   default: {
-    return {MakeErrorResult(-3012, "Unable to partition geometry - Unknown geometry type detected.")};
+    return MakeErrorResult(-3012, "Unable to partition geometry - Unknown geometry type detected.");
   }
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadVolumeGraphicsFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadVolumeGraphicsFile.cpp
@@ -43,7 +43,7 @@ Result<> ReadVolumeGraphicsFile::operator()()
 
   if(filesize < allocatedBytes)
   {
-    return {MakeErrorResult(k_VolBinaryAllocateMismatch, fmt::format("Binary file size ({}) is smaller than the number of allocated bytes ({}).", filesize, allocatedBytes))};
+    return MakeErrorResult(k_VolBinaryAllocateMismatch, fmt::format("Binary file size ({}) is smaller than the number of allocated bytes ({}).", filesize, allocatedBytes));
   }
 
   m_MessageHandler(IFilter::Message::Type::Info, "Reading Data from .vol File.....");

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
@@ -214,7 +214,7 @@ Result<> ScalarSegmentFeatures::operator()()
   // Sanity check the result.
   if(this->m_FoundFeatures < 1)
   {
-    return {MakeErrorResult(-87000, fmt::format("The number of Features is '{}' which means no Features were detected. A threshold value may be set incorrectly", this->m_FoundFeatures))};
+    return MakeErrorResult(-87000, fmt::format("The number of Features is '{}' which means no Features were detected. A threshold value may be set incorrectly", this->m_FoundFeatures));
   }
 
   // Resize the Feature Attribute Matrix

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PartitionGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PartitionGeometryFilter.cpp
@@ -524,22 +524,22 @@ Result<> PartitionGeometryFilter::DataCheckDimensionality(const INodeGeometry0D&
   Result<bool> yzPlaneResult = geometry.isYZPlane();
   if(yzPlaneResult.valid() && yzPlaneResult.value())
   {
-    return {MakeErrorResult(-3040, "Unable to create a partitioning scheme with a X dimension size of 0.  Vertices are in an YZ plane.  Use the Advanced or Bounding Box "
-                                   "partitioning modes to manually create a partitioning scheme.")};
+    return MakeErrorResult(-3040, "Unable to create a partitioning scheme with a X dimension size of 0.  Vertices are in an YZ plane.  Use the Advanced or Bounding Box "
+                                  "partitioning modes to manually create a partitioning scheme.");
   }
 
   Result<bool> xzPlaneResult = geometry.isXZPlane();
   if(xzPlaneResult.valid() && xzPlaneResult.value())
   {
-    return {MakeErrorResult(-3041, "Unable to create a partitioning scheme with a Y dimension size of 0.  Vertices are in an XZ plane.  Use the Advanced or Bounding Box "
-                                   "partitioning modes to manually create a partitioning scheme.")};
+    return MakeErrorResult(-3041, "Unable to create a partitioning scheme with a Y dimension size of 0.  Vertices are in an XZ plane.  Use the Advanced or Bounding Box "
+                                  "partitioning modes to manually create a partitioning scheme.");
   }
 
   Result<bool> xyPlaneResult = geometry.isXYPlane();
   if(xyPlaneResult.valid() && xyPlaneResult.value())
   {
-    return {MakeErrorResult(-3042, "Unable to create a partitioning scheme with a Z dimension size of 0.  Vertices are in an XY plane.  Use the Advanced or Bounding Box "
-                                   "partitioning modes to manually create a partitioning scheme.")};
+    return MakeErrorResult(-3042, "Unable to create a partitioning scheme with a Z dimension size of 0.  Vertices are in an XY plane.  Use the Advanced or Bounding Box "
+                                  "partitioning modes to manually create a partitioning scheme.");
   }
 
   return {};
@@ -609,15 +609,15 @@ Result<> PartitionGeometryFilter::dataCheckAdvancedMode(const SizeVec3& numOfPar
 
   if(lengthPerPartition.getX() < 0)
   {
-    return {MakeErrorResult(-3003, fmt::format("{}: Length Per Partition - The X value cannot be negative.", humanName()))};
+    return MakeErrorResult(-3003, fmt::format("{}: Length Per Partition - The X value cannot be negative.", humanName()));
   }
   if(lengthPerPartition.getY() < 0)
   {
-    return {MakeErrorResult(-3004, fmt::format("{}: Length Per Partition - The Y value cannot be negative.", humanName()))};
+    return MakeErrorResult(-3004, fmt::format("{}: Length Per Partition - The Y value cannot be negative.", humanName()));
   }
   if(lengthPerPartition.getZ() < 0)
   {
-    return {MakeErrorResult(-3005, fmt::format("{}: Length Per Partition - The Z value cannot be negative.", humanName()))};
+    return MakeErrorResult(-3005, fmt::format("{}: Length Per Partition - The Z value cannot be negative.", humanName()));
   }
 
   result = dataCheckPartitioningScheme<GeomType>(geometryToPartition, attrMatrix);
@@ -642,17 +642,17 @@ Result<> PartitionGeometryFilter::dataCheckBoundingBoxMode(const SizeVec3& numOf
 
   if(llCoord.getX() > urCoord.getX())
   {
-    return {MakeErrorResult(-3006, fmt::format("{}: Lower Left Coordinate - X value is larger than the upper right coordinate X value.", humanName()))};
+    return MakeErrorResult(-3006, fmt::format("{}: Lower Left Coordinate - X value is larger than the upper right coordinate X value.", humanName()));
   }
 
   if(llCoord.getY() > urCoord.getY())
   {
-    return {MakeErrorResult(-3007, fmt::format("{}: Lower Left Coordinate - Y value is larger than the upper right coordinate Y value.", humanName()))};
+    return MakeErrorResult(-3007, fmt::format("{}: Lower Left Coordinate - Y value is larger than the upper right coordinate Y value.", humanName()));
   }
 
   if(llCoord.getZ() > urCoord.getZ())
   {
-    return {MakeErrorResult(-3008, fmt::format("{}: Lower Left Coordinate - Z value is larger than the upper right coordinate Z value.", humanName()))};
+    return MakeErrorResult(-3008, fmt::format("{}: Lower Left Coordinate - Z value is larger than the upper right coordinate Z value.", humanName()));
   }
 
   result = dataCheckPartitioningScheme<GeomType>(geometryToPartition, attrMatrix);
@@ -679,8 +679,8 @@ Result<> PartitionGeometryFilter::dataCheckPartitioningScheme(const GeomType& ge
   {
     if(attrMatrix.getNumTuples() != geometryToPartition.getNumberOfCells())
     {
-      return {MakeErrorResult(-3009, fmt::format("{}: The attribute matrix '{}' does not have the same tuple count ({}) as geometry \"{}\"'s cell count ({}).", humanName(), attrMatrix.getName(),
-                                                 attrMatrix.getNumTuples(), geometryToPartition.getName(), geometryToPartition.getNumberOfCells()))};
+      return MakeErrorResult(-3009, fmt::format("{}: The attribute matrix '{}' does not have the same tuple count ({}) as geometry \"{}\"'s cell count ({}).", humanName(), attrMatrix.getName(),
+                                                attrMatrix.getNumTuples(), geometryToPartition.getName(), geometryToPartition.getNumberOfCells()));
     }
   }
   else
@@ -688,8 +688,8 @@ Result<> PartitionGeometryFilter::dataCheckPartitioningScheme(const GeomType& ge
     const IGeometry::SharedVertexList& vertexList = geometryToPartition.getVertices();
     if(attrMatrix.getNumTuples() != vertexList.getNumberOfTuples())
     {
-      return {MakeErrorResult(-3010, fmt::format("{}: The attribute matrix '{}' does not have the same tuple count ({}) as geometry \"{}\"'s vertex count ({}).", humanName(), attrMatrix.getName(),
-                                                 attrMatrix.getNumTuples(), geometryToPartition.getName(), vertexList.getNumberOfTuples()))};
+      return MakeErrorResult(-3010, fmt::format("{}: The attribute matrix '{}' does not have the same tuple count ({}) as geometry \"{}\"'s vertex count ({}).", humanName(), attrMatrix.getName(),
+                                                attrMatrix.getNumTuples(), geometryToPartition.getName(), vertexList.getNumberOfTuples()));
     }
   }
 
@@ -701,17 +701,17 @@ Result<> PartitionGeometryFilter::DataCheckNumberOfPartitions(const SizeVec3& nu
 {
   if(numberOfPartitionsPerAxis.getX() <= 0)
   {
-    return {MakeErrorResult(-3012, "Number of Partitions Per Axis: The X dimension must be greater than 0.")};
+    return MakeErrorResult(-3012, "Number of Partitions Per Axis: The X dimension must be greater than 0.");
   }
 
   if(numberOfPartitionsPerAxis.getY() <= 0)
   {
-    return {MakeErrorResult(-3013, "Number of Partitions Per Axis: The Y dimension must be greater than 0.")};
+    return MakeErrorResult(-3013, "Number of Partitions Per Axis: The Y dimension must be greater than 0.");
   }
 
   if(numberOfPartitionsPerAxis.getZ() <= 0)
   {
-    return {MakeErrorResult(-3014, "Number of Partitions Per Axis: The Z dimension must be greater than 0.")};
+    return MakeErrorResult(-3014, "Number of Partitions Per Axis: The Z dimension must be greater than 0.");
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitDataArrayByTupleFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitDataArrayByTupleFilter.cpp
@@ -144,9 +144,9 @@ Result<> preflightDataGroupOutput(SplitDataArrayByTuple::OutputContainer outputC
 {
   if(splitDimension >= inputArrayTupleShape.size())
   {
-    return {MakeErrorResult(to_underlying(SplitDataArrayByTuple::ErrorCodes::SplitDimOutOfRange),
-                            fmt::format("The chosen split dimension ({}) is out of range of the input array's tuple shape rank (0-{}).  Please choose a dimension within this range.", splitDimension,
-                                        inputArrayTupleShape.size() - 1))};
+    return MakeErrorResult(to_underlying(SplitDataArrayByTuple::ErrorCodes::SplitDimOutOfRange),
+                           fmt::format("The chosen split dimension ({}) is out of range of the input array's tuple shape rank (0-{}).  Please choose a dimension within this range.", splitDimension,
+                                       inputArrayTupleShape.size() - 1));
   }
 
   splitArrayTupleShapes = std::vector<std::vector<usize>>(splitDimensionCounts.size(), inputArrayTupleShape);
@@ -160,16 +160,16 @@ Result<> preflightDataGroupOutput(SplitDataArrayByTuple::OutputContainer outputC
     const auto& row = splitDimensionCounts[i];
     if(row.size() > 1)
     {
-      return {MakeErrorResult(
+      return MakeErrorResult(
           to_underlying(SplitDataArrayByTuple::ErrorCodes::MultiDimensionalSplitCount),
-          fmt::format("Split Array {} contains a multi-dimensional split dimension count ({}).  The split dimension count should be a single dimension.", i, valuesToString(row, "x")))};
+          fmt::format("Split Array {} contains a multi-dimensional split dimension count ({}).  The split dimension count should be a single dimension.", i, valuesToString(row, "x")));
     }
 
     const auto& splitDimensionCount = splitDimensionCounts[i][0];
     if(splitDimensionCount <= 0)
     {
-      return {MakeErrorResult(to_underlying(SplitDataArrayByTuple::ErrorCodes::SplitCountLessThanZero),
-                              fmt::format("Split Array {} contains \"{}\" at Tuple Dim {}.  All tuple shape values must be >= 1.", i, splitDimensionCount, splitDimension))};
+      return MakeErrorResult(to_underlying(SplitDataArrayByTuple::ErrorCodes::SplitCountLessThanZero),
+                             fmt::format("Split Array {} contains \"{}\" at Tuple Dim {}.  All tuple shape values must be >= 1.", i, splitDimensionCount, splitDimension));
     }
     auto splitCount = static_cast<usize>(splitDimensionCount);
     splitArrayTupleShapes[i][splitDimension] = splitCount;
@@ -179,9 +179,9 @@ Result<> preflightDataGroupOutput(SplitDataArrayByTuple::OutputContainer outputC
 
   if(splitCountsTotal != inputArrayTupleShape[splitDimension])
   {
-    return {MakeErrorResult(to_underlying(SplitDataArrayByTuple::ErrorCodes::SplitCountSumNotEqual),
-                            fmt::format("The sum of your Split Dimension Counts ({} = {}) does not equal the input array's tuple count for dimension {} ({}).",
-                                        valuesToString(splitDimensionCountsUSize, "+"), splitCountsTotal, splitDimension, inputArrayTupleShape[splitDimension]))};
+    return MakeErrorResult(to_underlying(SplitDataArrayByTuple::ErrorCodes::SplitCountSumNotEqual),
+                           fmt::format("The sum of your Split Dimension Counts ({} = {}) does not equal the input array's tuple count for dimension {} ({}).",
+                                       valuesToString(splitDimensionCountsUSize, "+"), splitCountsTotal, splitDimension, inputArrayTupleShape[splitDimension]));
   }
 
   arrayPaths.reserve(splitArrayTupleShapes.size());
@@ -225,8 +225,8 @@ Result<> preflightAttrMatrixOutput(SplitDataArrayByTuple::OutputContainer output
     {
       if(newAttrMatrixTupleShape[j] <= 0)
       {
-        return {MakeErrorResult(to_underlying(SplitDataArrayByTuple::ErrorCodes::AttrMatrixTupleShapeNegative),
-                                fmt::format("Attribute matrix tuple shape contains \"{}\" at Tuple Dim {}.  All tuple shape values must be >= 1.", newAttrMatrixTupleShape[j], j))};
+        return MakeErrorResult(to_underlying(SplitDataArrayByTuple::ErrorCodes::AttrMatrixTupleShapeNegative),
+                               fmt::format("Attribute matrix tuple shape contains \"{}\" at Tuple Dim {}.  All tuple shape values must be >= 1.", newAttrMatrixTupleShape[j], j));
       }
     }
     tupleShape.resize(newAttrMatrixTupleShape.size());
@@ -244,11 +244,11 @@ Result<> preflightAttrMatrixOutput(SplitDataArrayByTuple::OutputContainer output
   auto result = commonMultiplier(inputArrayTupleShape, tupleShape, static_cast<usize>(splitDimension));
   if(result.invalid())
   {
-    return {MakeErrorResult(to_underlying(SplitDataArrayByTuple::ErrorCodes::AttrMatrixTupleShapeNoCommonMultiplier),
-                            fmt::format("The selected tuple shape ({0}) cannot cleanly split the input array '{1}' tuple shape ({2}) along dimension {3}.\n\n"
-                                        "No integer multiplier applied to dimension {3} of the selected tuple shape ({4}) will produce the corresponding value in the input array's tuple shape ({5}).",
-                                        valuesToString(tupleShape), inputArrayPath.toString(), valuesToString(inputArrayTupleShape), splitDimension, tupleShape[splitDimension],
-                                        inputArrayTupleShape[splitDimension]))};
+    return MakeErrorResult(to_underlying(SplitDataArrayByTuple::ErrorCodes::AttrMatrixTupleShapeNoCommonMultiplier),
+                           fmt::format("The selected tuple shape ({0}) cannot cleanly split the input array '{1}' tuple shape ({2}) along dimension {3}.\n\n"
+                                       "No integer multiplier applied to dimension {3} of the selected tuple shape ({4}) will produce the corresponding value in the input array's tuple shape ({5}).",
+                                       valuesToString(tupleShape), inputArrayPath.toString(), valuesToString(inputArrayTupleShape), splitDimension, tupleShape[splitDimension],
+                                       inputArrayTupleShape[splitDimension]));
   }
   usize numOfAttrMatrixSplitArrays = result.value();
 

--- a/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.cpp
+++ b/src/Plugins/TestOne/src/TestOne/Filters/ErrorWarningFilter.cpp
@@ -132,7 +132,7 @@ nx::core::Result<> ErrorWarningFilter::executeImpl(DataStructure& dataStructure,
   }
   if(executeError)
   {
-    return {MakeErrorResult(-666001, "Intentional execute error generated")};
+    return MakeErrorResult(-666001, "Intentional execute error generated");
   }
   if(executeException)
   {

--- a/src/simplnx/Utilities/Parsing/HDF5/H5DataStore.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/H5DataStore.hpp
@@ -28,10 +28,10 @@ Result<> FillDataStore(DataArray<T>& dataArray, const DataPath& dataArrayPath, c
     }
     if(result.invalid())
     {
-      return {MakeErrorResult(-21002,
-                              fmt::format("Error reading dataset '{}' with '{}' total elements into data store for data array '{}' with '{}' total elements ('{}' tuples and '{}' components):\n\n{}",
-                                          dataArrayPath.getTargetName(), datasetReader.getNumElements(), dataArrayPath.toString(), dataArray.getSize(), dataArray.getNumberOfTuples(),
-                                          dataArray.getNumberOfComponents(), result.errors()[0].message))};
+      return MakeErrorResult(-21002,
+                             fmt::format("Error reading dataset '{}' with '{}' total elements into data store for data array '{}' with '{}' total elements ('{}' tuples and '{}' components):\n\n{}",
+                                         dataArrayPath.getTargetName(), datasetReader.getNumElements(), dataArrayPath.toString(), dataArray.getSize(), dataArray.getNumberOfTuples(),
+                                         dataArray.getNumberOfComponents(), result.errors()[0].message));
     }
   } catch(const std::exception& e)
   {

--- a/wrapping/python/CxPybind/CxPybind/CxPybind.hpp
+++ b/wrapping/python/CxPybind/CxPybind/CxPybind.hpp
@@ -628,10 +628,10 @@ protected:
       return result;
     } catch(const py::error_already_set& pyException)
     {
-      return {MakeErrorResult(-42002, fmt::format("Python exception: {}", pyException.what()))};
+      return MakeErrorResult(-42002, fmt::format("Python exception: {}", pyException.what()));
     } catch(const std::exception& exception)
     {
-      return {MakeErrorResult(-42003, fmt::format("C++ exception: {}", exception.what()))};
+      return MakeErrorResult(-42003, fmt::format("C++ exception: {}", exception.what()));
     }
   }
 


### PR DESCRIPTION
Possibly unintended object slicing: struct 'ResultVoid' is value-initialized from derived struct 'Result<void>'