### PR TITLE
ENH: Remove redundant preflight checks that are already done in the parameter

### DIFF
--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/CAxisSegmentFeaturesFilter.cpp
@@ -18,13 +18,6 @@
 #include "simplnx/Parameters/NumberParameter.hpp"
 
 using namespace nx::core;
-namespace
-{
-constexpr int32 k_MissingGeomError = -440;
-constexpr int32 k_IncorrectInputArray = -600;
-constexpr int32 k_MissingInputArray = -601;
-constexpr int32 k_MissingOrIncorrectGoodVoxelsArray = -602;
-} // namespace
 
 namespace nx::core
 {
@@ -146,22 +139,9 @@ IFilter::PreflightResult CAxisSegmentFeaturesFilter::preflightImpl(const DataStr
 
   // Validate the GoodVoxels/Mask Array combination
   bool useGoodVoxels = filterArgs.value<bool>(k_UseMask_Key);
-  DataPath goodVoxelsPath;
   if(useGoodVoxels)
   {
-    goodVoxelsPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
-
-    const auto* goodVoxelsArray = dataStructure.getDataAs<IDataArray>(goodVoxelsPath);
-    if(nullptr == goodVoxelsArray)
-    {
-      return {MakeErrorResult<OutputActions>(k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array is not located at path: '{}'", goodVoxelsPath.toString()))};
-    }
-    if(goodVoxelsArray->getDataType() != DataType::boolean && goodVoxelsArray->getDataType() != DataType::uint8)
-    {
-      return {
-          MakeErrorResult<OutputActions>(k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array at path '{}' is not of the correct type. It must be Bool or UInt8.", goodVoxelsPath.toString()))};
-    }
-    dataPaths.push_back(goodVoxelsPath);
+    dataPaths.push_back(filterArgs.value<DataPath>(k_MaskArrayPath_Key));
   }
 
   auto tupleValidityCheck = dataStructure.validateNumberOfTuples(dataPaths);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgOrientationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgOrientationsFilter.cpp
@@ -13,17 +13,6 @@
 
 using namespace nx::core;
 
-namespace
-{
-
-using FeatureIdsArrayType = Int32Array;
-using GoodVoxelsArrayType = BoolArray;
-
-constexpr int32 k_IncorrectInputArray = -7000;
-constexpr int32 k_MissingInputArray = -7001;
-constexpr int32 k_MissingOrIncorrectGoodVoxelsArray = -7002;
-} // namespace
-
 namespace nx::core
 {
 //------------------------------------------------------------------------------
@@ -110,37 +99,10 @@ IFilter::PreflightResult ComputeAvgOrientationsFilter::preflightImpl(const DataS
   auto pAvgQuatsArrayPathValue = pCellFeatureAttributeMatrixPathValue.createChildPath(filterArgs.value<std::string>(k_AvgQuatsArrayName_Key));
   auto pAvgEulerAnglesArrayPathValue = pCellFeatureAttributeMatrixPathValue.createChildPath(filterArgs.value<std::string>(k_AvgEulerAnglesArrayName_Key));
 
-  // Validate the Crystal Structures array
-  const UInt32Array& crystalStructures = dataStructure.getDataRefAs<UInt32Array>(pCrystalStructuresArrayPathValue);
-  if(crystalStructures.getNumberOfComponents() != 1)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, "Crystal Structures Input Array must be a 1 component Int32 array")};
-  }
-
   std::vector<DataPath> dataPaths;
 
-  // Validate the Quats array
-  const Float32Array& quats = dataStructure.getDataRefAs<Float32Array>(pCellQuatsArrayPathValue);
-  if(quats.getNumberOfComponents() != 4)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, "Quaternion Input Array must be a 4 component Float32 array")};
-  }
   dataPaths.push_back(pCellQuatsArrayPathValue);
-
-  // Validate the Phases array
-  const Int32Array& phases = dataStructure.getDataRefAs<Int32Array>(pCellPhasesArrayPathValue);
-  if(phases.getNumberOfComponents() != 1)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, "Phases Input Array must be a 1 component Int32 array")};
-  }
   dataPaths.push_back(pCellPhasesArrayPathValue);
-
-  // Validate the FeatureIds array
-  const Int32Array& featureIds = dataStructure.getDataRefAs<Int32Array>(pCellFeatureIdsArrayPathValue);
-  if(featureIds.getNumberOfComponents() != 1)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, "FeatureIds Input Array must be a 1 component Int32 array")};
-  }
   dataPaths.push_back(pCellFeatureIdsArrayPathValue);
 
   // Make sure all the arrays have the same number of Tuples
@@ -150,15 +112,10 @@ IFilter::PreflightResult ComputeAvgOrientationsFilter::preflightImpl(const DataS
     return {MakeErrorResult<OutputActions>(-651, fmt::format("The following DataArrays all must have equal number of tuples but this was not satisfied.\n{}", tupleValidityCheck.error()))};
   }
 
-  const auto* cellFeatAttMatrix = dataStructure.getDataAs<AttributeMatrix>(pCellFeatureAttributeMatrixPathValue);
-  if(cellFeatAttMatrix == nullptr)
-  {
-    return {
-        nonstd::make_unexpected(std::vector<Error>{Error{k_MissingInputArray, fmt::format("Could not find selected Attribute matrix at path '{}'", pCellFeatureAttributeMatrixPathValue.toString())}})};
-  }
+  const auto& cellFeatAttMatrix = dataStructure.getDataRefAs<AttributeMatrix>(pCellFeatureAttributeMatrixPathValue);
 
   // Create output DataStructure Items
-  auto tDims = cellFeatAttMatrix->getShape();
+  auto tDims = cellFeatAttMatrix.getShape();
   auto createAvgQuatAction = std::make_unique<CreateArrayAction>(DataType::float32, tDims, std::vector<usize>{4}, pAvgQuatsArrayPathValue);
   auto createAvgEulerAction = std::make_unique<CreateArrayAction>(DataType::float32, tDims, std::vector<usize>{3}, pAvgEulerAnglesArrayPathValue);
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceMisorientationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeFeatureReferenceMisorientationsFilter.cpp
@@ -171,13 +171,9 @@ IFilter::PreflightResult ComputeFeatureReferenceMisorientationsFilter::preflight
     }
     else
     {
-      auto* cellFeatAM = dataStructure.getDataAs<AttributeMatrix>(pCellFeatAttributeMatrixArrayPathValue);
-      if(cellFeatAM == nullptr)
-      {
-        return {MakeErrorResult<OutputActions>(-94520, fmt::format("Could not find selected cell feature Attribute Matrix at path '{}'", pCellFeatAttributeMatrixArrayPathValue.toString()))};
-      }
+      const auto& cellFeatAM = dataStructure.getDataRefAs<AttributeMatrix>(pCellFeatAttributeMatrixArrayPathValue);
       featAvgMisorientationsPath = pCellFeatAttributeMatrixArrayPathValue.createChildPath(pFeatureAvgMisorientationsArrayNameValue);
-      tupleShape = cellFeatAM->getShape();
+      tupleShape = cellFeatAM.getShape();
 
       auto createArrayAction =
           std::make_unique<CreateArrayAction>(DataType::float32, tupleShape, ShapeType{3}, pCellFeatAttributeMatrixArrayPathValue.createChildPath(pFeatureEuclideanArrayNameValue));

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDFilter.cpp
@@ -2,7 +2,6 @@
 #include "OrientationAnalysis/Filters/Algorithms/ComputeGBCD.hpp"
 
 #include "simplnx/DataStructure/DataPath.hpp"
-#include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Filter/Actions/CreateArrayAction.hpp"
 #include "simplnx/Filter/Actions/CreateAttributeMatrixAction.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
@@ -120,42 +119,12 @@ IFilter::PreflightResult ComputeGBCDFilter::preflightImpl(const DataStructure& d
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  if(dataStructure.getDataAs<Float32Array>(pFeatureEulerAnglesArrayPathValue) == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-74350, fmt::format("Could not find euler angles array at path '{}'", pFeatureEulerAnglesArrayPathValue.toString()))};
-  }
-  if(dataStructure.getDataAs<Int32Array>(pFeaturePhasesArrayPathValue) == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-74351, fmt::format("Could not find phases array at path '{}'", pFeaturePhasesArrayPathValue.toString()))};
-  }
-  const auto* crystalStructures = dataStructure.getDataAs<UInt32Array>(pCrystalStructuresArrayPathValue);
-  if(crystalStructures == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-74352, fmt::format("Could not find crystal structures array at path '{}'", pCrystalStructuresArrayPathValue.toString()))};
-  }
+  // Use the size of the crystal structures to size the face AttributeMatrix
+  const auto& crystalStructures = dataStructure.getDataRefAs<UInt32Array>(pCrystalStructuresArrayPathValue);
 
-  // order here matters...because we are going to use the size of the crystal structures to size the face AttributeMatrix
-  if(dataStructure.getDataAs<TriangleGeom>(pTriangleGeometryPathValue) == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-74353, fmt::format("Could not find triangle geometry array at path '{}'", pTriangleGeometryPathValue.toString()))};
-  }
-
-  ShapeType tupleShape(1, crystalStructures->getNumberOfTuples());
+  ShapeType tupleShape(1, crystalStructures.getNumberOfTuples());
   auto createAttributeMatrixAction = std::make_unique<CreateAttributeMatrixAction>(faceEnsembleAttributeMatrixPath, tupleShape);
   resultOutputActions.value().appendAction(std::move(createAttributeMatrixAction));
-
-  if(dataStructure.getDataAs<Int32Array>(pSurfaceMeshFaceLabelsArrayPathValue) == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-74354, fmt::format("Could not find face labels array at path '{}'", pSurfaceMeshFaceLabelsArrayPathValue.toString()))};
-  }
-  if(dataStructure.getDataAs<Float64Array>(pSurfaceMeshFaceNormalsArrayPathValue) == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-74355, fmt::format("Could not find face normals array at path '{}'", pSurfaceMeshFaceNormalsArrayPathValue.toString()))};
-  }
-  if(dataStructure.getDataAs<Float64Array>(pSurfaceMeshFaceAreasArrayPathValue) == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-74356, fmt::format("Could not find face areas array at path '{}'", pSurfaceMeshFaceAreasArrayPathValue.toString()))};
-  }
 
   // call the sizeGBCD function to get the GBCD ranges, dimensions, etc.  Note that the input parameters do not affect the size and can be dummy values here;
   SizeGBCD sizeGbcd(0, 0, pGBCDResValue);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDPoleFigureFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeGBCDPoleFigureFilter.cpp
@@ -105,18 +105,9 @@ IFilter::PreflightResult ComputeGBCDPoleFigureFilter::preflightImpl(const DataSt
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  if(dataStructure.getDataAs<UInt32Array>(pCrystalStructuresArrayPathValue) == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-34640, fmt::format("Could not find crystal structures array at path '{}'", pCrystalStructuresArrayPathValue.toString()))};
-  }
+  const auto& gbcd = dataStructure.getDataRefAs<Float64Array>(pGBCDArrayPathValue);
 
-  const auto gbcd = dataStructure.getDataAs<Float64Array>(pGBCDArrayPathValue);
-  if(gbcd == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-34641, fmt::format("Could not find GBCD array at path '{}'", pGBCDArrayPathValue.toString()))};
-  }
-
-  auto numEnsembles = gbcd->getNumberOfTuples();
+  auto numEnsembles = gbcd.getNumberOfTuples();
   if(pPhaseOfInterestValue >= numEnsembles)
   {
     return {MakeErrorResult<OutputActions>(-34642, fmt::format("The phase index {} is larger than the number of Ensembles {}", pPhaseOfInterestValue, numEnsembles))};

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeIPFColorsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeIPFColorsFilter.cpp
@@ -14,17 +14,6 @@
 #include "simplnx/Parameters/VectorParameter.hpp"
 
 using namespace nx::core;
-namespace
-{
-
-using FeatureIdsArrayType = Int32Array;
-using GoodVoxelsArrayType = BoolArray;
-
-constexpr int32 k_MissingGeomError = -71440;
-constexpr int32 k_IncorrectInputArray = -71441;
-constexpr int32 k_MissingInputArray = -71442;
-constexpr int32 k_MissingOrIncorrectGoodVoxelsArray = -71443;
-} // namespace
 
 namespace nx::core
 {
@@ -116,49 +105,14 @@ IFilter::PreflightResult ComputeIPFColorsFilter::preflightImpl(const DataStructu
   auto pCrystalStructuresArrayPathValue = filterArgs.value<DataPath>(k_CrystalStructuresArrayPath_Key);
   auto pCellIPFColorsArrayNameValue = pCellEulerAnglesArrayPathValue.replaceName(filterArgs.value<std::string>(k_CellIPFColorsArrayName_Key));
 
-  // Validate the Crystal Structures array
-  const UInt32Array& crystalStructures = dataStructure.getDataRefAs<UInt32Array>(pCrystalStructuresArrayPathValue);
-  if(crystalStructures.getNumberOfComponents() != 1)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, "Crystal Structures Input Array must be a 1 component Int32 array")};
-  }
-
   std::vector<DataPath> dataPaths;
 
