### PR TITLE
BUG: Fix int32 overflow bug and code refactoring in Require Minimum Feature Size

### DIFF
--- a/src/Plugins/SimplnxCore/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/CMakeLists.txt
@@ -284,6 +284,7 @@ set(AlgorithmList
  # RenameDataObject
   ReplaceElementAttributesWithNeighborValues
   RequireMinNumNeighbors
+  RequireMinimumSizeFeatures
   ResampleImageGeom
   ResampleRectGridToImageGeom
   ReshapeDataArray

--- a/src/Plugins/SimplnxCore/docs/RequireMinimumSizeFeaturesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/RequireMinimumSizeFeaturesFilter.md
@@ -6,7 +6,7 @@ Processing (Cleanup)
 
 ## Description
 
-This **Filter** removes **Features** that have a total number of **Cells** below the minimum threshold defined by the user. Entering a number larger than the largest **Feature** generates an *error* (since all **Features** would be removed). Hence, a choice of threshold should be carefully be chosen if it is not known how many **Cells** are in the largest **Features**. After removing all the small **Features**, the remaining **Features** are isotropically coarsened to fill the gaps left by the small **Features**.
+This **Filter** removes **Features** that have a total number of **Cells** below the minimum threshold defined by the user. Entering a number larger than the largest **Feature** generates an *error* (since all **Features** would be removed). Hence, a choice of threshold should be carefully chosen if it is not known how many **Cells** are in the largest **Features**. After removing all the small **Features**, the remaining **Features** are isotropically coarsened to fill the gaps left by the small **Features**.
 
 The **Filter** can be run in a mode where the minimum number of neighbors is applied to a single **Ensemble**.  The user can select to apply the minimum to one specific **Ensemble**.
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.cpp
@@ -120,10 +120,17 @@ Result<> RequireMinimumSizeFeatures::operator()()
   {
     return {nonstd::make_unexpected(std::vector<Error>{errorReturn})};
   }
+  if(m_ShouldCancel)
+  {
+    return {};
+  }
 
   auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->InputImageGeometryPath);
   assignBadVoxels(imageGeom.getDimensions(), featureNumCellsStoreRef);
-
+  if(m_ShouldCancel)
+  {
+    return {};
+  }
   DataPath cellFeatureGroupPath = m_InputValues->FeatureNumCellsPath.getParent();
   usize currentFeatureCount = featureNumCellsStoreRef.getNumberOfTuples();
 
