### PR TITLE
ENH: Resample Image Geometry uses much less memory at the cost of some computation time

### DIFF
--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.cpp
@@ -18,14 +18,12 @@ template <typename T>
 class ResampleImageGeomArrayImpl
 {
 public:
-  ResampleImageGeomArrayImpl(const IDataArray& srcArray, IDataArray& destArray, const FloatVec3& newSpacing, const FloatVec3& origSpacing, const SizeVec3& origDims, const SizeVec3& destDims,
-                             const std::atomic_bool& shouldCancel, ProgressMessageHelper& progressMessageHelper)
+  ResampleImageGeomArrayImpl(const IDataArray& srcArray, IDataArray& destArray, const ImageGeom& srcImageGeom, const ImageGeom& destImageGeom, const std::atomic_bool& shouldCancel,
+                             ProgressMessageHelper& progressMessageHelper)
   : m_SrcArray(srcArray)
   , m_DestArray(destArray)
-  , m_NewSpacing(newSpacing)
-  , m_OrigSpacing(origSpacing)
-  , m_OrigDims(origDims)
-  , m_DestDims(destDims)
+  , m_SrcImageGeom(srcImageGeom)
+  , m_DestImageGeom(destImageGeom)
   , m_ShouldCancel(shouldCancel)
   , m_ProgressMessageHelper(progressMessageHelper)
   {
@@ -39,7 +37,6 @@ public:
     ProgressMessenger progressMessenger = m_ProgressMessageHelper.createProgressMessenger();
 
     usize counter = 0;
-    usize counterIncrement = (range.max() - range.min()) / 100;
 
     for(usize idx = range.min(); idx < range.max(); idx++)
     {
@@ -48,22 +45,14 @@ public:
         return;
       }
 
-      // Decompose linear index to 3D (z-slowest, x-fastest)
-      usize z = idx / (m_DestDims[0] * m_DestDims[1]);
-      usize rem = idx % (m_DestDims[0] * m_DestDims[1]);
-      usize y = rem / m_DestDims[0];
-      usize x = rem % m_DestDims[0];
+      // Get the destination voxel center.
+      Point3D<float64> coords = m_DestImageGeom.getPlaneCoords(idx);
+      // Based on that position, figure out which source voxel we are in...
+      std::optional<usize> srcIndex = m_SrcImageGeom.getIndex(coords[0], coords[1], coords[2]);
 
-      // Compute source voxel coordinates
-      auto col = static_cast<int64>(static_cast<float32>(x) * m_NewSpacing[0] / m_OrigSpacing[0]);
-      auto row = static_cast<int64>(static_cast<float32>(y) * m_NewSpacing[1] / m_OrigSpacing[1]);
-      auto plane = static_cast<int64>(static_cast<float32>(z) * m_NewSpacing[2] / m_OrigSpacing[2]);
-
-      int64 srcIndex = static_cast<int64>(plane * m_OrigDims[1] * m_OrigDims[0]) + static_cast<int64>(row * m_OrigDims[0]) + col;
-
-      if(srcIndex >= 0)
+      if(srcIndex.has_value())
       {
-        destDataStore.copyFrom(idx, srcDataStore, static_cast<usize>(srcIndex), 1);
+        destDataStore.copyFrom(idx, srcDataStore, srcIndex.value(), 1);
       }
       else
       {
@@ -71,11 +60,6 @@ public:
       }
 
       counter++;
-      if(counter >= counterIncrement)
-      {
-        progressMessenger.sendProgressMessage(counter);
-        counter = 0;
-      }
     }
     progressMessenger.sendProgressMessage(counter);
   }
@@ -83,10 +67,8 @@ public:
 private:
   const IDataArray& m_SrcArray;
   IDataArray& m_DestArray;
-  FloatVec3 m_NewSpacing;
-  FloatVec3 m_OrigSpacing;
-  SizeVec3 m_OrigDims;
-  SizeVec3 m_DestDims;
+  const ImageGeom& m_SrcImageGeom;
+  const ImageGeom& m_DestImageGeom;
   const std::atomic_bool& m_ShouldCancel;
   ProgressMessageHelper& m_ProgressMessageHelper;
 };