-  // Validate the Eulers array
-  const Float32Array& quats = dataStructure.getDataRefAs<Float32Array>(pCellEulerAnglesArrayPathValue);
-  if(quats.getNumberOfComponents() != 3)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, "Euler Angles Input Array must be a 3 component Float32 array")};
-  }
   dataPaths.push_back(pCellEulerAnglesArrayPathValue);
-
-  // Validate the Phases array
-  const Int32Array& phases = dataStructure.getDataRefAs<Int32Array>(pCellPhasesArrayPathValue);
-  if(phases.getNumberOfComponents() != 1)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, "Phases Input Array must be a 1 component Int32 array")};
-  }
   dataPaths.push_back(pCellPhasesArrayPathValue);
 
-  // Validate the GoodVoxels/Mask Array combination
-  DataPath goodVoxelsPath;
   if(pUseGoodVoxelsValue)
   {
-    goodVoxelsPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
-
-    const nx::core::IDataArray* goodVoxelsArray = dataStructure.getDataAs<IDataArray>(goodVoxelsPath);
-    if(nullptr == goodVoxelsArray)
-    {
-      return {MakeErrorResult<OutputActions>(k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array is not located at path: '{}'", goodVoxelsPath.toString()))};
-    }
-
-    if(goodVoxelsArray->getDataType() != DataType::boolean && goodVoxelsArray->getDataType() != DataType::uint8)
-    {
-      return {nonstd::make_unexpected(
-          std::vector<Error>{Error{k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array at path '{}' is not of the correct type. It must be Bool or UInt8", goodVoxelsPath.toString())}})};
-    }
-    dataPaths.push_back(goodVoxelsPath);
+    dataPaths.push_back(pGoodVoxelsArrayPathValue);
   }
 
   auto tupleValidityCheck = dataStructure.validateNumberOfTuples(dataPaths);
@@ -168,10 +122,10 @@ IFilter::PreflightResult ComputeIPFColorsFilter::preflightImpl(const DataStructu
   }
 
   // Get the number of tuples
-  auto* eulersArray = dataStructure.getDataAs<Float32Array>(pCellEulerAnglesArrayPathValue);
+  const auto& eulersArray = dataStructure.getDataRefAs<Float32Array>(pCellEulerAnglesArrayPathValue);
 
   // Create output DataStructure Items
-  auto createIpfColorsAction = std::make_unique<CreateArrayAction>(DataType::uint8, eulersArray->getIDataStore()->getTupleShape(), std::vector<usize>{3}, pCellIPFColorsArrayNameValue);
+  auto createIpfColorsAction = std::make_unique<CreateArrayAction>(DataType::uint8, eulersArray.getIDataStore()->getTupleShape(), std::vector<usize>{3}, pCellIPFColorsArrayNameValue);
 
   OutputActions actions;
   actions.appendAction(std::move(createIpfColorsAction));

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeQuaternionConjugateFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeQuaternionConjugateFilter.cpp
@@ -15,12 +15,6 @@
 
 using namespace nx::core;
 
-namespace
-{
-constexpr int32 k_IncorrectInputArray = -7100;
-constexpr int32 k_MissingInputArray = -7101;
-} // namespace
-
 namespace nx::core
 {
 //------------------------------------------------------------------------------
@@ -92,12 +86,7 @@ IFilter::PreflightResult ComputeQuaternionConjugateFilter::preflightImpl(const D
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  // Validate the Quats array
   const auto& quats = dataStructure.getDataRefAs<Float32Array>(pQuaternionDataArrayPathValue);
-  if(quats.getNumberOfComponents() != 4)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, "Quaternion Input Array must be a 4 component Float32 array")};
-  }
 
   {
     auto createConvertedQuatAction = std::make_unique<CreateArrayAction>(DataType::float32, quats.getTupleShape(), std::vector<usize>{4}, pOutputDataArrayPathValue);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeShapesFilter.cpp
@@ -118,13 +118,6 @@ IFilter::PreflightResult ComputeShapesFilter::preflightImpl(const DataStructure&
     return {MakeErrorResult<OutputActions>(-12801, fmt::format("Could not find selected cell feature Attibute Matrix at path '{}'", featureAttrMatrixPath.toString()))};
   }
 
-  // Get the Centroids Feature Array and get its TupleShape
-  const auto* centroids = dataStructure.getDataAs<Float32Array>(pCentroidsArrayPath);
-  if(nullptr == centroids)
-  {
-    return {MakeErrorResult<OutputActions>(-12802, "Centroids Feature Data Array is not of the correct type")};
-  }
-
   ShapeType tupleShape = featureAttrMatrix->getShape();
 
   // Create the CreateArrayAction within a scope so that we do not accidentally use the variable is it is getting "moved"

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertOrientationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertOrientationsFilter.cpp
@@ -21,15 +21,6 @@
 #endif
 using namespace nx::core;
 
-namespace
-{
-// Error Code constants
-constexpr nx::core::int32 k_InputRepresentationTypeError = -67001;
-constexpr nx::core::int32 k_OutputRepresentationTypeError = -67002;
-constexpr nx::core::int32 k_InputComponentDimensionError = -67003;
-constexpr nx::core::int32 k_InputComponentCountError = -67004;
-} // namespace
-
 namespace nx::core
 {
 //------------------------------------------------------------------------------
@@ -100,18 +91,6 @@ IFilter::PreflightResult ConvertOrientationsFilter::preflightImpl(const DataStru
 {
   auto inputType = static_cast<ebsdlib::orientations::Type>(filterArgs.value<ChoicesParameter::ValueType>(k_InputType_Key));
   auto outputType = static_cast<ebsdlib::orientations::Type>(filterArgs.value<ChoicesParameter::ValueType>(k_OutputType_Key));
-
-  if(static_cast<int>(inputType) < 0 || inputType >= ebsdlib::orientations::Type::Unknown)
-  {
-    return {MakeErrorResult<OutputActions>(convert_orientations_constants::k_InputRepresentationTypeError,
-                                           fmt::format("Input Representation Type must be a value from 0 to 6. '{}'", fmt::underlying(inputType)))};
-  }
-
-  if(static_cast<int>(outputType) < 0 || outputType >= ebsdlib::orientations::Type::Unknown)
-  {
-    return {MakeErrorResult<OutputActions>(convert_orientations_constants::k_OutputRepresentationTypeError,
-                                           fmt::format("Output Representation Type must be a value from 0 to 6. '{}'", fmt::underlying(outputType)))};
-  }
 
   if(inputType == outputType)
   {

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertOrientationsToVertexGeometryFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertOrientationsToVertexGeometryFilter.cpp
@@ -119,18 +119,9 @@ IFilter::PreflightResult ConvertOrientationsToVertexGeometryFilter::preflightImp
 
   nx::core::Result<OutputActions> resultOutputActions;
 
-  if(static_cast<int>(inputRepType) < 0 || inputRepType >= ebsdlib::orientations::Type::Unknown)
-  {
-    return {MakeErrorResult<OutputActions>(-1001, fmt::format("Input Representation Type must be a value from 0 to 6. '{}'", fmt::underlying(inputRepType)))};
-  }
-
   auto& inputOrientationsArray = dataStructure.getDataRefAs<Float32Array>(inputOrientationsArrayPath);
 
   std::vector<usize> inputCompShape = inputOrientationsArray.getComponentShape();
-  if(inputCompShape.size() > 1)
-  {
-    return {MakeErrorResult<OutputActions>(-1002, fmt::format("Input Component Shape has multiple dimensions. It can only have 1 dimension. '{}'", inputCompShape.size()))};
-  }
 
   using OrientationConverterType = ebsdlib::OrientationConverter<EbsdDataArray<float32>, float32>;
   auto representationNames = OrientationConverterType::GetOrientationTypeStrings<std::vector<std::string>>();

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertQuaternionFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ConvertQuaternionFilter.cpp
@@ -19,9 +19,6 @@ using namespace nx::core;
 namespace
 {
 const ChoicesParameter::Choices k_Choices = {"To Scalar Vector ( w, [x, y, z] )", "To Vector Scalar ( [x, y, z], w )"};
-
-constexpr int32 k_IncorrectInputArray = -7000;
-constexpr int32 k_MissingInputArray = -7001;
 } // namespace
 
 namespace nx::core
@@ -98,12 +95,7 @@ IFilter::PreflightResult ConvertQuaternionFilter::preflightImpl(const DataStruct
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  // Validate the Quats array
   const auto& quats = dataStructure.getDataRefAs<IDataArray>(pQuaternionDataArrayPathValue);
-  if(quats.getNumberOfComponents() != 4)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, "Quaternion Input Array must be a 4 component Float32 array")};
-  }
 
   {
     auto createConvertedQuatAction = std::make_unique<CreateArrayAction>(quats.getDataType(), quats.getTupleShape(), std::vector<usize>{4}, pOutputDataArrayPathValue);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EBSDSegmentFeaturesFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EBSDSegmentFeaturesFilter.cpp
@@ -15,14 +15,6 @@
 
 using namespace nx::core;
 
-namespace
-{
-constexpr int32 k_MissingGeomError = -440;
-constexpr int32 k_IncorrectInputArray = -600;
-constexpr int32 k_MissingInputArray = -601;
-constexpr int32 k_MissingOrIncorrectGoodVoxelsArray = -602;
-} // namespace
-
 namespace nx::core
 {
 //------------------------------------------------------------------------------
@@ -146,22 +138,9 @@ IFilter::PreflightResult EBSDSegmentFeaturesFilter::preflightImpl(const DataStru
 
   // Validate the GoodVoxels/Mask Array combination
   bool useGoodVoxels = filterArgs.value<bool>(k_UseMask_Key);
-  DataPath goodVoxelsPath;
   if(useGoodVoxels)
   {
-    goodVoxelsPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
-
-    const auto* goodVoxelsArray = dataStructure.getDataAs<IDataArray>(goodVoxelsPath);
-    if(nullptr == goodVoxelsArray)
-    {
-      return {MakeErrorResult<OutputActions>(k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array is not located at path: '{}'", goodVoxelsPath.toString()))};
-    }
-    if(goodVoxelsArray->getDataType() != DataType::boolean && goodVoxelsArray->getDataType() != DataType::uint8)
-    {
-      return {
-          MakeErrorResult<OutputActions>(k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array at path '{}' is not of the correct type. It must be Bool or UInt8.", goodVoxelsPath.toString()))};
-    }
-    dataPaths.push_back(goodVoxelsPath);
+    dataPaths.push_back(filterArgs.value<DataPath>(k_MaskArrayPath_Key));
   }
 
   auto tupleValidityCheck = dataStructure.validateNumberOfTuples(dataPaths);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/MergeTwinsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/MergeTwinsFilter.cpp
@@ -4,7 +4,6 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataPath.hpp"
-#include "simplnx/DataStructure/NeighborList.hpp"
 #include "simplnx/Filter/Actions/CreateArrayAction.hpp"
 #include "simplnx/Filter/Actions/CreateAttributeMatrixAction.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
@@ -139,11 +138,6 @@ IFilter::PreflightResult MergeTwinsFilter::preflightImpl(const DataStructure& da
   std::vector<PreflightValue> preflightUpdatedValues;
 
   std::vector<size_t> cDims(1, 1);
-  const auto* contiguousNeighborList = dataStructure.getDataAs<NeighborList<int32>>(pContiguousNeighborListArrayPathValue);
-  if(contiguousNeighborList == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-6874600, fmt::format("Could not find contiguous neighbor list of type Int32 at path '{}' ", pContiguousNeighborListArrayPathValue.toString())), {}};
-  }
 
   std::vector<size_t> tDims(1, 0);
   auto newCellFeatureAction = std::make_unique<CreateAttributeMatrixAction>(pNewCellFeatureAttributeMatrixNameValue, tDims);
@@ -152,44 +146,22 @@ IFilter::PreflightResult MergeTwinsFilter::preflightImpl(const DataStructure& da
   std::vector<DataPath> dataArrayPaths;
 
   // Cell Data
-  const auto* featureIds = dataStructure.getDataAs<Int32Array>(pFeatureIdsArrayPathValue);
-  if(nullptr == featureIds)
-  {
-    return {MakeErrorResult<OutputActions>(-6874602, fmt::format("Could not find feature ids array of type Int32 at path '{}' ", pFeatureIdsArrayPathValue.toString())), {}};
-  }
-  auto cellParentIdsAction = std::make_unique<CreateArrayAction>(DataType::int32, featureIds->getIDataStore()->getTupleShape(), cDims, pCellParentIdsArrayNameValue);
+  const auto& featureIds = dataStructure.getDataRefAs<Int32Array>(pFeatureIdsArrayPathValue);
+  auto cellParentIdsAction = std::make_unique<CreateArrayAction>(DataType::int32, featureIds.getIDataStore()->getTupleShape(), cDims, pCellParentIdsArrayNameValue);
   resultOutputActions.value().appendAction(std::move(cellParentIdsAction));
 
   // Feature Data
-  const auto* phases = dataStructure.getDataAs<Int32Array>(pFeaturePhasesArrayPathValue);
-  if(nullptr == phases)
-  {
-    return {MakeErrorResult<OutputActions>(-6874603, fmt::format("Could not find phases array of type Int32 at path '{}' ", pFeaturePhasesArrayPathValue.toString())), {}};
-  }
+  const auto& phases = dataStructure.getDataRefAs<Int32Array>(pFeaturePhasesArrayPathValue);
   dataArrayPaths.push_back(pFeaturePhasesArrayPathValue);
 
-  auto featureParentIdsAction = std::make_unique<CreateArrayAction>(DataType::int32, phases->getIDataStore()->getTupleShape(), cDims, pFeatureParentIdsArrayNameValue);
+  auto featureParentIdsAction = std::make_unique<CreateArrayAction>(DataType::int32, phases.getIDataStore()->getTupleShape(), cDims, pFeatureParentIdsArrayNameValue);
   resultOutputActions.value().appendAction(std::move(featureParentIdsAction));
 
-  cDims[0] = 4;
-  const auto* avgQuats = dataStructure.getDataAs<Float32Array>(pAvgQuatsArrayPathValue);
-  if(nullptr == avgQuats)
-  {
-    return {MakeErrorResult<OutputActions>(-6874602, fmt::format("Could not find average quaternions array of type Float32 at path '{}' ", pAvgQuatsArrayPathValue.toString())), {}};
-  }
   dataArrayPaths.push_back(pAvgQuatsArrayPathValue);
 
   // New Feature Data
-  cDims[0] = 1;
   auto activeAction = std::make_unique<CreateArrayAction>(DataType::boolean, tDims, cDims, pActiveArrayNameValue);
   resultOutputActions.value().appendAction(std::move(activeAction));
-
-  // Ensemble Data
-  const auto* crystalStructures = dataStructure.getDataAs<UInt32Array>(pCrystalStructuresArrayPathValue);
-  if(nullptr == crystalStructures)
-  {
-    return {MakeErrorResult<OutputActions>(-6874602, fmt::format("Could not find crystal structures array of type UInt32 at path '{}' ", pCrystalStructuresArrayPathValue.toString())), {}};
-  }
 
   auto tupleValidityCheck = dataStructure.validateNumberOfTuples(dataArrayPaths);
   if(!tupleValidityCheck)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.cpp
@@ -17,9 +17,6 @@ using namespace nx::core;
 
 namespace
 {
-constexpr int32 k_MissingGeomError = -580090;
-constexpr int32 k_MissingInputArray = -580091;
-constexpr int32 k_IncorrectInputArray = -580092;
 constexpr int32 k_InvalidNumTuples = -580093;
 } // namespace
 
@@ -114,83 +111,12 @@ IFilter::PreflightResult NeighborOrientationCorrelationFilter::preflightImpl(con
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  auto* imageGeomPtr = dataStructure.getDataAs<ImageGeom>(pImageGeomPathValue);
-  if(imageGeomPtr == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(k_MissingGeomError, fmt::format("Could not find input image geometry at path '{}'", pImageGeomPathValue.toString()))};
-  }
+  const auto& imageGeom = dataStructure.getDataRefAs<ImageGeom>(pImageGeomPathValue);
 
   std::vector<DataPath> dataArrayPaths;
 
-  // Validate the confidence index array
-  auto* confIndexPtr = dataStructure.getDataAs<IDataArray>(pConfidenceIndexArrayPathValue);
-  if(nullptr == confIndexPtr)
-  {
-    return {MakeErrorResult<OutputActions>(k_MissingInputArray, fmt::format("Could not find confidence index array at path '{}'", pConfidenceIndexArrayPathValue.toString()))};
-  }
-  auto* confIndexFloatPtr = dataStructure.getDataAs<Float32Array>(pConfidenceIndexArrayPathValue);
-  if(nullptr == confIndexFloatPtr)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray,
-                                           fmt::format("Confidence index array at path '{}' is not of the correct type. It must be Float32.", pConfidenceIndexArrayPathValue.toString()))};
-  }
-  if(confIndexFloatPtr->getNumberOfComponents() != 1)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, "Confidence index input array must be a 1 component Float32 array")};
-  }
   dataArrayPaths.push_back(pConfidenceIndexArrayPathValue);
-
-  // validate the cell phases array
-  auto* cellPhasesPtr = dataStructure.getDataAs<IDataArray>(pCellPhasesArrayPathValue);
-  if(nullptr == cellPhasesPtr)
-  {
-    return {MakeErrorResult<OutputActions>(k_MissingInputArray, fmt::format("Could not find cell phases array at path '{}'", pCellPhasesArrayPathValue.toString()))};
-  }
-  auto* cellPhasesInt32Ptr = dataStructure.getDataAs<Int32Array>(pCellPhasesArrayPathValue);
-  if(nullptr == cellPhasesInt32Ptr)
-  {
-    return {nonstd::make_unexpected(
-        std::vector<Error>{Error{k_IncorrectInputArray, fmt::format("Cell phases array at path '{}' is not of the correct type. It must be Int32.", pCellPhasesArrayPathValue.toString())}})};
-  }
-  if(cellPhasesInt32Ptr->getNumberOfComponents() != 1)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, "Cell phases input array must be a 1 component Int32 array")};
-  }
   dataArrayPaths.push_back(pCellPhasesArrayPathValue);
-
-  // validate the crystal structures array
-  auto* crystalStructuresPtr = dataStructure.getDataAs<IDataArray>(pCrystalStructuresArrayPathValue);
-  if(nullptr == crystalStructuresPtr)
-  {
-    return {MakeErrorResult<OutputActions>(k_MissingInputArray, fmt::format("Could not find crystal structures array at path '{}'", pCrystalStructuresArrayPathValue.toString()))};
-  }
-  auto* crystalStructuresUInt32Ptr = dataStructure.getDataAs<UInt32Array>(pCrystalStructuresArrayPathValue);
-  if(nullptr == crystalStructuresUInt32Ptr)
-  {
-    return {nonstd::make_unexpected(
-        std::vector<Error>{Error{k_IncorrectInputArray, fmt::format("Crystal structures array at path '{}' is not of the correct type. It must be UInt32.", pCellPhasesArrayPathValue.toString())}})};
-  }
-  if(crystalStructuresUInt32Ptr->getNumberOfComponents() != 1)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, "Crystal structures input array must be a 1 component UInt32 array")};
-  }
-
-  // validate the quaternions array
-  auto* quatsPtr = dataStructure.getDataAs<IDataArray>(pQuatsArrayPathValue);
-  if(nullptr == quatsPtr)
-  {
-    return {MakeErrorResult<OutputActions>(k_MissingInputArray, fmt::format("Could not find quaternions array at path '{}'", pQuatsArrayPathValue.toString()))};
-  }
-  auto* quatsFloat32Ptr = dataStructure.getDataAs<Float32Array>(pQuatsArrayPathValue);
-  if(nullptr == quatsFloat32Ptr)
-  {
-    return {nonstd::make_unexpected(
-        std::vector<Error>{Error{k_IncorrectInputArray, fmt::format("Quaternions array at path '{}' is not of the correct type. It must be Float32.", pCellPhasesArrayPathValue.toString())}})};
-  }
-  if(quatsFloat32Ptr->getNumberOfComponents() != 4)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, "Quaternion input array must be a 4 component Float32 array")};
-  }
   dataArrayPaths.push_back(pQuatsArrayPathValue);
 
   // collect the rest of the geometry's arrays that aren't ignored to check the tuple count
