### PR TITLE
VERS: Update to EbsdLib 2.1.0

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/bluequartzsoftware/simplnx-registry",
-      "baseline": "a2b02a9b0181ddc1def0fe21c8df07f6d27d6b24",
+      "baseline": "fc1e12b6502374fdda171a1df44d8e3f3b61e84c",
       "packages": [
         "benchmark",
         "blosc",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -77,7 +77,7 @@
       "dependencies": [
         {
           "name": "ebsdlib",
-          "version>=": "2.0.0"
+          "version>=": "2.1.0"
         }
       ]
     },


### PR DESCRIPTION
The commits need to be updated to use master from simplnx-registry before this is merged.