@@ -114,13 +96,10 @@ const std::atomic_bool& ResampleImageGeom::getCancel()
 Result<> ResampleImageGeom::operator()()
 {
   const auto& selectedImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->SelectedImageGeometryPath);
-  SizeVec3 sourceDims = selectedImageGeom.getDimensions();
-  FloatVec3 origSpacing = selectedImageGeom.getSpacing();
 
   auto& destImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->CreatedImageGeometryPath);
   SizeVec3 destDims = destImageGeom.getDimensions();
 
-  FloatVec3 newSpacing = {m_InputValues->Spacing[0], m_InputValues->Spacing[1], m_InputValues->Spacing[2]};
   usize totalDestTuples = destDims[0] * destDims[1] * destDims[2];
 
   const auto& srcCellDataAM = selectedImageGeom.getCellDataRef();
@@ -151,8 +130,7 @@ Result<> ResampleImageGeom::operator()()
 
     ParallelDataAlgorithm dataAlg;
     dataAlg.setRange(0, totalDestTuples);
-    ExecuteParallelFunction<ResampleImageGeomArrayImpl>(oldDataArray.getDataType(), dataAlg, oldDataArray, newDataArray, newSpacing, origSpacing, sourceDims, destDims, m_ShouldCancel,
-                                                        progressMessageHelper);
+    ExecuteParallelFunction<ResampleImageGeomArrayImpl>(oldDataArray.getDataType(), dataAlg, oldDataArray, newDataArray, selectedImageGeom, destImageGeom, m_ShouldCancel, progressMessageHelper);
   }
 
   if(m_ShouldCancel)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 #include "simplnx/Utilities/SamplingUtils.hpp"
@@ -18,7 +19,7 @@ class ResampleImageGeomArrayImpl
 {
 public:
   ResampleImageGeomArrayImpl(const IDataArray& srcArray, IDataArray& destArray, const FloatVec3& newSpacing, const FloatVec3& origSpacing, const SizeVec3& origDims, const SizeVec3& destDims,
-                             const std::atomic_bool& shouldCancel)
+                             const std::atomic_bool& shouldCancel, ProgressMessageHelper& progressMessageHelper)
   : m_SrcArray(srcArray)
   , m_DestArray(destArray)
   , m_NewSpacing(newSpacing)
@@ -26,6 +27,7 @@ public:
   , m_OrigDims(origDims)
   , m_DestDims(destDims)
   , m_ShouldCancel(shouldCancel)
+  , m_ProgressMessageHelper(progressMessageHelper)
   {
   }
 
@@ -33,6 +35,11 @@ public:
   {
     const auto& srcDataStore = m_SrcArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
     auto& destDataStore = m_DestArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
+
+    ProgressMessenger progressMessenger = m_ProgressMessageHelper.createProgressMessenger();
+
+    usize counter = 0;
+    usize counterIncrement = (range.max() - range.min()) / 100;
 
     for(usize idx = range.min(); idx < range.max(); idx++)
     {
@@ -62,7 +69,15 @@ public:
       {
         destDataStore.fillTuple(idx, 0);
       }
+
+      counter++;
+      if(counter >= counterIncrement)
+      {
+        progressMessenger.sendProgressMessage(counter);
+        counter = 0;
+      }
     }
+    progressMessenger.sendProgressMessage(counter);
   }
 
 private:
@@ -73,6 +88,7 @@ private:
   SizeVec3 m_OrigDims;
   SizeVec3 m_DestDims;
   const std::atomic_bool& m_ShouldCancel;
+  ProgressMessageHelper& m_ProgressMessageHelper;
 };
 } // namespace
 
@@ -110,6 +126,13 @@ Result<> ResampleImageGeom::operator()()
   const auto& srcCellDataAM = selectedImageGeom.getCellDataRef();
   auto& destCellDataAM = destImageGeom.getCellDataRef();
 
+  MessageHelper messageHelper(m_MessageHandler);
+  ProgressMessageHelper progressMessageHelper = messageHelper.createProgressMessageHelper();
+  progressMessageHelper.setMaxProgresss(totalDestTuples);
+
+  usize arrayIndex = 0;
+  usize totalArrays = srcCellDataAM.getSize();
+
   for(const auto& [dataId, oldDataObject] : srcCellDataAM)
   {
     if(m_ShouldCancel)
@@ -117,14 +140,19 @@ Result<> ResampleImageGeom::operator()()
       return {};
     }
 