@@ -232,7 +158,7 @@ IFilter::PreflightResult NeighborOrientationCorrelationFilter::preflightImpl(con
 
   // Inform users that the following arrays are going to be modified in place
   // Cell Data is going to be modified
-  nx::core::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, imageGeomPtr->getCellDataPath(), {});
+  nx::core::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, imageGeom.getCellDataPath(), {});
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RodriguesConvertorFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/RodriguesConvertorFilter.cpp
@@ -14,11 +14,6 @@
 #include "simplnx/Parameters/DataObjectNameParameter.hpp"
 
 using namespace nx::core;
-namespace
-{
-constexpr int32 k_IncorrectInputArray = -7300;
-constexpr int32 k_MissingInputArray = -7301;
-} // namespace
 
 namespace nx::core
 {
@@ -92,12 +87,7 @@ IFilter::PreflightResult RodriguesConvertorFilter::preflightImpl(const DataStruc
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  // Validate the Rodrigues array
   const auto& quats = dataStructure.getDataRefAs<Float32Array>(pRodriguesDataArrayPathValue);
-  if(quats.getNumberOfComponents() != 3)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, "Rodrigues Input Array must be a 3 component Float32 array")};
-  }
 
   {
     auto createConvertedQuatAction = std::make_unique<CreateArrayAction>(DataType::float32, quats.getTupleShape(), std::vector<usize>{4}, pOutputDataArrayPathValue);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDGMTFileFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/WriteGBCDGMTFileFilter.cpp
@@ -106,18 +106,9 @@ IFilter::PreflightResult WriteGBCDGMTFileFilter::preflightImpl(const DataStructu
     pOutputFileValue = pOutputFileValue.parent_path() / fileName;
   }
 
-  if(dataStructure.getDataAs<UInt32Array>(pCrystalStructuresArrayPathValue) == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-96710, fmt::format("Could not find crystal structures array at path '{}'", pCrystalStructuresArrayPathValue.toString()))};
-  }
+  const auto& gbcd = dataStructure.getDataRefAs<Float64Array>(pGBCDArrayPathValue);
 
-  const auto* gbcd = dataStructure.getDataAs<Float64Array>(pGBCDArrayPathValue);
-  if(gbcd == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-96711, fmt::format("Could not find GBCD array at path '{}'", pGBCDArrayPathValue.toString()))};
-  }
-
-  auto numEnsembles = gbcd->getNumberOfTuples();
+  auto numEnsembles = gbcd.getNumberOfTuples();
   if(pPhaseOfInterestValue >= numEnsembles)
   {
     return {MakeErrorResult<OutputActions>(-96712, fmt::format("The phase index {} is larger than the number of Ensembles {}", pPhaseOfInterestValue, numEnsembles))};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignGeometriesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/AlignGeometriesFilter.cpp
@@ -75,14 +75,6 @@ IFilter::UniquePointer AlignGeometriesFilter::clone() const
 IFilter::PreflightResult AlignGeometriesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
-  auto alignmentType = filterArgs.value<uint64>(k_AlignmentType_Key);
-
-  if(alignmentType != 0 && alignmentType != 1)
-  {
-    std::string ss = fmt::format("Invalid selection for alignment type");
-    return {MakeErrorResult<OutputActions>(-1, ss)};
-  }
-
   OutputActions actions;
   return {std::move(actions)};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApplyTransformationToGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ApplyTransformationToGeometryFilter.cpp
@@ -166,13 +166,6 @@ IFilter::PreflightResult ApplyTransformationToGeometryFilter::preflightImpl(cons
 
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  const auto* iGeometryPtr = dataStructure.getDataAs<IGeometry>(pSelectedGeometryPathValue);
-
-  if(iGeometryPtr == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-82000, "Input Geometry must be either ImageGeom or Vertex, Edge, Triangle, Quad, Hexahedron, Tetrahedron.")};
-  }
-
   const ShapeType cDims = {4, 4};
 
   // Reset the final Transformation Matrix to all Zeros before we fill it with what the user has entered.
@@ -267,9 +260,6 @@ IFilter::PreflightResult ApplyTransformationToGeometryFilter::preflightImpl(cons
       }
       transformationMatrixDesc = ImageRotationUtilities::GenerateTransformationMatrixDescription(transformationMatrix);
       break;
-    }
-    default: {
-      return {MakeErrorResult<OutputActions>(-82003, "Invalid selection for transformation operation. Valid values are [0,5]")};
     }
     }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ChangeAngleRepresentationFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ChangeAngleRepresentationFilter.cpp
@@ -115,13 +115,6 @@ IFilter::UniquePointer ChangeAngleRepresentationFilter::clone() const
 IFilter::PreflightResult ChangeAngleRepresentationFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
-  auto pConversionTypeValue = filterArgs.value<ChoicesParameter::ValueType>(k_ConversionType_Key);
-
-  if(pConversionTypeValue > 1)
-  {
-    return {MakeErrorResult<OutputActions>(-67001, fmt::format("The conversion type must be either [0|1]. Value given is '{}'", pConversionTypeValue))};
-  }
-
   return {};
 }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayHistogramByFeatureFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayHistogramByFeatureFilter.cpp
@@ -149,10 +149,6 @@ IFilter::PreflightResult ComputeArrayHistogramByFeatureFilter::preflightImpl(con
   if(pUseMaskValue)
   {
     maskArray = dataStructure.getDataAs<IDataArray>(pMaskArrayPathValue);
-    if(maskArray->getDataType() != DataType::boolean && maskArray->getDataType() != DataType::uint8)
-    {
-      return {MakeErrorResult<OutputActions>(-57206, fmt::format("Mask array '{}' must be of type Boolean or UInt8", maskArray->getName())), {}};
-    }
   }
 
   for(auto& selectedArrayPath : pSelectedArrayPathsValue)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayHistogramFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeArrayHistogramFilter.cpp
@@ -149,10 +149,6 @@ IFilter::PreflightResult ComputeArrayHistogramFilter::preflightImpl(const DataSt
   if(useMask)
   {
     maskArray = dataStructure.getDataAs<IDataArray>(maskArrayPath);
-    if(maskArray->getDataType() != DataType::boolean && maskArray->getDataType() != DataType::uint8)
-    {
-      return {MakeErrorResult<OutputActions>(-57206, fmt::format("Mask array '{}' must be of type Boolean or UInt8", maskArray->getName())), {}};
-    }
   }
 
   for(auto& selectedArrayPath : pSelectedArrayPathsValue)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeDifferencesMapFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeDifferencesMapFilter.cpp
@@ -17,7 +17,6 @@ namespace nx::core
 
 namespace
 {
-constexpr int32 k_MissingInputArray = -567;
 constexpr int32 k_ComponentCountMismatchError = -90003;
 constexpr int32 k_InvalidNumTuples = -90004;
 
@@ -142,21 +141,10 @@ IFilter::PreflightResult ComputeDifferencesMapFilter::preflightImpl(const DataSt
 
   std::vector<DataPath> dataArrayPaths;
 
-  auto* firstInputArray = dataStructure.getDataAs<IDataArray>(firstInputArrayPath);
-  if(firstInputArray == nullptr)
-  {
-    std::string ss = fmt::format("Could not find input array at path {}", firstInputArrayPath.toString());
-    return {MakeErrorResult<OutputActions>(-k_MissingInputArray, ss)};
-  }
-
+  const auto& firstInputArray = dataStructure.getDataRefAs<IDataArray>(firstInputArrayPath);
   dataArrayPaths.push_back(firstInputArrayPath);
 
-  auto* secondInputArray = dataStructure.getDataAs<IDataArray>(secondInputArrayPath);
-  if(secondInputArray == nullptr)
-  {
-    std::string ss = fmt::format("Could not find input array at path {}", secondInputArrayPath.toString());
-    return {MakeErrorResult<OutputActions>(-k_MissingInputArray, ss)};
-  }
+  const auto& secondInputArray = dataStructure.getDataRefAs<IDataArray>(secondInputArrayPath);
   dataArrayPaths.push_back(secondInputArrayPath);
 
   if(!dataArrayPaths.empty())
@@ -174,8 +162,7 @@ IFilter::PreflightResult ComputeDifferencesMapFilter::preflightImpl(const DataSt
     warnings = warnOnUnsignedTypes(dataStructure, dataArrayPaths);
   }
 
-  // Safe to check array component dimensions since we won't get here if the pointers are null
-  if(firstInputArray->getNumberOfComponents() != secondInputArray->getNumberOfComponents())
+  if(firstInputArray.getNumberOfComponents() != secondInputArray.getNumberOfComponents())
   {
     std::string ss = fmt::format("Selected Attribute Arrays must have the same component dimensions");
     return {MakeErrorResult<OutputActions>(nx::core::k_ComponentCountMismatchError, ss)};
@@ -191,9 +178,9 @@ IFilter::PreflightResult ComputeDifferencesMapFilter::preflightImpl(const DataSt
 
   // At this point we have two valid arrays of the same type and component dimensions, so we
   // are safe to make the output array with the correct type and component dimensions
-  DataType dataType = firstInputArray->getDataType();
-  auto action = std::make_unique<CreateArrayAction>(dataType, firstInputArray->getIDataStore()->getTupleShape(), firstInputArray->getIDataStore()->getComponentShape(), differenceMapArrayPath,
-                                                    firstInputArray->getDataFormat());
+  DataType dataType = firstInputArray.getDataType();
+  auto action = std::make_unique<CreateArrayAction>(dataType, firstInputArray.getIDataStore()->getTupleShape(), firstInputArray.getIDataStore()->getComponentShape(), differenceMapArrayPath,
+                                                    firstInputArray.getDataFormat());
 
   //
   nx::core::Result<OutputActions> actions;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureNeighborsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureNeighborsFilter.cpp
@@ -140,12 +140,8 @@ IFilter::PreflightResult ComputeFeatureNeighborsFilter::preflightImpl(const Data
   // Feature Data:
   // Validating the Feature Attribute Matrix and trying to find a child of the Group
   // that is an IDataArray subclass, so we can get the proper tuple shape
-  const auto* featureAttrMatrix = dataStructure.getDataAs<AttributeMatrix>(featureAttrMatrixPath);
-  if(featureAttrMatrix == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-12600, "Cell Feature AttributeMatrix Path is NOT an AttributeMatrix")};
-  }
-  tupleShape = featureAttrMatrix->getShape();
+  const auto& featureAttrMatrix = dataStructure.getDataRefAs<AttributeMatrix>(featureAttrMatrixPath);
+  tupleShape = featureAttrMatrix.getShape();
 
   // Create the NumNeighbors Output Data Array in the Feature Attribute Matrix
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeaturePhasesFilter.cpp
@@ -88,18 +88,10 @@ IFilter::PreflightResult ComputeFeaturePhasesFilter::preflightImpl(const DataStr
 
   nx::core::Result<OutputActions> resultOutputActions;
 
-  if(dataStructure.getDataAs<Int32Array>(pFeatureIdsArrayPathValue) == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-4630, fmt::format("Could not find selected feature ids array at path '{}'", pFeatureIdsArrayPathValue.toString()))};
-  }
-  const auto* cellFeatData = dataStructure.getDataAs<AttributeMatrix>(pCellFeatureAMPathValue);
-  if(cellFeatData == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-4631, fmt::format("Could not find selected cell features Attribute Matrix at path '{}'", pCellFeatureAMPathValue.toString()))};
-  }
+  const auto& cellFeatData = dataStructure.getDataRefAs<AttributeMatrix>(pCellFeatureAMPathValue);
 
   {
-    auto createFeaturePhasesAction = std::make_unique<CreateArrayAction>(DataType::int32, cellFeatData->getShape(), std::vector<usize>{1}, pFeaturePhasesArrayPathValue);
+    auto createFeaturePhasesAction = std::make_unique<CreateArrayAction>(DataType::int32, cellFeatData.getShape(), std::vector<usize>{1}, pFeaturePhasesArrayPathValue);
     resultOutputActions.value().appendAction(std::move(createFeaturePhasesAction));
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
@@ -15,13 +15,6 @@
 
 namespace nx::core
 {
-namespace
-{
-constexpr nx::core::int32 k_MissingGeometry = -73225;
-constexpr nx::core::int32 k_MissingFeatureIds = -74789;
-constexpr nx::core::int32 k_MissingFeatureAttributeMatrix = -74769;
-} // namespace
-
 std::string ComputeFeatureSizesFilter::name() const
 {
   return FilterTraits<ComputeFeatureSizesFilter>::name;
@@ -99,30 +92,13 @@ IFilter::PreflightResult ComputeFeatureSizesFilter::preflightImpl(const DataStru
   DataPath equivalentDiametersPath = featureAttributeMatrixPath.createChildPath(equivalentDiametersName);
   DataPath numElementsPath = featureAttributeMatrixPath.createChildPath(numElementsName);
 
-  const auto* featureIdsArray = dataStructure.getDataAs<Int32Array>(featureIdsPath);
+  const auto& featureIdsArray = dataStructure.getDataRefAs<Int32Array>(featureIdsPath);
 
-  const auto* geometry = dataStructure.getDataAs<IGeometry>(geometryPath);
+  const std::string arrayDataFormat = featureIdsArray.getDataFormat();
 
-  if(geometry == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(k_MissingGeometry, "Could not find the target geometry.")};
-  }
+  const auto& featAttributeMatrix = dataStructure.getDataRefAs<AttributeMatrix>(featureAttributeMatrixPath);
 
-  if(featureIdsArray == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(k_MissingFeatureIds, "Could not find Feature IDs array.")};
-  }
-
-  const std::string arrayDataFormat = featureIdsArray->getDataFormat();
-
-  const auto* featAttributeMatrix = dataStructure.getDataAs<AttributeMatrix>(featureAttributeMatrixPath);
-  if(featAttributeMatrix == nullptr)
-  {
-    return {nonstd::make_unexpected(
-        std::vector<Error>{Error{k_MissingFeatureAttributeMatrix, fmt::format("Could not find Feature Attribute Matrix at path '{}'", featureAttributeMatrixPath.toString())}})};
-  }
-
-  ShapeType tupleDimensions = featAttributeMatrix->getShape();
+  ShapeType tupleDimensions = featAttributeMatrix.getShape();
   uint64 numberOfComponents = 1;
 
   auto createVolumesAction = std::make_unique<CreateArrayAction>(DataType::float32, tupleDimensions, std::vector<usize>{numberOfComponents}, volumesPath, arrayDataFormat);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNumFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeNumFeaturesFilter.cpp
@@ -89,13 +89,9 @@ IFilter::PreflightResult ComputeNumFeaturesFilter::preflightImpl(const DataStruc
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  const auto* cellEnsembleData = dataStructure.getDataAs<AttributeMatrix>(pEnsembleDataPathValue);
-  if(cellEnsembleData == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-47630, fmt::format("Could not find selected ensemble Attribute Matrix at path '{}'", pEnsembleDataPathValue.toString()))};
-  }
+  const auto& cellEnsembleData = dataStructure.getDataRefAs<AttributeMatrix>(pEnsembleDataPathValue);
 
-  auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::int32, cellEnsembleData->getShape(), std::vector<usize>{1}, pNumFeaturesArrayPathValue);
+  auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::int32, cellEnsembleData.getShape(), std::vector<usize>{1}, pNumFeaturesArrayPathValue);
   resultOutputActions.value().appendAction(std::move(createArrayAction));
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVertexToTriangleDistancesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVertexToTriangleDistancesFilter.cpp
@@ -102,32 +102,22 @@ IFilter::PreflightResult ComputeVertexToTriangleDistancesFilter::preflightImpl(c
 
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  auto* vertexGeomPtr = dataStructure.getDataAs<VertexGeom>(pVertexGeometryDataPath);
-  if(vertexGeomPtr == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-4530, fmt::format("The DataPath {} is not a valid VertexGeometry.", pVertexGeometryDataPath.toString()))};
-  }
+  const auto& vertexGeom = dataStructure.getDataRefAs<VertexGeom>(pVertexGeometryDataPath);
+  const auto& triangleGeom = dataStructure.getDataRefAs<TriangleGeom>(pTriangleGeometryDataPath);
 
-  auto* triangleGeomPtr = dataStructure.getDataAs<TriangleGeom>(pTriangleGeometryDataPath);
-  if(triangleGeomPtr == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-4531, fmt::format("The DataPath {} is not a valid TriangleGeometry.", pTriangleGeometryDataPath.toString()))};
-  }
+  const DataPath vertexDataPath = pVertexGeometryDataPath.createChildPath(vertexGeom.getVertexAttributeMatrix()->getName());
 
-  const DataPath vertexDataPath = pVertexGeometryDataPath.createChildPath(vertexGeomPtr->getVertexAttributeMatrix()->getName());
-
-  auto createDistancesArrayAction = std::make_unique<CreateArrayAction>(nx::core::DataType::float32, std::vector<usize>{vertexGeomPtr->getNumberOfVertices()}, std::vector<usize>{1},
-                                                                        vertexDataPath.createChildPath(pDistancesDataName));
+  auto createDistancesArrayAction =
+      std::make_unique<CreateArrayAction>(nx::core::DataType::float32, std::vector<usize>{vertexGeom.getNumberOfVertices()}, std::vector<usize>{1}, vertexDataPath.createChildPath(pDistancesDataName));
   resultOutputActions.value().appendAction(std::move(createDistancesArrayAction));
 