@@ -147,6 +154,7 @@ void RequireMinimumSizeFeatures::assignBadVoxels(SizeVec3 dimensions, const Int3
 {
   MessageHelper messageHelper(m_MessageHandler);
 
+  messageHelper.sendMessage(fmt::format("RequireMinimumSizeFeatures::assignBadVoxels Starting"));
   Int32AbstractDataStore& featureIds = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsPath)->getDataStoreRef();
   usize totalPoints = featureIds.getNumberOfTuples();
 
@@ -180,6 +188,10 @@ void RequireMinimumSizeFeatures::assignBadVoxels(SizeVec3 dimensions, const Int3
     counter = 0;
     for(int64 zIdx = 0; zIdx < dims[2]; zIdx++)
     {
+      if(m_ShouldCancel)
+      {
+        return;
+      }
       kstride = dims[0] * dims[1] * zIdx;
       for(int64 yIdx = 0; yIdx < dims[1]; yIdx++)
       {
@@ -262,6 +274,10 @@ std::vector<bool> RequireMinimumSizeFeatures::removeSmallFeatures(Int32AbstractD
 
   for(usize i = 1; i < totalFeatures; i++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
     if(!applyToSinglePhase)
     {
       if(featureNumCellsStoreRef.getValue(i) >= minAllowedFeatureSize)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.cpp
@@ -20,13 +20,14 @@ public:
   RequireMinimumSizeFeaturesTransferDataImpl(const RequireMinimumSizeFeaturesTransferDataImpl&) = default;
 
   RequireMinimumSizeFeaturesTransferDataImpl(RequireMinimumSizeFeatures* filterAlg, usize totalPoints, const Int32AbstractDataStore& featureIds, const std::vector<int64>& neighborVoxelIndex,
-                                             const std::shared_ptr<IDataArray>& dataArrayPtr, MessageHelper& messageHelper)
+                                             const std::shared_ptr<IDataArray>& dataArrayPtr, MessageHelper& messageHelper, const std::atomic_bool& shouldCancel)
   : m_FilterAlg(filterAlg)
   , m_TotalPoints(totalPoints)
   , m_NeighborsVoxelIndex(neighborVoxelIndex)
   , m_DataArrayPtr(dataArrayPtr)
   , m_FeatureIds(featureIds)
   , m_MessageHelper(messageHelper)
+  , m_ShouldCancel(shouldCancel)
   {
   }
   RequireMinimumSizeFeaturesTransferDataImpl(RequireMinimumSizeFeaturesTransferDataImpl&&) = default;                // Move Constructor is Not Implemented
@@ -39,16 +40,16 @@ public:
   {
     ThrottledMessenger throttledMessenger = m_MessageHelper.createThrottledMessenger();
     std::string arrayName = m_DataArrayPtr->getName();
-    usize prog = m_TotalPoints / 100;
-    if(prog == 0)
-    {
-      prog = 1;
-    }
+    usize prog = std::max(m_TotalPoints / 100ULL, 1ULL);
     for(usize voxelIndex = 0; voxelIndex < m_TotalPoints; voxelIndex++)
     {
       if(voxelIndex % prog == 0)
       {
         throttledMessenger.sendThrottledMessage([&]() { return fmt::format("Processing {}: {:.2f}% completed", arrayName, CalculatePercentComplete(voxelIndex, m_TotalPoints)); });
+      }
+      if(m_ShouldCancel)
+      {
+        return;
       }
 
       int32 currentFeatureId = m_FeatureIds.getValue(voxelIndex);
@@ -70,6 +71,7 @@ private:
   const std::shared_ptr<IDataArray> m_DataArrayPtr;
   const Int32AbstractDataStore& m_FeatureIds;
   MessageHelper& m_MessageHelper;
+  const std::atomic_bool& m_ShouldCancel;
 };
 
 } // namespace
@@ -159,8 +161,8 @@ Result<> RequireMinimumSizeFeatures::operator()()
 void RequireMinimumSizeFeatures::assignBadVoxels(SizeVec3 dimensions, const Int32AbstractDataStore& featureNumCellsStoreRef)
 {
   MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage(fmt::format("Assigning voxels...."));
 
-  messageHelper.sendMessage(fmt::format("RequireMinimumSizeFeatures::assignBadVoxels Starting"));
   Int32AbstractDataStore& featureIds = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsPath)->getDataStoreRef();
   usize totalPoints = featureIds.getNumberOfTuples();
 
@@ -240,13 +242,13 @@ void RequireMinimumSizeFeatures::assignBadVoxels(SizeVec3 dimensions, const Int3
       }
     }
 
-    StopWatch stopWatch;
-    stopWatch.start();
+    messageHelper.sendMessage(fmt::format("Remaining voxels: {} - Updating Data Arrays... ", counter));
+
     // Build up a list of the DataArrays that we are going to operate on.
     const std::vector<std::shared_ptr<IDataArray>> voxelArrays = nx::core::GenerateDataArrayList(m_DataStructure, m_InputValues->FeatureIdsPath, {});
 
     ParallelTaskAlgorithm taskRunner;
-    taskRunner.setParallelizationEnabled(false);
+    taskRunner.setParallelizationEnabled(true);
     for(const auto& voxelArray : voxelArrays)
     {
       // We need to skip updating the FeatureIds until all the other arrays are updated
@@ -256,16 +258,13 @@ void RequireMinimumSizeFeatures::assignBadVoxels(SizeVec3 dimensions, const Int3
         continue;
       }
 
-      taskRunner.execute(RequireMinimumSizeFeaturesTransferDataImpl(this, totalPoints, featureIds, neighborsVoxelIndex, voxelArray, messageHelper));
+      taskRunner.execute(RequireMinimumSizeFeaturesTransferDataImpl(this, totalPoints, featureIds, neighborsVoxelIndex, voxelArray, messageHelper, m_ShouldCancel));
     }
     taskRunner.wait(); // This will spill over if the number of DataArrays to process does not divide evenly by the number of threads.
     // Now update the feature Ids
     auto featureIDataArray = m_DataStructure.getSharedDataAs<IDataArray>(m_InputValues->FeatureIdsPath);
     taskRunner.setParallelizationEnabled(false); // Do this to make the next call synchronous
-    taskRunner.execute(RequireMinimumSizeFeaturesTransferDataImpl(this, totalPoints, featureIds, neighborsVoxelIndex, featureIDataArray, messageHelper));
-    stopWatch.stop();
-
-    messageHelper.sendMessage(fmt::format("RequireMinimumSizeFeatures::assignBadVoxels Updating Data Arrays Complete. Time:{}", stopWatch.toString()));
+    taskRunner.execute(RequireMinimumSizeFeaturesTransferDataImpl(this, totalPoints, featureIds, neighborsVoxelIndex, featureIDataArray, messageHelper, m_ShouldCancel));
   }
 }
 
@@ -274,6 +273,9 @@ std::vector<bool> RequireMinimumSizeFeatures::removeSmallFeatures(Int32AbstractD
                                                                   const Int32AbstractDataStore* featurePhases, int32 phaseNumber, bool applyToSinglePhase, int64 minAllowedFeatureSize,
                                                                   Error& errorReturn)
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage(fmt::format("Removing small features...."));
+
   usize totalPoints = featureIdsStoreRef.getNumberOfTuples();
 
   bool good = false;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.cpp
@@ -6,6 +6,7 @@
 #include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/NeighborUtilities.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
+#include "simplnx/Utilities/TimeUtilities.hpp"
 
 using namespace nx::core;
 
@@ -38,20 +39,25 @@ public:
   {
     ThrottledMessenger throttledMessenger = m_MessageHelper.createThrottledMessenger();
     std::string arrayName = m_DataArrayPtr->getName();
-    for(usize i = 0; i < m_TotalPoints; i++)
+    usize prog = m_TotalPoints / 100;
+    if(prog == 0)
     {
-      if(m_TotalPoints % 100 == 0)
+      prog = 1;
+    }
+    for(usize voxelIndex = 0; voxelIndex < m_TotalPoints; voxelIndex++)
+    {
+      if(voxelIndex % prog == 0)
       {
-        throttledMessenger.sendThrottledMessage([&]() { return fmt::format("Processing {}: {:.2f}% completed", arrayName, CalculatePercentComplete(i, m_TotalPoints)); });
+        throttledMessenger.sendThrottledMessage([&]() { return fmt::format("Processing {}: {:.2f}% completed", arrayName, CalculatePercentComplete(voxelIndex, m_TotalPoints)); });
       }
 
-      int32 currentFeatureId = m_FeatureIds.getValue(i);
-      int64 currentNeighborFeatureId = m_NeighborsVoxelIndex[i];
+      int32 currentFeatureId = m_FeatureIds.getValue(voxelIndex);
+      int64 currentNeighborFeatureId = m_NeighborsVoxelIndex[voxelIndex];
       if(currentNeighborFeatureId >= 0)
       {
         if(currentFeatureId < 0 && m_FeatureIds.getValue(currentNeighborFeatureId) >= 0)
         {
-          m_DataArrayPtr->copyTuple(currentNeighborFeatureId, i);
+          m_DataArrayPtr->copyTuple(currentNeighborFeatureId, voxelIndex);
         }
       }
     }
@@ -234,11 +240,13 @@ void RequireMinimumSizeFeatures::assignBadVoxels(SizeVec3 dimensions, const Int3
       }
     }
 
+    StopWatch stopWatch;
+    stopWatch.start();
     // Build up a list of the DataArrays that we are going to operate on.
     const std::vector<std::shared_ptr<IDataArray>> voxelArrays = nx::core::GenerateDataArrayList(m_DataStructure, m_InputValues->FeatureIdsPath, {});
 
     ParallelTaskAlgorithm taskRunner;
-    taskRunner.setParallelizationEnabled(true);
+    taskRunner.setParallelizationEnabled(false);
     for(const auto& voxelArray : voxelArrays)
     {
       // We need to skip updating the FeatureIds until all the other arrays are updated
@@ -255,6 +263,9 @@ void RequireMinimumSizeFeatures::assignBadVoxels(SizeVec3 dimensions, const Int3
     auto featureIDataArray = m_DataStructure.getSharedDataAs<IDataArray>(m_InputValues->FeatureIdsPath);
     taskRunner.setParallelizationEnabled(false); // Do this to make the next call synchronous
     taskRunner.execute(RequireMinimumSizeFeaturesTransferDataImpl(this, totalPoints, featureIds, neighborsVoxelIndex, featureIDataArray, messageHelper));
+    stopWatch.stop();
+
+    messageHelper.sendMessage(fmt::format("RequireMinimumSizeFeatures::assignBadVoxels Updating Data Arrays Complete. Time:{}", stopWatch.toString()));
   }
 }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.cpp
@@ -4,10 +4,10 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/MessageHelper.hpp"
+#include "simplnx/Utilities/NeighborUtilities.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
 using namespace nx::core;
-
 
 namespace
 {
@@ -18,8 +18,8 @@ public:
   RequireMinimumSizeFeaturesTransferDataImpl() = delete;
   RequireMinimumSizeFeaturesTransferDataImpl(const RequireMinimumSizeFeaturesTransferDataImpl&) = default;
 
-  RequireMinimumSizeFeaturesTransferDataImpl(RequireMinimumSizeFeatures* filterAlg, usize totalPoints, const Int32AbstractDataStore& featureIds,
-                                     const std::vector<int64>& neighborVoxelIndex, const std::shared_ptr<IDataArray>& dataArrayPtr, MessageHelper& messageHelper)
+  RequireMinimumSizeFeaturesTransferDataImpl(RequireMinimumSizeFeatures* filterAlg, usize totalPoints, const Int32AbstractDataStore& featureIds, const std::vector<int64>& neighborVoxelIndex,
+                                             const std::shared_ptr<IDataArray>& dataArrayPtr, MessageHelper& messageHelper)
   : m_FilterAlg(filterAlg)
   , m_TotalPoints(totalPoints)
   , m_NeighborsVoxelIndex(neighborVoxelIndex)
@@ -66,8 +66,7 @@ private:
   MessageHelper& m_MessageHelper;
 };
 
-}
-
+} // namespace
 
 // -----------------------------------------------------------------------------
 RequireMinimumSizeFeatures::RequireMinimumSizeFeatures(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel,
@@ -98,7 +97,7 @@ Result<> RequireMinimumSizeFeatures::operator()()
   {
     usize numFeatures = featurePhases->getNumberOfTuples();
     bool unavailablePhase = true;
-    for(size_t i = 0; i < numFeatures; i++)
+    for(usize i = 0; i < numFeatures; i++)
     {
       if(featurePhases->getValue(i) == m_InputValues->PhaseNumber)
       {
@@ -115,7 +114,8 @@ Result<> RequireMinimumSizeFeatures::operator()()
   }
 
   Error errorReturn = {0, ""};
-  std::vector<bool> activeObjects = removeSmallFeatures(featureIdsStoreRef, featureNumCellsStoreRef, featurePhases, m_InputValues->PhaseNumber, m_InputValues->ApplySinglePhase, m_InputValues->MinAllowedFeaturesSize, errorReturn);
+  std::vector<bool> activeObjects =
+      removeSmallFeatures(featureIdsStoreRef, featureNumCellsStoreRef, featurePhases, m_InputValues->PhaseNumber, m_InputValues->ApplySinglePhase, m_InputValues->MinAllowedFeaturesSize, errorReturn);
   if(errorReturn.code < 0)
   {
     return {nonstd::make_unexpected(std::vector<Error>{errorReturn})};
@@ -125,7 +125,7 @@ Result<> RequireMinimumSizeFeatures::operator()()
   assignBadVoxels(imageGeom.getDimensions(), featureNumCellsStoreRef);
 
   DataPath cellFeatureGroupPath = m_InputValues->FeatureNumCellsPath.getParent();
-  size_t currentFeatureCount = featureNumCellsStoreRef.getNumberOfTuples();
+  usize currentFeatureCount = featureNumCellsStoreRef.getNumberOfTuples();
 
   int32 count = 0;
   for(const auto& value : activeObjects)
@@ -143,28 +143,27 @@ Result<> RequireMinimumSizeFeatures::operator()()
   return {};
 }
 
-
-void RequireMinimumSizeFeatures::assignBadVoxels( SizeVec3 dimensions, const Int32AbstractDataStore& featureNumCellsStoreRef)
+void RequireMinimumSizeFeatures::assignBadVoxels(SizeVec3 dimensions, const Int32AbstractDataStore& featureNumCellsStoreRef)
 {
   MessageHelper messageHelper(m_MessageHandler);
 
   Int32AbstractDataStore& featureIds = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsPath)->getDataStoreRef();
   usize totalPoints = featureIds.getNumberOfTuples();
 
-  std::array<int64_t, 3> dims = {
+  std::array<int64, 3> dims = {
       static_cast<int64>(dimensions[0]),
       static_cast<int64>(dimensions[1]),
       static_cast<int64>(dimensions[2]),
   };
 
-  std::vector<int64_t> neighborsVoxelIndex(totalPoints * featureIds.getNumberOfComponents(), -1);
+  std::vector<int64> neighborsVoxelIndex(totalPoints * featureIds.getNumberOfComponents(), -1);
 
-  int32 good = 1;
+  // int32 good = 1;
   int64 neighborVoxelIdx = 0;
 
   // These are the offsets that are applied to a voxel index to get to a specific neighbor voxel
-  std::array<int64_t, 6> neighborVoxelIndexOffsets = {-dims[0] * dims[1], -dims[0], -1, 1, dims[0], dims[0] * dims[1]};
-
+  std::array<int64, 6> neighborVoxelIndexOffsets = initializeFaceNeighborOffsets(dims);
+  std::array<FaceNeighborType, 6> faceNeighborInternalIdx = initializeFaceNeighborInternalIdx();
   usize counter = 1;
   int64 count = 0;
   int64 kstride = 0;
@@ -179,61 +178,39 @@ void RequireMinimumSizeFeatures::assignBadVoxels( SizeVec3 dimensions, const Int
   while(counter != 0)
   {
     counter = 0;
-    for(int64 k = 0; k < dims[2]; k++)
+    for(int64 zIdx = 0; zIdx < dims[2]; zIdx++)
     {
-      kstride = dims[0] * dims[1] * k;
-      for(int64 j = 0; j < dims[1]; j++)
+      kstride = dims[0] * dims[1] * zIdx;
+      for(int64 yIdx = 0; yIdx < dims[1]; yIdx++)
       {
-        jstride = dims[0] * j;
-        for(int64 i = 0; i < dims[0]; i++)
+        jstride = dims[0] * yIdx;
+        for(int64 xIdx = 0; xIdx < dims[0]; xIdx++)
         {
-          count = kstride + jstride + i;
+          count = kstride + jstride + xIdx;
           int32 currentFeatureId = featureIds.getValue(count);
           if(currentFeatureId < 0)
           {
             counter++;
             uint8 maxVoteCount = 0;
-            for(size_t l = 0; l < neighborVoxelIndexOffsets.size(); l++)
+            // Loop over the 6 face neighbors of the voxel
+            std::array<bool, 6> isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
+            for(const auto& faceIndex : faceNeighborInternalIdx)
             {
-              good = 1;
-              neighborVoxelIdx = count + neighborVoxelIndexOffsets[l];
-              if(l == 0 && k == 0)
+              if(!isValidFaceNeighbor[faceIndex])
               {
-                good = 0;
-              }
-              if(l == 5 && k == (dims[2] - 1))
-              {
-                good = 0;
-              }
-              if(l == 1 && j == 0)
-              {
-                good = 0;
-              }
-              if(l == 4 && j == (dims[1] - 1))
-              {
-                good = 0;
-              }
-              if(l == 2 && i == 0)
-              {
-                good = 0;
-              }
-              if(l == 3 && i == (dims[0] - 1))
-              {
-                good = 0;
+                continue;
               }
 
-              if(good == 1)
+              neighborVoxelIdx = count + neighborVoxelIndexOffsets[faceIndex];
+              int32 neighborFeatureId = featureIds.getValue(neighborVoxelIdx);
+              if(neighborFeatureId >= 0)
               {
-                int32 neighborFeatureId = featureIds.getValue(neighborVoxelIdx);
-                if(neighborFeatureId >= 0)
+                voteCounter[neighborFeatureId]++;
+                uint8 currentVoteCount = voteCounter[neighborFeatureId];
+                if(currentVoteCount > maxVoteCount)
                 {
-                  voteCounter[neighborFeatureId]++;
-                  uint8 currentVoteCount = voteCounter[neighborFeatureId];
-                  if(currentVoteCount > maxVoteCount)
-                  {
-                    maxVoteCount = currentVoteCount;
-                    neighborsVoxelIndex[count] = neighborVoxelIdx;
-                  }
+                  maxVoteCount = currentVoteCount;
+                  neighborsVoxelIndex[count] = neighborVoxelIdx;
                 }
               }
             }
@@ -266,24 +243,24 @@ void RequireMinimumSizeFeatures::assignBadVoxels( SizeVec3 dimensions, const Int
     auto featureIDataArray = m_DataStructure.getSharedDataAs<IDataArray>(m_InputValues->FeatureIdsPath);
     taskRunner.setParallelizationEnabled(false); // Do this to make the next call synchronous
     taskRunner.execute(RequireMinimumSizeFeaturesTransferDataImpl(this, totalPoints, featureIds, neighborsVoxelIndex, featureIDataArray, messageHelper));
-
   }
 }
 
 // -----------------------------------------------------------------------------
-std::vector<bool> RequireMinimumSizeFeatures::removeSmallFeatures(Int32AbstractDataStore& featureIdsStoreRef, const Int32AbstractDataStore& featureNumCellsStoreRef, const Int32AbstractDataStore* featurePhases,
-                                       int32_t phaseNumber, bool applyToSinglePhase, int64 minAllowedFeatureSize, Error& errorReturn)
+std::vector<bool> RequireMinimumSizeFeatures::removeSmallFeatures(Int32AbstractDataStore& featureIdsStoreRef, const Int32AbstractDataStore& featureNumCellsStoreRef,
+                                                                  const Int32AbstractDataStore* featurePhases, int32 phaseNumber, bool applyToSinglePhase, int64 minAllowedFeatureSize,
+                                                                  Error& errorReturn)
 {
-  size_t totalPoints = featureIdsStoreRef.getNumberOfTuples();
+  usize totalPoints = featureIdsStoreRef.getNumberOfTuples();
 
   bool good = false;
   int32 gnum;
 
-  size_t totalFeatures = featureNumCellsStoreRef.getNumberOfTuples();
+  usize totalFeatures = featureNumCellsStoreRef.getNumberOfTuples();
 
   std::vector<bool> activeObjects(totalFeatures, true);
 
-  for(size_t i = 1; i < totalFeatures; i++)
+  for(usize i = 1; i < totalFeatures; i++)
   {
     if(!applyToSinglePhase)
     {
@@ -313,7 +290,7 @@ std::vector<bool> RequireMinimumSizeFeatures::removeSmallFeatures(Int32AbstractD
     errorReturn = Error{-1, "The minimum size is larger than the largest Feature.  All Features would be removed"};
     return activeObjects;
   }
-  for(size_t i = 0; i < totalPoints; i++)
+  for(usize i = 0; i < totalPoints; i++)
   {
     gnum = featureIdsStoreRef.getValue(i);
     if(!activeObjects[gnum])

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.hpp
@@ -61,7 +61,7 @@ protected:
    * @return
    */
   std::vector<bool> removeSmallFeatures(Int32AbstractDataStore& featureIdsStoreRef, const Int32AbstractDataStore& featureNumCellsStoreRef, const Int32AbstractDataStore* featurePhases,
-                                               int32_t phaseNumber, bool applyToSinglePhase, int64 minAllowedFeatureSize, Error& errorReturn);
+                                        int32_t phaseNumber, bool applyToSinglePhase, int64 minAllowedFeatureSize, Error& errorReturn);
 
 private:
   DataStructure& m_DataStructure;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.hpp
@@ -60,7 +60,7 @@ protected:
    * @param errorReturn
    * @return
    */
-  static std::vector<bool> removeSmallFeatures(Int32AbstractDataStore& featureIdsStoreRef, const Int32AbstractDataStore& featureNumCellsStoreRef, const Int32AbstractDataStore* featurePhases,
+  std::vector<bool> removeSmallFeatures(Int32AbstractDataStore& featureIdsStoreRef, const Int32AbstractDataStore& featureNumCellsStoreRef, const Int32AbstractDataStore* featurePhases,
                                                int32_t phaseNumber, bool applyToSinglePhase, int64 minAllowedFeatureSize, Error& errorReturn);
 
 private:

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.hpp
@@ -49,7 +49,7 @@ protected:
    */
   void assignBadVoxels(SizeVec3 dimensions, const Int32AbstractDataStore& featureNumCellsStoreRef);
 
-    /**
+  /**
    *
    * @param featureIdsStoreRef
    * @param featureNumCellsStoreRef
@@ -60,8 +60,9 @@ protected:
    * @param errorReturn
    * @return
    */
-static std::vector<bool> removeSmallFeatures(Int32AbstractDataStore& featureIdsStoreRef, const Int32AbstractDataStore& featureNumCellsStoreRef, const Int32AbstractDataStore* featurePhases,
-                                         int32_t phaseNumber, bool applyToSinglePhase, int64 minAllowedFeatureSize, Error& errorReturn);
+  static std::vector<bool> removeSmallFeatures(Int32AbstractDataStore& featureIdsStoreRef, const Int32AbstractDataStore& featureNumCellsStoreRef, const Int32AbstractDataStore* featurePhases,
+                                               int32_t phaseNumber, bool applyToSinglePhase, int64 minAllowedFeatureSize, Error& errorReturn);
+
 private:
   DataStructure& m_DataStructure;
   const RequireMinimumSizeFeaturesInputValues* m_InputValues = nullptr;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/not_used/RequireMinimumSizeFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/not_used/RequireMinimumSizeFeatures.cpp
@@ -2,8 +2,235 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/DataGroupUtilities.hpp"
 
 using namespace nx::core;
+
+
+namespace
+{
+using FeatureIdsArrayType = Int32Array;
+using NumCellsArrayType = Int32Array;
+using PhasesArrayType = Int32Array;
+
+void assign_badpoints(DataStructure& dataStructure, const DataPath& featureIdsPath, SizeVec3 dimensions, const NumCellsArrayType::store_type& numCellsStoreRef)
+{
+  FeatureIdsArrayType::store_type* featureIds = dataStructure.getDataAs<FeatureIdsArrayType>(featureIdsPath)->getDataStore();
+  usize totalPoints = featureIds->getNumberOfTuples();
+
+  std::array<int64_t, 3> dims = {
+      static_cast<int64>(dimensions[0]),
+      static_cast<int64>(dimensions[1]),
+      static_cast<int64>(dimensions[2]),
+  };
+
+  std::vector<int32_t> neighbors(totalPoints * featureIds->getNumberOfComponents(), -1);
+
+  int32 good = 1;
+  int32 current = 0;
+  int32 most = 0;
+  int64 neighpoint = 0;
+
+  std::array<int64_t, 6> neighpoints = {-dims[0] * dims[1], -dims[0], -1, 1, dims[0], dims[0] * dims[1]};
+
+  usize counter = 1;
+  int64 count = 0;
+  int64 kstride = 0;
+  int64 jstride = 0;
+  int32 featurename = 0;
+  int32 feature = 0;
+  int32 neighbor = 0;
+  std::vector<int32> n(numCellsStoreRef.getNumberOfTuples(), 0);
+
+  while(counter != 0)
+  {
+    counter = 0;
+    for(int64 k = 0; k < dims[2]; k++)
+    {
+      kstride = dims[0] * dims[1] * k;
+      for(int64 j = 0; j < dims[1]; j++)
+      {
+        jstride = dims[0] * j;
+        for(int64 i = 0; i < dims[0]; i++)
+        {
+          count = kstride + jstride + i;
+          featurename = featureIds->getValue(count);
+          if(featurename < 0)
+          {
+            counter++;
+            most = 0;
+            for(size_t l = 0; l < neighpoints.size(); l++)
+            {
+              good = 1;
+              neighpoint = count + neighpoints[l];
+              if(l == 0 && k == 0)
+              {
+                good = 0;
+              }
+              if(l == 5 && k == (dims[2] - 1))
+              {
+                good = 0;
+              }
+              if(l == 1 && j == 0)
+              {
+                good = 0;
+              }
+              if(l == 4 && j == (dims[1] - 1))
+              {
+                good = 0;
+              }
+              if(l == 2 && i == 0)
+              {
+                good = 0;
+              }
+              if(l == 3 && i == (dims[0] - 1))
+              {
+                good = 0;
+              }
+              if(good == 1)
+              {
+                feature = featureIds->getValue(neighpoint);
+                if(feature >= 0)
+                {
+                  n[feature]++;
+                  current = n[feature];
+                  if(current > most)
+                  {
+                    most = current;
+                    neighbors[count] = neighpoint;
+                  }
+                }
+              }
+            }
+            for(int32 l = 0; l < neighpoints.size(); l++)
+            {
+              good = 1;
+              neighpoint = count + neighpoints[l];
+              if(l == 0 && k == 0)
+              {
+                good = 0;
+              }
+              if(l == 5 && k == (dims[2] - 1))
+              {
+                good = 0;
+              }
+              if(l == 1 && j == 0)
+              {
+                good = 0;
+              }
+              if(l == 4 && j == (dims[1] - 1))
+              {
+                good = 0;
+              }
+              if(l == 2 && i == 0)
+              {
+                good = 0;
+              }
+              if(l == 3 && i == (dims[0] - 1))
+              {
+                good = 0;
+              }
+              if(good == 1)
+              {
+                feature = featureIds->getValue(neighpoint);
+                if(feature >= 0)
+                {
+                  n[feature] = 0;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    DataPath attrMatPath = featureIdsPath.getParent();
+    auto* parentGroup = dataStructure.getDataAs<BaseGroup>(attrMatPath);
+    std::vector<std::string> voxelArrayNames;
+    for(const auto& [identifier, sharedChild] : *parentGroup)
+    {
+      if(std::dynamic_pointer_cast<IDataArray>(sharedChild))
+      {
+        voxelArrayNames.push_back(sharedChild->getName());
+      }
+    }
+
+    // TODO: This loop could be parallelized. Look at NeighborOrientationCorrelation filter
+    for(size_t j = 0; j < totalPoints; j++)
+    {
+      featurename = featureIds->getValue(j);
+      neighbor = neighbors[j];
+      if(neighbor >= 0)
+      {
+        if(featurename < 0 && featureIds->getValue(neighbor) >= 0)
+        {
+          for(auto& voxelArrayName : voxelArrayNames)
+          {
+            auto arrayPath = attrMatPath.createChildPath(voxelArrayName);
+            auto* arr = dataStructure.getDataAs<IDataArray>(arrayPath);
+            arr->copyTuple(neighbor, j);
+          }
+        }
+      }
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+std::vector<bool> remove_smallfeatures(FeatureIdsArrayType::store_type& featureIdsStoreRef, const NumCellsArrayType::store_type& numCells, const PhasesArrayType::store_type* featurePhases,
+                                       int32_t phaseNumber, bool applyToSinglePhase, int64 minAllowedFeatureSize, Error& errorReturn)
+{
+  size_t totalPoints = featureIdsStoreRef.getNumberOfTuples();
+
+  bool good = false;
+  int32 gnum;
+
+  size_t totalFeatures = numCells.getNumberOfTuples();
+
+  std::vector<bool> activeObjects(totalFeatures, true);
+
+  for(size_t i = 1; i < totalFeatures; i++)
+  {
+    if(!applyToSinglePhase)
+    {
+      if(numCells.getValue(i) >= minAllowedFeatureSize)
+      {
+        good = true;
+      }
+      else
+      {
+        activeObjects[i] = false;
+      }
+    }
+    else
+    {
+      if(numCells.getValue(i) >= minAllowedFeatureSize || featurePhases->getValue(i) != phaseNumber)
+      {
+        good = true;
+      }
+      else
+      {
+        activeObjects[i] = false;
+      }
+    }
+  }
+  if(!good)
+  {
+    errorReturn = Error{-1, "The minimum size is larger than the largest Feature.  All Features would be removed"};
+    return activeObjects;
+  }
+  for(size_t i = 0; i < totalPoints; i++)
+  {
+    gnum = featureIdsStoreRef.getValue(i);
+    if(!activeObjects[gnum])
+    {
+      featureIdsStoreRef.setValue(i, -1);
+    }
+  }
+  return activeObjects;
+}
+}
+
 
 // -----------------------------------------------------------------------------
 RequireMinimumSizeFeatures::RequireMinimumSizeFeatures(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel,
@@ -21,6 +248,59 @@ RequireMinimumSizeFeatures::~RequireMinimumSizeFeatures() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> RequireMinimumSizeFeatures::operator()()
 {
+  PhasesArrayType::store_type* featurePhases = m_InputValues->ApplySinglePhase ? m_DataStructure.getDataAs<PhasesArrayType>(m_InputValues->FeaturePhasesPath)->getDataStore() : nullptr;
+
+  FeatureIdsArrayType::store_type& featureIdsStoreRef = m_DataStructure.getDataAs<FeatureIdsArrayType>(m_InputValues->FeatureIdsPath)->getDataStoreRef();
+
+  auto& numCellsArrayRef = m_DataStructure.getDataRefAs<NumCellsArrayType>(m_InputValues->NumCellsPath);
+  NumCellsArrayType::store_type& numCellsStoreRef = numCellsArrayRef.getDataStoreRef();
+
+  if(m_InputValues->ApplySinglePhase && featurePhases != nullptr)
+  {
+    usize numFeatures = featurePhases->getNumberOfTuples();
+
+    bool unavailablePhase = true;
+    for(size_t i = 0; i < numFeatures; i++)
+    {
+      if(featurePhases->getValue(i) == m_InputValues->PhaseNumber)
+      {
+        unavailablePhase = false;
+        break;
+      }
+    }
+
+    if(unavailablePhase)
+    {
+      std::string ss = fmt::format("The phase number {} is not available in the supplied Feature phases array with path {}", m_InputValues->PhaseNumber, m_InputValues->FeaturePhasesPath.toString());
+      return MakeErrorResult(-5555, ss);
+    }
+  }
+
+  Error errorReturn;
+  std::vector<bool> activeObjects = remove_smallfeatures(featureIdsStoreRef, numCellsStoreRef, featurePhases, m_InputValues->PhaseNumber, m_InputValues->ApplySinglePhase, m_InputValues->MinAllowedFeaturesSize, errorReturn);
+  if(errorReturn.code < 0)
+  {
+    return {nonstd::make_unexpected(std::vector<Error>{errorReturn})};
+  }
+
+  auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->InputImageGeometryPath);
+  assign_badpoints(m_DataStructure, m_InputValues->FeatureIdsPath, imageGeom.getDimensions(), numCellsStoreRef);
+
+  DataPath cellFeatureGroupPath = m_InputValues->NumCellsPath.getParent();
+  size_t currentFeatureCount = numCellsStoreRef.getNumberOfTuples();
+
+  int32 count = 0;
+  for(const auto& value : activeObjects)
+  {
+    if(value)
+    {
+      count++;
+    }
+  }
+  std::string message = fmt::format("Feature Count Changed: Previous: {} New: {}", currentFeatureCount, count);
+  m_MessageHandler(nx::core::IFilter::Message{nx::core::IFilter::Message::Type::Info, message});
+
+  nx::core::RemoveInactiveObjects(m_DataStructure, cellFeatureGroupPath, activeObjects, featureIdsStoreRef, currentFeatureCount, m_MessageHandler, m_ShouldCancel);
 
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/not_used/RequireMinimumSizeFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/not_used/RequireMinimumSizeFeatures.cpp
@@ -1,23 +1,155 @@
 #include "RequireMinimumSizeFeatures.hpp"
 
 #include "simplnx/DataStructure/DataArray.hpp"
-#include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
+#include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
 using namespace nx::core;
 
 
 namespace
 {
-using FeatureIdsArrayType = Int32Array;
-using NumCellsArrayType = Int32Array;
-using PhasesArrayType = Int32Array;
 
-void assign_badpoints(DataStructure& dataStructure, const DataPath& featureIdsPath, SizeVec3 dimensions, const NumCellsArrayType::store_type& numCellsStoreRef)
+class RequireMinimumSizeFeaturesTransferDataImpl
 {
-  FeatureIdsArrayType::store_type* featureIds = dataStructure.getDataAs<FeatureIdsArrayType>(featureIdsPath)->getDataStore();
-  usize totalPoints = featureIds->getNumberOfTuples();
+public:
+  RequireMinimumSizeFeaturesTransferDataImpl() = delete;
+  RequireMinimumSizeFeaturesTransferDataImpl(const RequireMinimumSizeFeaturesTransferDataImpl&) = default;
+
+  RequireMinimumSizeFeaturesTransferDataImpl(RequireMinimumSizeFeatures* filterAlg, usize totalPoints, const Int32AbstractDataStore& featureIds,
+                                     const std::vector<int64>& neighborVoxelIndex, const std::shared_ptr<IDataArray>& dataArrayPtr, MessageHelper& messageHelper)
+  : m_FilterAlg(filterAlg)
+  , m_TotalPoints(totalPoints)
+  , m_NeighborsVoxelIndex(neighborVoxelIndex)
+  , m_DataArrayPtr(dataArrayPtr)
+  , m_FeatureIds(featureIds)
+  , m_MessageHelper(messageHelper)
+  {
+  }
+  RequireMinimumSizeFeaturesTransferDataImpl(RequireMinimumSizeFeaturesTransferDataImpl&&) = default;                // Move Constructor is Not Implemented
+  RequireMinimumSizeFeaturesTransferDataImpl& operator=(const RequireMinimumSizeFeaturesTransferDataImpl&) = delete; // Copy Assignment is Not Implemented
+  RequireMinimumSizeFeaturesTransferDataImpl& operator=(RequireMinimumSizeFeaturesTransferDataImpl&&) = delete;      // Move Assignment is Not Implemented
+
+  ~RequireMinimumSizeFeaturesTransferDataImpl() = default;
+
+  void operator()() const
+  {
+    ThrottledMessenger throttledMessenger = m_MessageHelper.createThrottledMessenger();
+    std::string arrayName = m_DataArrayPtr->getName();
+    for(usize i = 0; i < m_TotalPoints; i++)
+    {
+      if(m_TotalPoints % 100 == 0)
+      {
+        throttledMessenger.sendThrottledMessage([&]() { return fmt::format("Processing {}: {:.2f}% completed", arrayName, CalculatePercentComplete(i, m_TotalPoints)); });
+      }
+
+      int32 currentFeatureId = m_FeatureIds.getValue(i);
+      int64 currentNeighborFeatureId = m_NeighborsVoxelIndex[i];
+      if(currentNeighborFeatureId >= 0)
+      {
+        if(currentFeatureId < 0 && m_FeatureIds.getValue(currentNeighborFeatureId) >= 0)
+        {
+          m_DataArrayPtr->copyTuple(currentNeighborFeatureId, i);
+        }
+      }
+    }
+  }
+
+private:
+  RequireMinimumSizeFeatures* m_FilterAlg = nullptr;
+  usize m_TotalPoints = 0;
+  std::vector<int64> m_NeighborsVoxelIndex;
+  const std::shared_ptr<IDataArray> m_DataArrayPtr;
+  const Int32AbstractDataStore& m_FeatureIds;
+  MessageHelper& m_MessageHelper;
+};
+
+}
+
+
+// -----------------------------------------------------------------------------
+RequireMinimumSizeFeatures::RequireMinimumSizeFeatures(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel,
+                                                       RequireMinimumSizeFeaturesInputValues* inputValues)
+: m_DataStructure(dataStructure)
+, m_InputValues(inputValues)
+, m_ShouldCancel(shouldCancel)
+, m_MessageHandler(mesgHandler)
+{
+}
+
+// -----------------------------------------------------------------------------
+RequireMinimumSizeFeatures::~RequireMinimumSizeFeatures() noexcept = default;
+
+// -----------------------------------------------------------------------------
+Result<> RequireMinimumSizeFeatures::operator()()
+{
+
+  // Input Cell Level Data
+  auto& featureIdsStoreRef = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsPath)->getDataStoreRef();
+
+  // Input Feature Level Data
+  auto& featureNumCellsStoreRef = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->FeatureNumCellsPath).getDataStoreRef();
+
+  // Optionally allow applying to a single phase
+  auto* featurePhases = m_InputValues->ApplySinglePhase ? m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeaturePhasesPath)->getDataStore() : nullptr;
+  if(m_InputValues->ApplySinglePhase && featurePhases != nullptr)
+  {
+    usize numFeatures = featurePhases->getNumberOfTuples();
+    bool unavailablePhase = true;
+    for(size_t i = 0; i < numFeatures; i++)
+    {
+      if(featurePhases->getValue(i) == m_InputValues->PhaseNumber)
+      {
+        unavailablePhase = false;
+        break;
+      }
+    }
+
+    if(unavailablePhase)
+    {
+      std::string ss = fmt::format("The phase number {} is not available in the supplied Feature phases array with path {}", m_InputValues->PhaseNumber, m_InputValues->FeaturePhasesPath.toString());
+      return MakeErrorResult(-5555, ss);
+    }
+  }
+
+  Error errorReturn = {0, ""};
+  std::vector<bool> activeObjects = removeSmallFeatures(featureIdsStoreRef, featureNumCellsStoreRef, featurePhases, m_InputValues->PhaseNumber, m_InputValues->ApplySinglePhase, m_InputValues->MinAllowedFeaturesSize, errorReturn);
+  if(errorReturn.code < 0)
+  {
+    return {nonstd::make_unexpected(std::vector<Error>{errorReturn})};
+  }
+
+  auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->InputImageGeometryPath);
+  assignBadVoxels(imageGeom.getDimensions(), featureNumCellsStoreRef);
+
+  DataPath cellFeatureGroupPath = m_InputValues->FeatureNumCellsPath.getParent();
+  size_t currentFeatureCount = featureNumCellsStoreRef.getNumberOfTuples();
+
+  int32 count = 0;
+  for(const auto& value : activeObjects)
+  {
+    if(value)
+    {
+      count++;
+    }
+  }
+  std::string message = fmt::format("Feature Count Changed: Previous: {} New: {}", currentFeatureCount, count);
+  m_MessageHandler(nx::core::IFilter::Message{nx::core::IFilter::Message::Type::Info, message});
+
+  nx::core::RemoveInactiveObjects(m_DataStructure, cellFeatureGroupPath, activeObjects, featureIdsStoreRef, currentFeatureCount, m_MessageHandler, m_ShouldCancel);
+
+  return {};
+}
+
+
+void RequireMinimumSizeFeatures::assignBadVoxels( SizeVec3 dimensions, const Int32AbstractDataStore& featureNumCellsStoreRef)
+{
+  MessageHelper messageHelper(m_MessageHandler);
+
+  Int32AbstractDataStore& featureIds = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsPath)->getDataStoreRef();
+  usize totalPoints = featureIds.getNumberOfTuples();
 
   std::array<int64_t, 3> dims = {
       static_cast<int64>(dimensions[0]),
@@ -25,23 +157,24 @@ void assign_badpoints(DataStructure& dataStructure, const DataPath& featureIdsPa
       static_cast<int64>(dimensions[2]),
   };
 
-  std::vector<int32_t> neighbors(totalPoints * featureIds->getNumberOfComponents(), -1);
+  std::vector<int64_t> neighborsVoxelIndex(totalPoints * featureIds.getNumberOfComponents(), -1);
 
   int32 good = 1;
-  int32 current = 0;
-  int32 most = 0;
-  int64 neighpoint = 0;
+  int64 neighborVoxelIdx = 0;
 
-  std::array<int64_t, 6> neighpoints = {-dims[0] * dims[1], -dims[0], -1, 1, dims[0], dims[0] * dims[1]};
+  // These are the offsets that are applied to a voxel index to get to a specific neighbor voxel
+  std::array<int64_t, 6> neighborVoxelIndexOffsets = {-dims[0] * dims[1], -dims[0], -1, 1, dims[0], dims[0] * dims[1]};
 
   usize counter = 1;
   int64 count = 0;
   int64 kstride = 0;
   int64 jstride = 0;
-  int32 featurename = 0;
-  int32 feature = 0;
-  int32 neighbor = 0;
-  std::vector<int32> n(numCellsStoreRef.getNumberOfTuples(), 0);
+
+  // `voteCounter` serves as a vote counter array for determining which feature ID should
+  // be assigned to "bad" voxels (those with featureId < 0 after small features
+  // were removed). The array indexing is by feature ID. The largest value that could
+  // be saved is 6 since there are only 6 face neighbors.
+  std::vector<uint8> voteCounter(featureNumCellsStoreRef.getNumberOfTuples(), 0);
 
   while(counter != 0)
   {
@@ -55,15 +188,15 @@ void assign_badpoints(DataStructure& dataStructure, const DataPath& featureIdsPa
         for(int64 i = 0; i < dims[0]; i++)
         {
           count = kstride + jstride + i;
-          featurename = featureIds->getValue(count);
-          if(featurename < 0)
+          int32 currentFeatureId = featureIds.getValue(count);
+          if(currentFeatureId < 0)
           {
             counter++;
-            most = 0;
-            for(size_t l = 0; l < neighpoints.size(); l++)
+            uint8 maxVoteCount = 0;
+            for(size_t l = 0; l < neighborVoxelIndexOffsets.size(); l++)
             {
               good = 1;
-              neighpoint = count + neighpoints[l];
+              neighborVoxelIdx = count + neighborVoxelIndexOffsets[l];
               if(l == 0 && k == 0)
               {
                 good = 0;
@@ -88,96 +221,57 @@ void assign_badpoints(DataStructure& dataStructure, const DataPath& featureIdsPa
               {
                 good = 0;
               }
+
               if(good == 1)
               {
-                feature = featureIds->getValue(neighpoint);
-                if(feature >= 0)
+                int32 neighborFeatureId = featureIds.getValue(neighborVoxelIdx);
+                if(neighborFeatureId >= 0)
                 {
-                  n[feature]++;
-                  current = n[feature];
-                  if(current > most)
+                  voteCounter[neighborFeatureId]++;
+                  uint8 currentVoteCount = voteCounter[neighborFeatureId];
+                  if(currentVoteCount > maxVoteCount)
                   {
-                    most = current;
-                    neighbors[count] = neighpoint;
+                    maxVoteCount = currentVoteCount;
+                    neighborsVoxelIndex[count] = neighborVoxelIdx;
                   }
                 }
               }
             }
-            for(int32 l = 0; l < neighpoints.size(); l++)
-            {
-              good = 1;
-              neighpoint = count + neighpoints[l];
-              if(l == 0 && k == 0)
-              {
-                good = 0;
-              }
-              if(l == 5 && k == (dims[2] - 1))
-              {
-                good = 0;
-              }
-              if(l == 1 && j == 0)
-              {
-                good = 0;
-              }
-              if(l == 4 && j == (dims[1] - 1))
-              {
-                good = 0;
-              }
-              if(l == 2 && i == 0)
-              {
-                good = 0;
-              }
-              if(l == 3 && i == (dims[0] - 1))
-              {
-                good = 0;
-              }
-              if(good == 1)
-              {
-                feature = featureIds->getValue(neighpoint);
-                if(feature >= 0)
-                {
-                  n[feature] = 0;
-                }
-              }
-            }
+
+            // Reset the VoteCounter back to Zero...
+            std::fill(voteCounter.begin(), voteCounter.end(), 0);
           }
         }
-      }
-    }
-    DataPath attrMatPath = featureIdsPath.getParent();
-    auto* parentGroup = dataStructure.getDataAs<BaseGroup>(attrMatPath);
-    std::vector<std::string> voxelArrayNames;
-    for(const auto& [identifier, sharedChild] : *parentGroup)
-    {
-      if(std::dynamic_pointer_cast<IDataArray>(sharedChild))
-      {
-        voxelArrayNames.push_back(sharedChild->getName());
       }
     }
 
-    // TODO: This loop could be parallelized. Look at NeighborOrientationCorrelation filter
-    for(size_t j = 0; j < totalPoints; j++)
+    // Build up a list of the DataArrays that we are going to operate on.
+    const std::vector<std::shared_ptr<IDataArray>> voxelArrays = nx::core::GenerateDataArrayList(m_DataStructure, m_InputValues->FeatureIdsPath, {});
+
+    ParallelTaskAlgorithm taskRunner;
+    taskRunner.setParallelizationEnabled(true);
+    for(const auto& voxelArray : voxelArrays)
     {
-      featurename = featureIds->getValue(j);
-      neighbor = neighbors[j];
-      if(neighbor >= 0)
+      // We need to skip updating the FeatureIds until all the other arrays are updated
+      // since we actually depend on the feature Ids values.
+      if(voxelArray->getName() == m_InputValues->FeatureIdsPath.getTargetName())
       {
-        if(featurename < 0 && featureIds->getValue(neighbor) >= 0)
-        {
-          for(auto& voxelArrayName : voxelArrayNames)
-          {
-            auto arrayPath = attrMatPath.createChildPath(voxelArrayName);
-            auto* arr = dataStructure.getDataAs<IDataArray>(arrayPath);
-            arr->copyTuple(neighbor, j);
-          }
-        }
+        continue;
       }
+
+      taskRunner.execute(RequireMinimumSizeFeaturesTransferDataImpl(this, totalPoints, featureIds, neighborsVoxelIndex, voxelArray, messageHelper));
     }
+    taskRunner.wait(); // This will spill over if the number of DataArrays to process does not divide evenly by the number of threads.
+    // Now update the feature Ids
+    auto featureIDataArray = m_DataStructure.getSharedDataAs<IDataArray>(m_InputValues->FeatureIdsPath);
+    taskRunner.setParallelizationEnabled(false); // Do this to make the next call synchronous
+    taskRunner.execute(RequireMinimumSizeFeaturesTransferDataImpl(this, totalPoints, featureIds, neighborsVoxelIndex, featureIDataArray, messageHelper));
+
   }
 }
 
 // -----------------------------------------------------------------------------
-std::vector<bool> remove_smallfeatures(FeatureIdsArrayType::store_type& featureIdsStoreRef, const NumCellsArrayType::store_type& numCells, const PhasesArrayType::store_type* featurePhases,
+std::vector<bool> RequireMinimumSizeFeatures::removeSmallFeatures(Int32AbstractDataStore& featureIdsStoreRef, const Int32AbstractDataStore& featureNumCellsStoreRef, const Int32AbstractDataStore* featurePhases,
                                        int32_t phaseNumber, bool applyToSinglePhase, int64 minAllowedFeatureSize, Error& errorReturn)
 {
   size_t totalPoints = featureIdsStoreRef.getNumberOfTuples();
@@ -185,7 +279,7 @@ std::vector<bool> remove_smallfeatures(FeatureIdsArrayType::store_type& featureI
   bool good = false;
   int32 gnum;
 
-  size_t totalFeatures = numCells.getNumberOfTuples();
+  size_t totalFeatures = featureNumCellsStoreRef.getNumberOfTuples();
 
   std::vector<bool> activeObjects(totalFeatures, true);
 
@@ -193,7 +287,7 @@ std::vector<bool> remove_smallfeatures(FeatureIdsArrayType::store_type& featureI
   {
     if(!applyToSinglePhase)
     {
-      if(numCells.getValue(i) >= minAllowedFeatureSize)
+      if(featureNumCellsStoreRef.getValue(i) >= minAllowedFeatureSize)
       {
         good = true;
       }
@@ -204,7 +298,7 @@ std::vector<bool> remove_smallfeatures(FeatureIdsArrayType::store_type& featureI
     }
     else
     {
-      if(numCells.getValue(i) >= minAllowedFeatureSize || featurePhases->getValue(i) != phaseNumber)
+      if(featureNumCellsStoreRef.getValue(i) >= minAllowedFeatureSize || featurePhases->getValue(i) != phaseNumber)
       {
         good = true;
       }
@@ -228,79 +322,4 @@ std::vector<bool> remove_smallfeatures(FeatureIdsArrayType::store_type& featureI
     }
   }
   return activeObjects;
-}
-}
-
-
-// -----------------------------------------------------------------------------
-RequireMinimumSizeFeatures::RequireMinimumSizeFeatures(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel,
-                                                       RequireMinimumSizeFeaturesInputValues* inputValues)
-: m_DataStructure(dataStructure)
-, m_InputValues(inputValues)
-, m_ShouldCancel(shouldCancel)
-, m_MessageHandler(mesgHandler)
-{
-}
-
-// -----------------------------------------------------------------------------
-RequireMinimumSizeFeatures::~RequireMinimumSizeFeatures() noexcept = default;
-
-// -----------------------------------------------------------------------------
-Result<> RequireMinimumSizeFeatures::operator()()
-{
-  PhasesArrayType::store_type* featurePhases = m_InputValues->ApplySinglePhase ? m_DataStructure.getDataAs<PhasesArrayType>(m_InputValues->FeaturePhasesPath)->getDataStore() : nullptr;
-
-  FeatureIdsArrayType::store_type& featureIdsStoreRef = m_DataStructure.getDataAs<FeatureIdsArrayType>(m_InputValues->FeatureIdsPath)->getDataStoreRef();
-
-  auto& numCellsArrayRef = m_DataStructure.getDataRefAs<NumCellsArrayType>(m_InputValues->NumCellsPath);
-  NumCellsArrayType::store_type& numCellsStoreRef = numCellsArrayRef.getDataStoreRef();
-
-  if(m_InputValues->ApplySinglePhase && featurePhases != nullptr)
-  {
-    usize numFeatures = featurePhases->getNumberOfTuples();
-
-    bool unavailablePhase = true;
-    for(size_t i = 0; i < numFeatures; i++)
-    {
-      if(featurePhases->getValue(i) == m_InputValues->PhaseNumber)
-      {
-        unavailablePhase = false;
-        break;
-      }
-    }
-
-    if(unavailablePhase)
-    {
-      std::string ss = fmt::format("The phase number {} is not available in the supplied Feature phases array with path {}", m_InputValues->PhaseNumber, m_InputValues->FeaturePhasesPath.toString());
-      return MakeErrorResult(-5555, ss);
-    }
-  }
-
-  Error errorReturn;
-  std::vector<bool> activeObjects = remove_smallfeatures(featureIdsStoreRef, numCellsStoreRef, featurePhases, m_InputValues->PhaseNumber, m_InputValues->ApplySinglePhase, m_InputValues->MinAllowedFeaturesSize, errorReturn);
-  if(errorReturn.code < 0)
-  {
-    return {nonstd::make_unexpected(std::vector<Error>{errorReturn})};
-  }
-
-  auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->InputImageGeometryPath);
-  assign_badpoints(m_DataStructure, m_InputValues->FeatureIdsPath, imageGeom.getDimensions(), numCellsStoreRef);
-
-  DataPath cellFeatureGroupPath = m_InputValues->NumCellsPath.getParent();
-  size_t currentFeatureCount = numCellsStoreRef.getNumberOfTuples();
-
-  int32 count = 0;
-  for(const auto& value : activeObjects)
-  {
-    if(value)
-    {
-      count++;
-    }
-  }
-  std::string message = fmt::format("Feature Count Changed: Previous: {} New: {}", currentFeatureCount, count);
-  m_MessageHandler(nx::core::IFilter::Message{nx::core::IFilter::Message::Type::Info, message});
-
-  nx::core::RemoveInactiveObjects(m_DataStructure, cellFeatureGroupPath, activeObjects, featureIdsStoreRef, currentFeatureCount, m_MessageHandler, m_ShouldCancel);
-
-  return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/not_used/RequireMinimumSizeFeatures.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/not_used/RequireMinimumSizeFeatures.hpp
@@ -19,8 +19,8 @@ struct SIMPLNXCORE_EXPORT RequireMinimumSizeFeaturesInputValues
   ArraySelectionParameter::ValueType FeaturePhasesPath;
   GeometrySelectionParameter::ValueType InputImageGeometryPath;
   Int64Parameter::ValueType MinAllowedFeaturesSize;
-  ArraySelectionParameter::ValueType NumCellsPath;
-  Int64Parameter::ValueType PhaseNumber;
+  ArraySelectionParameter::ValueType FeatureNumCellsPath;
+  Int32Parameter::ValueType PhaseNumber;
 };
 
 /**
@@ -41,6 +41,27 @@ public:
 
   Result<> operator()();
 
+protected:
+  /**
+   *
+   * @param dimensions
+   * @param featureNumCellsStoreRef
+   */
+  void assignBadVoxels(SizeVec3 dimensions, const Int32AbstractDataStore& featureNumCellsStoreRef);
+
+    /**
+   *
+   * @param featureIdsStoreRef
+   * @param featureNumCellsStoreRef
+   * @param featurePhases
+   * @param phaseNumber
+   * @param applyToSinglePhase
+   * @param minAllowedFeatureSize
+   * @param errorReturn
+   * @return
+   */
+static std::vector<bool> removeSmallFeatures(Int32AbstractDataStore& featureIdsStoreRef, const Int32AbstractDataStore& featureNumCellsStoreRef, const Int32AbstractDataStore* featurePhases,
+                                         int32_t phaseNumber, bool applyToSinglePhase, int64 minAllowedFeatureSize, Error& errorReturn);
 private:
   DataStructure& m_DataStructure;
   const RequireMinimumSizeFeaturesInputValues* m_InputValues = nullptr;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/not_used/RequireMinimumSizeFeatures.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/not_used/RequireMinimumSizeFeatures.hpp
@@ -3,26 +3,11 @@
 #include "SimplnxCore/SimplnxCore_export.hpp"
 
 #include "simplnx/DataStructure/DataPath.hpp"
-#include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/Filter/IFilter.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/GeometrySelectionParameter.hpp"
 #include "simplnx/Parameters/NumberParameter.hpp"
-
-/**
-* This is example code to put in the Execute Method of the filter.
-  RequireMinimumSizeFeaturesInputValues inputValues;
-  inputValues.ApplySinglePhase = filterArgs.value<BoolParameter::ValueType>(apply_single_phase);
-  inputValues.FeatureIdsPath = filterArgs.value<ArraySelectionParameter::ValueType>(feature_ids_path);
-  inputValues.FeaturePhasesPath = filterArgs.value<ArraySelectionParameter::ValueType>(feature_phases_path);
-  inputValues.InputImageGeometryPath = filterArgs.value<GeometrySelectionParameter::ValueType>(input_image_geometry_path);
-  inputValues.MinAllowedFeaturesSize = filterArgs.value<Int64Parameter::ValueType>(min_allowed_features_size);
-  inputValues.NumCellsPath = filterArgs.value<ArraySelectionParameter::ValueType>(num_cells_path);
-  inputValues.PhaseNumber = filterArgs.value<Int64Parameter::ValueType>(phase_number);
-  return RequireMinimumSizeFeatures(dataStructure, messageHandler, shouldCancel, &inputValues)();
-
-*/
 
 namespace nx::core
 {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.cpp
@@ -1,5 +1,7 @@
 #include "RequireMinimumSizeFeaturesFilter.hpp"
 
+#include "SimplnxCore/Filters/Algorithms/RequireMinimumSizeFeatures.hpp"
+
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Filter/Actions/DeleteDataAction.hpp"
@@ -8,7 +10,6 @@
 #include "simplnx/Parameters/DataGroupSelectionParameter.hpp"
 #include "simplnx/Parameters/GeometrySelectionParameter.hpp"
 #include "simplnx/Parameters/NumberParameter.hpp"
-#include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
 
@@ -28,221 +29,6 @@ constexpr int32 k_BadMinAllowedFeatureSize = -5555;
 constexpr int32 k_BadNumCellsPath = -5556;
 constexpr int32 k_ParentlessPathError = -5557;
 
-void assign_badpoints(DataStructure& dataStructure, const DataPath& featureIdsPath, SizeVec3 dimensions, const NumCellsArrayType::store_type& numCellsStoreRef)
-{
-  FeatureIdsArrayType::store_type* featureIds = dataStructure.getDataAs<FeatureIdsArrayType>(featureIdsPath)->getDataStore();
-  usize totalPoints = featureIds->getNumberOfTuples();
-
-  std::array<int64_t, 3> dims = {
-      static_cast<int64>(dimensions[0]),
-      static_cast<int64>(dimensions[1]),
-      static_cast<int64>(dimensions[2]),
-  };
-
-  std::vector<int32_t> neighbors(totalPoints * featureIds->getNumberOfComponents(), -1);
-
-  int32 good = 1;
-  int32 current = 0;
-  int32 most = 0;
-  int64 neighpoint = 0;
-
-  std::array<int64_t, 6> neighpoints = {-dims[0] * dims[1], -dims[0], -1, 1, dims[0], dims[0] * dims[1]};
-
-  usize counter = 1;
-  int64 count = 0;
-  int64 kstride = 0;
-  int64 jstride = 0;
-  int32 featurename = 0;
-  int32 feature = 0;
-  int32 neighbor = 0;
-  std::vector<int32> n(numCellsStoreRef.getNumberOfTuples(), 0);
-
-  while(counter != 0)
-  {
-    counter = 0;
-    for(int64 k = 0; k < dims[2]; k++)
-    {
-      kstride = dims[0] * dims[1] * k;
-      for(int64 j = 0; j < dims[1]; j++)
-      {
-        jstride = dims[0] * j;
-        for(int64 i = 0; i < dims[0]; i++)
-        {
-          count = kstride + jstride + i;
-          featurename = featureIds->getValue(count);
-          if(featurename < 0)
-          {
-            counter++;
-            most = 0;
-            for(size_t l = 0; l < neighpoints.size(); l++)
-            {
-              good = 1;
-              neighpoint = count + neighpoints[l];
-              if(l == 0 && k == 0)
-              {
-                good = 0;
-              }
-              if(l == 5 && k == (dims[2] - 1))
-              {
-                good = 0;
-              }
-              if(l == 1 && j == 0)
-              {
-                good = 0;
-              }
-              if(l == 4 && j == (dims[1] - 1))
-              {
-                good = 0;
-              }
-              if(l == 2 && i == 0)
-              {
-                good = 0;
-              }
-              if(l == 3 && i == (dims[0] - 1))
-              {
-                good = 0;
-              }
-              if(good == 1)
-              {
-                feature = featureIds->getValue(neighpoint);
-                if(feature >= 0)
-                {
-                  n[feature]++;
-                  current = n[feature];
-                  if(current > most)
-                  {
-                    most = current;
-                    neighbors[count] = neighpoint;
-                  }
-                }
-              }
-            }
-            for(int32 l = 0; l < neighpoints.size(); l++)
-            {
-              good = 1;
-              neighpoint = count + neighpoints[l];
-              if(l == 0 && k == 0)
-              {
-                good = 0;
-              }
-              if(l == 5 && k == (dims[2] - 1))
-              {
-                good = 0;
-              }
-              if(l == 1 && j == 0)
-              {
-                good = 0;
-              }
-              if(l == 4 && j == (dims[1] - 1))
-              {
-                good = 0;
-              }
-              if(l == 2 && i == 0)
-              {
-                good = 0;
-              }
-              if(l == 3 && i == (dims[0] - 1))
-              {
-                good = 0;
-              }
-              if(good == 1)
-              {
-                feature = featureIds->getValue(neighpoint);
-                if(feature >= 0)
-                {
-                  n[feature] = 0;
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    DataPath attrMatPath = featureIdsPath.getParent();
-    auto* parentGroup = dataStructure.getDataAs<BaseGroup>(attrMatPath);
-    std::vector<std::string> voxelArrayNames;
-    for(const auto& [identifier, sharedChild] : *parentGroup)
-    {
-      if(std::dynamic_pointer_cast<IDataArray>(sharedChild))
-      {
-        voxelArrayNames.push_back(sharedChild->getName());
-      }
-    }
-
-    // TODO: This loop could be parallelized. Look at NeighborOrientationCorrelation filter
-    for(size_t j = 0; j < totalPoints; j++)
-    {
-      featurename = featureIds->getValue(j);
-      neighbor = neighbors[j];
-      if(neighbor >= 0)
-      {
-        if(featurename < 0 && featureIds->getValue(neighbor) >= 0)
-        {
-          for(auto& voxelArrayName : voxelArrayNames)
-          {
-            auto arrayPath = attrMatPath.createChildPath(voxelArrayName);
-            auto* arr = dataStructure.getDataAs<IDataArray>(arrayPath);
-            arr->copyTuple(neighbor, j);
-          }
-        }
-      }
-    }
-  }
-}
-
-// -----------------------------------------------------------------------------
-std::vector<bool> remove_smallfeatures(FeatureIdsArrayType::store_type& featureIdsStoreRef, const NumCellsArrayType::store_type& numCells, const PhasesArrayType::store_type* featurePhases,
-                                       int32_t phaseNumber, bool applyToSinglePhase, int64 minAllowedFeatureSize, Error& errorReturn)
-{
-  size_t totalPoints = featureIdsStoreRef.getNumberOfTuples();
-
-  bool good = false;
-  int32 gnum;
-
-  size_t totalFeatures = numCells.getNumberOfTuples();
-
-  std::vector<bool> activeObjects(totalFeatures, true);
-
-  for(size_t i = 1; i < totalFeatures; i++)
-  {
-    if(!applyToSinglePhase)
-    {
-      if(numCells.getValue(i) >= minAllowedFeatureSize)
-      {
-        good = true;
-      }
-      else
-      {
-        activeObjects[i] = false;
-      }
-    }
-    else
-    {
-      if(numCells.getValue(i) >= minAllowedFeatureSize || featurePhases->getValue(i) != phaseNumber)
-      {
-        good = true;
-      }
-      else
-      {
-        activeObjects[i] = false;
-      }
-    }
-  }
-  if(!good)
-  {
-    errorReturn = Error{-1, "The minimum size is larger than the largest Feature.  All Features would be removed"};
-    return activeObjects;
-  }
-  for(size_t i = 0; i < totalPoints; i++)
-  {
-    gnum = featureIdsStoreRef.getValue(i);
-    if(!activeObjects[gnum])
-    {
-      featureIdsStoreRef.setValue(i, -1);
-    }
-  }
-  return activeObjects;
-}
 } // namespace
 
 std::string RequireMinimumSizeFeaturesFilter::name() const
@@ -385,69 +171,17 @@ IFilter::PreflightResult RequireMinimumSizeFeaturesFilter::preflightImpl(const D
 Result<> RequireMinimumSizeFeaturesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                                        const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
-  auto featurePhasesPath = filterArgs.value<DataPath>(k_FeaturePhasesPath_Key);
-  auto featureIdsPath = filterArgs.value<DataPath>(k_FeatureIdsPath_Key);
-  auto imageGeomPath = filterArgs.value<DataPath>(k_ImageGeomPath_Key);
-  auto numCellsPath = filterArgs.value<DataPath>(k_NumCellsPath_Key);
-  auto applyToSinglePhase = filterArgs.value<bool>(k_ApplySinglePhase_Key);
-  auto minAllowedFeatureSize = filterArgs.value<int64>(k_MinAllowedFeaturesSize_Key);
-  auto phaseNumber = filterArgs.value<int64>(k_PhaseNumber_Key);
+  RequireMinimumSizeFeaturesInputValues inputValues;
 
-  PhasesArrayType::store_type* featurePhases = applyToSinglePhase ? dataStructure.getDataAs<PhasesArrayType>(featurePhasesPath)->getDataStore() : nullptr;
+  inputValues.ApplySinglePhase = filterArgs.value<BoolParameter::ValueType>(k_ApplySinglePhase_Key);
+  inputValues.FeatureIdsPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_FeatureIdsPath_Key);
+  inputValues.FeaturePhasesPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_FeaturePhasesPath_Key);
+  inputValues.InputImageGeometryPath = filterArgs.value<GeometrySelectionParameter::ValueType>(k_ImageGeomPath_Key);
+  inputValues.MinAllowedFeaturesSize = filterArgs.value<Int64Parameter::ValueType>(k_MinAllowedFeaturesSize_Key);
+  inputValues.NumCellsPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_NumCellsPath_Key);
+  inputValues.PhaseNumber = filterArgs.value<Int64Parameter::ValueType>(k_PhaseNumber_Key);
 
-  FeatureIdsArrayType::store_type& featureIdsStoreRef = dataStructure.getDataAs<FeatureIdsArrayType>(featureIdsPath)->getDataStoreRef();
-
-  auto& numCellsArrayRef = dataStructure.getDataRefAs<NumCellsArrayType>(numCellsPath);
-  NumCellsArrayType::store_type& numCellsStoreRef = numCellsArrayRef.getDataStoreRef();
-
-  if(applyToSinglePhase && featurePhases != nullptr)
-  {
-    usize numFeatures = featurePhases->getNumberOfTuples();
-
-    bool unavailablePhase = true;
-    for(size_t i = 0; i < numFeatures; i++)
-    {
-      if(featurePhases->getValue(i) == phaseNumber)
-      {
-        unavailablePhase = false;
-        break;
-      }
-    }
-
-    if(unavailablePhase)
-    {
-      std::string ss = fmt::format("The phase number {} is not available in the supplied Feature phases array with path {}", phaseNumber, featurePhasesPath.toString());
-      return MakeErrorResult(-5555, ss);
-    }
-  }
-
-  Error errorReturn;
-  std::vector<bool> activeObjects = remove_smallfeatures(featureIdsStoreRef, numCellsStoreRef, featurePhases, phaseNumber, applyToSinglePhase, minAllowedFeatureSize, errorReturn);
-  if(errorReturn.code < 0)
-  {
-    return {nonstd::make_unexpected(std::vector<Error>{errorReturn})};
-  }
-
-  auto& imageGeom = dataStructure.getDataRefAs<ImageGeom>(imageGeomPath);
-  assign_badpoints(dataStructure, featureIdsPath, imageGeom.getDimensions(), numCellsStoreRef);
-
-  DataPath cellFeatureGroupPath = numCellsPath.getParent();
-  size_t currentFeatureCount = numCellsStoreRef.getNumberOfTuples();
-
-  int32 count = 0;
-  for(const auto& value : activeObjects)
-  {
-    if(value)
-    {
-      count++;
-    }
-  }
-  std::string message = fmt::format("Feature Count Changed: Previous: {} New: {}", currentFeatureCount, count);
-  messageHandler(nx::core::IFilter::Message{nx::core::IFilter::Message::Type::Info, message});
-
-  nx::core::RemoveInactiveObjects(dataStructure, cellFeatureGroupPath, activeObjects, featureIdsStoreRef, currentFeatureCount, messageHandler, shouldCancel);
-
-  return {};
+  return RequireMinimumSizeFeatures(dataStructure, messageHandler, shouldCancel, &inputValues)();
 }
 
 namespace

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.cpp
@@ -205,7 +205,7 @@ Result<Arguments> RequireMinimumSizeFeaturesFilter::FromSIMPLJson(const nlohmann
 
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::IntFilterParameterConverter<int64>>(args, json, SIMPL::k_MinAllowedFeatureSizeKey, k_MinAllowedFeaturesSize_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::LinkedBooleanFilterParameterConverter>(args, json, SIMPL::k_ApplyToSinglePhaseKey, k_ApplySinglePhase_Key));
-  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::IntFilterParameterConverter<int64>>(args, json, SIMPL::k_PhaseNumberKey, k_SinglePhaseNumber_Key));
+  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::IntFilterParameterConverter<int32>>(args, json, SIMPL::k_PhaseNumberKey, k_SinglePhaseNumber_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataContainerSelectionFilterParameterConverter>(args, json, SIMPL::k_FeatureIdsArrayPathKey, k_ImageGeomPath_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_FeatureIdsArrayPathKey, k_FeatureIdsPath_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_FeaturePhasesArrayPathKey, k_FeaturePhasesPath_Key));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.cpp
@@ -65,7 +65,7 @@ Parameters RequireMinimumSizeFeaturesFilter::parameters() const
   params.insert(std::make_unique<NumberParameter<int64>>(k_MinAllowedFeaturesSize_Key, "Minimum Allowed Features Size", "Minimum allowed features size", 0));
 
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_ApplySinglePhase_Key, "Apply to Single Phase", "Apply to Single Phase", false));
-  params.insert(std::make_unique<NumberParameter<int64>>(k_PhaseNumber_Key, "Phase Index", "Target phase to remove", 0));
+  params.insert(std::make_unique<NumberParameter<int32>>(k_SinglePhaseNumber_Key, "Phase Index", "Target phase to remove", 0));
 
   params.insertSeparator(Parameters::Separator{"Input Cell Data"});
   params.insert(std::make_unique<GeometrySelectionParameter>(k_ImageGeomPath_Key, "Input Image Geometry", "The input image geometry (cell)", DataPath{},
@@ -74,12 +74,12 @@ Parameters RequireMinimumSizeFeaturesFilter::parameters() const
                                                           ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
 
   params.insertSeparator(Parameters::Separator{"Input Feature Data"});
-  params.insert(std::make_unique<ArraySelectionParameter>(k_NumCellsPath_Key, "Feature Num. Cells Array", "DataPath to NumCells DataArray", DataPath({"NumElements"}),
+  params.insert(std::make_unique<ArraySelectionParameter>(k_FeatureNumCellsPath_Key, "Feature Num. Cells Array", "DataPath to NumCells DataArray", DataPath({"NumElements"}),
                                                           ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
   params.insert(std::make_unique<ArraySelectionParameter>(k_FeaturePhasesPath_Key, "Feature Phases", "DataPath to Feature Phases DataArray", DataPath{},
                                                           ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
   // Link the checkbox to the other parameters
-  params.linkParameters(k_ApplySinglePhase_Key, k_PhaseNumber_Key, std::make_any<bool>(true));
+  params.linkParameters(k_ApplySinglePhase_Key, k_SinglePhaseNumber_Key, std::make_any<bool>(true));
   params.linkParameters(k_ApplySinglePhase_Key, k_FeaturePhasesPath_Key, std::make_any<bool>(true));
 
   return params;
@@ -102,7 +102,7 @@ IFilter::PreflightResult RequireMinimumSizeFeaturesFilter::preflightImpl(const D
   auto featurePhasesPath = filterArgs.value<DataPath>(k_FeaturePhasesPath_Key);
   auto featureIdsPath = filterArgs.value<DataPath>(k_FeatureIdsPath_Key);
   auto imageGeomPath = filterArgs.value<DataPath>(k_ImageGeomPath_Key);
-  auto numCellsPath = filterArgs.value<DataPath>(k_NumCellsPath_Key);
+  auto featureNumCellsPath = filterArgs.value<DataPath>(k_FeatureNumCellsPath_Key);
   auto applyToSinglePhase = filterArgs.value<bool>(k_ApplySinglePhase_Key);
   auto minAllowedFeatureSize = filterArgs.value<int64>(k_MinAllowedFeaturesSize_Key);
 
@@ -119,12 +119,12 @@ IFilter::PreflightResult RequireMinimumSizeFeaturesFilter::preflightImpl(const D
   {
     return {MakeErrorResult<OutputActions>(k_BadNumCellsPath, "FeatureIds not provided as an Int32 Array.")};
   }
-  const auto* numCellsPtr = dataStructure.getDataAs<NumCellsArrayType>(numCellsPath);
+  const auto* numCellsPtr = dataStructure.getDataAs<NumCellsArrayType>(featureNumCellsPath);
   if(numCellsPtr == nullptr)
   {
     return {MakeErrorResult<OutputActions>(k_BadNumCellsPath, "Num Cells not provided as an Int32 Array.")};
   }
-  dataArrayPaths.push_back(numCellsPath);
+  dataArrayPaths.push_back(featureNumCellsPath);
 
   if(applyToSinglePhase)
   {
@@ -141,7 +141,7 @@ IFilter::PreflightResult RequireMinimumSizeFeaturesFilter::preflightImpl(const D
     return MakePreflightErrorResult(-2071, fmt::format("The following DataArrays all must have equal number of tuples but this was not satisfied.\n{}", tupleValidityCheck.error()));
   }
 
-  DataPath featureGroupDataPath = numCellsPath.getParent();
+  DataPath featureGroupDataPath = featureNumCellsPath.getParent();
   const auto* featureDataGroup = dataStructure.getDataAs<BaseGroup>(featureGroupDataPath);
   if(nullptr == featureDataGroup)
   {
@@ -157,7 +157,7 @@ IFilter::PreflightResult RequireMinimumSizeFeaturesFilter::preflightImpl(const D
   preflightUpdatedValues.emplace_back(PreflightValue{"Feature Data Modification Warning", featureModificationWarning});
 
   // This section will warn the user about the removal of NeighborLists
-  auto result = nx::core::NeighborListRemovalPreflightCode(dataStructure, featureIdsPath, numCellsPath, resultOutputActions);
+  auto result = nx::core::NeighborListRemovalPreflightCode(dataStructure, featureIdsPath, featureNumCellsPath, resultOutputActions);
   if(result.outputActions.invalid())
   {
     return result;
@@ -173,13 +173,13 @@ Result<> RequireMinimumSizeFeaturesFilter::executeImpl(DataStructure& dataStruct
 {
   RequireMinimumSizeFeaturesInputValues inputValues;
 
-  inputValues.ApplySinglePhase = filterArgs.value<BoolParameter::ValueType>(k_ApplySinglePhase_Key);
-  inputValues.FeatureIdsPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_FeatureIdsPath_Key);
-  inputValues.FeaturePhasesPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_FeaturePhasesPath_Key);
-  inputValues.InputImageGeometryPath = filterArgs.value<GeometrySelectionParameter::ValueType>(k_ImageGeomPath_Key);
   inputValues.MinAllowedFeaturesSize = filterArgs.value<Int64Parameter::ValueType>(k_MinAllowedFeaturesSize_Key);
-  inputValues.NumCellsPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_NumCellsPath_Key);
-  inputValues.PhaseNumber = filterArgs.value<Int64Parameter::ValueType>(k_PhaseNumber_Key);
+  inputValues.FeatureIdsPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_FeatureIdsPath_Key);
+  inputValues.InputImageGeometryPath = filterArgs.value<GeometrySelectionParameter::ValueType>(k_ImageGeomPath_Key);
+  inputValues.FeatureNumCellsPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_FeatureNumCellsPath_Key);
+  inputValues.FeaturePhasesPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_FeaturePhasesPath_Key);
+  inputValues.ApplySinglePhase = filterArgs.value<BoolParameter::ValueType>(k_ApplySinglePhase_Key);
+  inputValues.PhaseNumber = filterArgs.value<Int32Parameter::ValueType>(k_SinglePhaseNumber_Key);
 
   return RequireMinimumSizeFeatures(dataStructure, messageHandler, shouldCancel, &inputValues)();
 }
@@ -205,11 +205,11 @@ Result<Arguments> RequireMinimumSizeFeaturesFilter::FromSIMPLJson(const nlohmann
 
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::IntFilterParameterConverter<int64>>(args, json, SIMPL::k_MinAllowedFeatureSizeKey, k_MinAllowedFeaturesSize_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::LinkedBooleanFilterParameterConverter>(args, json, SIMPL::k_ApplyToSinglePhaseKey, k_ApplySinglePhase_Key));
-  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::IntFilterParameterConverter<int64>>(args, json, SIMPL::k_PhaseNumberKey, k_PhaseNumber_Key));
+  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::IntFilterParameterConverter<int64>>(args, json, SIMPL::k_PhaseNumberKey, k_SinglePhaseNumber_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataContainerSelectionFilterParameterConverter>(args, json, SIMPL::k_FeatureIdsArrayPathKey, k_ImageGeomPath_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_FeatureIdsArrayPathKey, k_FeatureIdsPath_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_FeaturePhasesArrayPathKey, k_FeaturePhasesPath_Key));
-  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_NumCellsArrayPathKey, k_NumCellsPath_Key));
+  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_NumCellsArrayPathKey, k_FeatureNumCellsPath_Key));
   // Ignored Array Paths parameter is not applicable in NX
 
   Result<> conversionResult = MergeResults(std::move(results));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.hpp
@@ -25,12 +25,12 @@ public:
   RequireMinimumSizeFeaturesFilter& operator=(RequireMinimumSizeFeaturesFilter&&) noexcept = delete;
 
   static constexpr StringLiteral k_FeaturePhasesPath_Key = "feature_phases_path";
-  static constexpr StringLiteral k_NumCellsPath_Key = "num_cells_path";
+  static constexpr StringLiteral k_FeatureNumCellsPath_Key = "num_cells_path";
   static constexpr StringLiteral k_FeatureIdsPath_Key = "feature_ids_path";
   static constexpr StringLiteral k_ImageGeomPath_Key = "input_image_geometry_path";
-  static constexpr StringLiteral k_ApplySinglePhase_Key = "apply_single_phase";
   static constexpr StringLiteral k_MinAllowedFeaturesSize_Key = "min_allowed_features_size";
-  static constexpr StringLiteral k_PhaseNumber_Key = "phase_number";
+  static constexpr StringLiteral k_ApplySinglePhase_Key = "apply_single_phase";
+  static constexpr StringLiteral k_SinglePhaseNumber_Key = "phase_number";
 
   /**
    * @brief Reads SIMPL json and converts it simplnx Arguments.

--- a/src/Plugins/SimplnxCore/test/RequireMinimumSizeFeaturesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/RequireMinimumSizeFeaturesTest.cpp
@@ -50,10 +50,10 @@ TEST_CASE("SimplnxCore::RequireMinimumSizeFeatures: Small IN100 Pipeline", "[Sim
     // Create default Parameters for the filter.
     args.insertOrAssign(RequireMinimumSizeFeaturesFilter::k_MinAllowedFeaturesSize_Key, std::make_any<int64>(16));
     args.insertOrAssign(RequireMinimumSizeFeaturesFilter::k_ApplySinglePhase_Key, std::make_any<bool>(false));
-    args.insertOrAssign(RequireMinimumSizeFeaturesFilter::k_PhaseNumber_Key, std::make_any<int64>(1));
+    args.insertOrAssign(RequireMinimumSizeFeaturesFilter::k_SinglePhaseNumber_Key, std::make_any<int32>(1));
     args.insertOrAssign(RequireMinimumSizeFeaturesFilter::k_ImageGeomPath_Key, std::make_any<DataPath>(k_DataContainerPath));
     args.insertOrAssign(RequireMinimumSizeFeaturesFilter::k_FeatureIdsPath_Key, std::make_any<DataPath>(k_FeatureIdsArrayPath));
-    args.insertOrAssign(RequireMinimumSizeFeaturesFilter::k_NumCellsPath_Key, std::make_any<DataPath>(k_NumCellsPath));
+    args.insertOrAssign(RequireMinimumSizeFeaturesFilter::k_FeatureNumCellsPath_Key, std::make_any<DataPath>(k_NumCellsPath));
     args.insertOrAssign(RequireMinimumSizeFeaturesFilter::k_FeaturePhasesPath_Key, std::make_any<DataPath>(k_FeaturePhasesPath));
 
     // Preflight the filter and check result


### PR DESCRIPTION
Due to casting there could be an int32 overflow issue that occurs during the running of this filter. 

The filter was also heavily refactored in the process:
* Variable names were updated to reflect their actual usage
* One parameter type was changed from an int64 to an int32
* Functions were moved around and also renamed to conform to the current naming standards.