+    arrayIndex++;
     const auto& oldDataArray = dynamic_cast<const IDataArray&>(*oldDataObject);
     const std::string srcName = oldDataArray.getName();
     auto& newDataArray = dynamic_cast<IDataArray&>(destCellDataAM.at(srcName));
-    m_MessageHandler(fmt::format("Resample Volume || Resampling Data Array {}", srcName));
+    m_MessageHandler(fmt::format("Resample Volume || Resampling Data Array {} ({}/{})", srcName, arrayIndex, totalArrays));
+
+    progressMessageHelper.resetProgress();
+    progressMessageHelper.setProgressMessageTemplate(fmt::format("Resample Volume || Array {} ({}/{}): {{:.2f}}% complete", srcName, arrayIndex, totalArrays));
 
     ParallelDataAlgorithm dataAlg;
     dataAlg.setRange(0, totalDestTuples);
-    ExecuteParallelFunction<ResampleImageGeomArrayImpl>(oldDataArray.getDataType(), dataAlg, oldDataArray, newDataArray, newSpacing, origSpacing, sourceDims, destDims, m_ShouldCancel);
+    ExecuteParallelFunction<ResampleImageGeomArrayImpl>(oldDataArray.getDataType(), dataAlg, oldDataArray, newDataArray, newSpacing, origSpacing, sourceDims, destDims, m_ShouldCancel,
+                                                        progressMessageHelper);
   }
 
   if(m_ShouldCancel)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.cpp
@@ -47,14 +47,18 @@ public:
         return;
       }
 
-      // Get the destination voxel center.
+      // Get the destination voxel origin (min corner).
       Point3D<float64> coords = m_DestImageGeom.getPlaneCoords(destVoxelIdx);
       // Based on that position, figure out which source voxel we are in...
       std::optional<usize> srcIndex = m_SrcImageGeom.getIndex(coords[0], coords[1], coords[2]);
 
       if(srcIndex.has_value())
       {
-        destDataStore.copyFrom(destVoxelIdx, srcDataStore, srcIndex.value(), 1);
+        auto result = destDataStore.copyFrom(destVoxelIdx, srcDataStore, srcIndex.value(), 1);
+        if(result.invalid())
+        {
+          destDataStore.fillTuple(destVoxelIdx, 0);
+        }
       }
       else
       {
@@ -110,10 +114,6 @@ Result<> ResampleImageGeom::operator()()
   const auto& selectedImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->SelectedImageGeometryPath);
 
   auto& destImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->CreatedImageGeometryPath);
-  SizeVec3 destDims = destImageGeom.getDimensions();
-
-  usize totalDestTuples = destDims[0] * destDims[1] * destDims[2];
-
   const auto& srcCellDataAM = selectedImageGeom.getCellDataRef();
   auto& destCellDataAM = destImageGeom.getCellDataRef();
 
@@ -139,7 +139,7 @@ Result<> ResampleImageGeom::operator()()
     ExecuteParallelFunction<ResampleImageGeomArrayImpl>(oldDataArray.getDataType(), taskRunner, this, oldDataArray, newDataArray, selectedImageGeom, destImageGeom, m_ShouldCancel);
   }
 
-  taskRunner.wait(); // This will spill over if the number of geometries to processes does not divide evenly by the number of threads.
+  taskRunner.wait(); // This will spill over if the number of geometries to process does not divide evenly by the number of threads.
 
   if(m_ShouldCancel)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.cpp
@@ -5,9 +5,7 @@
 #include "simplnx/DataStructure/StringArray.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
-#include "simplnx/Utilities/ParallelData3DAlgorithm.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
-#include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 #include "simplnx/Utilities/SamplingUtils.hpp"
 
 using namespace nx::core;