-  auto createClosestTriangleIdArrayAction = std::make_unique<CreateArrayAction>(nx::core::DataType::int64, std::vector<usize>{vertexGeomPtr->getNumberOfVertices()}, std::vector<usize>{1},
+  auto createClosestTriangleIdArrayAction = std::make_unique<CreateArrayAction>(nx::core::DataType::int64, std::vector<usize>{vertexGeom.getNumberOfVertices()}, std::vector<usize>{1},
                                                                                 vertexDataPath.createChildPath(pClosestTriangleIdDataName));
   resultOutputActions.value().appendAction(std::move(createClosestTriangleIdArrayAction));
 
   // Create temp array then deferred delete
   auto tempTriBoundsDataPath = DataPath({::k_TriangleBounds});
-  auto createTriBoundsArrayAction =
-      std::make_unique<CreateArrayAction>(nx::core::DataType::float32, std::vector<usize>{triangleGeomPtr->getNumberOfFaces()}, std::vector<usize>{6}, tempTriBoundsDataPath);
+  auto createTriBoundsArrayAction = std::make_unique<CreateArrayAction>(nx::core::DataType::float32, std::vector<usize>{triangleGeom.getNumberOfFaces()}, std::vector<usize>{6}, tempTriBoundsDataPath);
   resultOutputActions.value().appendAction(std::move(createTriBoundsArrayAction));
 
   auto removeTempArrayAction = std::make_unique<DeleteDataAction>(tempTriBoundsDataPath);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVolumeFractionsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVolumeFractionsFilter.cpp
@@ -90,13 +90,9 @@ IFilter::PreflightResult ComputeVolumeFractionsFilter::preflightImpl(const DataS
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  const auto* cellEnsembleData = dataStructure.getDataAs<AttributeMatrix>(pCellEnsembleAttributeMatrixPathValue);
-  if(cellEnsembleData == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-47630, fmt::format("Could not find selected feature Attribute Matrix at path '{}'", pCellEnsembleAttributeMatrixPathValue.toString()))};
-  }
+  const auto& cellEnsembleData = dataStructure.getDataRefAs<AttributeMatrix>(pCellEnsembleAttributeMatrixPathValue);
 
-  auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::float32, cellEnsembleData->getShape(), std::vector<usize>{1}, volFractionsArrayPath);
+  auto createArrayAction = std::make_unique<CreateArrayAction>(DataType::float32, cellEnsembleData.getShape(), std::vector<usize>{1}, volFractionsArrayPath);
   resultOutputActions.value().appendAction(std::move(createArrayAction));
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertColorToGrayScaleFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertColorToGrayScaleFilter.cpp
@@ -102,12 +102,6 @@ IFilter::PreflightResult ConvertColorToGrayScaleFilter::preflightImpl(const Data
 
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  if(pConversionAlgorithmValue > 3)
-  {
-    return {MakeErrorResult<OutputActions>(
-        -10701, fmt::format("Conversion Algorithm choice is invalid. Valid values are 0=Luminosity, 1=Average, 2=Lightness, 3=SingleChannel. Value supplied is {}", pConversionAlgorithmValue))};
-  }
-
   if(pConversionAlgorithmValue == 3 && pColorChannelValue > 3)
   {
     return {MakeErrorResult<OutputActions>(-10701, fmt::format("Color channel selection is invalid. Valid values are 0, 1, 2. Value supplied is {}", pColorChannelValue))};
@@ -135,18 +129,14 @@ IFilter::PreflightResult ConvertColorToGrayScaleFilter::preflightImpl(const Data
   DataPath outputDataArrayPath;
   for(const auto& inputDataArrayPath : inputDataArrayPaths)
   {
-    const auto* inputArray = dataStructure.getDataAs<IDataArray>(inputDataArrayPath);
-    if(inputArray == nullptr)
-    {
-      return {MakeErrorResult<OutputActions>(-10700, fmt::format("Input Data Array does not exist at DataPath {}", inputDataArrayPath.toString()))};
-    }
+    const auto& inputArray = dataStructure.getDataRefAs<IDataArray>(inputDataArrayPath);
     std::vector<std::string> inputPathVector = inputDataArrayPath.getPathVector();
     std::string inputArrayName = inputDataArrayPath.getTargetName();
     std::string outputArrayName = fmt::format("{}{}", outputArrayPrefix, inputArrayName);
     inputPathVector.back() = outputArrayName;
     outputDataArrayPath = DataPath(inputPathVector);
     resultOutputActions.value().appendAction(
-        std::make_unique<CreateArrayAction>(nx::core::DataType::uint8, inputArray->getIDataStoreRef().getTupleShape(), std::vector<usize>(1, 1), outputDataArrayPath));
+        std::make_unique<CreateArrayAction>(nx::core::DataType::uint8, inputArray.getIDataStoreRef().getTupleShape(), std::vector<usize>(1, 1), outputDataArrayPath));
   }
 
   // Return both the resultOutputActions and the preflightUpdatedValues via std::move()

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ConvertDataFilter.cpp
@@ -104,14 +104,10 @@ IFilter::PreflightResult ConvertDataFilter::preflightImpl(const DataStructure& d
 
   Result<OutputActions> resultOutputActions;
 
-  auto* inputArrayPtr = dataStructure.getDataAs<IDataArray>(pInputArrayPath);
-  if(inputArrayPtr == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-15201, fmt::format("Cannot find input data array at path '{}'", pInputArrayPath.toString()))};
-  }
+  const auto& inputArray = dataStructure.getDataRefAs<IDataArray>(pInputArrayPath);
 
   resultOutputActions.value().appendAction(
-      std::make_unique<CreateArrayAction>(pScalarType, inputArrayPtr->getIDataStoreRef().getTupleShape(), inputArrayPtr->getIDataStoreRef().getComponentShape(), convertedArrayPath));
+      std::make_unique<CreateArrayAction>(pScalarType, inputArray.getIDataStoreRef().getTupleShape(), inputArray.getIDataStoreRef().getComponentShape(), convertedArrayPath));
 
   if(pRemoveOriginal)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateColorMapFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateColorMapFilter.cpp
@@ -19,10 +19,6 @@
 using namespace nx::core;
 namespace
 {
-constexpr int32 k_MissingGeomError = -72440;
-constexpr int32 k_IncorrectInputArray = -72441;
-constexpr int32 k_MissingInputArray = -72442;
-constexpr int32 k_MissingOrIncorrectGoodVoxelsArray = -72443;
 } // namespace
 
 namespace nx::core
@@ -122,23 +118,9 @@ IFilter::PreflightResult CreateColorMapFilter::preflightImpl(const DataStructure
   dataPaths.push_back(pSelectedDataArrayPathValue);
 
   // Validate the GoodVoxels/Mask Array combination
-  DataPath goodVoxelsPath;
   if(pUseGoodVoxelsValue)
   {
-    goodVoxelsPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
-
-    const auto* goodVoxelsArray = dataStructure.getDataAs<IDataArray>(goodVoxelsPath);
-    if(nullptr == goodVoxelsArray)
-    {
-      return {MakeErrorResult<OutputActions>(k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array is not located at path: '{}'", goodVoxelsPath.toString()))};
-    }
-
-    if(goodVoxelsArray->getDataType() != DataType::boolean && goodVoxelsArray->getDataType() != DataType::uint8)
-    {
-      return {nonstd::make_unexpected(
-          std::vector<Error>{Error{k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array at path '{}' is not of the correct type. It must be Bool or UInt8", goodVoxelsPath.toString())}})};
-    }
-    dataPaths.push_back(goodVoxelsPath);
+    dataPaths.push_back(pGoodVoxelsArrayPathValue);
   }
 
   auto tupleValidityCheck = dataStructure.validateNumberOfTuples(dataPaths);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CreateGeometryFilter.cpp
@@ -233,11 +233,6 @@ IFilter::PreflightResult CreateGeometryFilter::preflightImpl(const DataStructure
   {
     pVertexListPath = filterArgs.value<DataPath>(k_VertexListPath_Key);
     pVertexAMName = filterArgs.value<std::string>(k_VertexAttributeMatrixName_Key);
-
-    if(dataStructure.getDataAs<Float32Array>(pVertexListPath) == nullptr)
-    {
-      return {MakeErrorResult<OutputActions>(-9840, fmt::format("Cannot find selected vertex list at path '{}'", pVertexListPath.toString()))};
-    }
   }
   if(pGeometryType == k_TriangleGeometry || pGeometryType == k_QuadGeometry)
   {
@@ -280,29 +275,17 @@ IFilter::PreflightResult CreateGeometryFilter::preflightImpl(const DataStructure
     auto pXBoundsPath = filterArgs.value<DataPath>(k_XBoundsPath_Key);
     auto pYBoundsPath = filterArgs.value<DataPath>(k_YBoundsPath_Key);
     auto pZBoundsPath = filterArgs.value<DataPath>(k_ZBoundsPath_Key);
-    const auto xBounds = dataStructure.getDataAs<Float32Array>(pXBoundsPath);
-    if(xBounds == nullptr)
-    {
-      return {MakeErrorResult<OutputActions>(-9841, fmt::format("Cannot find selected quadrilateral list at path '{}'", pXBoundsPath.toString()))};
-    }
-    const auto yBounds = dataStructure.getDataAs<Float32Array>(pYBoundsPath);
-    if(yBounds == nullptr)
-    {
-      return {MakeErrorResult<OutputActions>(-9842, fmt::format("Cannot find selected quadrilateral list at path '{}'", pYBoundsPath.toString()))};
-    }
-    const auto zBounds = dataStructure.getDataAs<Float32Array>(pZBoundsPath);
-    if(zBounds == nullptr)
-    {
-      return {MakeErrorResult<OutputActions>(-9843, fmt::format("Cannot find selected quadrilateral list at path '{}'", pZBoundsPath.toString()))};
-    }
-    usize xTuples = xBounds->getNumberOfTuples();
-    usize yTuples = yBounds->getNumberOfTuples();
-    usize zTuples = zBounds->getNumberOfTuples();
+    const auto& xBounds = dataStructure.getDataRefAs<Float32Array>(pXBoundsPath);
+    const auto& yBounds = dataStructure.getDataRefAs<Float32Array>(pYBoundsPath);
+    const auto& zBounds = dataStructure.getDataRefAs<Float32Array>(pZBoundsPath);
+    usize xTuples = xBounds.getNumberOfTuples();
+    usize yTuples = yBounds.getNumberOfTuples();
+    usize zTuples = zBounds.getNumberOfTuples();
     if(xTuples < 2 || yTuples < 2 || zTuples < 2)
     {
       return {nonstd::make_unexpected(
           std::vector<Error>{Error{-9844, fmt::format("One of the bounds arrays has a size less than two; all sizes must be at least two\nX Bounds Size: {}\nY Bounds Size: {}\nZ Bounds Size: {}\n",
-                                                      xBounds->getNumberOfTuples(), yBounds->getNumberOfTuples(), zBounds->getNumberOfTuples())}})};
+                                                      xBounds.getNumberOfTuples(), yBounds.getNumberOfTuples(), zBounds.getNumberOfTuples())}})};
     }
 
     auto createRectGridGeometryAction = std::make_unique<CreateRectGridGeometryAction>(pGeometryPath, pXBoundsPath, pYBoundsPath, pZBoundsPath, pCellAMName, ArrayHandlingType{pArrayHandling});
@@ -317,10 +300,6 @@ IFilter::PreflightResult CreateGeometryFilter::preflightImpl(const DataStructure
   {
     auto pEdgeListPath = filterArgs.value<DataPath>(k_EdgeListPath_Key);
     auto pEdgeAMName = filterArgs.value<std::string>(k_EdgeAttributeMatrixName_Key);
-    if(const auto* edgeList = dataStructure.getDataAs<UInt64Array>(pEdgeListPath); edgeList == nullptr)
-    {
-      return {MakeErrorResult<OutputActions>(-9845, fmt::format("Cannot find selected edge list at path '{}'", pEdgeListPath.toString()))};
-    }
 
     auto createEdgeGeomAction = std::make_unique<CreateEdgeGeometryAction>(pGeometryPath, pVertexListPath, pEdgeListPath, pVertexAMName, pEdgeAMName, ArrayHandlingType{pArrayHandling});
     resultOutputActions.value().appendAction(std::move(createEdgeGeomAction));
@@ -328,10 +307,6 @@ IFilter::PreflightResult CreateGeometryFilter::preflightImpl(const DataStructure
   if(pGeometryType == k_TriangleGeometry) // TriangleGeom
   {
     auto pTriangleListPath = filterArgs.value<DataPath>(k_TriangleListPath_Key);
-    if(const auto* triangleList = dataStructure.getDataAs<UInt64Array>(pTriangleListPath); triangleList == nullptr)
-    {
-      return {MakeErrorResult<OutputActions>(-9846, fmt::format("Cannot find selected triangle list at path '{}'", pTriangleListPath.toString()))};
-    }
 
     auto createTriangleGeomAction = std::make_unique<CreateTriangleGeometryAction>(pGeometryPath, pVertexListPath, pTriangleListPath, pVertexAMName, pFaceAMName, ArrayHandlingType{pArrayHandling});
     resultOutputActions.value().appendAction(std::move(createTriangleGeomAction));
@@ -339,10 +314,6 @@ IFilter::PreflightResult CreateGeometryFilter::preflightImpl(const DataStructure
   if(pGeometryType == k_QuadGeometry) // QuadGeom
   {
     auto pQuadListPath = filterArgs.value<DataPath>(k_QuadrilateralListPath_Key);
-    if(const auto* quadList = dataStructure.getDataAs<UInt64Array>(pQuadListPath); quadList == nullptr)
-    {
-      return {MakeErrorResult<OutputActions>(-9847, fmt::format("Cannot find selected quadrilateral list at path '{}'", pQuadListPath.toString()))};
-    }
 
     auto createQuadGeomAction = std::make_unique<CreateQuadGeometryAction>(pGeometryPath, pVertexListPath, pQuadListPath, pVertexAMName, pFaceAMName, ArrayHandlingType{pArrayHandling});
     resultOutputActions.value().appendAction(std::move(createQuadGeomAction));
@@ -350,10 +321,6 @@ IFilter::PreflightResult CreateGeometryFilter::preflightImpl(const DataStructure
   if(pGeometryType == k_TetGeometry) // TetrahedralGeom
   {
     auto pTetListPath = filterArgs.value<DataPath>(k_TetrahedralListPath_Key);
-    if(const auto* tetList = dataStructure.getDataAs<UInt64Array>(pTetListPath); tetList == nullptr)
-    {
-      return {MakeErrorResult<OutputActions>(-9848, fmt::format("Cannot find selected quadrilateral list at path '{}'", pTetListPath.toString()))};
-    }
 
     auto createTetGeomAction = std::make_unique<CreateTetrahedralGeometryAction>(pGeometryPath, pVertexListPath, pTetListPath, pVertexAMName, pCellAMName, ArrayHandlingType{pArrayHandling});
     resultOutputActions.value().appendAction(std::move(createTetGeomAction));
@@ -361,10 +328,6 @@ IFilter::PreflightResult CreateGeometryFilter::preflightImpl(const DataStructure
   if(pGeometryType == k_HexGeometry) // HexahedralGeom
   {
     auto pHexListPath = filterArgs.value<DataPath>(k_HexahedralListPath_Key);
-    if(const auto* hexList = dataStructure.getDataAs<UInt64Array>(pHexListPath); hexList == nullptr)
-    {
-      return {MakeErrorResult<OutputActions>(-9849, fmt::format("Cannot find selected quadrilateral list at path '{}'", pHexListPath.toString()))};
-    }
 
     auto createHexGeomAction = std::make_unique<CreateHexahedralGeometryAction>(pGeometryPath, pVertexListPath, pHexListPath, pVertexAMName, pCellAMName, ArrayHandlingType{pArrayHandling});
     resultOutputActions.value().appendAction(std::move(createHexGeomAction));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropImageGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CropImageGeometryFilter.cpp
@@ -492,16 +492,12 @@ IFilter::PreflightResult CropImageGeometryFilter::preflightImpl(const DataStruct
   {
     ignorePaths.push_back(cellFeatureAmPath);
 
-    const auto* srcCellFeatureData = dataStructure.getDataAs<AttributeMatrix>(cellFeatureAmPath);
-    if(nullptr == srcCellFeatureData)
-    {
-      return {MakeErrorResult<OutputActions>(-55502, fmt::format("Could not find the selected Attribute Matrix '{}'", cellFeatureAmPath.toString())), preflightUpdatedValues};
-    }
+    const auto& srcCellFeatureData = dataStructure.getDataRefAs<AttributeMatrix>(cellFeatureAmPath);
     std::string warningMsg;
     DataPath destCellFeatureAmPath = destImagePath.createChildPath(cellFeatureAmPath.getTargetName());
-    auto tDims = srcCellFeatureData->getShape();
+    auto tDims = srcCellFeatureData.getShape();
     resultOutputActions.value().appendAction(std::make_unique<CreateAttributeMatrixAction>(destCellFeatureAmPath, tDims));
-    for(const auto& [identifier, object] : *srcCellFeatureData)
+    for(const auto& [identifier, object] : srcCellFeatureData)
     {
       if(const auto* srcArray = dynamic_cast<const IDataArray*>(object.get()); srcArray != nullptr)
       {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateBadDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateBadDataFilter.cpp
@@ -109,11 +109,6 @@ IFilter::PreflightResult ErodeDilateBadDataFilter::preflightImpl(const DataStruc
   preflightUpdatedValues.emplace_back(PreflightValue{"Feature Data Modification Warning", featureModificationWarning});
   resultOutputActions.warnings().push_back(Warning{-14600, featureModificationWarning});
 
-  if(pOperationValue != detail::k_DilateIndex && pOperationValue != detail::k_ErodeIndex)
-  {
-    MakeErrorResult(-16700, fmt::format("Operation Selection must be 0 (Dilate) or 1 (Erode). {} was passed into the filter. ", pOperationValue));
-  }
-
   // Inform users that the following arrays are going to be modified in place
   // Cell Data is going to be modified
   nx::core::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, pFeatureIdsArrayPathValue.getParent(), pIgnoredDataArrayPathsValue);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractInternalSurfacesFromTriangleGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractInternalSurfacesFromTriangleGeometryFilter.cpp
@@ -16,7 +16,6 @@ namespace
 {
 constexpr int32 k_MissingTriangleVerticesArray = -351;
 constexpr int32 k_MissingTriangleFacesArray = -352;
-constexpr int32 k_NoNodeTypesArray = -353;
 constexpr int32 k_MissingVertexArray = -354;
 constexpr int32 k_MissingTriangleArray = -355;
 
@@ -121,12 +120,6 @@ IFilter::PreflightResult ExtractInternalSurfacesFromTriangleGeometryFilter::pref
     }
     std::vector<DataPath> vertexArrays;
     vertexArrays.push_back(triangleGeom.getVertices()->getDataPaths().front());
-    const auto* nodeTypesPtr = dataStructure.getDataAs<Int8Array>(nodeTypesArrayPath);
-    if(nodeTypesPtr == nullptr)
-    {
-      std::string ss("Node Types array not found at path '{}'. Array must be of type Int8");
-      return {MakeErrorResult<OutputActions>(k_NoNodeTypesArray, ss)};
-    }
     vertexArrays.push_back(nodeTypesArrayPath);
 
     auto tupleValidityCheck = dataStructure.validateNumberOfTuples(vertexArrays);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractVertexGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ExtractVertexGeometryFilter.cpp
@@ -19,10 +19,6 @@
 using namespace nx::core;
 namespace
 {
-constexpr int32 k_MissingGeomError = -72440;
-constexpr int32 k_IncorrectInputArray = -72441;
-constexpr int32 k_MissingInputArray = -72442;
-constexpr int32 k_MissingOrIncorrectGoodVoxelsArray = -72443;
 } // namespace
 
 namespace nx::core
@@ -133,17 +129,6 @@ IFilter::PreflightResult ExtractVertexGeometryFilter::preflightImpl(const DataSt
   // Validate the GoodVoxels/Mask Array combination
   if(pUseGoodVoxelsValue)
   {
-    const auto* goodVoxelsArray = dataStructure.getDataAs<IDataArray>(pMaskArrayPathValue);
-    if(nullptr == goodVoxelsArray)
-    {
-      return {MakeErrorResult<OutputActions>(k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array is not located at path: '{}'", pMaskArrayPathValue.toString()))};
-    }
-
-    if(goodVoxelsArray->getDataType() != DataType::boolean && goodVoxelsArray->getDataType() != DataType::uint8)
-    {
-      return {nonstd::make_unexpected(
-          std::vector<Error>{Error{k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array at path '{}' is not of the correct type. It must be Bool or UInt8", pMaskArrayPathValue.toString())}})};
-    }
     dataPaths.push_back(pMaskArrayPathValue);
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FillBadDataFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/FillBadDataFilter.cpp
@@ -92,7 +92,6 @@ IFilter::PreflightResult FillBadDataFilter::preflightImpl(const DataStructure& d
                                                           const ExecutionContext& executionContext) const
 {
   auto pMinAllowedDefectSizeValue = filterArgs.value<int32>(k_MinAllowedDefectSize_Key);
-  auto cellPhasesArrayPath = filterArgs.value<DataPath>(k_CellPhasesArrayPath_Key);
 
   if(pMinAllowedDefectSizeValue < 1)
   {
@@ -107,14 +106,6 @@ IFilter::PreflightResult FillBadDataFilter::preflightImpl(const DataStructure& d
                                            "level data should be rerun to ensure accurate final results from your pipeline.";
   preflightUpdatedValues.emplace_back(PreflightValue{"Feature Data Modification Warning", featureModificationWarning});
   resultOutputActions.warnings().push_back(Warning{-14600, featureModificationWarning});
-
-  auto storeAsNewPhase = filterArgs.value<bool>(k_StoreAsNewPhase_Key);
-  // Get the Feature Phases Array and get its TupleShape
-  const auto* cellPhases = dataStructure.getDataAs<Int32Array>(cellPhasesArrayPath);
-  if(storeAsNewPhase && nullptr == cellPhases)
-  {
-    return MakePreflightErrorResult(-12801, "Cell Phases Data Array is not of the correct type or was not found at the given path");
-  }
 
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IterativeClosestPointFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/IterativeClosestPointFilter.cpp
@@ -17,8 +17,6 @@ namespace nx::core
 {
 namespace
 {
-constexpr int32 k_MissingMovingVertex = -4500;
-constexpr int32 k_MissingTargetVertex = -4501;
 constexpr int32 k_BadNumIterations = -4502;
 } // namespace
 
@@ -88,21 +86,8 @@ IFilter::UniquePointer IterativeClosestPointFilter::clone() const
 IFilter::PreflightResult IterativeClosestPointFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
-  auto movingVertexPath = filterArgs.value<DataPath>(k_MovingVertexPath_Key);
-  auto targetVertexPath = filterArgs.value<DataPath>(k_TargetVertexPath_Key);
   auto numIterations = filterArgs.value<uint64>(k_NumIterations_Key);
   auto transformArrayPath = filterArgs.value<DataPath>(k_TransformArrayPath_Key);
-
-  if(dataStructure.getDataAs<VertexGeom>(movingVertexPath) == nullptr)
-  {
-    auto ss = fmt::format("Moving Vertex Geometry not found at path: {}", movingVertexPath.toString());
-    return {MakeErrorResult<OutputActions>(k_MissingMovingVertex, ss)};
-  }
-  if(dataStructure.getDataAs<VertexGeom>(targetVertexPath) == nullptr)
-  {
-    auto ss = fmt::format("Target Vertex Geometry not found at path: {}", targetVertexPath.toString());
-    return {MakeErrorResult<OutputActions>(k_MissingTargetVertex, ss)};
-  }
 
   if(numIterations < 1)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PadImageGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PadImageGeometryFilter.cpp
@@ -141,16 +141,12 @@ IFilter::PreflightResult PadImageGeometryFilter::preflightImpl(const DataStructu
 
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  const auto* srcImageGeomPtr = dataStructure.getDataAs<ImageGeom>(srcImagePath);
-  if(nullptr == srcImageGeomPtr)
-  {
-    return {MakeErrorResult<OutputActions>(-4115, "Input Image geometry pointer was null")};
-  }
-  auto srcDims = srcImageGeomPtr->getDimensions();
-  auto srcOrigin = srcImageGeomPtr->getOrigin();
-  auto srcSpacing = srcImageGeomPtr->getSpacing();
+  const auto& srcImageGeom = dataStructure.getDataRefAs<ImageGeom>(srcImagePath);
+  auto srcDims = srcImageGeom.getDimensions();
+  auto srcOrigin = srcImageGeom.getOrigin();
+  auto srcSpacing = srcImageGeom.getSpacing();
 
-  SizeVec3 destGeomDims = srcImageGeomPtr->getDimensions();
+  SizeVec3 destGeomDims = srcImageGeom.getDimensions();
   if(pPadXDim)
   {
     destGeomDims[0] += (pXMinMaxValue[0] + pXMinMaxValue[1]);
@@ -164,7 +160,7 @@ IFilter::PreflightResult PadImageGeometryFilter::preflightImpl(const DataStructu
     destGeomDims[2] += (pZMinMaxValue[0] + pZMinMaxValue[1]);
   }
 
-  FloatVec3 targetOrigin = srcImageGeomPtr->getOrigin();
+  FloatVec3 targetOrigin = srcImageGeom.getOrigin();
   if(pUpdateOriginValue)
   {
     if(pPadXDim)
@@ -211,7 +207,7 @@ IFilter::PreflightResult PadImageGeometryFilter::preflightImpl(const DataStructu
   // not need to manually copy these arrays to the destination image geometry
   {
     // Get the name of the Cell Attribute Matrix, so we can use that in the CreateImageGeometryAction
-    const AttributeMatrix* selectedCellData = srcImageGeomPtr->getCellData();
+    const AttributeMatrix* selectedCellData = srcImageGeom.getCellData();
     if(selectedCellData == nullptr)
     {
       return {MakeErrorResult<OutputActions>(-4014, fmt::format("'{}' must have cell data attribute matrix", srcImagePath.toString()))};
@@ -221,7 +217,7 @@ IFilter::PreflightResult PadImageGeometryFilter::preflightImpl(const DataStructu
 
     resultOutputActions.value().appendAction(std::make_unique<CreateImageGeometryAction>(destImagePath, destGeomDims.toContainer<CreateImageGeometryAction::DimensionType>(),
                                                                                          targetOrigin.toContainer<CreateImageGeometryAction::OriginType>(),
-                                                                                         srcSpacing.toContainer<CreateImageGeometryAction::SpacingType>(), cellDataName, srcImageGeomPtr->getUnits()));
+                                                                                         srcSpacing.toContainer<CreateImageGeometryAction::SpacingType>(), cellDataName, srcImageGeom.getUnits()));
 
     // Now loop over each array in the source image geometry's cell attribute matrix and create the corresponding arrays
     // in the destination image geometry's attribute matrix
@@ -242,10 +238,10 @@ IFilter::PreflightResult PadImageGeometryFilter::preflightImpl(const DataStructu
     cropOptionsStr.append(pPadZDim ? "Z" : "");
     preflightUpdatedValues.push_back({"Pad Dimensions", cropOptionsStr});
 
-    preflightUpdatedValues.push_back({"Input Geometry Info", nx::core::GeometryHelpers::Description::GenerateGeometryInfo(srcImageGeomPtr->getDimensions(), srcImageGeomPtr->getSpacing(),
-                                                                                                                          srcImageGeomPtr->getOrigin(), srcImageGeomPtr->getUnits())});
+    preflightUpdatedValues.push_back({"Input Geometry Info", nx::core::GeometryHelpers::Description::GenerateGeometryInfo(srcImageGeom.getDimensions(), srcImageGeom.getSpacing(),
+                                                                                                                          srcImageGeom.getOrigin(), srcImageGeom.getUnits())});
     preflightUpdatedValues.push_back({"Padded Image Geometry Info", nx::core::GeometryHelpers::Description::GenerateGeometryInfo(
-                                                                        destGeomDims, srcSpacing.toContainer<CreateImageGeometryAction::SpacingType>(), targetOrigin, srcImageGeomPtr->getUnits())});
+                                                                        destGeomDims, srcSpacing.toContainer<CreateImageGeometryAction::SpacingType>(), targetOrigin, srcImageGeom.getUnits())});
   }
 
   // This section covers copying the other Attribute Matrix objects from the source geometry

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PartitionGeometryFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/PartitionGeometryFilter.cpp
@@ -198,9 +198,6 @@ Result<PartitionGeometry::PSGeomInfo> GeneratePartitioningSchemeInfo(const Geom&
     psGeomMetadata.geometryUnits = psGeom.getUnits();
     break;
   }
-  default: {
-    return {MakeErrorResult<PartitionGeometry::PSGeomInfo>(-3011, "Unable to create partitioning scheme geometry - Unknown partitioning mode.")};
-  }
   }
 
   return {psGeomMetadata};
@@ -435,9 +432,6 @@ IFilter::PreflightResult PartitionGeometryFilter::preflightImpl(const DataStruct
     }
     inputGeometryInformation = "Hexahedral geometry space unknown during preflight.";
     break;
-  }
-  default: {
-    return {MakeErrorResult<OutputActions>(-3017, fmt::format("{}: Unable to partition geometry - Unknown geometry type detected.", humanName()))};
   }
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/QuickSurfaceMeshFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/QuickSurfaceMeshFilter.cpp
@@ -136,13 +136,9 @@ IFilter::PreflightResult QuickSurfaceMeshFilter::preflightImpl(const DataStructu
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  const auto* gridGeom = dataStructure.getDataAs<IGridGeometry>(pGridGeomDataPath);
-  if(gridGeom == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-76530, fmt::format("Could not find find selected grid geometry at path '{}'", pGridGeomDataPath.toString()))};
-  }
+  const auto& gridGeom = dataStructure.getDataRefAs<IGridGeometry>(pGridGeomDataPath);
 
-  const usize elementTupleCount = gridGeom->getCellData()->getNumberOfTuples();
+  const usize elementTupleCount = gridGeom.getCellData()->getNumberOfTuples();
   constexpr usize numElements = 0;
 
   // Use FeatureIds DataStore format for created DataArrays

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedFeaturesFilter.cpp
@@ -121,16 +121,7 @@ IFilter::PreflightResult RemoveFlaggedFeaturesFilter::preflightImpl(const DataSt
 
   nx::core::Result<OutputActions> resultOutputActions;
 
-  auto* featureIdsPtr = dataStructure.getDataAs<Int32Array>(pFeatureIdsArrayPathValue);
-  if(featureIdsPtr == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-9890, fmt::format("Could not find selected Feature Ids Data Array at path '{}'", pFeatureIdsArrayPathValue.toString()))};
-  }
-
-  if(dataStructure.getDataAs<BoolArray>(pFlaggedFeaturesArrayPathValue) == nullptr && dataStructure.getDataAs<UInt8Array>(pFlaggedFeaturesArrayPathValue) == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-9891, fmt::format("Could not find selected Flagged Features Data Array at path '{}'", pFlaggedFeaturesArrayPathValue.toString()))};
-  }
+  const auto& featureIdsArray = dataStructure.getDataRefAs<Int32Array>(pFeatureIdsArrayPathValue);
 
   DataPath const cellFeatureAttributeMatrixPath = pFlaggedFeaturesArrayPathValue.getParent();
   const auto* cellFeatureAmPtr = dataStructure.getDataAs<AttributeMatrix>(cellFeatureAttributeMatrixPath);
@@ -159,7 +150,7 @@ IFilter::PreflightResult RemoveFlaggedFeaturesFilter::preflightImpl(const DataSt
   {
     DataPath const tempPath = pFlaggedFeaturesArrayPathValue.replaceName(k_boundsName);
     auto action =
-        std::make_unique<CreateArrayAction>(DataType::uint32, std::vector<usize>{featureIdsPtr->getNumberOfTuples()}, std::vector<usize>{featureIdsPtr->getNumberOfComponents() * 6}, tempPath);
+        std::make_unique<CreateArrayAction>(DataType::uint32, std::vector<usize>{featureIdsArray.getNumberOfTuples()}, std::vector<usize>{featureIdsArray.getNumberOfComponents() * 6}, tempPath);
 
     // After the execute function has been done, delete the temp array
     resultOutputActions.value().appendDeferredAction(std::make_unique<DeleteDataAction>(tempPath));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedVerticesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RemoveFlaggedVerticesFilter.cpp
@@ -27,8 +27,6 @@ using namespace nx::core;
 
 namespace
 {
-constexpr int32 k_VertexGeomNotFound = -277;
-
 struct RemoveFlaggedVerticesFunctor
 {
   // copy data to masked geometry
@@ -125,24 +123,13 @@ IFilter::PreflightResult RemoveFlaggedVerticesFilter::preflightImpl(const DataSt
 
   std::vector<DataPath> dataArrayPaths;
 
-  const auto* inputVertexGeomPtr = dataStructure.getDataAs<VertexGeom>(vertexGeomPath);
-  if(inputVertexGeomPtr == nullptr)
-  {
-    const std::string errorMsg = fmt::format("Vertex Geometry not found at path: '{}'", vertexGeomPath.toString());
-    return {MakeErrorResult<OutputActions>(::k_VertexGeomNotFound, errorMsg)};
-  }
-  auto verticesId = inputVertexGeomPtr->getSharedVertexDataArrayId();
-  const auto* inputSharedVertexPtr = dataStructure.getDataAs<Float32Array>(verticesId);
-  if(inputSharedVertexPtr == nullptr)
-  {
-    const std::string errorMsg = fmt::format("Vertex Geometry does not have a vertex list");
-    return {MakeErrorResult<OutputActions>(::k_VertexGeomNotFound, errorMsg)};
-  }
+  const auto& inputVertexGeom = dataStructure.getDataRefAs<VertexGeom>(vertexGeomPath);
+  auto verticesId = inputVertexGeom.getSharedVertexDataArrayId();
 
-  const std::string vertexAttrMatName = inputVertexGeomPtr->getVertexAttributeMatrixDataPath().getTargetName();
+  const std::string vertexAttrMatName = inputVertexGeom.getVertexAttributeMatrixDataPath().getTargetName();
 
   // Create vertex geometry
-  const uint64 numVertices = inputVertexGeomPtr->getNumberOfVertices();
+  const uint64 numVertices = inputVertexGeom.getNumberOfVertices();
   auto reduced = std::make_unique<CreateVertexGeometryAction>(reducedVertexPath, numVertices, vertexAttrMatName, VertexGeom::k_SharedVertexListName);
   const DataPath reducedVertexDataPath = reduced->getVertexDataPath();
   resultOutputActions.value().appendAction(std::move(reduced));
@@ -161,7 +148,7 @@ IFilter::PreflightResult RemoveFlaggedVerticesFilter::preflightImpl(const DataSt
   // not need to manually copy these arrays to the destination image geometry
   {
     // Get the name of the Cell Attribute Matrix, so we can use that in the CreateImageGeometryAction
-    const AttributeMatrix* selectedCellDataPtr = inputVertexGeomPtr->getVertexAttributeMatrix();
+    const AttributeMatrix* selectedCellDataPtr = inputVertexGeom.getVertexAttributeMatrix();
     if(selectedCellDataPtr == nullptr)
     {
       return {MakeErrorResult<OutputActions>(-5751, fmt::format("'{}' must have cell data attribute matrix", vertexGeomPath.toString()))};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinNumNeighborsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinNumNeighborsFilter.cpp
@@ -18,7 +18,6 @@ namespace nx::core
 {
 namespace
 {
-constexpr int64 k_MissingFeaturePhasesError = -251;
 constexpr int32 k_InconsistentTupleCount = -252;
 
 } // namespace
@@ -128,13 +127,6 @@ IFilter::PreflightResult RequireMinNumNeighborsFilter::preflightImpl(const DataS
 
   if(applyToSinglePhase)
   {
-    auto* featurePhasesArray = dataStructure.getDataAs<Int32Array>(featurePhasesPath);
-    if(featurePhasesArray == nullptr)
-    {
-      std::string ss = fmt::format("Could not find Feature Phases array at path '{}'", featurePhasesPath.toString());
-      return {MakeErrorResult<OutputActions>(k_MissingFeaturePhasesError, ss)};
-    }
-
     dataArrayPaths.push_back(featurePhasesPath);
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RequireMinimumSizeFeaturesFilter.cpp
@@ -26,7 +26,6 @@ using PhasesArrayType = Int32Array;
 namespace
 {
 constexpr int32 k_BadMinAllowedFeatureSize = -5555;
-constexpr int32 k_BadNumCellsPath = -5556;
 constexpr int32 k_ParentlessPathError = -5557;
 
 } // namespace
@@ -114,16 +113,6 @@ IFilter::PreflightResult RequireMinimumSizeFeaturesFilter::preflightImpl(const D
     return {MakeErrorResult<OutputActions>(-k_BadMinAllowedFeatureSize, ss)};
   }
 
-  const auto* featureIdsPtr = dataStructure.getDataAs<FeatureIdsArrayType>(featureIdsPath);
-  if(featureIdsPtr == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(k_BadNumCellsPath, "FeatureIds not provided as an Int32 Array.")};
-  }
-  const auto* numCellsPtr = dataStructure.getDataAs<NumCellsArrayType>(featureNumCellsPath);
-  if(numCellsPtr == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(k_BadNumCellsPath, "Num Cells not provided as an Int32 Array.")};
-  }
   dataArrayPaths.push_back(featureNumCellsPath);
 
   if(applyToSinglePhase)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RobustAutomaticThresholdFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RobustAutomaticThresholdFilter.cpp
@@ -14,7 +14,6 @@ using namespace nx::core;
 
 namespace
 {
-constexpr int32 k_IncorrectInputArrayType = -2363;
 constexpr int32 k_InconsistentTupleCount = -2364;
 
 struct FindThresholdFunctor
@@ -114,21 +113,8 @@ IFilter::PreflightResult RobustAutomaticThresholdFilter::preflightImpl(const Dat
 
   std::vector<DataPath> dataPaths;
 
-  // Validate that the input path is NOT a bool array.
   const auto& inputArray = dataStructure.getDataRefAs<IDataArray>(inputArrayPath);
-  if(dynamic_cast<const BoolArray*>(&inputArray) != nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArrayType, "Input Data Array to threshold cannot be of type bool")};
-  }
   dataPaths.push_back(inputArrayPath);
-
-  // Validate that the Gradient Image is of the correct type
-  const DataObject* dataObject = dataStructure.getData(gradientArrayPath);
-  if(dynamic_cast<const Float32Array*>(dataObject) == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(k_IncorrectInputArrayType,
-                                           fmt::format("Gradient Data Array must be of type Float. The object at path '{}' is '{}'", gradientArrayPath.toString(), dataObject->getTypeName()))};
-  }
   dataPaths.push_back(gradientArrayPath);
 
   ShapeType tupleDims = {inputArray.getTupleShape()};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RotateSampleRefFrameFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RotateSampleRefFrameFilter.cpp
@@ -190,12 +190,8 @@ IFilter::PreflightResult RotateSampleRefFrameFilter::preflightImpl(const DataStr
   }
 
   {
-    const AttributeMatrix* selectedCellData = selectedImageGeom.getCellData();
-    if(selectedCellData == nullptr)
-    {
-      return {MakeErrorResult<OutputActions>(-5951, fmt::format("'{}' must have cell data attribute matrix", srcImagePath.toString()))};
-    }
-    std::string cellDataName = selectedCellData->getName();
+    const AttributeMatrix& selectedCellData = selectedImageGeom.getCellDataRef();
+    std::string cellDataName = selectedCellData.getName();
     ignorePaths.push_back(srcImagePath.createChildPath(cellDataName));
 
     resultOutputActions.value().appendAction(std::make_unique<CreateImageGeometryAction>(destImagePath, dims, origin, spacing, cellDataName));
@@ -203,7 +199,7 @@ IFilter::PreflightResult RotateSampleRefFrameFilter::preflightImpl(const DataStr
     // Create the Cell AttributeMatrix in the Destination Geometry
     DataPath newCellAttributeMatrixPath = destImagePath.createChildPath(cellDataName);
 
-    for(const auto& [id, object] : *selectedCellData)
+    for(const auto& [id, object] : selectedCellData)
     {
       const auto& srcArray = dynamic_cast<const IDataArray&>(*object);
       DataType dataType = srcArray.getDataType();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ScalarSegmentFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ScalarSegmentFeaturesFilter.cpp
@@ -23,10 +23,6 @@ using namespace nx::core;
 
 namespace
 {
-constexpr int64 k_IncorrectInputArray = -600;
-constexpr int64 k_MissingInputArray = -601;
-constexpr int64 k_MissingOrIncorrectGoodVoxelsArray = -602;
-constexpr int32 k_MissingGeomError = -440;
 } // namespace
 
 namespace nx::core
@@ -116,49 +112,21 @@ IFilter::PreflightResult ScalarSegmentFeaturesFilter::preflightImpl(const DataSt
   DataPath cellFeaturesPath = gridGeomPath.createChildPath(cellFeaturesName);
   DataPath activeArrayPath = cellFeaturesPath.createChildPath(activeArrayName);
 
-  if(dataStructure.getDataAs<IGridGeometry>(gridGeomPath) == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(k_MissingGeomError, fmt::format("A Grid Geometry is required for {}", humanName()))};
-  }
-
-  const auto* gridGeometryPtr = dataStructure.getDataAs<IGridGeometry>(gridGeomPath);
-  auto gridDims = gridGeometryPtr->getDimensions();
+  const auto& gridGeometry = dataStructure.getDataRefAs<IGridGeometry>(gridGeomPath);
+  auto gridDims = gridGeometry.getDimensions();
   const std::vector<usize> cellTupleDims = {gridDims[2], gridDims[1], gridDims[0]};
   std::vector<DataPath> dataPaths;
 
-  std::string createdArrayFormat = "";
   // Input Array
-  if(const auto* inputDataArrayPtr = dataStructure.getDataAs<IDataArray>(inputDataPath))
-  {
-    createdArrayFormat = inputDataArrayPtr->getDataFormat();
-    if(inputDataArrayPtr->getNumberOfComponents() != 1)
-    {
-      return {MakeErrorResult<OutputActions>(k_IncorrectInputArray, fmt::format("Input Array must be a an array with a single component.", inputDataArrayPtr->getNumberOfComponents()))};
-    }
-    dataPaths.push_back(inputDataPath);
-  }
-  else
-  {
-    return {MakeErrorResult<OutputActions>(k_MissingInputArray, "Input Array must be specified")};
-  }
+  const auto& inputDataArray = dataStructure.getDataRefAs<IDataArray>(inputDataPath);
+  std::string createdArrayFormat = inputDataArray.getDataFormat();
+  dataPaths.push_back(inputDataPath);
 
   // Validate the GoodVoxels/Mask Array combination
   bool useGoodVoxels = filterArgs.value<bool>(k_UseMask_Key);
-  DataPath goodVoxelsPath;
   if(useGoodVoxels)
   {
-    goodVoxelsPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
-
-    const auto* goodVoxelsArray = dataStructure.getDataAs<IDataArray>(goodVoxelsPath);
-    if(nullptr == goodVoxelsArray)
-    {
-      return {MakeErrorResult<OutputActions>(k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array is not located at path: '{}'", goodVoxelsPath.toString()))};
-    }
-    if(goodVoxelsArray->getDataType() != DataType::boolean && goodVoxelsArray->getDataType() != DataType::uint8)
-    {
-      return {
-          MakeErrorResult<OutputActions>(k_MissingOrIncorrectGoodVoxelsArray, fmt::format("Mask array at path '{}' is not of the correct type. It must be Bool or UInt8.", goodVoxelsPath.toString()))};
-    }
+    DataPath goodVoxelsPath = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
     dataPaths.push_back(goodVoxelsPath);
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitDataArrayByComponentFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitDataArrayByComponentFilter.cpp
@@ -93,11 +93,8 @@ IFilter::PreflightResult SplitDataArrayByComponentFilter::preflightImpl(const Da
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  auto* inputArray = dataStructure.getDataAs<IDataArray>(pInputArrayPath);
-  if(inputArray == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-65400, fmt::format("Cannot find input data array at path '{}'", pInputArrayPath.toString()))};
-  }
+  const auto& inputArrayRef = dataStructure.getDataRefAs<IDataArray>(pInputArrayPath);
+  const auto* inputArray = &inputArrayRef;
   usize numComponents = inputArray->getNumberOfComponents();
   if(numComponents <= 1)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitDataArrayByTupleFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SplitDataArrayByTupleFilter.cpp
@@ -412,14 +412,10 @@ IFilter::PreflightResult SplitDataArrayByTupleFilter::preflightImpl(const DataSt
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  auto* inputArray = dataStructure.getDataAs<IArray>(pInputArrayPath);
-  if(inputArray == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(to_underlying(SplitDataArrayByTuple::ErrorCodes::NoInputArray), fmt::format("Cannot find input array at path '{}'", pInputArrayPath.toString()))};
-  }
+  const auto& inputArray = dataStructure.getDataRefAs<IArray>(pInputArrayPath);
 
   // Output input array's tuple shape to preflight updated values
-  std::vector<std::string> displayPaths = createDisplayPaths({pInputArrayPath.toString()}, {inputArray->getTupleShape()});
+  std::vector<std::string> displayPaths = createDisplayPaths({pInputArrayPath.toString()}, {inputArray.getTupleShape()});
   std::vector<std::string_view> displayPathsViews(displayPaths.begin(), displayPaths.end());
   preflightUpdatedValues.push_back({"Input Array", StringUtilities::join(displayPathsViews, "\n")});
 
@@ -437,8 +433,8 @@ IFilter::PreflightResult SplitDataArrayByTupleFilter::preflightImpl(const DataSt
   if(pOutputContainer == SplitDataArrayByTuple::OutputContainer::NewDataGroup || pOutputContainer == SplitDataArrayByTuple::OutputContainer::ExistingDataGroup)
   {
     // Outputting to data group
-    auto result = preflightDataGroupOutput(pOutputContainer, pInputArrayPath, pNewDataGroupPath, pExistingDataGroupPath, inputArray->getTupleShape(), pSplitDimensionCounts, splitDimension,
-                                           tupleShapes, arrayPaths, preflightUpdatedValues);
+    auto result = preflightDataGroupOutput(pOutputContainer, pInputArrayPath, pNewDataGroupPath, pExistingDataGroupPath, inputArray.getTupleShape(), pSplitDimensionCounts, splitDimension, tupleShapes,
+                                           arrayPaths, preflightUpdatedValues);
     if(result.invalid())
     {
       return {ConvertResultTo<OutputActions>(std::move(result), {}), preflightUpdatedValues};
@@ -452,7 +448,7 @@ IFilter::PreflightResult SplitDataArrayByTupleFilter::preflightImpl(const DataSt
   else
   {
     // Outputting to attribute matrix
-    auto result = preflightAttrMatrixOutput(pOutputContainer, pInputArrayPath, pNewAttrMatrixPath, pExistingAttrMatrixPath, inputArray->getTupleShape(), pNewAttrMatrixTupleShape[0], splitDimension,
+    auto result = preflightAttrMatrixOutput(pOutputContainer, pInputArrayPath, pNewAttrMatrixPath, pExistingAttrMatrixPath, inputArray.getTupleShape(), pNewAttrMatrixTupleShape[0], splitDimension,
                                             dataStructure, arrayPaths, tupleShapes, preflightUpdatedValues);
     if(result.invalid())
     {
@@ -468,16 +464,16 @@ IFilter::PreflightResult SplitDataArrayByTupleFilter::preflightImpl(const DataSt
   // Create the split arrays
   for(usize i = 0; i < arrayPaths.size(); ++i)
   {
-    switch(inputArray->getArrayType())
+    switch(inputArray.getArrayType())
     {
     case IArray::ArrayType::DataArray: {
-      auto iInputDataArray = dynamic_cast<const IDataArray*>(inputArray);
+      auto iInputDataArray = dynamic_cast<const IDataArray*>(&inputArray);
       ShapeType cDims = iInputDataArray->getComponentShape();
       resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(iInputDataArray->getDataType(), tupleShapes[i], cDims, arrayPaths[i]));
       break;
     }
     case IArray::ArrayType::NeighborListArray: {
-      auto iInputNeighborList = dynamic_cast<const INeighborList*>(inputArray);
+      auto iInputNeighborList = dynamic_cast<const INeighborList*>(&inputArray);
       resultOutputActions.value().appendAction(std::make_unique<CreateNeighborListAction>(iInputNeighborList->getDataType(), tupleShapes[i], arrayPaths[i]));
       break;
     }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SurfaceNetsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/SurfaceNetsFilter.cpp
@@ -137,11 +137,7 @@ IFilter::PreflightResult SurfaceNetsFilter::preflightImpl(const DataStructure& d
 
   nx::core::Result<OutputActions> resultOutputActions;
 
-  const auto* gridGeom = dataStructure.getDataAs<IGridGeometry>(pGridGeomDataPath);
-  if(gridGeom == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-76530, fmt::format("Could not find find selected grid geometry at path '{}'", pGridGeomDataPath.toString()))};
-  }
+  const auto& gridGeom = dataStructure.getDataRefAs<IGridGeometry>(pGridGeomDataPath);
   constexpr usize numElements = 0;
 
   // Use FeatureIds DataStore format for created DataArrays

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleDihedralAngleFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/TriangleDihedralAngleFilter.cpp
@@ -168,13 +168,9 @@ IFilter::PreflightResult TriangleDihedralAngleFilter::preflightImpl(const DataSt
 
   nx::core::Result<OutputActions> resultOutputActions;
 
-  const auto* triangleGeom = dataStructure.getDataAs<TriangleGeom>(pTriangleGeometryDataPath);
-  if(triangleGeom == nullptr)
-  {
-    return {MakeErrorResult<OutputActions>(-9860, fmt::format("Cannot find the selected Triangle Geometry at path '{}'", pTriangleGeometryDataPath.toString()))};
-  }
+  const auto& triangleGeom = dataStructure.getDataRefAs<TriangleGeom>(pTriangleGeometryDataPath);
   // Get the Face AttributeMatrix from the Geometry (It should have been set at construction of the Triangle Geometry)
-  const AttributeMatrix* faceAttributeMatrix = triangleGeom->getFaceAttributeMatrix();
+  const AttributeMatrix* faceAttributeMatrix = triangleGeom.getFaceAttributeMatrix();
   if(faceAttributeMatrix == nullptr)
   {
     return {MakeErrorResult<OutputActions>(-9861, fmt::format("Cannot find the face data Attribute Matrix for the selected Triangle Geometry at path '{}'", pTriangleGeometryDataPath.toString()))};
@@ -184,7 +180,7 @@ IFilter::PreflightResult TriangleDihedralAngleFilter::preflightImpl(const DataSt
   {
     DataPath createArrayDataPath = pTriangleGeometryDataPath.createChildPath(faceAttributeMatrix->getName()).createChildPath(pMinDihedralAnglesName);
     // Create the face areas DataArray Action and store it into the resultOutputActions
-    auto createArrayAction = std::make_unique<CreateArrayAction>(nx::core::DataType::float64, std::vector<usize>{triangleGeom->getNumberOfFaces()}, std::vector<usize>{1}, createArrayDataPath);
+    auto createArrayAction = std::make_unique<CreateArrayAction>(nx::core::DataType::float64, std::vector<usize>{triangleGeom.getNumberOfFaces()}, std::vector<usize>{1}, createArrayDataPath);
     resultOutputActions.value().appendAction(std::move(createArrayAction));
   }
 


### PR DESCRIPTION
A lot of these filters were written before we had all of the available sanity checks in the Parameter Classes. This PR removes all redundant preflight checks.