@@ -15,58 +13,65 @@ using namespace nx::core;
 namespace
 {
 // -----------------------------------------------------------------------------
-class ResampleImageGeomImpl
+template <typename T>
+class ResampleImageGeomArrayImpl
 {
 public:
-  ResampleImageGeomImpl(std::vector<int64>& newIndices, std::vector<float> spacing, FloatVec3 sourceSpacing, SizeVec3 sourceDims, SizeVec3 destDims, const std::atomic_bool& shouldCancel)
-  : m_NewIndices(newIndices)
-  , m_Spacing(std::move(spacing))
-  , m_OrigSpacing(std::move(sourceSpacing))
-  , m_OrigDims(std::move(sourceDims))
-  , m_CopyDims(std::move(destDims))
+  ResampleImageGeomArrayImpl(const IDataArray& srcArray, IDataArray& destArray, const FloatVec3& newSpacing, const FloatVec3& origSpacing, const SizeVec3& origDims, const SizeVec3& destDims,
+                             const std::atomic_bool& shouldCancel)
+  : m_SrcArray(srcArray)
+  , m_DestArray(destArray)
+  , m_NewSpacing(newSpacing)
+  , m_OrigSpacing(origSpacing)
+  , m_OrigDims(origDims)
+  , m_DestDims(destDims)
   , m_ShouldCancel(shouldCancel)
   {
   }
 
-  // -----------------------------------------------------------------------------
-  void compute(size_t xStart, size_t xEnd, size_t yStart, size_t yEnd, size_t zStart, size_t zEnd) const
+  void operator()(const Range& range) const
   {
-    for(size_t i = zStart; i < zEnd; i++)
-    {
-      for(size_t j = yStart; j < yEnd; j++)
-      {
-        if(m_ShouldCancel)
-        {
-          return;
-        }
+    const auto& srcDataStore = m_SrcArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
+    auto& destDataStore = m_DestArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
 
-        for(size_t k = xStart; k < xEnd; k++)
-        {
-          float32 x = (static_cast<float32>(k) * m_Spacing[0]);
-          float32 y = (static_cast<float32>(j) * m_Spacing[1]);
-          float32 z = (static_cast<float32>(i) * m_Spacing[2]);
-          auto col = static_cast<int64>(x / m_OrigSpacing[0]);
-          auto row = static_cast<int64>(y / m_OrigSpacing[1]);
-          auto plane = static_cast<int64>(z / m_OrigSpacing[2]);
-          int64 indexOld = static_cast<int64>(plane * m_OrigDims[1] * m_OrigDims[0]) + static_cast<int64>(row * m_OrigDims[0]) + col;
-          auto index = static_cast<size_t>((i * m_CopyDims[0] * m_CopyDims[1]) + (j * m_CopyDims[0]) + k);
-          m_NewIndices[index] = indexOld;
-        }
+    for(usize idx = range.min(); idx < range.max(); idx++)
+    {
+      if(m_ShouldCancel)
+      {
+        return;
+      }
+
+      // Decompose linear index to 3D (z-slowest, x-fastest)
+      usize z = idx / (m_DestDims[0] * m_DestDims[1]);
+      usize rem = idx % (m_DestDims[0] * m_DestDims[1]);
+      usize y = rem / m_DestDims[0];
+      usize x = rem % m_DestDims[0];
+
+      // Compute source voxel coordinates
+      auto col = static_cast<int64>(static_cast<float32>(x) * m_NewSpacing[0] / m_OrigSpacing[0]);
+      auto row = static_cast<int64>(static_cast<float32>(y) * m_NewSpacing[1] / m_OrigSpacing[1]);
+      auto plane = static_cast<int64>(static_cast<float32>(z) * m_NewSpacing[2] / m_OrigSpacing[2]);
+
+      int64 srcIndex = static_cast<int64>(plane * m_OrigDims[1] * m_OrigDims[0]) + static_cast<int64>(row * m_OrigDims[0]) + col;
+
+      if(srcIndex >= 0)
+      {
+        destDataStore.copyFrom(idx, srcDataStore, static_cast<usize>(srcIndex), 1);
+      }
+      else
+      {
+        destDataStore.fillTuple(idx, 0);
       }
     }
   }
 
-  void operator()(const Range3D& r) const
-  {
-    compute(r[0], r[1], r[2], r[3], r[4], r[5]);
-  }
-
 private:
-  std::vector<int64>& m_NewIndices;
-  std::vector<float> m_Spacing;
+  const IDataArray& m_SrcArray;
+  IDataArray& m_DestArray;
+  FloatVec3 m_NewSpacing;
   FloatVec3 m_OrigSpacing;
   SizeVec3 m_OrigDims;
-  SizeVec3 m_CopyDims;
+  SizeVec3 m_DestDims;
   const std::atomic_bool& m_ShouldCancel;
 };
 } // namespace
@@ -92,8 +97,6 @@ const std::atomic_bool& ResampleImageGeom::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ResampleImageGeom::operator()()
 {
-  m_MessageHandler(IFilter::Message::Type::Info, "Computing new indices...");
-
   const auto& selectedImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->SelectedImageGeometryPath);
   SizeVec3 sourceDims = selectedImageGeom.getDimensions();
   FloatVec3 origSpacing = selectedImageGeom.getSpacing();
@@ -101,28 +104,12 @@ Result<> ResampleImageGeom::operator()()
   auto& destImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->CreatedImageGeometryPath);
   SizeVec3 destDims = destImageGeom.getDimensions();
 
-  std::vector<int64> newIndices(destDims[2] * destDims[1] * destDims[0]);
-  ParallelData3DAlgorithm dataAlg;
-  dataAlg.setRange(destDims[0], destDims[1], destDims[2]);
-  dataAlg.execute(ResampleImageGeomImpl(newIndices, m_InputValues->Spacing, origSpacing, sourceDims, destDims, m_ShouldCancel));
+  FloatVec3 newSpacing = {m_InputValues->Spacing[0], m_InputValues->Spacing[1], m_InputValues->Spacing[2]};
+  usize totalDestTuples = destDims[0] * destDims[1] * destDims[2];
 
-  auto cellDataGroupPath = m_InputValues->CellDataGroupPath;
-  auto& cellDataGroup = m_DataStructure.getDataRefAs<AttributeMatrix>(cellDataGroupPath);
-  std::vector<DataPath> selectedCellArrays;
-
-  // Create the vector of selected cell DataPaths
-  for(const auto& child : cellDataGroup)
-  {
-    selectedCellArrays.push_back(m_InputValues->CellDataGroupPath.createChildPath(child.second->getName()));
-  }
-
-  // The actual cropping of the dataStructure arrays is done in parallel where parallel here
-  // refers to the cropping of each DataArray being done on a separate thread.
-  ParallelTaskAlgorithm taskRunner;
   const auto& srcCellDataAM = selectedImageGeom.getCellDataRef();
   auto& destCellDataAM = destImageGeom.getCellDataRef();
 
-  // copy over/resample the cell data
   for(const auto& [dataId, oldDataObject] : srcCellDataAM)
   {
     if(m_ShouldCancel)
@@ -132,14 +119,14 @@ Result<> ResampleImageGeom::operator()()
 
     const auto& oldDataArray = dynamic_cast<const IDataArray&>(*oldDataObject);
     const std::string srcName = oldDataArray.getName();
-
     auto& newDataArray = dynamic_cast<IDataArray&>(destCellDataAM.at(srcName));
-    m_MessageHandler(fmt::format("Resample Volume || Copying Data Array {}", srcName));
+    m_MessageHandler(fmt::format("Resample Volume || Resampling Data Array {}", srcName));
 
-    ExecuteParallelFunction<CopyTupleUsingIndexList>(oldDataArray.getDataType(), taskRunner, oldDataArray, newDataArray, newIndices);
+    ParallelDataAlgorithm dataAlg;
+    dataAlg.setRange(0, totalDestTuples);
+    ExecuteParallelFunction<ResampleImageGeomArrayImpl>(oldDataArray.getDataType(), dataAlg, oldDataArray, newDataArray, newSpacing, origSpacing, sourceDims, destDims, m_ShouldCancel);
   }
 
-  taskRunner.wait(); // This will spill over if the number of DataArrays to process does not divide evenly by the number of threads.
   if(m_ShouldCancel)
   {
     return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.cpp
@@ -7,6 +7,7 @@
 #include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
+#include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 #include "simplnx/Utilities/SamplingUtils.hpp"
 
 using namespace nx::core;
@@ -18,27 +19,28 @@ template <typename T>
 class ResampleImageGeomArrayImpl
 {
 public:
-  ResampleImageGeomArrayImpl(const IDataArray& srcArray, IDataArray& destArray, const ImageGeom& srcImageGeom, const ImageGeom& destImageGeom, const std::atomic_bool& shouldCancel,
-                             ProgressMessageHelper& progressMessageHelper)
-  : m_SrcArray(srcArray)
+  ResampleImageGeomArrayImpl(ResampleImageGeom* algorithm, const IDataArray& srcArray, IDataArray& destArray, const ImageGeom& srcImageGeom, const ImageGeom& destImageGeom,
+                             const std::atomic_bool& shouldCancel)
+  : m_AlgorithmPtr(algorithm)
+  , m_SrcArray(srcArray)
   , m_DestArray(destArray)
   , m_SrcImageGeom(srcImageGeom)
   , m_DestImageGeom(destImageGeom)
   , m_ShouldCancel(shouldCancel)
-  , m_ProgressMessageHelper(progressMessageHelper)
   {
   }
 
-  void operator()(const Range& range) const
+  void operator()() const
   {
     const auto& srcDataStore = m_SrcArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
     auto& destDataStore = m_DestArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
 
-    ProgressMessenger progressMessenger = m_ProgressMessageHelper.createProgressMessenger();
-
     usize counter = 0;
 
-    for(usize idx = range.min(); idx < range.max(); idx++)
+    usize numVoxels = m_DestImageGeom.getNumberOfCells();
+    usize counterIncrement = numVoxels / 100 == 0 ? 100 : numVoxels / 100;
+
+    for(usize destVoxelIdx = 0; destVoxelIdx < numVoxels; destVoxelIdx++)
     {
       if(m_ShouldCancel)
       {
@@ -46,31 +48,37 @@ public:
       }
 
       // Get the destination voxel center.
-      Point3D<float64> coords = m_DestImageGeom.getPlaneCoords(idx);
+      Point3D<float64> coords = m_DestImageGeom.getPlaneCoords(destVoxelIdx);
       // Based on that position, figure out which source voxel we are in...
       std::optional<usize> srcIndex = m_SrcImageGeom.getIndex(coords[0], coords[1], coords[2]);
 
       if(srcIndex.has_value())
       {
-        destDataStore.copyFrom(idx, srcDataStore, srcIndex.value(), 1);
+        destDataStore.copyFrom(destVoxelIdx, srcDataStore, srcIndex.value(), 1);
       }
       else
       {
-        destDataStore.fillTuple(idx, 0);
+        destDataStore.fillTuple(destVoxelIdx, 0);
       }
 
       counter++;
+      if(counter >= counterIncrement)
+      {
+        float progress = static_cast<float>(destVoxelIdx) / static_cast<float>(numVoxels) * 100.0f;
+        m_AlgorithmPtr->sendThreadSafeProgressMessage(fmt::format("Resampling Data Array '{}' {:.0f}% Complete", m_DestArray.getName(), progress));
+        counter = 0;
+      }
     }
-    progressMessenger.sendProgressMessage(counter);
+    m_AlgorithmPtr->sendThreadSafeProgressMessage(fmt::format("Resampling Data Array '{}' Complete", m_DestArray.getName()));
   }
 
 private:
+  ResampleImageGeom* m_AlgorithmPtr = nullptr;
   const IDataArray& m_SrcArray;
   IDataArray& m_DestArray;
   const ImageGeom& m_SrcImageGeom;
   const ImageGeom& m_DestImageGeom;
   const std::atomic_bool& m_ShouldCancel;
-  ProgressMessageHelper& m_ProgressMessageHelper;
 };
 } // namespace
 
@@ -95,6 +103,10 @@ const std::atomic_bool& ResampleImageGeom::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ResampleImageGeom::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  ThrottledMessenger throttledMessenger = messageHelper.createThrottledMessenger();
+  m_ThrottledMessengerPtr = &throttledMessenger;
+
   const auto& selectedImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->SelectedImageGeometryPath);
 
   auto& destImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->CreatedImageGeometryPath);
@@ -105,12 +117,11 @@ Result<> ResampleImageGeom::operator()()
   const auto& srcCellDataAM = selectedImageGeom.getCellDataRef();
   auto& destCellDataAM = destImageGeom.getCellDataRef();
 
-  MessageHelper messageHelper(m_MessageHandler);
-  ProgressMessageHelper progressMessageHelper = messageHelper.createProgressMessageHelper();
-  progressMessageHelper.setMaxProgresss(totalDestTuples);
-
   usize arrayIndex = 0;
   usize totalArrays = srcCellDataAM.getSize();
+
+  ParallelTaskAlgorithm taskRunner;
+  taskRunner.setParallelizationEnabled(true);
 
   for(const auto& [dataId, oldDataObject] : srcCellDataAM)
   {
@@ -123,15 +134,12 @@ Result<> ResampleImageGeom::operator()()
     const auto& oldDataArray = dynamic_cast<const IDataArray&>(*oldDataObject);
     const std::string srcName = oldDataArray.getName();
     auto& newDataArray = dynamic_cast<IDataArray&>(destCellDataAM.at(srcName));
-    m_MessageHandler(fmt::format("Resample Volume || Resampling Data Array {} ({}/{})", srcName, arrayIndex, totalArrays));
+    m_MessageHandler(fmt::format("Resampling Data Array: '{}' ({}/{})", srcName, arrayIndex, totalArrays));
 
-    progressMessageHelper.resetProgress();
-    progressMessageHelper.setProgressMessageTemplate(fmt::format("Resample Volume || Array {} ({}/{}): {{:.2f}}% complete", srcName, arrayIndex, totalArrays));
-
-    ParallelDataAlgorithm dataAlg;
-    dataAlg.setRange(0, totalDestTuples);
-    ExecuteParallelFunction<ResampleImageGeomArrayImpl>(oldDataArray.getDataType(), dataAlg, oldDataArray, newDataArray, selectedImageGeom, destImageGeom, m_ShouldCancel, progressMessageHelper);
+    ExecuteParallelFunction<ResampleImageGeomArrayImpl>(oldDataArray.getDataType(), taskRunner, this, oldDataArray, newDataArray, selectedImageGeom, destImageGeom, m_ShouldCancel);
   }
+
+  taskRunner.wait(); // This will spill over if the number of geometries to processes does not divide evenly by the number of threads.
 
   if(m_ShouldCancel)
   {
@@ -200,4 +208,13 @@ Result<> ResampleImageGeom::operator()()
   }
 
   return {};
+}
+
+void ResampleImageGeom::sendThreadSafeProgressMessage(const std::string& message)
+{
+  std::lock_guard<std::mutex> guard(m_ProgressMessage_Mutex);
+  if(nullptr != m_ThrottledMessengerPtr)
+  {
+    m_ThrottledMessengerPtr->sendThrottledMessage([&]() { return message; });
+  }
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.hpp
@@ -53,7 +53,6 @@ private:
 
   // Thread safe Progress Message
   mutable std::mutex m_ProgressMessage_Mutex;
-  std::chrono::steady_clock::time_point m_InitialPoint = std::chrono::steady_clock::now();
 
   ThrottledMessenger* m_ThrottledMessengerPtr = nullptr;
 };

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleImageGeom.hpp
@@ -6,6 +6,7 @@
 #include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/Filter/IFilter.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <vector>
 
@@ -42,11 +43,19 @@ public:
 
   const std::atomic_bool& getCancel();
 
+  void sendThreadSafeProgressMessage(const std::string& message);
+
 private:
   DataStructure& m_DataStructure;
   const ResampleImageGeomInputValues* m_InputValues = nullptr;
   const std::atomic_bool& m_ShouldCancel;
   const IFilter::MessageHandler& m_MessageHandler;
+
+  // Thread safe Progress Message
+  mutable std::mutex m_ProgressMessage_Mutex;
+  std::chrono::steady_clock::time_point m_InitialPoint = std::chrono::steady_clock::now();
+
+  ThrottledMessenger* m_ThrottledMessengerPtr = nullptr;
 };
 
 } // namespace nx::core


### PR DESCRIPTION
The code was updated to remove the pre-calculated voxel indices which added an 8 byte integer at every voxel which can quickly blow up memory usage. The code now uses some extra cpu cycles to compute the source and destination indices.