### PR TITLE
REV/ENH: Compute Feature Sizes and Geometry Error Handling

### DIFF
--- a/src/Plugins/SimplnxCore/docs/ComputeFeatureSizesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeFeatureSizesFilter.md
@@ -6,9 +6,24 @@ Statistics (Morphological)
 
 ## Description
 
-This **Filter** calculates the sizes of all **Features**.  The **Filter** simply iterates through all **Elements** querying for the **Feature** that owns them and keeping a tally for each **Feature**.  The tally is then stored as *NumElements* and the *Volume* and *EquivalentDiameter* are also calculated (and stored) by knowing the volume of each **Element**.
+**Note:** Regarding using an *Image Geometry* as input, if you have a `1` in any of the dimensions it will be turned into a 2D calculation instead. See *Image Geometry Additional Considerations* section for more details.
+
+This **Filter** calculates the sizes, volumes/areas, and equivalent diameters of all **Features** in an **Image Geometry** or **Rectilinear Grid Geometry**.
+
+To do so, the **Filter** simply iterates through all **Elements** querying for the **Feature** that owns them and keeping a tally for each **Feature**. The tally is then stored as *NumElements* and the *Volume* and *EquivalentDiameter* are also calculated (and stored) by knowing the volume of each **Element**.
+
+Note here that **Image Geometry** will always be faster than its equivalent **Rectilinear Grid Geometry** because we leverage the uniformity of voxel sizes to preform volume/area calculations at the feature level rather than the cell level.
 
 During the computation of the **Feature** sizes, the size of each individual **Element** is computed and stored in the corresponding **Geometry**. By default, these sizes are deleted after executing the **Filter** to save memory. If you wish to store the **Element** sizes, select the *Generate Missing Element Sizes* option. The sizes will be stored within the **Geometry** definition itself, not as a separate **Attribute Array**.
+
+## Image Geometry Additional Considerations
+
+A typical Image Stack *(an `Image Geometry` that contains 3 dimensions greater than 1)* conceptually consists of a series of 2D images stacked on top of one another to create a 3D object, thus it functions in 3D space as expected. This means it produces **Volumes** and **Equivalent Spherical Diameters**.
+
+Due to the way *Image Geometry* is stored, if you have a `1` in any of the dimensions
+it will be turned into a 2D calculation instead. This means **Areas instead of Volumes** and **Equivalent Circular Diameters instead of Equivalent Spherical Diameters**. Furthermore, you must have two dimensions greater than `1` to pass preflight. The reason for this being orientation becomes ambigous once a second dimension is "empty".
+
+To illustrate why this is think about an image geometry with the dimensions of `1x1x5 (XYZ)`. There is no way to tell whether a `Z * X` or `Z * Y` scaling would be appropriate for the area calculation, given the current information accessible in the algorithm.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/ComputeFeatureSizesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeFeatureSizesFilter.md
@@ -12,7 +12,7 @@ This **Filter** calculates the sizes, volumes/areas, and equivalent diameters of
 
 To do so, the **Filter** simply iterates through all **Elements** querying for the **Feature** that owns them and keeping a tally for each **Feature**. The tally is then stored as *NumElements* and the *Volume* and *EquivalentDiameter* are also calculated (and stored) by knowing the volume of each **Element**.
 
-Note here that **Image Geometry** will always be faster than its equivalent **Rectilinear Grid Geometry** because we leverage the uniformity of voxel sizes to preform volume/area calculations at the feature level rather than the cell level.
+Note here that **Image Geometry** will always be faster than its equivalent **Rectilinear Grid Geometry** because we leverage the uniformity of voxel sizes to perform volume/area calculations at the feature level rather than the cell level.
 
 During the computation of the **Feature** sizes, the size of each individual **Element** is computed and stored in the corresponding **Geometry**. By default, these sizes are deleted after executing the **Filter** to save memory. If you wish to store the **Element** sizes, select the *Generate Missing Element Sizes* option. The sizes will be stored within the **Geometry** definition itself, not as a separate **Attribute Array**.
 
@@ -21,7 +21,7 @@ During the computation of the **Feature** sizes, the size of each individual **E
 A typical Image Stack *(an `Image Geometry` that contains 3 dimensions greater than 1)* conceptually consists of a series of 2D images stacked on top of one another to create a 3D object, thus it functions in 3D space as expected. This means it produces **Volumes** and **Equivalent Spherical Diameters**.
 
 Due to the way *Image Geometry* is stored, if you have a `1` in any of the dimensions
-it will be turned into a 2D calculation instead. This means **Areas instead of Volumes** and **Equivalent Circular Diameters instead of Equivalent Spherical Diameters**. Furthermore, you must have two dimensions greater than `1` to pass preflight. The reason for this being orientation becomes ambigous once a second dimension is "empty".
+it will be turned into a 2D calculation instead. This means **Areas instead of Volumes** and **Equivalent Circular Diameters instead of Equivalent Spherical Diameters**. Furthermore, you must have two dimensions greater than `1` to pass preflight. The reason for this being orientation becomes ambiguous once a second dimension is "empty".
 
 To illustrate why this is think about an image geometry with the dimensions of `1x1x5 (XYZ)`. There is no way to tell whether a `Z * X` or `Z * Y` scaling would be appropriate for the area calculation, given the current information accessible in the algorithm.
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureSizes.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureSizes.cpp
@@ -32,14 +32,11 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
   ThrottledMessenger throttledMessenger = msgHelper.createThrottledMessenger();
 
   const usize numVoxels = featureIds.getNumberOfTuples();
-
-  msgHelper.sendMessage("Finding Max Feature Id...");
-  const usize maxFeatureIdx = *std::max_element(featureIds.cbegin(), featureIds.cend());
-  const usize numFeatures = maxFeatureIdx + 1;
+  const usize numFeatures = volumes.getNumberOfTuples();
 
   std::vector<uint64> featureVoxelCounts(numFeatures, 0);
 
-  msgHelper.sendMessage("Cell Level: Finding Voxel Counts...");
+  msgHelper.sendMessage("Finding Voxel Counts...");
   // Count and store the number of voxels in each feature
   for(usize voxelIdx = 0; voxelIdx < numVoxels; voxelIdx++)
   {
@@ -63,7 +60,7 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
   if(xDimSize == 1 || yDimSize == 1 || zDimSize == 1)
   {
     msgHelper.sendMessage("Singular image detected. Proceeding with 2D calculations...");
-    // One of the dimensions is empty so we will be calculating area instead
+    // One of the dimensions is empty, so we will be calculating area instead
 
     /**
      * IMPORTANT: Due the nature of ImageGeom the preflight is expected to impose a
@@ -86,11 +83,11 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
      * For these two cases the following code would BREAK, so do not enable.
      **/
 
-    // if x dimension has a size of 1 then xSpacing = 1; else xSpacing = spacing[0]
+    // if x dimension has a size of 1, then xSpacing = 1; else xSpacing = spacing[0]
     const float64 xSpacing = (static_cast<float64>(spacing[0]) * static_cast<float64>(xDimSize > 1ULL)) + (1.0f * static_cast<float64>(xDimSize < 2ULL));
-    // if y dimension has a size of 1 then ySpacing = 1; else ySpacing = spacing[1]
+    // if y dimension has a size of 1, then ySpacing = 1; else ySpacing = spacing[1]
     const float64 ySpacing = (static_cast<float64>(spacing[1]) * static_cast<float64>(yDimSize > 1ULL)) + (1.0f * static_cast<float64>(yDimSize < 2ULL));
-    // if z dimension has a size of 1 then zSpacing = 1; else zSpacing = spacing[2]
+    // if z dimension has a size of 1, then zSpacing = 1; else zSpacing = spacing[2]
     const float64 zSpacing = (static_cast<float64>(spacing[2]) * static_cast<float64>(zDimSize > 1ULL)) + (1.0f * static_cast<float64>(zDimSize < 2ULL));
 
     // Calculate the area of a single voxel
@@ -132,7 +129,7 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
   }
   else
   {
-    // If we are here it is an image stack and thus should be treated as 3D
+    // If we are here, it is an image stack and thus should be treated as 3D.
     msgHelper.sendMessage("Image Stack detected. Proceeding with 3D calculations...");
 
     // Calculate the volume of a single voxel
@@ -220,13 +217,13 @@ Result<> ProcessRectGridGeom(RectGridGeom& rectGridGeom, Float32AbstractDataStor
 
     // Use Kahan summation to determine overall volume
 
-    // Attempt to recover low-order into value, first instance is 0
+    // Attempt to recover low order into the value. The first instance is 0
     float64 value = static_cast<float64>(elemSizes.getValue(voxelIdx)) - featureCompensators[voxelFeatureId];
 
-    // low-order may be lost
+    // low order may be lost
     float64 volSum = featureVolumes[voxelFeatureId] + value;
 
-    // recover and cache low-order
+    // recover and cache low order
     featureCompensators[voxelFeatureId] = (volSum - featureVolumes[voxelFeatureId]) - value;
 
     // store volumes

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureSizes.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureSizes.cpp
@@ -201,6 +201,8 @@ Result<> ProcessRectGridGeom(RectGridGeom& rectGridGeom, Float32AbstractDataStor
 
   std::vector<uint64> featureVoxelCounts(numFeatures, 0);
   std::vector<float64> featureVolumes(numFeatures, 0.0);
+  // Needed for Kahan summation of volumes
+  std::vector<float64> featureCompensators(numFeatures, 0.0);
 
   msgHelper.sendMessage("Cell Level: Finding Voxel Counts and Summing Volumes...");
   // Count and store the number of voxels in each feature
@@ -216,8 +218,19 @@ Result<> ProcessRectGridGeom(RectGridGeom& rectGridGeom, Float32AbstractDataStor
     const int32 voxelFeatureId = featureIds.getValue(voxelIdx);
     featureVoxelCounts[featureIds.getValue(voxelIdx)]++;
 
-    // Use summation to determine overall volume
-    featureVolumes[voxelFeatureId] += static_cast<float64>(elemSizes.getValue(voxelIdx));
+    // Use Kahan summation to determine overall volume
+
+    // Attempt to recover low-order into value, first instance is 0
+    float64 value = static_cast<float64>(elemSizes.getValue(voxelIdx)) - featureCompensators[voxelFeatureId];
+
+    // low-order may be lost
+    float64 volSum = featureVolumes[voxelFeatureId] + value;
+
+    // recover and cache low-order
+    featureCompensators[voxelFeatureId] = (volSum - featureVolumes[voxelFeatureId]) - value;
+
+    // store volumes
+    featureVolumes[voxelFeatureId] = volSum;
   }
 
   msgHelper.sendMessage("Feature Level: Storing Voxel Counts and Calculating ESD...");

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureSizes.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureSizes.cpp
@@ -39,7 +39,7 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
 
   std::vector<uint64> featureVoxelCounts(numFeatures, 0);
 
-  msgHelper.sendMessage("Finding Max Feature Id...");
+  msgHelper.sendMessage("Cell Level: Finding Voxel Counts...");
   // Count and store the number of voxels in each feature
   for(usize voxelIdx = 0; voxelIdx < numVoxels; voxelIdx++)
   {
@@ -67,7 +67,7 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
 
     /**
      * IMPORTANT: Due the nature of ImageGeom the preflight is expected to impose a
-     * restriction on the number of empty dimensions (dentoted as `1`) in an input
+     * restriction on the number of empty dimensions (denoted as `1`) in an input
      * ImageGeom. To illustrate why this is consider the following cases:
      *
      * An ImageGeom with 2 "empty" dimensions, such as 5x1x1. In this case the code would
@@ -79,9 +79,9 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
      * but you lack the orientation information to determine the proper orientation.
      *
      * An ImageGeom with 3 "empty" dimensions, ie 1x1x1. This is a semi-ludicrous case since
-     * the value can be derived directly from the spcaing, but the issue previously outlined
+     * the value can be derived directly from the spacing, but the issue previously outlined
      * will present itself once again. You cannot determine the orientation for proper area
-     * calcualtion.
+     * calculation.
      *
      * For these two cases the following code would BREAK, so do not enable.
      **/
@@ -216,7 +216,7 @@ Result<> ProcessRectGridGeom(RectGridGeom& rectGridGeom, Float32AbstractDataStor
     throttledMessenger.sendThrottledMessage([&] { return fmt::format(" - Calculating || {:.2f}% Complete", CalculatePercentComplete(voxelIdx, numVoxels)); });
 
     const int32 voxelFeatureId = featureIds.getValue(voxelIdx);
-    featureVoxelCounts[featureIds.getValue(voxelIdx)]++;
+    featureVoxelCounts[voxelFeatureId]++;
 
     // Use Kahan summation to determine overall volume
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureSizes.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureSizes.cpp
@@ -169,11 +169,7 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
   if(saveElementSizes)
   {
     msgHelper.sendMessage("Calculating Element Sizes...");
-    int32 err = imageGeom.findElementSizes(false);
-    if(err < 0)
-    {
-      return MakeErrorResult(err, fmt::format("Error computing Element sizes for Geometry type {}", imageGeom.getTypeName()));
-    }
+    return imageGeom.findElementSizes(false);
   }
 
   return {};
@@ -188,10 +184,10 @@ Result<> ProcessRectGridGeom(RectGridGeom& rectGridGeom, Float32AbstractDataStor
   const usize numFeatures = volumes.getNumberOfTuples();
 
   msgHelper.sendMessage("Finding Element Sizes...");
-  int32 err = rectGridGeom.findElementSizes(false);
-  if(err < 0)
+  Result<> result = rectGridGeom.findElementSizes(false);
+  if(result.invalid())
   {
-    return MakeErrorResult(err, fmt::format("Error computing Element sizes for Geometry type {}", rectGridGeom.getTypeName()));
+    return result;
   }
 
   const Float32AbstractDataStore& elemSizes = rectGridGeom.getElementSizes()->getDataStoreRef();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureSizes.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureSizes.cpp
@@ -2,8 +2,9 @@
 
 #include "simplnx/Common/Numbers.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
-#include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/DataStructure/Geometry/IGeometry.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/DataStructure/Geometry/RectGridGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 
 #include <cmath>
@@ -12,9 +13,197 @@ using namespace nx::core;
 
 namespace
 {
-constexpr nx::core::int32 k_BadFeatureCount = -78231;
-constexpr nx::core::float32 k_PI = nx::core::numbers::pi_v<nx::core::float32>;
+constexpr int32 k_BadFeatureCount = -78231;
+constexpr uint64 k_MaxVoxelCount = std::numeric_limits<int32>::max();
+constexpr float32 k_ESDVolumeDenominator = (4.0f / 3.0f) * nx::core::numbers::pi_v<float32>;
+constexpr float32 k_ECDAreaDenominator = nx::core::numbers::pi_v<float32>;
 
+Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volumes, Float32AbstractDataStore& equivalentDiameters, Int32AbstractDataStore& numElements,
+                          const Int32AbstractDataStore& featureIds, const bool saveElementSizes)
+{
+  const usize numVoxels = featureIds.getNumberOfTuples();
+
+  const usize maxFeatureIdx = *std::max_element(featureIds.cbegin(), featureIds.cend());
+  const usize numFeatures = maxFeatureIdx + 1;
+
+  std::vector<uint64> featureVoxelCounts(numFeatures, 0);
+
+  // Count and store the number of voxels in each feature
+  for(usize voxelIdx = 0; voxelIdx < numVoxels; voxelIdx++)
+  {
+    featureVoxelCounts[featureIds.getValue(voxelIdx)]++;
+  }
+
+  const FloatVec3 spacing = imageGeom.getSpacing();
+
+  const usize xDimSize = imageGeom.getNumXCells();
+  const usize yDimSize = imageGeom.getNumYCells();
+  const usize zDimSize = imageGeom.getNumZCells();
+
+  // Treat dimensions of 1 as flat for image geom
+  if(xDimSize == 1 || yDimSize == 1 || zDimSize == 1)
+  {
+    // One of the dimensions is empty so we will be calculating area instead
+
+    /**
+     * IMPORTANT: Due the nature of ImageGeom the preflight is expected to impose a
+     * restriction on the number of empty dimensions (dentoted as `1`) in an input
+     * ImageGeom. To illustrate why this is consider the following cases:
+     *
+     * An ImageGeom with 2 "empty" dimensions, such as 5x1x1. In this case the code would
+     * calculate the area/volume (ie distance between points) by only using the valid dimension.
+     * Functionally flattening the problem to 1D. You may think the solution is to explicitly
+     * define the area cases, but there is a caveat of which of the two empty dimensions to
+     * select for the area calculation. An image with 1x1x5 (XYZ) illustrates this problem,
+     * would you select X or Y for the scaling for area calculation? Clearly it has been rotated,
+     * but you lack the orientation information to determine the proper orientation.
+     *
+     * An ImageGeom with 3 "empty" dimensions, ie 1x1x1. This is a semi-ludicrous case since
+     * the value can be derived directly from the spcaing, but the issue previously outlined
+     * will present itself once again. You cannot determine the orientation for proper area
+     * calcualtion.
+     *
+     * For these two cases the following code would BREAK, so do not enable.
+     **/
+
+    // if x dimension has a size of 1 then xSpacing = 1; else xSpacing = spacing[0]
+    const float32 xSpacing = (spacing[0] * static_cast<float32>(xDimSize > 1ULL)) + (1.0f * static_cast<float32>(xDimSize < 2ULL));
+    // if y dimension has a size of 1 then ySpacing = 1; else ySpacing = spacing[1]
+    const float32 ySpacing = (spacing[1] * static_cast<float32>(yDimSize > 1ULL)) + (1.0f * static_cast<float32>(yDimSize < 2ULL));
+    // if z dimension has a size of 1 then zSpacing = 1; else zSpacing = spacing[2]
+    const float32 zSpacing = (spacing[2] * static_cast<float32>(zDimSize > 1ULL)) + (1.0f * static_cast<float32>(zDimSize < 2ULL));
+
+    // Calculate the area of a single voxel
+    const float32 voxelArea = xSpacing * ySpacing * zSpacing;
+
+    // Process each feature storing feature voxel counts, areas, and equivalent circular diameter
+    for(usize featureIdx = 1; featureIdx < numFeatures; featureIdx++)
+    {
+      // Check for integer overflow
+      if(featureVoxelCounts[featureIdx] > k_MaxVoxelCount)
+      {
+        return MakeErrorResult(k_BadFeatureCount, fmt::format("Feature {} contains more voxels ({}) than the 32-bit integer limit ({}).", featureIdx, featureVoxelCounts[featureIdx], k_MaxVoxelCount));
+      }
+
+      // Store the number of voxels in feature as int32
+      numElements.setValue(featureIdx, static_cast<int32>(featureVoxelCounts[featureIdx]));
+
+      // Calculate and store the area of the feature
+      const float32 newArea = static_cast<float32>(featureVoxelCounts[featureIdx]) * voxelArea;
+      volumes.setValue(featureIdx, newArea);
+
+      /** Determine diameter from area:
+       * Area of Circle - `A = pi * r^2`
+       * Radius of Circle - `r = square_root(A / pi)`
+       * Diameter of Circle - `d = 2 * r`
+       * Thus
+       * Equivalent Circular Diameter - `2 * square_root(A / pi)`
+       **/
+      equivalentDiameters.setValue(featureIdx, 2 * std::sqrt(newArea / k_ECDAreaDenominator));
+    }
+  }
+  else
+  {
+    // If we are here it is an image stack and thus should be treated as 3D
+
+    // Calculate the volume of a single voxel
+    const float32 voxelVolume = spacing[0] * spacing[1] * spacing[2];
+
+    // Process each feature storing feature voxel counts, volumes, and equivalent spherical diameter
+    for(usize featureIdx = 1; featureIdx < numFeatures; featureIdx++)
+    {
+      // Check for integer overflow
+      if(featureVoxelCounts[featureIdx] > k_MaxVoxelCount)
+      {
+        return MakeErrorResult(k_BadFeatureCount, fmt::format("Feature {} contains more voxels ({}) than the 32-bit integer limit ({}).", featureIdx, featureVoxelCounts[featureIdx], k_MaxVoxelCount));
+      }
+
+      // Store the number of voxels in feature as int32
+      numElements.setValue(featureIdx, static_cast<int32>(featureVoxelCounts[featureIdx]));
+
+      // Calculate and store the volume of the feature
+      const float32 newVolume = static_cast<float32>(featureVoxelCounts[featureIdx]) * voxelVolume;
+      volumes.setValue(featureIdx, newVolume);
+
+      /** Determine diameter from volume:
+       * Volume of Sphere - `V = 4/3 * pi * r^3`
+       * Radius of Sphere - `r = cubed_root(V / (4/3 * pi))`
+       * Diameter of Sphere - `d = 2 * r`
+       * Thus
+       * Equivalent Spherical Diameter - `2 * cubed_root(V / (4/3 * pi))`
+       **/
+      equivalentDiameters.setValue(featureIdx, 2.0f * std::cbrt(newVolume / k_ESDVolumeDenominator));
+    }
+  }
+
+  if(saveElementSizes)
+  {
+    int32 err = imageGeom.findElementSizes(false);
+    if(err < 0)
+    {
+      return MakeErrorResult(err, fmt::format("Error computing Element sizes for Geometry type {}", imageGeom.getTypeName()));
+    }
+  }
+
+  return {};
+}
+
+Result<> ProcessRectGridGeom(RectGridGeom& rectGridGeom, Float32AbstractDataStore& volumes, Float32AbstractDataStore& equivalentDiameters, Int32AbstractDataStore& numElements,
+                             const Int32AbstractDataStore& featureIds, const bool saveElementSizes)
+{
+  const usize numVoxels = featureIds.getNumberOfTuples();
+  const usize numFeatures = volumes.getNumberOfTuples();
+
+  int32 err = rectGridGeom.findElementSizes(false);
+  if(err < 0)
+  {
+    return MakeErrorResult(err, fmt::format("Error computing Element sizes for Geometry type {}", rectGridGeom.getTypeName()));
+  }
+
+  const Float32AbstractDataStore& elemSizes = rectGridGeom.getElementSizes()->getDataStoreRef();
+
+  std::vector<uint64> featureVoxelCounts(numFeatures, 0);
+
+  // Count and store the number of voxels in each feature
+  for(usize voxelIdx = 0; voxelIdx < numVoxels; voxelIdx++)
+  {
+    const int32 voxelFeatureId = featureIds.getValue(voxelIdx);
+    featureVoxelCounts[featureIds.getValue(voxelIdx)] += 1.0f;
+
+    // Use summation to determine overall volume
+    const float32 temp2 = volumes.getValue(voxelFeatureId);
+    volumes.setValue(voxelFeatureId, temp2 + elemSizes.getValue(voxelIdx));
+  }
+
+  // Process each feature storing feature voxel counts and equivalent spherical diameter
+  for(usize featureIdx = 1; featureIdx < numFeatures; featureIdx++)
+  {
+    // Check for integer overflow
+    if(featureVoxelCounts[featureIdx] > k_MaxVoxelCount)
+    {
+      return MakeErrorResult(k_BadFeatureCount, fmt::format("Feature {} contains more voxels ({}) than the 32-bit integer limit ({}).", featureIdx, featureVoxelCounts[featureIdx], k_MaxVoxelCount));
+    }
+
+    // Store the number of voxels in feature as int32
+    numElements.setValue(featureIdx, static_cast<int32>(featureVoxelCounts[featureIdx]));
+
+    /** Determine diameter from volume:
+     * Volume of Sphere - `V = 4/3 * pi * r^3`
+     * Radius of Sphere - `r = cubed_root(V / (4/3 * pi))`
+     * Diameter of Sphere - `d = 2 * r`
+     * Thus
+     * Equivalent Spherical Diameter - `2 * cubed_root(V / (4/3 * pi))`
+     **/
+    equivalentDiameters.setValue(featureIdx, 2.0f * std::cbrt(volumes.getValue(featureIdx) / k_ESDVolumeDenominator));
+  }
+
+  if(!saveElementSizes)
+  {
+    rectGridGeom.deleteElementSizes();
+  }
+
+  return {};
+}
 } // namespace
 
 // -----------------------------------------------------------------------------
@@ -32,156 +221,42 @@ ComputeFeatureSizes::~ComputeFeatureSizes() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ComputeFeatureSizes::operator()()
 {
+  const bool saveElementSizes = m_InputValues->SaveElementSizes;
 
-  auto saveElementSizes = m_InputValues->SaveElementSizes;
-
-  auto featureIdsArrayPath = m_InputValues->FeatureIdsPath;
+  const DataPath featureIdsArrayPath = m_InputValues->FeatureIdsPath;
   auto featureIdsArrayPtr = m_DataStructure.getDataAs<Int32Array>(featureIdsArrayPath);
-  const auto& featureIdsStoreRef = featureIdsArrayPtr->getDataStoreRef();
   {
-    auto featureAttributeMatrixPath = m_InputValues->FeatureAttributeMatrixPath;
-    auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, featureAttributeMatrixPath, *featureIdsArrayPtr, false, m_MessageHandler);
+    const DataPath featureAttributeMatrixPath = m_InputValues->FeatureAttributeMatrixPath;
+    Result<> validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, featureAttributeMatrixPath, *featureIdsArrayPtr, false, m_MessageHandler);
     if(validateNumFeatResult.invalid())
     {
       return validateNumFeatResult;
     }
   }
-  usize totalPoints = featureIdsStoreRef.getNumberOfTuples();
 
-  auto geomPath = m_InputValues->InputImageGeometryPath;
-  auto* geom = m_DataStructure.getDataAs<IGeometry>(geomPath);
-  auto featureAttributeMatrixPath = m_InputValues->FeatureAttributeMatrixPath;
+  const DataPath geomPath = m_InputValues->InputImageGeometryPath;
+  auto& geom = m_DataStructure.getDataRefAs<IGeometry>(geomPath);
+  const auto& featureIds = featureIdsArrayPtr->getDataStoreRef();
 
-  DataPath volumesPath = featureAttributeMatrixPath.createChildPath(m_InputValues->VolumesName);
-  DataPath equivDiamPath = featureAttributeMatrixPath.createChildPath(m_InputValues->EquivalentDiametersName);
-  DataPath numElementsPath = featureAttributeMatrixPath.createChildPath(m_InputValues->NumElementsName);
+  const DataPath featureAttributeMatrixPath = m_InputValues->FeatureAttributeMatrixPath;
+  const DataPath volumesPath = featureAttributeMatrixPath.createChildPath(m_InputValues->VolumesName);
+  const DataPath equivDiamPath = featureAttributeMatrixPath.createChildPath(m_InputValues->EquivalentDiametersName);
+  const DataPath numElementsPath = featureAttributeMatrixPath.createChildPath(m_InputValues->NumElementsName);
 
-  // If the geometry is an ImageGeometry or a RectilinearGeometry
-  auto* imageGeom = dynamic_cast<ImageGeom*>(geom);
-  if(nullptr != imageGeom)
+  auto& volumes = m_DataStructure.getDataAs<Float32Array>(volumesPath)->getDataStoreRef();
+  auto& equivalentDiameters = m_DataStructure.getDataAs<Float32Array>(equivDiamPath)->getDataStoreRef();
+  auto& numElements = m_DataStructure.getDataAs<Int32Array>(numElementsPath)->getDataStoreRef();
+
+  const IGeometry::Type geomType = geom.getGeomType();
+  if(geomType == IGeometry::Type::Image)
   {
-
-    auto& volumes = m_DataStructure.getDataAs<Float32Array>(volumesPath)->getDataStoreRef();
-    auto& equivalentDiameters = m_DataStructure.getDataAs<Float32Array>(equivDiamPath)->getDataStoreRef();
-    auto& numElements = m_DataStructure.getDataAs<Int32Array>(numElementsPath)->getDataStoreRef();
-
-    usize featureIdsMaxIdx = std::distance(featureIdsStoreRef.begin(), std::max_element(featureIdsStoreRef.cbegin(), featureIdsStoreRef.cend()));
-    usize maxValue = featureIdsStoreRef[featureIdsMaxIdx];
-    usize numFeatures = maxValue + 1;
-
-    std::vector<uint64> featureCounts(numFeatures, 0);
-
-    for(size_t j = 0; j < totalPoints; j++)
-    {
-      int32_t gnum = featureIdsStoreRef[j];
-      auto temp = featureCounts[gnum] + 1;
-      featureCounts[gnum] = temp;
-    }
-
-    FloatVec3 spacing = imageGeom->getSpacing();
-
-    if(imageGeom->getNumXCells() == 1 || imageGeom->getNumYCells() == 1 || imageGeom->getNumZCells() == 1)
-    {
-      float res_scalar = 0.0f;
-      if(imageGeom->getNumXCells() == 1)
-      {
-        res_scalar = spacing[1] * spacing[2];
-      }
-      else if(imageGeom->getNumYCells() == 1)
-      {
-        res_scalar = spacing[0] * spacing[2];
-      }
-      else if(imageGeom->getNumZCells() == 1)
-      {
-        res_scalar = spacing[0] * spacing[1];
-      }
-
-      for(size_t i = 1; i < numFeatures; i++)
-      {
-        numElements[i] = static_cast<int32_t>(featureCounts[i]);
-        if(featureCounts[i] > 9007199254740992ULL)
-        {
-          std::string ss = fmt::format("Number of voxels belonging to feature {} ({}) is greater than 9007199254740992", i, featureCounts[i]);
-          return MakeErrorResult(k_BadFeatureCount, ss);
-        }
-        volumes[i] = static_cast<float32>(featureCounts[i]) * static_cast<float32>(res_scalar);
-
-        float32 rad = volumes[i] / k_PI;
-        float32 diameter = (2 * sqrtf(rad));
-        equivalentDiameters[i] = diameter;
-      }
-    }
-    else
-    {
-      float32 res_scalar = spacing[0] * spacing[1] * spacing[2];
-      float vol_term = (4.0f / 3.0f) * k_PI;
-      for(usize i = 1; i < numFeatures; i++)
-      {
-        numElements[i] = static_cast<int32>(featureCounts[i]);
-        if(featureCounts[i] > 9007199254740992ULL)
-        {
-          std::string ss = fmt::format("Number of voxels belonging to feature {} ({}) is greater than 9007199254740992", i, featureCounts[i]);
-          return MakeErrorResult(k_BadFeatureCount, ss);
-        }
-
-        volumes[i] = static_cast<float32>(featureCounts[i]) * static_cast<float32>(res_scalar);
-
-        float32 rad = volumes[i] / vol_term;
-        float32 diameter = 2.0f * powf(rad, 0.3333333333f);
-        equivalentDiameters[i] = diameter;
-      }
-    }
-
-    if(saveElementSizes)
-    {
-      int32 err = imageGeom->findElementSizes(false);
-      if(err < 0)
-      {
-        std::string ss = fmt::format("Error computing Element sizes for Geometry type {}", imageGeom->getTypeName());
-        return MakeErrorResult(err, ss);
-      }
-    }
+    auto& imageGeom = dynamic_cast<ImageGeom&>(geom);
+    return ProcessImageGeom(imageGeom, volumes, equivalentDiameters, numElements, featureIds, saveElementSizes);
   }
-  else
+  if(geomType == IGeometry::Type::RectGrid)
   {
-    auto& volumes = m_DataStructure.getDataAs<Float32Array>(volumesPath)->getDataStoreRef();
-    auto& equivalentDiameters = m_DataStructure.getDataAs<Float32Array>(equivDiamPath)->getDataStoreRef();
-    auto& numElements = m_DataStructure.getDataAs<Int32Array>(numElementsPath)->getDataStoreRef();
-
-    usize numFeatures = volumes.getNumberOfTuples();
-
-    int32_t err = geom->findElementSizes(false);
-    if(err < 0)
-    {
-      std::string ss = fmt::format("Error computing Element sizes for Geometry type {}", geom->getTypeName());
-      return MakeErrorResult(err, ss);
-    }
-
-    const Float32Array* elemSizes = geom->getElementSizes();
-
-    std::vector<float> featureCounts(numFeatures, 1);
-
-    for(size_t j = 0; j < totalPoints; j++)
-    {
-      int32 gnum = featureIdsStoreRef[j];
-      auto temp = featureCounts[gnum] + 1;
-      featureCounts[gnum] = temp;
-      auto temp2 = volumes[gnum];
-      volumes[gnum] = temp2 + (*elemSizes)[j];
-    }
-    float vol_term = (4.0f / 3.0f) * k_PI;
-    for(size_t i = 1; i < numFeatures; i++)
-    {
-      numElements[i] = static_cast<int32>(featureCounts[i]);
-      float rad = volumes[i] / vol_term;
-      float diameter = 2.0f * powf(rad, 0.3333333333f);
-      equivalentDiameters[i] = diameter;
-    }
-
-    if(!saveElementSizes)
-    {
-      geom->deleteElementSizes();
-    }
+    auto& rectGridGeom = dynamic_cast<RectGridGeom&>(geom);
+    return ProcessRectGridGeom(rectGridGeom, volumes, equivalentDiameters, numElements, featureIds, saveElementSizes);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureSizes.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureSizes.cpp
@@ -16,8 +16,15 @@ namespace
 {
 constexpr int32 k_BadFeatureCount = -78231;
 constexpr uint64 k_MaxVoxelCount = std::numeric_limits<int32>::max();
-constexpr float32 k_ESDVolumeDenominator = (4.0f / 3.0f) * nx::core::numbers::pi_v<float32>;
-constexpr float32 k_ECDAreaDenominator = nx::core::numbers::pi_v<float32>;
+/**
+ * Volume of Sphere - `V = 4/3 * pi * r^3`
+ * Radius of Sphere - `r = cubed_root(3V / 4pi)`
+ * However we can cut a multiplication out of the
+ * equation at runtime by isolating the `V`
+ * 3V / 4pi == V / (4pi / 3)
+ */
+constexpr float64 k_ESDVolumeDenominator = (4.0 * nx::core::numbers::pi_v<float64>) / 3.0;
+constexpr float64 k_ECDAreaDenominator = nx::core::numbers::pi_v<float64>;
 
 Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volumes, Float32AbstractDataStore& equivalentDiameters, Int32AbstractDataStore& numElements,
                           const Int32AbstractDataStore& featureIds, const bool saveElementSizes, MessageHelper& msgHelper, const std::atomic_bool& shouldCancel)
@@ -80,14 +87,14 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
      **/
 
     // if x dimension has a size of 1 then xSpacing = 1; else xSpacing = spacing[0]
-    const float32 xSpacing = (spacing[0] * static_cast<float32>(xDimSize > 1ULL)) + (1.0f * static_cast<float32>(xDimSize < 2ULL));
+    const float64 xSpacing = (static_cast<float64>(spacing[0]) * static_cast<float64>(xDimSize > 1ULL)) + (1.0f * static_cast<float64>(xDimSize < 2ULL));
     // if y dimension has a size of 1 then ySpacing = 1; else ySpacing = spacing[1]
-    const float32 ySpacing = (spacing[1] * static_cast<float32>(yDimSize > 1ULL)) + (1.0f * static_cast<float32>(yDimSize < 2ULL));
+    const float64 ySpacing = (static_cast<float64>(spacing[1]) * static_cast<float64>(yDimSize > 1ULL)) + (1.0f * static_cast<float64>(yDimSize < 2ULL));
     // if z dimension has a size of 1 then zSpacing = 1; else zSpacing = spacing[2]
-    const float32 zSpacing = (spacing[2] * static_cast<float32>(zDimSize > 1ULL)) + (1.0f * static_cast<float32>(zDimSize < 2ULL));
+    const float64 zSpacing = (static_cast<float64>(spacing[2]) * static_cast<float64>(zDimSize > 1ULL)) + (1.0f * static_cast<float64>(zDimSize < 2ULL));
 
     // Calculate the area of a single voxel
-    const float32 voxelArea = xSpacing * ySpacing * zSpacing;
+    const float64 voxelArea = xSpacing * ySpacing * zSpacing;
 
     msgHelper.sendMessage("Feature Level: Storing Voxel Counts and Calculating Area and ECD...");
     // Process each feature storing feature voxel counts, areas, and equivalent circular diameter
@@ -110,8 +117,8 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
       numElements.setValue(featureIdx, static_cast<int32>(featureVoxelCounts[featureIdx]));
 
       // Calculate and store the area of the feature
-      const float32 newArea = static_cast<float32>(featureVoxelCounts[featureIdx]) * voxelArea;
-      volumes.setValue(featureIdx, newArea);
+      const float64 newArea = static_cast<float64>(featureVoxelCounts[featureIdx]) * voxelArea;
+      volumes.setValue(featureIdx, static_cast<float32>(newArea));
 
       /** Determine diameter from area:
        * Area of Circle - `A = pi * r^2`
@@ -120,7 +127,7 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
        * Thus
        * Equivalent Circular Diameter - `2 * square_root(A / pi)`
        **/
-      equivalentDiameters.setValue(featureIdx, 2 * std::sqrt(newArea / k_ECDAreaDenominator));
+      equivalentDiameters.setValue(featureIdx, static_cast<float32>(2.0 * std::sqrt(newArea / k_ECDAreaDenominator)));
     }
   }
   else
@@ -129,7 +136,7 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
     msgHelper.sendMessage("Image Stack detected. Proceeding with 3D calculations...");
 
     // Calculate the volume of a single voxel
-    const float32 voxelVolume = spacing[0] * spacing[1] * spacing[2];
+    const float64 voxelVolume = spacing[0] * spacing[1] * spacing[2];
 
     msgHelper.sendMessage("Feature Level: Storing Voxel Counts and Calculating Volume and ESD...");
     // Process each feature storing feature voxel counts, volumes, and equivalent spherical diameter
@@ -152,17 +159,17 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
       numElements.setValue(featureIdx, static_cast<int32>(featureVoxelCounts[featureIdx]));
 
       // Calculate and store the volume of the feature
-      const float32 newVolume = static_cast<float32>(featureVoxelCounts[featureIdx]) * voxelVolume;
-      volumes.setValue(featureIdx, newVolume);
+      const float64 newVolume = static_cast<float64>(featureVoxelCounts[featureIdx]) * voxelVolume;
+      volumes.setValue(featureIdx, static_cast<float32>(newVolume));
 
       /** Determine diameter from volume:
        * Volume of Sphere - `V = 4/3 * pi * r^3`
-       * Radius of Sphere - `r = cubed_root(V / (4/3 * pi))`
+       * Radius of Sphere - `r = cubed_root(3V / 4pi)`
        * Diameter of Sphere - `d = 2 * r`
        * Thus
-       * Equivalent Spherical Diameter - `2 * cubed_root(V / (4/3 * pi))`
+       * Equivalent Spherical Diameter - `2 * cubed_root(V / (4pi / 3))`
        **/
-      equivalentDiameters.setValue(featureIdx, 2.0f * std::cbrt(newVolume / k_ESDVolumeDenominator));
+      equivalentDiameters.setValue(featureIdx, static_cast<float32>(2.0 * std::cbrt(newVolume / k_ESDVolumeDenominator)));
     }
   }
 
@@ -193,6 +200,7 @@ Result<> ProcessRectGridGeom(RectGridGeom& rectGridGeom, Float32AbstractDataStor
   const Float32AbstractDataStore& elemSizes = rectGridGeom.getElementSizes()->getDataStoreRef();
 
   std::vector<uint64> featureVoxelCounts(numFeatures, 0);
+  std::vector<float64> featureVolumes(numFeatures, 0.0);
 
   msgHelper.sendMessage("Cell Level: Finding Voxel Counts and Summing Volumes...");
   // Count and store the number of voxels in each feature
@@ -206,11 +214,10 @@ Result<> ProcessRectGridGeom(RectGridGeom& rectGridGeom, Float32AbstractDataStor
     throttledMessenger.sendThrottledMessage([&] { return fmt::format(" - Calculating || {:.2f}% Complete", CalculatePercentComplete(voxelIdx, numVoxels)); });
 
     const int32 voxelFeatureId = featureIds.getValue(voxelIdx);
-    featureVoxelCounts[featureIds.getValue(voxelIdx)] += 1.0f;
+    featureVoxelCounts[featureIds.getValue(voxelIdx)]++;
 
     // Use summation to determine overall volume
-    const float32 temp2 = volumes.getValue(voxelFeatureId);
-    volumes.setValue(voxelFeatureId, temp2 + elemSizes.getValue(voxelIdx));
+    featureVolumes[voxelFeatureId] += static_cast<float64>(elemSizes.getValue(voxelIdx));
   }
 
   msgHelper.sendMessage("Feature Level: Storing Voxel Counts and Calculating ESD...");
@@ -232,15 +239,17 @@ Result<> ProcessRectGridGeom(RectGridGeom& rectGridGeom, Float32AbstractDataStor
 
     // Store the number of voxels in feature as int32
     numElements.setValue(featureIdx, static_cast<int32>(featureVoxelCounts[featureIdx]));
+    // Store the volume of the feature
+    volumes.setValue(featureIdx, static_cast<float32>(featureVolumes[featureIdx]));
 
     /** Determine diameter from volume:
      * Volume of Sphere - `V = 4/3 * pi * r^3`
-     * Radius of Sphere - `r = cubed_root(V / (4/3 * pi))`
+     * Radius of Sphere - `r = cubed_root(3V / 4pi)`
      * Diameter of Sphere - `d = 2 * r`
      * Thus
-     * Equivalent Spherical Diameter - `2 * cubed_root(V / (4/3 * pi))`
+     * Equivalent Spherical Diameter - `2 * cubed_root(V / (4pi / 3))`
      **/
-    equivalentDiameters.setValue(featureIdx, 2.0f * std::cbrt(volumes.getValue(featureIdx) / k_ESDVolumeDenominator));
+    equivalentDiameters.setValue(featureIdx, static_cast<float32>(2.0 * std::cbrt(featureVolumes[featureIdx] / k_ESDVolumeDenominator)));
   }
 
   if(!saveElementSizes)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureSizes.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureSizes.cpp
@@ -6,6 +6,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/Geometry/RectGridGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <cmath>
 
@@ -19,18 +20,29 @@ constexpr float32 k_ESDVolumeDenominator = (4.0f / 3.0f) * nx::core::numbers::pi
 constexpr float32 k_ECDAreaDenominator = nx::core::numbers::pi_v<float32>;
 
 Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volumes, Float32AbstractDataStore& equivalentDiameters, Int32AbstractDataStore& numElements,
-                          const Int32AbstractDataStore& featureIds, const bool saveElementSizes)
+                          const Int32AbstractDataStore& featureIds, const bool saveElementSizes, MessageHelper& msgHelper, const std::atomic_bool& shouldCancel)
 {
+  ThrottledMessenger throttledMessenger = msgHelper.createThrottledMessenger();
+
   const usize numVoxels = featureIds.getNumberOfTuples();
 
+  msgHelper.sendMessage("Finding Max Feature Id...");
   const usize maxFeatureIdx = *std::max_element(featureIds.cbegin(), featureIds.cend());
   const usize numFeatures = maxFeatureIdx + 1;
 
   std::vector<uint64> featureVoxelCounts(numFeatures, 0);
 
+  msgHelper.sendMessage("Finding Max Feature Id...");
   // Count and store the number of voxels in each feature
   for(usize voxelIdx = 0; voxelIdx < numVoxels; voxelIdx++)
   {
+    if(shouldCancel)
+    {
+      return {};
+    }
+
+    throttledMessenger.sendThrottledMessage([&] { return fmt::format(" - Counting || {:.2f}% Complete", CalculatePercentComplete(voxelIdx, numVoxels)); });
+
     featureVoxelCounts[featureIds.getValue(voxelIdx)]++;
   }
 
@@ -43,6 +55,7 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
   // Treat dimensions of 1 as flat for image geom
   if(xDimSize == 1 || yDimSize == 1 || zDimSize == 1)
   {
+    msgHelper.sendMessage("Singular image detected. Proceeding with 2D calculations...");
     // One of the dimensions is empty so we will be calculating area instead
 
     /**
@@ -76,14 +89,22 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
     // Calculate the area of a single voxel
     const float32 voxelArea = xSpacing * ySpacing * zSpacing;
 
+    msgHelper.sendMessage("Feature Level: Storing Voxel Counts and Calculating Area and ECD...");
     // Process each feature storing feature voxel counts, areas, and equivalent circular diameter
     for(usize featureIdx = 1; featureIdx < numFeatures; featureIdx++)
     {
+      if(shouldCancel)
+      {
+        return {};
+      }
+
       // Check for integer overflow
       if(featureVoxelCounts[featureIdx] > k_MaxVoxelCount)
       {
         return MakeErrorResult(k_BadFeatureCount, fmt::format("Feature {} contains more voxels ({}) than the 32-bit integer limit ({}).", featureIdx, featureVoxelCounts[featureIdx], k_MaxVoxelCount));
       }
+
+      throttledMessenger.sendThrottledMessage([&] { return fmt::format(" - Calculating || {:.2f}% Complete", CalculatePercentComplete(featureIdx, numFeatures)); });
 
       // Store the number of voxels in feature as int32
       numElements.setValue(featureIdx, static_cast<int32>(featureVoxelCounts[featureIdx]));
@@ -105,18 +126,27 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
   else
   {
     // If we are here it is an image stack and thus should be treated as 3D
+    msgHelper.sendMessage("Image Stack detected. Proceeding with 3D calculations...");
 
     // Calculate the volume of a single voxel
     const float32 voxelVolume = spacing[0] * spacing[1] * spacing[2];
 
+    msgHelper.sendMessage("Feature Level: Storing Voxel Counts and Calculating Volume and ESD...");
     // Process each feature storing feature voxel counts, volumes, and equivalent spherical diameter
     for(usize featureIdx = 1; featureIdx < numFeatures; featureIdx++)
     {
+      if(shouldCancel)
+      {
+        return {};
+      }
+
       // Check for integer overflow
       if(featureVoxelCounts[featureIdx] > k_MaxVoxelCount)
       {
         return MakeErrorResult(k_BadFeatureCount, fmt::format("Feature {} contains more voxels ({}) than the 32-bit integer limit ({}).", featureIdx, featureVoxelCounts[featureIdx], k_MaxVoxelCount));
       }
+
+      throttledMessenger.sendThrottledMessage([&] { return fmt::format(" - Calculating || {:.2f}% Complete", CalculatePercentComplete(featureIdx, numFeatures)); });
 
       // Store the number of voxels in feature as int32
       numElements.setValue(featureIdx, static_cast<int32>(featureVoxelCounts[featureIdx]));
@@ -138,6 +168,7 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
 
   if(saveElementSizes)
   {
+    msgHelper.sendMessage("Calculating Element Sizes...");
     int32 err = imageGeom.findElementSizes(false);
     if(err < 0)
     {
@@ -149,11 +180,14 @@ Result<> ProcessImageGeom(ImageGeom& imageGeom, Float32AbstractDataStore& volume
 }
 
 Result<> ProcessRectGridGeom(RectGridGeom& rectGridGeom, Float32AbstractDataStore& volumes, Float32AbstractDataStore& equivalentDiameters, Int32AbstractDataStore& numElements,
-                             const Int32AbstractDataStore& featureIds, const bool saveElementSizes)
+                             const Int32AbstractDataStore& featureIds, const bool saveElementSizes, MessageHelper& msgHelper, const std::atomic_bool& shouldCancel)
 {
+  ThrottledMessenger throttledMessenger = msgHelper.createThrottledMessenger();
+
   const usize numVoxels = featureIds.getNumberOfTuples();
   const usize numFeatures = volumes.getNumberOfTuples();
 
+  msgHelper.sendMessage("Finding Element Sizes...");
   int32 err = rectGridGeom.findElementSizes(false);
   if(err < 0)
   {
@@ -164,9 +198,17 @@ Result<> ProcessRectGridGeom(RectGridGeom& rectGridGeom, Float32AbstractDataStor
 
   std::vector<uint64> featureVoxelCounts(numFeatures, 0);
 
+  msgHelper.sendMessage("Cell Level: Finding Voxel Counts and Summing Volumes...");
   // Count and store the number of voxels in each feature
   for(usize voxelIdx = 0; voxelIdx < numVoxels; voxelIdx++)
   {
+    if(shouldCancel)
+    {
+      return {};
+    }
+
+    throttledMessenger.sendThrottledMessage([&] { return fmt::format(" - Calculating || {:.2f}% Complete", CalculatePercentComplete(voxelIdx, numVoxels)); });
+
     const int32 voxelFeatureId = featureIds.getValue(voxelIdx);
     featureVoxelCounts[featureIds.getValue(voxelIdx)] += 1.0f;
 
@@ -175,9 +217,17 @@ Result<> ProcessRectGridGeom(RectGridGeom& rectGridGeom, Float32AbstractDataStor
     volumes.setValue(voxelFeatureId, temp2 + elemSizes.getValue(voxelIdx));
   }
 
+  msgHelper.sendMessage("Feature Level: Storing Voxel Counts and Calculating ESD...");
   // Process each feature storing feature voxel counts and equivalent spherical diameter
   for(usize featureIdx = 1; featureIdx < numFeatures; featureIdx++)
   {
+    if(shouldCancel)
+    {
+      return {};
+    }
+
+    throttledMessenger.sendThrottledMessage([&] { return fmt::format(" - Calculating || {:.2f}% Complete", CalculatePercentComplete(featureIdx, numFeatures)); });
+
     // Check for integer overflow
     if(featureVoxelCounts[featureIdx] > k_MaxVoxelCount)
     {
@@ -199,6 +249,7 @@ Result<> ProcessRectGridGeom(RectGridGeom& rectGridGeom, Float32AbstractDataStor
 
   if(!saveElementSizes)
   {
+    msgHelper.sendMessage("Cleaning Up Element Sizes...");
     rectGridGeom.deleteElementSizes();
   }
 
@@ -221,10 +272,13 @@ ComputeFeatureSizes::~ComputeFeatureSizes() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ComputeFeatureSizes::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+
   const bool saveElementSizes = m_InputValues->SaveElementSizes;
 
+  messageHelper.sendMessage("Validating Feature Ids and Feature Attribute Matrix...");
   const DataPath featureIdsArrayPath = m_InputValues->FeatureIdsPath;
-  auto featureIdsArrayPtr = m_DataStructure.getDataAs<Int32Array>(featureIdsArrayPath);
+  const auto* featureIdsArrayPtr = m_DataStructure.getDataAs<Int32Array>(featureIdsArrayPath);
   {
     const DataPath featureAttributeMatrixPath = m_InputValues->FeatureAttributeMatrixPath;
     Result<> validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, featureAttributeMatrixPath, *featureIdsArrayPtr, false, m_MessageHandler);
@@ -250,13 +304,15 @@ Result<> ComputeFeatureSizes::operator()()
   const IGeometry::Type geomType = geom.getGeomType();
   if(geomType == IGeometry::Type::Image)
   {
+    messageHelper.sendMessage("Beginning Processing Features in Image Geometry...");
     auto& imageGeom = dynamic_cast<ImageGeom&>(geom);
-    return ProcessImageGeom(imageGeom, volumes, equivalentDiameters, numElements, featureIds, saveElementSizes);
+    return ProcessImageGeom(imageGeom, volumes, equivalentDiameters, numElements, featureIds, saveElementSizes, messageHelper, m_ShouldCancel);
   }
   if(geomType == IGeometry::Type::RectGrid)
   {
+    messageHelper.sendMessage("Beginning Processing Features in Rectilinear Grid Geometry...");
     auto& rectGridGeom = dynamic_cast<RectGridGeom&>(geom);
-    return ProcessRectGridGeom(rectGridGeom, volumes, equivalentDiameters, numElements, featureIds, saveElementSizes);
+    return ProcessRectGridGeom(rectGridGeom, volumes, equivalentDiameters, numElements, featureIds, saveElementSizes, messageHelper, m_ShouldCancel);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/FindNRingNeighbors.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/FindNRingNeighbors.cpp
@@ -32,10 +32,10 @@ Result<> FindNRingNeighbors::operator()(const IFilter::MessageHandler& mesgHandl
   m_NRingTriangles.clear();
 
   // Make sure we have the proper connectivity built
-  err = triangleGeom->findElementsContainingVert(false);
-  if(err < 0)
+  Result<> result = triangleGeom->findElementsContainingVert(false);
+  if(result.invalid())
   {
-    return MakeErrorResult(err, "Failed to find elements containing vert");
+    return result;
   }
   const INodeGeometry1D::ElementDynamicList* node2TrianglePtr = triangleGeom->getElementsContainingVert();
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LabelTriangleGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LabelTriangleGeometry.cpp
@@ -35,10 +35,10 @@ Result<> LabelTriangleGeometry::operator()()
   {
     usize numTris = triangle.getNumberOfFaces();
 
-    auto check = triangle.findElementNeighbors(false); // use auto since return time is a class declared typename
-    if(check < 0)
+    Result<> result = triangle.findElementNeighbors(false); // use auto since return time is a class declared typename
+    if(result.invalid())
     {
-      return MakeErrorResult(check, fmt::format("Error finding element neighbors for {} geometry", triangle.getName()));
+      return result;
     }
 
     const TriangleGeom::ElementDynamicList* triangleNeighborsPtr = triangle.getElementNeighbors();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LaplacianSmoothing.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LaplacianSmoothing.cpp
@@ -58,9 +58,9 @@ Result<> LaplacianSmoothing::edgeBasedSmoothing()
   if(nullptr != inode2DPtr)
   {
     //  Generate the Unique Edges
-    if(inode2DPtr->findEdges(false) < 0)
+    if(Result<> result = inode2DPtr->findEdges(false); result.invalid())
     {
-      return MakeErrorResult(-560, "Error retrieving or creating the shared edge list");
+      return result;
     }
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SliceTriangleGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SliceTriangleGeometry.cpp
@@ -30,10 +30,10 @@ const std::atomic_bool& SliceTriangleGeometry::getCancel()
 Result<> SliceTriangleGeometry::operator()()
 {
   auto& triangle = m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues->CADDataContainerName);
-  int32 err = triangle.findEdges(true);
-  if(err < 0)
+  Result<> edgesResult = triangle.findEdges(true);
+  if(edgesResult.invalid())
   {
-    return MakeErrorResult(-62101, "Error retrieving the shared edge list");
+    return edgesResult;
   }
 
   AbstractDataStore<int32>* triRegionIdPtr = nullptr;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
@@ -125,7 +125,7 @@ IFilter::PreflightResult ComputeFeatureSizesFilter::preflightImpl(const DataStru
   const auto& featAttributeMatrix = dataStructure.getDataRefAs<AttributeMatrix>(featureAttributeMatrixPath);
 
   ShapeType tupleDimensions = featAttributeMatrix.getShape();
-  uint64 numberOfComponents = 1;
+  usize numberOfComponents = 1;
 
   auto createVolumesAction = std::make_unique<CreateArrayAction>(DataType::float32, tupleDimensions, std::vector<usize>{numberOfComponents}, volumesPath, arrayDataFormat);
   auto createEquivalentDiametersAction = std::make_unique<CreateArrayAction>(DataType::float32, tupleDimensions, std::vector<usize>{numberOfComponents}, equivalentDiametersPath, arrayDataFormat);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
@@ -14,6 +14,11 @@
 
 namespace nx::core
 {
+namespace
+{
+constexpr int32 k_InvalidInputDimensions = -74770;
+} // namespace
+
 std::string ComputeFeatureSizesFilter::name() const
 {
   return FilterTraits<ComputeFeatureSizesFilter>::name;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
@@ -10,7 +10,6 @@
 #include "simplnx/Parameters/DataGroupSelectionParameter.hpp"
 #include "simplnx/Parameters/DataObjectNameParameter.hpp"
 #include "simplnx/Parameters/GeometrySelectionParameter.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
 
 namespace nx::core
@@ -50,8 +49,8 @@ Parameters ComputeFeatureSizesFilter::parameters() const
                                                 "If checked this will generate and store the element sizes ONLY if the geometry does not already contain them.", false));
 
   params.insertSeparator(Parameters::Separator{"Input Cell Data"});
-  params.insert(std::make_unique<GeometrySelectionParameter>(k_GeometryPath_Key, "Input Image Geometry", "DataPath to input Image Geometry", DataPath{},
-                                                             GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image}));
+  params.insert(std::make_unique<GeometrySelectionParameter>(k_GeometryPath_Key, "Input Grid Geometry", "DataPath to input Image or Rectilinear Grid Geometry", DataPath{},
+                                                             GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image, IGeometry::Type::RectGrid}));
 
   params.insert(std::make_unique<ArraySelectionParameter>(k_CellFeatureIdsArrayPath_Key, "Cell Feature Ids", "Specifies to which feature each cell belongs.", DataPath({"Cell Data", "FeatureIds"}),
                                                           ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
@@ -60,9 +59,10 @@ Parameters ComputeFeatureSizesFilter::parameters() const
                                                                     DataPath({"Cell Feature Data"})));
 
   params.insertSeparator(Parameters::Separator{"Output Feature Data"});
-  params.insert(std::make_unique<DataObjectNameParameter>(k_EquivalentDiametersName_Key, "Equivalent Diameters", "DataPath to equivalent diameters array", "EquivalentDiameters"));
-  params.insert(std::make_unique<DataObjectNameParameter>(k_NumElementsName_Key, "Number of Elements", "DataPath to Num Elements array", "NumElements"));
-  params.insert(std::make_unique<DataObjectNameParameter>(k_VolumesName_Key, "Volumes", "DataPath to volumes array", "Volumes"));
+  params.insert(std::make_unique<DataObjectNameParameter>(k_EquivalentDiametersName_Key, "Feature Equivalent Diameters Name",
+                                                          "Name of the array that will store the equivalent spherical/circular diameters of each feature", "EquivalentDiameters"));
+  params.insert(std::make_unique<DataObjectNameParameter>(k_NumElementsName_Key, "Feature Voxel Counts Name", "Name of the array that will store the number of voxels per feature", "NumElements"));
+  params.insert(std::make_unique<DataObjectNameParameter>(k_VolumesName_Key, "Volumes/Area Name", "Name of the array that will store the volumes/area of each feature", "Volumes"));
 
   return params;
 }
@@ -92,6 +92,32 @@ IFilter::PreflightResult ComputeFeatureSizesFilter::preflightImpl(const DataStru
   DataPath equivalentDiametersPath = featureAttributeMatrixPath.createChildPath(equivalentDiametersName);
   DataPath numElementsPath = featureAttributeMatrixPath.createChildPath(numElementsName);
 
+  const auto& geomRef = dataStructure.getDataRefAs<IGeometry>(geometryPath);
+  IGeometry::Type geomType = geomRef.getGeomType();
+  if(geomType == IGeometry::Type::Image)
+  {
+    const auto& imageGeom = dynamic_cast<const ImageGeom&>(geomRef);
+
+    usize emptyDimCount = 0;
+    if(imageGeom.getNumXCells() < 2)
+    {
+      emptyDimCount++;
+    }
+    if(imageGeom.getNumYCells() < 2)
+    {
+      emptyDimCount++;
+    }
+    if(imageGeom.getNumZCells() < 2)
+    {
+      emptyDimCount++;
+    }
+
+    if(emptyDimCount > 1)
+    {
+      return MakePreflightErrorResult(k_InvalidInputDimensions, "This filter requires at least 2 valid dimensions in the image geom. Two or more 1's were found in the image's dimensions");
+    }
+  }
+
   const auto& featureIdsArray = dataStructure.getDataRefAs<Int32Array>(featureIdsPath);
 
   const std::string arrayDataFormat = featureIdsArray.getDataFormat();
@@ -117,6 +143,7 @@ Result<> ComputeFeatureSizesFilter::executeImpl(DataStructure& dataStructure, co
                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   ComputeFeatureSizesInputValues inputValues;
+
   inputValues.EquivalentDiametersName = filterArgs.value<DataObjectNameParameter::ValueType>(k_EquivalentDiametersName_Key);
   inputValues.FeatureAttributeMatrixPath = filterArgs.value<AttributeMatrixSelectionParameter::ValueType>(k_CellFeatureAttributeMatrixPath_Key);
   inputValues.FeatureIdsPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_CellFeatureIdsArrayPath_Key);
@@ -124,6 +151,7 @@ Result<> ComputeFeatureSizesFilter::executeImpl(DataStructure& dataStructure, co
   inputValues.NumElementsName = filterArgs.value<DataObjectNameParameter::ValueType>(k_NumElementsName_Key);
   inputValues.SaveElementSizes = filterArgs.value<BoolParameter::ValueType>(k_SaveElementSizes_Key);
   inputValues.VolumesName = filterArgs.value<DataObjectNameParameter::ValueType>(k_VolumesName_Key);
+
   return ComputeFeatureSizes(dataStructure, messageHandler, shouldCancel, &inputValues)();
 }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeFeatureSizesFilter.cpp
@@ -75,7 +75,14 @@ Parameters ComputeFeatureSizesFilter::parameters() const
 //------------------------------------------------------------------------------
 IFilter::VersionType ComputeFeatureSizesFilter::parametersVersion() const
 {
-  return 1;
+  return 2;
+  // Version 1 -> 2
+  // Description:
+  // Enabled RectGrid Geom for Input Grid Geom (key: "input_image_geometry_path")
+  //
+  // Change 1:
+  // Expanded existing parameter acceptable types
+  // Solution - No change needed;
 }
 
 IFilter::UniquePointer ComputeFeatureSizesFilter::clone() const

--- a/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
@@ -280,7 +280,7 @@ void ValidateRectGridDataStructure(const DataStructure& dataStructure)
   const auto& volumes = dataStructure.getDataRefAs<Float32Array>(k_VolumesPath);
   REQUIRE(volumes.getValue(1) == 2358.834f);
   REQUIRE(volumes.getValue(2) == 356.062f);
-  REQUIRE(volumes.getValue(3) == 15.104f);
+  REQUIRE((volumes.getValue(3) - 15.104f) < std::numeric_limits<float32>::epsilon());
   // eqDiameters: 0.0 16.516 8.764 3.0994
   const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(k_EquivalentDiametersPath);
   REQUIRE(equivalentDiameters.getValue(1) == 16.516f);

--- a/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
@@ -308,6 +308,11 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image 2D", "[SimplnxCore][Co
 
   Test::Validate2DImageDataStructure(dataStructure);
 
+  // validate Feature Sizes does not exist
+  const auto& imageGeom = dataStructure.getDataRefAs<ImageGeom>(Test::k_ImageGeomPath);
+  REQUIRE_FALSE(imageGeom.getElementSizesId().has_value());
+  REQUIRE(imageGeom.getElementSizes() == nullptr);
+
   // Write the DataStructure out to the file system
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT
   WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/valid_image.dream3d", unit_test::k_BinaryTestOutputDir)));
@@ -342,6 +347,11 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image 2D with Element Sizes"
   }
 
   Test::Validate2DImageDataStructure(dataStructure);
+
+  // validate Feature Sizes exists
+  const auto& imageGeom = dataStructure.getDataRefAs<ImageGeom>(Test::k_ImageGeomPath);
+  REQUIRE(imageGeom.getElementSizesId().has_value());
+  REQUIRE(imageGeom.getElementSizes() != nullptr);
 
   // Write the DataStructure out to the file system
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT
@@ -378,6 +388,11 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image Stack 3D", "[SimplnxCo
 
   Test::Validate3DImageDataStructure(dataStructure);
 
+  // validate Feature Sizes does not exist
+  const auto& imageGeom = dataStructure.getDataRefAs<ImageGeom>(Test::k_ImageGeomPath);
+  REQUIRE_FALSE(imageGeom.getElementSizesId().has_value());
+  REQUIRE(imageGeom.getElementSizes() == nullptr);
+
   // Write the DataStructure out to the file system
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT
   WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/valid_image_stack.dream3d", unit_test::k_BinaryTestOutputDir)));
@@ -413,9 +428,14 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image Stack 3D with Element 
 
   Test::Validate3DImageDataStructure(dataStructure);
 
+  // validate Feature Sizes exists
+  const auto& imageGeom = dataStructure.getDataRefAs<ImageGeom>(Test::k_ImageGeomPath);
+  REQUIRE(imageGeom.getElementSizesId().has_value());
+  REQUIRE(imageGeom.getElementSizes() != nullptr);
+
   // Write the DataStructure out to the file system
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT
-  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/valid_image_stack_w_elemnt_sizes.dream3d", unit_test::k_BinaryTestOutputDir)));
+  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/valid_image_stack_w_element_sizes.dream3d", unit_test::k_BinaryTestOutputDir)));
 #endif
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
@@ -447,6 +467,11 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Rectilinear Grid", "[Simplnx
   }
 
   Test::ValidateRectGridDataStructure(dataStructure);
+
+  // validate Feature Sizes does not exist
+  const auto& rectGridGeom = dataStructure.getDataRefAs<RectGridGeom>(Test::k_ImageGeomPath);
+  REQUIRE_FALSE(rectGridGeom.getElementSizesId().has_value());
+  REQUIRE(rectGridGeom.getElementSizes() == nullptr);
 
   // Write the DataStructure out to the file system
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT
@@ -483,9 +508,14 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Rectilinear Grid with Elemen
 
   Test::ValidateRectGridDataStructure(dataStructure);
 
+  // validate Feature Sizes exists
+  const auto& rectGridGeom = dataStructure.getDataRefAs<RectGridGeom>(Test::k_ImageGeomPath);
+  REQUIRE(rectGridGeom.getElementSizesId().has_value());
+  REQUIRE(rectGridGeom.getElementSizes() != nullptr);
+
   // Write the DataStructure out to the file system
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT
-  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/valid_rect_grid_w_elemnt_sizes.dream3d", unit_test::k_BinaryTestOutputDir)));
+  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/valid_rect_grid_w_element_sizes.dream3d", unit_test::k_BinaryTestOutputDir)));
 #endif
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);

--- a/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
@@ -235,7 +235,7 @@ DataStructure CreateRectGridDataStructure()
   // numElements: 0 39 15 10
   // volumes: 0.0 2358.834 352.462 15.104
   // eqDiameters: 0.0 16.516 8.764 3.0994
-  const std::array<uint8, 125> featureIdsArray = {
+  const std::array<uint8, 64> featureIdsArray = {
     1, 2, 2, 2,
     1, 1, 1, 1,
     1, 1, 1, 2,

--- a/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
@@ -155,6 +155,8 @@ DataStructure CreateRectGridDataStructure()
   xBoundsArray->setValue(2, 0.9f);
   xBoundsArray->setValue(3, 2.1f);
   xBoundsArray->setValue(4, 13.0f);
+  rectGridGeom->setXBoundsId(xBoundsArray->getId());
+
   // yBounds -> 0.0f, 0.1f, 1.0f, 10.0f, 100.0f
   Float32Array* yBoundsArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "yBounds", ShapeType{5}, ShapeType{1}, rectGridGeom->getId());
   yBoundsArray->setValue(0, 0.0f);
@@ -162,6 +164,8 @@ DataStructure CreateRectGridDataStructure()
   yBoundsArray->setValue(2, 1.0f);
   yBoundsArray->setValue(3, 10.0f);
   yBoundsArray->setValue(4, 100.0f);
+  rectGridGeom->setYBoundsId(yBoundsArray->getId());
+
   // zBounds -> 0.0f, -1.0f, -1.2f, -2.0f, -2.1f
   Float32Array* zBoundsArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "zBounds", ShapeType{5}, ShapeType{1}, rectGridGeom->getId());
   zBoundsArray->setValue(0, 0.0f);
@@ -169,6 +173,7 @@ DataStructure CreateRectGridDataStructure()
   zBoundsArray->setValue(2, -1.2f);
   zBoundsArray->setValue(3, -2.0f);
   zBoundsArray->setValue(4, -2.1f);
+  rectGridGeom->setZBoundsId(zBoundsArray->getId());
 
   AttributeMatrix* cellData = AttributeMatrix::Create(dataStructure, k_CellAMName, ShapeType{5, 5, 5}, rectGridGeom->getId());
   rectGridGeom->setCellData(*cellData);

--- a/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
@@ -1,5 +1,4 @@
 #include "SimplnxCore/Filters/ComputeFeatureSizesFilter.hpp"
-#include "SimplnxCore/Filters/ReadRawBinaryFilter.hpp"
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
 
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
@@ -7,20 +6,564 @@
 #include <catch2/catch.hpp>
 
 using namespace nx::core;
-using namespace nx::core::Constants;
-using namespace nx::core::UnitTest;
 
 namespace fs = std::filesystem;
 
-namespace
+namespace LegacyTest
 {
-
 const std::string k_Volumes("Volumes");
 const std::string k_EquivalentDiameters("EquivalentDiameters");
+} // namespace LegacyTest
 
-} // namespace
+namespace Test
+{
+// Geometry Level
+const std::string k_ImageGeomName = "Image";
+const DataPath k_ImageGeomPath = DataPath({k_ImageGeomName});
 
-TEST_CASE("SimplnxCore::ComputeFeatureSizes", "[SimplnxCore][ComputeFeatureSizesFilter]")
+// Cell Level
+const std::string k_CellAMName = "CellData";
+const DataPath k_CellAMPath = k_ImageGeomPath.createChildPath(k_CellAMName);
+const std::string k_FeatureIdsName = "FeatureIds";
+const DataPath k_FeatureIdsPath = k_CellAMPath.createChildPath(k_FeatureIdsName);
+
+// Feature Level
+const std::string k_FeatureAMName = "FeatureData";
+const DataPath k_FeatureAMPath = k_ImageGeomPath.createChildPath(k_FeatureAMName);
+
+// Created Array Names and Paths
+const std::string k_NumElementsName = "NumElements";
+const DataPath k_NumElementsPath = k_FeatureAMPath.createChildPath(k_NumElementsName);
+const std::string k_VolumesName = "Volumes";
+const DataPath k_VolumesPath = k_FeatureAMPath.createChildPath(k_VolumesName);
+const std::string k_EquivalentDiametersName = "EquivalentDiameters";
+const DataPath k_EquivalentDiametersPath = k_FeatureAMPath.createChildPath(k_EquivalentDiametersName);
+
+DataStructure Create2DImageDataStructure()
+{
+  // Create an ImageGeom
+  DataStructure dataStructure = {};
+  ImageGeom* imageGeom = ImageGeom::Create(dataStructure, k_ImageGeomName);
+  imageGeom->setSpacing(FloatVec3{std::array<float32, 3>{20.2f, 0.1f, 67777.1f}});
+  imageGeom->setOrigin(FloatVec3{std::array<float32, 3>{0.0f, 0.0f, 0.0f}});
+  imageGeom->setDimensions(SizeVec3{std::array<usize, 3>{5, 5, 1}});
+
+  AttributeMatrix* cellData = AttributeMatrix::Create(dataStructure, k_CellAMName, ShapeType{5, 5, 1}, imageGeom->getId());
+  imageGeom->setCellData(*cellData);
+
+  Int32Array* featureIds = Int32Array::CreateWithStore<Int32DataStore>(dataStructure, k_FeatureIdsName, cellData->getShape(), ShapeType{1}, cellData->getId());
+
+  AttributeMatrix* featureData = AttributeMatrix::Create(dataStructure, k_FeatureAMName, ShapeType{4}, imageGeom->getId());
+
+  // clang-format off
+  // Expected Outputs:
+  // Single Voxel Area: 2.02
+  // numElements: 0 11 1 13
+  // areas: 0.0 22.22 2.02 26.26
+  // eqDiameters: 0.0 5.319 1.6037 5.782
+  const std::array<uint8, 25> featureIdsArray = {
+    1, 2, 3, 3, 3,
+    1, 1, 1, 1, 1,
+    1, 1, 1, 3, 3,
+    3, 3, 1, 1, 3,
+    3, 3, 3, 3, 3,
+  };
+  // clang-format on
+
+  for(usize i = 0; i < featureIds->getNumberOfTuples(); i++)
+  {
+    featureIds->setValue(i, featureIdsArray[i]);
+  }
+
+  return dataStructure;
+}
+
+DataStructure Create3DImageDataStructure()
+{
+  // Create an ImageGeom
+  DataStructure dataStructure = {};
+  ImageGeom* imageGeom = ImageGeom::Create(dataStructure, k_ImageGeomName);
+  imageGeom->setSpacing(FloatVec3{std::array<float32, 3>{1.2f, 0.9f, 2.1f}});
+  imageGeom->setOrigin(FloatVec3{std::array<float32, 3>{0.0f, 0.0f, 0.0f}});
+  imageGeom->setDimensions(SizeVec3{std::array<usize, 3>{5, 5, 5}});
+
+  AttributeMatrix* cellData = AttributeMatrix::Create(dataStructure, k_CellAMName, ShapeType{5, 5, 5}, imageGeom->getId());
+  imageGeom->setCellData(*cellData);
+
+  Int32Array* featureIds = Int32Array::CreateWithStore<Int32DataStore>(dataStructure, k_FeatureIdsName, cellData->getShape(), ShapeType{1}, cellData->getId());
+
+  AttributeMatrix* featureData = AttributeMatrix::Create(dataStructure, k_FeatureAMName, ShapeType{4}, imageGeom->getId());
+
+  // clang-format off
+  // Expected Outputs:
+  // Single Voxel Volume: 2.268
+  // numElements: 0 73 29 23
+  // volumes: 0.0 165.564 65.772 52.164
+  // eqDiameters: 0.0 6.813 5.008 4.636
+  const std::array<uint8, 125> featureIdsArray = {
+    1, 2, 2, 2, 2,
+    1, 1, 1, 1, 1,
+    1, 1, 1, 2, 2,
+    2, 2, 1, 1, 2,
+    2, 2, 2, 2, 2,
+
+    1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1,
+
+    3, 3, 3, 3, 1,
+    1, 3, 1, 3, 3,
+    2, 2, 1, 1, 1,
+    2, 2, 1, 1, 3,
+    2, 2, 1, 3, 3,
+
+    3, 2, 2, 1, 1,
+    3, 2, 1, 1, 1,
+    3, 1, 1, 1, 1,
+    3, 2, 1, 2, 1,
+    3, 2, 2, 2, 2,
+
+    3, 1, 3, 1, 1,
+    1, 1, 1, 1, 1,
+    3, 1, 1, 1, 3,
+    1, 1, 1, 3, 1,
+    3, 1, 3, 1, 3
+  };
+  // clang-format on
+
+  for(usize i = 0; i < featureIds->getNumberOfTuples(); i++)
+  {
+    featureIds->setValue(i, featureIdsArray[i]);
+  }
+
+  return dataStructure;
+}
+
+DataStructure CreateRectGridDataStructure()
+{
+  // Create an ImageGeom
+  DataStructure dataStructure = {};
+  RectGridGeom* rectGridGeom = RectGridGeom::Create(dataStructure, k_ImageGeomName);
+  rectGridGeom->setDimensions(SizeVec3{std::array<usize, 3>{4, 4, 4}});
+
+  // xBounds -> 0.0f, 0.6f, 0.9f, 2.1f, 13.0f
+  Float32Array* xBoundsArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "xBounds", ShapeType{5}, ShapeType{1}, rectGridGeom->getId());
+  xBoundsArray->setValue(0, 0.0f);
+  xBoundsArray->setValue(1, 0.6f);
+  xBoundsArray->setValue(2, 0.9f);
+  xBoundsArray->setValue(3, 2.1f);
+  xBoundsArray->setValue(4, 13.0f);
+  // yBounds -> 0.0f, 0.1f, 1.0f, 10.0f, 100.0f
+  Float32Array* yBoundsArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "yBounds", ShapeType{5}, ShapeType{1}, rectGridGeom->getId());
+  yBoundsArray->setValue(0, 0.0f);
+  yBoundsArray->setValue(1, 0.9f);
+  yBoundsArray->setValue(2, 1.0f);
+  yBoundsArray->setValue(3, 10.0f);
+  yBoundsArray->setValue(4, 100.0f);
+  // zBounds -> 0.0f, -1.0f, -1.2f, -2.0f, -2.1f
+  Float32Array* zBoundsArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "zBounds", ShapeType{5}, ShapeType{1}, rectGridGeom->getId());
+  zBoundsArray->setValue(0, 0.0f);
+  zBoundsArray->setValue(1, -1.0f);
+  zBoundsArray->setValue(2, -1.2f);
+  zBoundsArray->setValue(3, -2.0f);
+  zBoundsArray->setValue(4, -2.1f);
+
+  AttributeMatrix* cellData = AttributeMatrix::Create(dataStructure, k_CellAMName, ShapeType{5, 5, 5}, rectGridGeom->getId());
+  rectGridGeom->setCellData(*cellData);
+
+  Int32Array* featureIds = Int32Array::CreateWithStore<Int32DataStore>(dataStructure, k_FeatureIdsName, cellData->getShape(), ShapeType{1}, cellData->getId());
+
+  AttributeMatrix* featureData = AttributeMatrix::Create(dataStructure, k_FeatureAMName, ShapeType{4}, rectGridGeom->getId());
+
+  // clang-format off
+  // Expected Outputs:
+  // numElements: 0 39 15 10
+  // volumes: 0.0 0.0 0.0 0.0
+  // eqDiameters: 0.0 0.0 0.0 0.0
+  const std::array<uint8, 125> featureIdsArray = {
+    1, 2, 2, 2,
+    1, 1, 1, 1,
+    1, 1, 1, 2,
+    2, 2, 1, 1,
+
+    1, 1, 1, 1,
+    1, 1, 1, 1,
+    1, 1, 1, 1,
+    1, 1, 1, 1,
+
+    3, 3, 3, 3,
+    1, 3, 1, 3,
+    2, 2, 1, 1,
+    2, 2, 1, 1,
+
+    3, 2, 2, 1,
+    3, 2, 1, 1,
+    3, 1, 1, 1,
+    3, 2, 1, 2,
+  };
+  // clang-format on
+
+  for(usize i = 0; i < featureIds->getNumberOfTuples(); i++)
+  {
+    featureIds->setValue(i, featureIdsArray[i]);
+  }
+
+  return dataStructure;
+}
+} // namespace Test
+
+TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image 2D", "[SimplnxCore][ComputeFeatureSizes]")
+{
+  DataStructure dataStructure = Test::Create2DImageDataStructure();
+
+  {
+    ComputeFeatureSizesFilter filter;
+    Arguments args;
+
+    args.insert(ComputeFeatureSizesFilter::k_GeometryPath_Key, std::make_any<DataPath>(Test::k_ImageGeomPath));
+    args.insert(ComputeFeatureSizesFilter::k_SaveElementSizes_Key, std::make_any<bool>(false));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(Test::k_FeatureIdsPath));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(Test::k_FeatureAMPath));
+    args.insert(ComputeFeatureSizesFilter::k_VolumesName_Key, std::make_any<std::string>(Test::k_VolumesName));
+    args.insert(ComputeFeatureSizesFilter::k_EquivalentDiametersName_Key, std::make_any<std::string>(Test::k_EquivalentDiametersName));
+    args.insert(ComputeFeatureSizesFilter::k_NumElementsName_Key, std::make_any<std::string>(Test::k_NumElementsName));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+  }
+
+  // Expected Outputs:
+  // Single Voxel Area: 2.02
+  // numElements: 0 11 1 13
+  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(Test::k_NumElementsPath);
+  REQUIRE(numElements.getValue(1) == 11);
+  REQUIRE(numElements.getValue(2) == 1);
+  REQUIRE(numElements.getValue(3) == 13);
+  // areas: 0.0 22.22 2.02 26.26
+  const auto& areas = dataStructure.getDataRefAs<Float32Array>(Test::k_VolumesPath);
+  REQUIRE(areas.getValue(1) == 22.22f);
+  REQUIRE(areas.getValue(2) == 2.02f);
+  REQUIRE(areas.getValue(3) == 26.26f);
+  // eqDiameters: 0.0 5.319 1.6037 5.782
+  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(Test::k_EquivalentDiametersPath);
+  REQUIRE(equivalentDiameters.getValue(1) == 5.319f);
+  REQUIRE(equivalentDiameters.getValue(2) == 1.6037f);
+  REQUIRE(equivalentDiameters.getValue(3) == 5.782f);
+
+  // Write the DataStructure out to the file system
+#ifdef SIMPLNX_WRITE_TEST_OUTPUT
+  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/valid_image.dream3d", unit_test::k_BinaryTestOutputDir)));
+#endif
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image 2D with Element Sizes", "[SimplnxCore][ComputeFeatureSizes]")
+{
+  DataStructure dataStructure = Test::Create2DImageDataStructure();
+
+  {
+    ComputeFeatureSizesFilter filter;
+    Arguments args;
+
+    args.insert(ComputeFeatureSizesFilter::k_GeometryPath_Key, std::make_any<DataPath>(Test::k_ImageGeomPath));
+    args.insert(ComputeFeatureSizesFilter::k_SaveElementSizes_Key, std::make_any<bool>(true));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(Test::k_FeatureIdsPath));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(Test::k_FeatureAMPath));
+    args.insert(ComputeFeatureSizesFilter::k_VolumesName_Key, std::make_any<std::string>(Test::k_VolumesName));
+    args.insert(ComputeFeatureSizesFilter::k_EquivalentDiametersName_Key, std::make_any<std::string>(Test::k_EquivalentDiametersName));
+    args.insert(ComputeFeatureSizesFilter::k_NumElementsName_Key, std::make_any<std::string>(Test::k_NumElementsName));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+  }
+
+  // Expected Outputs:
+  // Single Voxel Area: 2.02
+  // numElements: 0 11 1 13
+  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(Test::k_NumElementsPath);
+  REQUIRE(numElements.getValue(1) == 11);
+  REQUIRE(numElements.getValue(2) == 1);
+  REQUIRE(numElements.getValue(3) == 13);
+  // areas: 0.0 22.22 2.02 26.26
+  const auto& areas = dataStructure.getDataRefAs<Float32Array>(Test::k_VolumesPath);
+  REQUIRE(areas.getValue(1) == 22.22f);
+  REQUIRE(areas.getValue(2) == 2.02f);
+  REQUIRE(areas.getValue(3) == 26.26f);
+  // eqDiameters: 0.0 5.319 1.6037 5.782
+  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(Test::k_EquivalentDiametersPath);
+  REQUIRE(equivalentDiameters.getValue(1) == 5.319f);
+  REQUIRE(equivalentDiameters.getValue(2) == 1.6037f);
+  REQUIRE(equivalentDiameters.getValue(3) == 5.782f);
+
+  // Write the DataStructure out to the file system
+#ifdef SIMPLNX_WRITE_TEST_OUTPUT
+  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/valid_image.dream3d", unit_test::k_BinaryTestOutputDir)));
+#endif
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image Stack 3D", "[SimplnxCore][ComputeFeatureSizes]")
+{
+  DataStructure dataStructure = Test::Create3DImageDataStructure();
+
+  {
+    ComputeFeatureSizesFilter filter;
+    Arguments args;
+
+    args.insert(ComputeFeatureSizesFilter::k_GeometryPath_Key, std::make_any<DataPath>(Test::k_ImageGeomPath));
+    args.insert(ComputeFeatureSizesFilter::k_SaveElementSizes_Key, std::make_any<bool>(false));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(Test::k_FeatureIdsPath));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(Test::k_FeatureAMPath));
+    args.insert(ComputeFeatureSizesFilter::k_VolumesName_Key, std::make_any<std::string>(Test::k_VolumesName));
+    args.insert(ComputeFeatureSizesFilter::k_EquivalentDiametersName_Key, std::make_any<std::string>(Test::k_EquivalentDiametersName));
+    args.insert(ComputeFeatureSizesFilter::k_NumElementsName_Key, std::make_any<std::string>(Test::k_NumElementsName));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+  }
+
+  // Expected Outputs:
+  // Single Voxel Volume: 2.268
+  // numElements: 0 73 29 23
+  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(Test::k_NumElementsPath);
+  REQUIRE(numElements.getValue(1) == 73);
+  REQUIRE(numElements.getValue(2) == 29);
+  REQUIRE(numElements.getValue(3) == 23);
+  // volumes: 0.0 165.564 65.772 52.164
+  const auto& volumes = dataStructure.getDataRefAs<Float32Array>(Test::k_VolumesPath);
+  REQUIRE(volumes.getValue(1) == 165.564f);
+  REQUIRE(volumes.getValue(2) == 65.772f);
+  REQUIRE(volumes.getValue(3) == 52.164f);
+  // eqDiameters: 0.0 6.813 5.008 4.636
+  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(Test::k_EquivalentDiametersPath);
+  REQUIRE(equivalentDiameters.getValue(1) == 6.183f);
+  REQUIRE(equivalentDiameters.getValue(2) == 5.008f);
+  REQUIRE(equivalentDiameters.getValue(3) == 4.636f);
+
+  // Write the DataStructure out to the file system
+#ifdef SIMPLNX_WRITE_TEST_OUTPUT
+  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/valid_image_stack.dream3d", unit_test::k_BinaryTestOutputDir)));
+#endif
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image Stack 3D with Element Size", "[SimplnxCore][ComputeFeatureSizes]")
+{
+  DataStructure dataStructure = Test::Create3DImageDataStructure();
+
+  {
+    ComputeFeatureSizesFilter filter;
+    Arguments args;
+
+    args.insert(ComputeFeatureSizesFilter::k_GeometryPath_Key, std::make_any<DataPath>(Test::k_ImageGeomPath));
+    args.insert(ComputeFeatureSizesFilter::k_SaveElementSizes_Key, std::make_any<bool>(true));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(Test::k_FeatureIdsPath));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(Test::k_FeatureAMPath));
+    args.insert(ComputeFeatureSizesFilter::k_VolumesName_Key, std::make_any<std::string>(Test::k_VolumesName));
+    args.insert(ComputeFeatureSizesFilter::k_EquivalentDiametersName_Key, std::make_any<std::string>(Test::k_EquivalentDiametersName));
+    args.insert(ComputeFeatureSizesFilter::k_NumElementsName_Key, std::make_any<std::string>(Test::k_NumElementsName));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+  }
+
+  // Expected Outputs:
+  // Single Voxel Volume: 2.268
+  // numElements: 0 73 29 23
+  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(Test::k_NumElementsPath);
+  REQUIRE(numElements.getValue(1) == 73);
+  REQUIRE(numElements.getValue(2) == 29);
+  REQUIRE(numElements.getValue(3) == 23);
+  // volumes: 0.0 165.564 65.772 52.164
+  const auto& volumes = dataStructure.getDataRefAs<Float32Array>(Test::k_VolumesPath);
+  REQUIRE(volumes.getValue(1) == 165.564f);
+  REQUIRE(volumes.getValue(2) == 65.772f);
+  REQUIRE(volumes.getValue(3) == 52.164f);
+  // eqDiameters: 0.0 6.813 5.008 4.636
+  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(Test::k_EquivalentDiametersPath);
+  REQUIRE(equivalentDiameters.getValue(1) == 6.183f);
+  REQUIRE(equivalentDiameters.getValue(2) == 5.008f);
+  REQUIRE(equivalentDiameters.getValue(3) == 4.636f);
+
+  // Write the DataStructure out to the file system
+#ifdef SIMPLNX_WRITE_TEST_OUTPUT
+  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/valid_image_stack_w_elemnt_sizes.dream3d", unit_test::k_BinaryTestOutputDir)));
+#endif
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Rectilinear Grid", "[SimplnxCore][ComputeFeatureSizes]")
+{
+  {
+    ComputeFeatureSizesFilter filter;
+    Arguments args;
+
+    args.insert(ComputeFeatureSizesFilter::k_GeometryPath_Key, std::make_any<DataPath>(smallIn100Group));
+    args.insert(ComputeFeatureSizesFilter::k_SaveElementSizes_Key, std::make_any<bool>(false));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(featureIdsPath));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(featureGroup));
+    args.insert(ComputeFeatureSizesFilter::k_VolumesName_Key, std::make_any<std::string>(volumesName));
+    args.insert(ComputeFeatureSizesFilter::k_EquivalentDiametersName_Key, std::make_any<std::string>(EquivalentDiametersName));
+    args.insert(ComputeFeatureSizesFilter::k_NumElementsName_Key, std::make_any<std::string>(numElementsName));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+  }
+}
+
+TEST_CASE("SimplnxCore::ComputeFeatureSizes: Invalid: Execution Failure", "[SimplnxCore][ComputeFeatureSizes]")
+{
+  DataStructure dataStructure = Test::Create3DImageDataStructure();
+  auto& featureIds = dataStructure.getDataRefAs<Int32Array>(Test::k_FeatureIdsPath);
+
+  featureIds.setValue(61, 10);
+
+  {
+    ComputeFeatureSizesFilter filter;
+    Arguments args;
+
+    args.insert(ComputeFeatureSizesFilter::k_GeometryPath_Key, std::make_any<DataPath>(Test::k_ImageGeomPath));
+    args.insert(ComputeFeatureSizesFilter::k_SaveElementSizes_Key, std::make_any<bool>(false));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(Test::k_FeatureIdsPath));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(Test::k_FeatureAMPath));
+    args.insert(ComputeFeatureSizesFilter::k_VolumesName_Key, std::make_any<std::string>(Test::k_VolumesName));
+    args.insert(ComputeFeatureSizesFilter::k_EquivalentDiametersName_Key, std::make_any<std::string>(Test::k_EquivalentDiametersName));
+    args.insert(ComputeFeatureSizesFilter::k_NumElementsName_Key, std::make_any<std::string>(Test::k_NumElementsName));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+  }
+
+  // Write the DataStructure out to the file system
+#ifdef SIMPLNX_WRITE_TEST_OUTPUT
+  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/invalid_execution.dream3d", unit_test::k_BinaryTestOutputDir)));
+#endif
+}
+
+TEST_CASE("SimplnxCore::ComputeFeatureSizes: Invalid: Preflight Failure", "[SimplnxCore][ComputeFeatureSizes]")
+{
+  DataStructure dataStructure = Test::Create3DImageDataStructure();
+  auto& imageGeom = dataStructure.getDataRefAs<ImageGeom>(Test::k_ImageGeomPath);
+
+  // Set first invalid dimensions
+  imageGeom.setDimensions(SizeVec3{std::array<usize, 3>{5, 1, 1}});
+  {
+    ComputeFeatureSizesFilter filter;
+    Arguments args;
+
+    args.insert(ComputeFeatureSizesFilter::k_GeometryPath_Key, std::make_any<DataPath>(Test::k_ImageGeomPath));
+    args.insert(ComputeFeatureSizesFilter::k_SaveElementSizes_Key, std::make_any<bool>(false));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(Test::k_FeatureIdsPath));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(Test::k_FeatureAMPath));
+    args.insert(ComputeFeatureSizesFilter::k_VolumesName_Key, std::make_any<std::string>(Test::k_VolumesName));
+    args.insert(ComputeFeatureSizesFilter::k_EquivalentDiametersName_Key, std::make_any<std::string>(Test::k_EquivalentDiametersName));
+    args.insert(ComputeFeatureSizesFilter::k_NumElementsName_Key, std::make_any<std::string>(Test::k_NumElementsName));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+  }
+
+  // Set second invalid dimensions
+  imageGeom.setDimensions(SizeVec3{std::array<usize, 3>{1, 5, 1}});
+  {
+    ComputeFeatureSizesFilter filter;
+    Arguments args;
+
+    args.insert(ComputeFeatureSizesFilter::k_GeometryPath_Key, std::make_any<DataPath>(Test::k_ImageGeomPath));
+    args.insert(ComputeFeatureSizesFilter::k_SaveElementSizes_Key, std::make_any<bool>(false));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(Test::k_FeatureIdsPath));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(Test::k_FeatureAMPath));
+    args.insert(ComputeFeatureSizesFilter::k_VolumesName_Key, std::make_any<std::string>(Test::k_VolumesName));
+    args.insert(ComputeFeatureSizesFilter::k_EquivalentDiametersName_Key, std::make_any<std::string>(Test::k_EquivalentDiametersName));
+    args.insert(ComputeFeatureSizesFilter::k_NumElementsName_Key, std::make_any<std::string>(Test::k_NumElementsName));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+  }
+
+  // Set third invalid dimensions
+  imageGeom.setDimensions(SizeVec3{std::array<usize, 3>{1, 1, 5}});
+  {
+    ComputeFeatureSizesFilter filter;
+    Arguments args;
+
+    args.insert(ComputeFeatureSizesFilter::k_GeometryPath_Key, std::make_any<DataPath>(Test::k_ImageGeomPath));
+    args.insert(ComputeFeatureSizesFilter::k_SaveElementSizes_Key, std::make_any<bool>(false));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(Test::k_FeatureIdsPath));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(Test::k_FeatureAMPath));
+    args.insert(ComputeFeatureSizesFilter::k_VolumesName_Key, std::make_any<std::string>(Test::k_VolumesName));
+    args.insert(ComputeFeatureSizesFilter::k_EquivalentDiametersName_Key, std::make_any<std::string>(Test::k_EquivalentDiametersName));
+    args.insert(ComputeFeatureSizesFilter::k_NumElementsName_Key, std::make_any<std::string>(Test::k_NumElementsName));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+  }
+
+  // Set fourth invalid dimensions
+  imageGeom.setDimensions(SizeVec3{std::array<usize, 3>{1, 1, 1}});
+  {
+    ComputeFeatureSizesFilter filter;
+    Arguments args;
+
+    args.insert(ComputeFeatureSizesFilter::k_GeometryPath_Key, std::make_any<DataPath>(Test::k_ImageGeomPath));
+    args.insert(ComputeFeatureSizesFilter::k_SaveElementSizes_Key, std::make_any<bool>(false));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(Test::k_FeatureIdsPath));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(Test::k_FeatureAMPath));
+    args.insert(ComputeFeatureSizesFilter::k_VolumesName_Key, std::make_any<std::string>(Test::k_VolumesName));
+    args.insert(ComputeFeatureSizesFilter::k_EquivalentDiametersName_Key, std::make_any<std::string>(Test::k_EquivalentDiametersName));
+    args.insert(ComputeFeatureSizesFilter::k_NumElementsName_Key, std::make_any<std::string>(Test::k_NumElementsName));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+  }
+
+  // Write the DataStructure out to the file system
+#ifdef SIMPLNX_WRITE_TEST_OUTPUT
+  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/invalid_preflight.dream3d", unit_test::k_BinaryTestOutputDir)));
+#endif
+}
+
+TEST_CASE("SimplnxCore::ComputeFeatureSizes: Legacy: Small IN100 Test", "[SimplnxCore][ComputeFeatureSizes]")
 {
   UnitTest::LoadPlugins();
 
@@ -29,16 +572,16 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes", "[SimplnxCore][ComputeFeatureSizes
   // Read the Small IN100 Data set
   auto baseDataFilePath = fs::path(fmt::format("{}/6_6_stats_test_v2.dream3d", unit_test::k_TestFilesDir));
   DataStructure dataStructure = UnitTest::LoadDataStructure(baseDataFilePath);
-  DataPath smallIn100Group({nx::core::Constants::k_DataContainer});
-  DataPath cellDataPath = smallIn100Group.createChildPath(nx::core::Constants::k_CellData);
-  DataPath cellPhasesPath = cellDataPath.createChildPath(nx::core::Constants::k_Phases);
-  DataPath featureIdsPath = cellDataPath.createChildPath(nx::core::Constants::k_FeatureIds);
-  DataPath featureGroup = smallIn100Group.createChildPath(nx::core::Constants::k_CellFeatureData);
+  DataPath smallIn100Group({Constants::k_DataContainer});
+  DataPath cellDataPath = smallIn100Group.createChildPath(Constants::k_CellData);
+  DataPath cellPhasesPath = cellDataPath.createChildPath(Constants::k_Phases);
+  DataPath featureIdsPath = cellDataPath.createChildPath(Constants::k_FeatureIds);
+  DataPath featureGroup = smallIn100Group.createChildPath(Constants::k_CellFeatureData);
   std::string volumesName = "computed_volumes";
   std::string numElementsName = "computed_NumElements";
   std::string EquivalentDiametersName = "computed_EquivalentDiameters";
 
-  std::vector<std::string> featureNames = {k_Volumes, k_EquivalentDiameters, ::k_NumElements};
+  std::vector<std::string> featureNames = {LegacyTest::k_Volumes, LegacyTest::k_EquivalentDiameters, Constants::k_NumElements};
 
   {
     ComputeFeatureSizesFilter filter;
@@ -63,23 +606,23 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes", "[SimplnxCore][ComputeFeatureSizes
 
   // Compare Outputs
   {
-    DataPath exemplaryDataPath = featureGroup.createChildPath(k_Volumes);
+    DataPath exemplaryDataPath = featureGroup.createChildPath(LegacyTest::k_Volumes);
     UnitTest::CompareArrays<float32>(dataStructure, exemplaryDataPath, featureGroup.createChildPath(volumesName));
   }
 
   {
-    DataPath exemplaryDataPath = featureGroup.createChildPath(k_EquivalentDiameters);
+    DataPath exemplaryDataPath = featureGroup.createChildPath(LegacyTest::k_EquivalentDiameters);
     UnitTest::CompareArrays<float32>(dataStructure, exemplaryDataPath, featureGroup.createChildPath(EquivalentDiametersName));
   }
 
   {
-    DataPath exemplaryDataPath = featureGroup.createChildPath(k_NumElements);
+    DataPath exemplaryDataPath = featureGroup.createChildPath(Constants::k_NumElements);
     UnitTest::CompareArrays<int32>(dataStructure, exemplaryDataPath, featureGroup.createChildPath(numElementsName));
   }
 
 // Write the DataStructure out to the file system
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT
-  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes.dream3d", unit_test::k_BinaryTestOutputDir)));
+  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/legacy_test.dream3d", unit_test::k_BinaryTestOutputDir)));
 #endif
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);

--- a/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
@@ -80,10 +80,6 @@ DataStructure Create2DImageDataStructure()
 
 void Validate2DImageDataStructure(const DataStructure& dataStructure)
 {
-  // Since we are using 20.2f the trash bits are one decimal place higher
-  // this means we cant use the typical 1e-6 epsilon provided by standard library
-  constexpr float32 epsilon = 0.00001;
-
   // Expected Outputs:
   // Single Voxel Area: 2.02
   // numElements: 0 11 1 13
@@ -93,14 +89,14 @@ void Validate2DImageDataStructure(const DataStructure& dataStructure)
   REQUIRE(numElements.getValue(3) == 13);
   // areas: 0.0 22.22 2.02 26.26
   const auto& areas = dataStructure.getDataRefAs<Float32Array>(k_VolumesPath);
-  REQUIRE((areas.getValue(1) - 22.22f) < epsilon);
-  REQUIRE((areas.getValue(2) - 2.02f) < epsilon);
-  REQUIRE((areas.getValue(3) - 26.26f) < epsilon);
-  // eqDiameters: 0.0 5.319 1.603728 5.78232
+  REQUIRE(std::abs(areas.getValue(1) - 22.220001f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(areas.getValue(2) - 2.0200002f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(areas.getValue(3) - 26.260002f) < std::numeric_limits<float32>::epsilon());
+  // eqDiameters: 0.0 5.318964 1.603728 5.78232
   const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(k_EquivalentDiametersPath);
-  REQUIRE((equivalentDiameters.getValue(1) - 5.319f) < epsilon);
-  REQUIRE((equivalentDiameters.getValue(2) - 1.603728f) < epsilon);
-  REQUIRE((equivalentDiameters.getValue(3) - 5.78232f) < epsilon);
+  REQUIRE(std::abs(equivalentDiameters.getValue(1) - 5.3189644f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(equivalentDiameters.getValue(2) - 1.60372818f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(equivalentDiameters.getValue(3) - 5.7823243f) < std::numeric_limits<float32>::epsilon());
 }
 
 DataStructure Create3DImageDataStructure()
@@ -168,8 +164,6 @@ DataStructure Create3DImageDataStructure()
 
 void Validate3DImageDataStructure(const DataStructure& dataStructure)
 {
-  constexpr float32 epsilon = 0.00001;
-
   // Expected Outputs:
   // Single Voxel Volume: 2.268
   // numElements: 0 73 29 23
@@ -179,14 +173,14 @@ void Validate3DImageDataStructure(const DataStructure& dataStructure)
   REQUIRE(numElements.getValue(3) == 23);
   // volumes: 0.0 165.564 65.772 52.164
   const auto& volumes = dataStructure.getDataRefAs<Float32Array>(k_VolumesPath);
-  REQUIRE((volumes.getValue(1) - 165.564f) < std::numeric_limits<float32>::epsilon());
-  REQUIRE((volumes.getValue(2) - 65.772f) < std::numeric_limits<float32>::epsilon());
-  REQUIRE((volumes.getValue(3) - 52.164f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(volumes.getValue(1) - 165.564f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(volumes.getValue(2) - 65.771995f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(volumes.getValue(3) - 52.163997f) < std::numeric_limits<float32>::epsilon());
   // eqDiameters: 0.0 6.81275 5.00819 4.63579
   const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(k_EquivalentDiametersPath);
-  REQUIRE((equivalentDiameters.getValue(1) - 6.81275f) < std::numeric_limits<float32>::epsilon());
-  REQUIRE((equivalentDiameters.getValue(2) - 5.00819f) < std::numeric_limits<float32>::epsilon());
-  REQUIRE((equivalentDiameters.getValue(3) - 4.63579f) < epsilon);
+  REQUIRE(std::abs(equivalentDiameters.getValue(1) - 6.8127493f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(equivalentDiameters.getValue(2) - 5.0081901f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(equivalentDiameters.getValue(3) - 4.6357936f) < std::numeric_limits<float32>::epsilon());
 }
 
 DataStructure CreateRectGridDataStructure()
@@ -268,8 +262,6 @@ DataStructure CreateRectGridDataStructure()
 
 void ValidateRectGridDataStructure(const DataStructure& dataStructure)
 {
-  constexpr float32 epsilon = 0.00001;
-
   // Expected Outputs:
   // numElements: 0 39 15 10
   const auto& numElements = dataStructure.getDataRefAs<Int32Array>(k_NumElementsPath);
@@ -278,14 +270,14 @@ void ValidateRectGridDataStructure(const DataStructure& dataStructure)
   REQUIRE(numElements.getValue(3) == 10);
   // volumes: 0.0 2362.434 352.462 15.104
   const auto& volumes = dataStructure.getDataRefAs<Float32Array>(k_VolumesPath);
-  REQUIRE((volumes.getValue(1) - 2362.434f) < std::numeric_limits<float32>::epsilon());
-  REQUIRE((volumes.getValue(2) - 352.462f) < std::numeric_limits<float32>::epsilon());
-  REQUIRE((volumes.getValue(3) - 15.104f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(volumes.getValue(1) - 2362.43384f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(volumes.getValue(2) - 352.461884f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(volumes.getValue(3) - 15.1039925f) < std::numeric_limits<float32>::epsilon());
   // eqDiameters: 0.0 16.5242 8.76404 3.06689
   const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(k_EquivalentDiametersPath);
-  REQUIRE((equivalentDiameters.getValue(1) - 16.5242f) < std::numeric_limits<float32>::epsilon());
-  REQUIRE((equivalentDiameters.getValue(2) - 8.76404f) < epsilon);
-  REQUIRE((equivalentDiameters.getValue(3) - 3.06689f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(equivalentDiameters.getValue(1) - 16.5241966f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(equivalentDiameters.getValue(2) - 8.7640428f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE(std::abs(equivalentDiameters.getValue(3) - 3.0668866f) < std::numeric_limits<float32>::epsilon());
 }
 } // namespace Test
 

--- a/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
@@ -276,16 +276,16 @@ void ValidateRectGridDataStructure(const DataStructure& dataStructure)
   REQUIRE(numElements.getValue(1) == 39);
   REQUIRE(numElements.getValue(2) == 15);
   REQUIRE(numElements.getValue(3) == 10);
-  // volumes: 0.0 2358.834 356.062 15.104
+  // volumes: 0.0 2362.434 352.462 15.104
   const auto& volumes = dataStructure.getDataRefAs<Float32Array>(k_VolumesPath);
-  REQUIRE(volumes.getValue(1) == 2358.834f);
-  REQUIRE(volumes.getValue(2) == 356.062f);
+  REQUIRE((volumes.getValue(1) - 2362.434f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE((volumes.getValue(2) - 352.462f) < std::numeric_limits<float32>::epsilon());
   REQUIRE((volumes.getValue(3) - 15.104f) < std::numeric_limits<float32>::epsilon());
-  // eqDiameters: 0.0 16.516 8.764 3.0994
+  // eqDiameters: 0.0 16.5242 8.76404 3.06689
   const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(k_EquivalentDiametersPath);
-  REQUIRE(equivalentDiameters.getValue(1) == 16.516f);
-  REQUIRE(equivalentDiameters.getValue(2) == 8.764f);
-  REQUIRE(equivalentDiameters.getValue(3) == 3.0994f);
+  REQUIRE((equivalentDiameters.getValue(1) - 16.5242f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE((equivalentDiameters.getValue(2) - 8.76404f) < epsilon);
+  REQUIRE((equivalentDiameters.getValue(3) - 3.06689f) < std::numeric_limits<float32>::epsilon());
 }
 } // namespace Test
 

--- a/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
@@ -208,7 +208,7 @@ DataStructure CreateRectGridDataStructure()
   // yBounds -> 0.0f, 0.1f, 1.0f, 10.0f, 100.0f
   Float32Array* yBoundsArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "yBounds", ShapeType{5}, ShapeType{1}, rectGridGeom->getId());
   yBoundsArray->setValue(0, 0.0f);
-  yBoundsArray->setValue(1, 0.9f);
+  yBoundsArray->setValue(1, 0.1f);
   yBoundsArray->setValue(2, 1.0f);
   yBoundsArray->setValue(3, 10.0f);
   yBoundsArray->setValue(4, 100.0f);

--- a/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
@@ -265,6 +265,28 @@ DataStructure CreateRectGridDataStructure()
 
   return dataStructure;
 }
+
+void ValidateRectGridDataStructure(const DataStructure& dataStructure)
+{
+  constexpr float32 epsilon = 0.00001;
+
+  // Expected Outputs:
+  // numElements: 0 39 15 10
+  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(k_NumElementsPath);
+  REQUIRE(numElements.getValue(1) == 39);
+  REQUIRE(numElements.getValue(2) == 15);
+  REQUIRE(numElements.getValue(3) == 10);
+  // volumes: 0.0 2358.834 356.062 15.104
+  const auto& volumes = dataStructure.getDataRefAs<Float32Array>(k_VolumesPath);
+  REQUIRE(volumes.getValue(1) == 2358.834f);
+  REQUIRE(volumes.getValue(2) == 356.062f);
+  REQUIRE(volumes.getValue(3) == 15.104f);
+  // eqDiameters: 0.0 16.516 8.764 3.0994
+  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(k_EquivalentDiametersPath);
+  REQUIRE(equivalentDiameters.getValue(1) == 16.516f);
+  REQUIRE(equivalentDiameters.getValue(2) == 8.764f);
+  REQUIRE(equivalentDiameters.getValue(3) == 3.0994f);
+}
 } // namespace Test
 
 TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image 2D", "[SimplnxCore][ComputeFeatureSizes]")
@@ -431,21 +453,8 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Rectilinear Grid", "[Simplnx
     auto executeResult = filter.execute(dataStructure, args);
     SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
-  // numElements: 0 39 15 10
-  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(Test::k_NumElementsPath);
-  REQUIRE(numElements.getValue(1) == 39);
-  REQUIRE(numElements.getValue(2) == 15);
-  REQUIRE(numElements.getValue(3) == 10);
-  // volumes: 0.0 2358.834 356.062 15.104
-  const auto& volumes = dataStructure.getDataRefAs<Float32Array>(Test::k_VolumesPath);
-  REQUIRE(volumes.getValue(1) == 2358.834f);
-  REQUIRE(volumes.getValue(2) == 356.062f);
-  REQUIRE(volumes.getValue(3) == 15.104f);
-  // eqDiameters: 0.0 16.516 8.764 3.0994
-  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(Test::k_EquivalentDiametersPath);
-  REQUIRE(equivalentDiameters.getValue(1) == 16.516f);
-  REQUIRE(equivalentDiameters.getValue(2) == 8.764f);
-  REQUIRE(equivalentDiameters.getValue(3) == 3.0994f);
+
+  Test::ValidateRectGridDataStructure(dataStructure);
 
   // Write the DataStructure out to the file system
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT
@@ -479,21 +488,8 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Rectilinear Grid with Elemen
     auto executeResult = filter.execute(dataStructure, args);
     SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
-  // numElements: 0 39 15 10
-  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(Test::k_NumElementsPath);
-  REQUIRE(numElements.getValue(1) == 39);
-  REQUIRE(numElements.getValue(2) == 15);
-  REQUIRE(numElements.getValue(3) == 10);
-  // volumes: 0.0 2358.834 352.462 15.59
-  const auto& volumes = dataStructure.getDataRefAs<Float32Array>(Test::k_VolumesPath);
-  REQUIRE(volumes.getValue(1) == 2358.834f);
-  REQUIRE(volumes.getValue(2) == 352.462f);
-  REQUIRE(volumes.getValue(3) == 15.59f);
-  // eqDiameters: 0.0 16.516 8.764 3.0994
-  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(Test::k_EquivalentDiametersPath);
-  REQUIRE(equivalentDiameters.getValue(1) == 16.516f);
-  REQUIRE(equivalentDiameters.getValue(2) == 8.764f);
-  REQUIRE(equivalentDiameters.getValue(3) == 3.0994f);
+
+  Test::ValidateRectGridDataStructure(dataStructure);
 
   // Write the DataStructure out to the file system
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT

--- a/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
@@ -78,6 +78,31 @@ DataStructure Create2DImageDataStructure()
   return dataStructure;
 }
 
+void Validate2DImageDataStructure(const DataStructure& dataStructure)
+{
+  // Since we are using 20.2f the trash bits are one decimal place higher
+  // this means we cant use the typical 1e-6 epsilon provided by standard library
+  constexpr float32 epsilon = 0.00001;
+
+  // Expected Outputs:
+  // Single Voxel Area: 2.02
+  // numElements: 0 11 1 13
+  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(k_NumElementsPath);
+  REQUIRE(numElements.getValue(1) == 11);
+  REQUIRE(numElements.getValue(2) == 1);
+  REQUIRE(numElements.getValue(3) == 13);
+  // areas: 0.0 22.22 2.02 26.26
+  const auto& areas = dataStructure.getDataRefAs<Float32Array>(k_VolumesPath);
+  REQUIRE((areas.getValue(1) - 22.22f) < epsilon);
+  REQUIRE((areas.getValue(2) - 2.02f) < epsilon);
+  REQUIRE((areas.getValue(3) - 26.26f) < epsilon);
+  // eqDiameters: 0.0 5.319 1.603728 5.78232
+  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(k_EquivalentDiametersPath);
+  REQUIRE((equivalentDiameters.getValue(1) - 5.319f) < epsilon);
+  REQUIRE((equivalentDiameters.getValue(2) - 1.603728f) < epsilon);
+  REQUIRE((equivalentDiameters.getValue(3) - 5.78232f) < epsilon);
+}
+
 DataStructure Create3DImageDataStructure()
 {
   // Create an ImageGeom
@@ -141,6 +166,29 @@ DataStructure Create3DImageDataStructure()
   return dataStructure;
 }
 
+void Validate3DImageDataStructure(const DataStructure& dataStructure)
+{
+  constexpr float32 epsilon = 0.00001;
+
+  // Expected Outputs:
+  // Single Voxel Volume: 2.268
+  // numElements: 0 73 29 23
+  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(k_NumElementsPath);
+  REQUIRE(numElements.getValue(1) == 73);
+  REQUIRE(numElements.getValue(2) == 29);
+  REQUIRE(numElements.getValue(3) == 23);
+  // volumes: 0.0 165.564 65.772 52.164
+  const auto& volumes = dataStructure.getDataRefAs<Float32Array>(k_VolumesPath);
+  REQUIRE((volumes.getValue(1) - 165.564f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE((volumes.getValue(2) - 65.772f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE((volumes.getValue(3) - 52.164f) < std::numeric_limits<float32>::epsilon());
+  // eqDiameters: 0.0 6.81275 5.00819 4.63579
+  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(k_EquivalentDiametersPath);
+  REQUIRE((equivalentDiameters.getValue(1) - 6.81275f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE((equivalentDiameters.getValue(2) - 5.00819f) < std::numeric_limits<float32>::epsilon());
+  REQUIRE((equivalentDiameters.getValue(3) - 4.63579f) < epsilon);
+}
+
 DataStructure CreateRectGridDataStructure()
 {
   // Create an ImageGeom
@@ -166,16 +214,16 @@ DataStructure CreateRectGridDataStructure()
   yBoundsArray->setValue(4, 100.0f);
   rectGridGeom->setYBoundsId(yBoundsArray->getId());
 
-  // zBounds -> 0.0f, -1.0f, -1.2f, -2.0f, -2.1f
+  // zBounds -> 0.0f, 1.0f, 1.2f, 2.0f, 2.1f
   Float32Array* zBoundsArray = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, "zBounds", ShapeType{5}, ShapeType{1}, rectGridGeom->getId());
   zBoundsArray->setValue(0, 0.0f);
-  zBoundsArray->setValue(1, -1.0f);
-  zBoundsArray->setValue(2, -1.2f);
-  zBoundsArray->setValue(3, -2.0f);
-  zBoundsArray->setValue(4, -2.1f);
+  zBoundsArray->setValue(1, 1.0f);
+  zBoundsArray->setValue(2, 1.2f);
+  zBoundsArray->setValue(3, 2.0f);
+  zBoundsArray->setValue(4, 2.1f);
   rectGridGeom->setZBoundsId(zBoundsArray->getId());
 
-  AttributeMatrix* cellData = AttributeMatrix::Create(dataStructure, k_CellAMName, ShapeType{5, 5, 5}, rectGridGeom->getId());
+  AttributeMatrix* cellData = AttributeMatrix::Create(dataStructure, k_CellAMName, ShapeType{4, 4, 4}, rectGridGeom->getId());
   rectGridGeom->setCellData(*cellData);
 
   Int32Array* featureIds = Int32Array::CreateWithStore<Int32DataStore>(dataStructure, k_FeatureIdsName, cellData->getShape(), ShapeType{1}, cellData->getId());
@@ -185,7 +233,7 @@ DataStructure CreateRectGridDataStructure()
   // clang-format off
   // Expected Outputs:
   // numElements: 0 39 15 10
-  // volumes: 0.0 2358.834 352.462 15.59
+  // volumes: 0.0 2358.834 352.462 15.104
   // eqDiameters: 0.0 16.516 8.764 3.0994
   const std::array<uint8, 125> featureIdsArray = {
     1, 2, 2, 2,
@@ -244,23 +292,7 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image 2D", "[SimplnxCore][Co
     SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
 
-  // Expected Outputs:
-  // Single Voxel Area: 2.02
-  // numElements: 0 11 1 13
-  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(Test::k_NumElementsPath);
-  REQUIRE(numElements.getValue(1) == 11);
-  REQUIRE(numElements.getValue(2) == 1);
-  REQUIRE(numElements.getValue(3) == 13);
-  // areas: 0.0 22.22 2.02 26.26
-  const auto& areas = dataStructure.getDataRefAs<Float32Array>(Test::k_VolumesPath);
-  REQUIRE(areas.getValue(1) == 22.22f);
-  REQUIRE(areas.getValue(2) == 2.02f);
-  REQUIRE(areas.getValue(3) == 26.26f);
-  // eqDiameters: 0.0 5.319 1.6037 5.782
-  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(Test::k_EquivalentDiametersPath);
-  REQUIRE(equivalentDiameters.getValue(1) == 5.319f);
-  REQUIRE(equivalentDiameters.getValue(2) == 1.6037f);
-  REQUIRE(equivalentDiameters.getValue(3) == 5.782f);
+  Test::Validate2DImageDataStructure(dataStructure);
 
   // Write the DataStructure out to the file system
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT
@@ -295,23 +327,7 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image 2D with Element Sizes"
     SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
 
-  // Expected Outputs:
-  // Single Voxel Area: 2.02
-  // numElements: 0 11 1 13
-  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(Test::k_NumElementsPath);
-  REQUIRE(numElements.getValue(1) == 11);
-  REQUIRE(numElements.getValue(2) == 1);
-  REQUIRE(numElements.getValue(3) == 13);
-  // areas: 0.0 22.22 2.02 26.26
-  const auto& areas = dataStructure.getDataRefAs<Float32Array>(Test::k_VolumesPath);
-  REQUIRE(areas.getValue(1) == 22.22f);
-  REQUIRE(areas.getValue(2) == 2.02f);
-  REQUIRE(areas.getValue(3) == 26.26f);
-  // eqDiameters: 0.0 5.319 1.6037 5.782
-  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(Test::k_EquivalentDiametersPath);
-  REQUIRE(equivalentDiameters.getValue(1) == 5.319f);
-  REQUIRE(equivalentDiameters.getValue(2) == 1.6037f);
-  REQUIRE(equivalentDiameters.getValue(3) == 5.782f);
+  Test::Validate2DImageDataStructure(dataStructure);
 
   // Write the DataStructure out to the file system
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT
@@ -346,23 +362,7 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image Stack 3D", "[SimplnxCo
     SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
 
-  // Expected Outputs:
-  // Single Voxel Volume: 2.268
-  // numElements: 0 73 29 23
-  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(Test::k_NumElementsPath);
-  REQUIRE(numElements.getValue(1) == 73);
-  REQUIRE(numElements.getValue(2) == 29);
-  REQUIRE(numElements.getValue(3) == 23);
-  // volumes: 0.0 165.564 65.772 52.164
-  const auto& volumes = dataStructure.getDataRefAs<Float32Array>(Test::k_VolumesPath);
-  REQUIRE(volumes.getValue(1) == 165.564f);
-  REQUIRE(volumes.getValue(2) == 65.772f);
-  REQUIRE(volumes.getValue(3) == 52.164f);
-  // eqDiameters: 0.0 6.813 5.008 4.636
-  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(Test::k_EquivalentDiametersPath);
-  REQUIRE(equivalentDiameters.getValue(1) == 6.183f);
-  REQUIRE(equivalentDiameters.getValue(2) == 5.008f);
-  REQUIRE(equivalentDiameters.getValue(3) == 4.636f);
+  Test::Validate3DImageDataStructure(dataStructure);
 
   // Write the DataStructure out to the file system
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT
@@ -397,23 +397,7 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image Stack 3D with Element 
     SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
 
-  // Expected Outputs:
-  // Single Voxel Volume: 2.268
-  // numElements: 0 73 29 23
-  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(Test::k_NumElementsPath);
-  REQUIRE(numElements.getValue(1) == 73);
-  REQUIRE(numElements.getValue(2) == 29);
-  REQUIRE(numElements.getValue(3) == 23);
-  // volumes: 0.0 165.564 65.772 52.164
-  const auto& volumes = dataStructure.getDataRefAs<Float32Array>(Test::k_VolumesPath);
-  REQUIRE(volumes.getValue(1) == 165.564f);
-  REQUIRE(volumes.getValue(2) == 65.772f);
-  REQUIRE(volumes.getValue(3) == 52.164f);
-  // eqDiameters: 0.0 6.813 5.008 4.636
-  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(Test::k_EquivalentDiametersPath);
-  REQUIRE(equivalentDiameters.getValue(1) == 6.183f);
-  REQUIRE(equivalentDiameters.getValue(2) == 5.008f);
-  REQUIRE(equivalentDiameters.getValue(3) == 4.636f);
+  Test::Validate3DImageDataStructure(dataStructure);
 
   // Write the DataStructure out to the file system
 #ifdef SIMPLNX_WRITE_TEST_OUTPUT
@@ -452,11 +436,11 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Rectilinear Grid", "[Simplnx
   REQUIRE(numElements.getValue(1) == 39);
   REQUIRE(numElements.getValue(2) == 15);
   REQUIRE(numElements.getValue(3) == 10);
-  // volumes: 0.0 2358.834 352.462 15.59
+  // volumes: 0.0 2358.834 356.062 15.104
   const auto& volumes = dataStructure.getDataRefAs<Float32Array>(Test::k_VolumesPath);
   REQUIRE(volumes.getValue(1) == 2358.834f);
-  REQUIRE(volumes.getValue(2) == 352.462f);
-  REQUIRE(volumes.getValue(3) == 15.59f);
+  REQUIRE(volumes.getValue(2) == 356.062f);
+  REQUIRE(volumes.getValue(3) == 15.104f);
   // eqDiameters: 0.0 16.516 8.764 3.0994
   const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(Test::k_EquivalentDiametersPath);
   REQUIRE(equivalentDiameters.getValue(1) == 16.516f);

--- a/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeFeatureSizesTest.cpp
@@ -180,8 +180,8 @@ DataStructure CreateRectGridDataStructure()
   // clang-format off
   // Expected Outputs:
   // numElements: 0 39 15 10
-  // volumes: 0.0 0.0 0.0 0.0
-  // eqDiameters: 0.0 0.0 0.0 0.0
+  // volumes: 0.0 2358.834 352.462 15.59
+  // eqDiameters: 0.0 16.516 8.764 3.0994
   const std::array<uint8, 125> featureIdsArray = {
     1, 2, 2, 2,
     1, 1, 1, 1,
@@ -236,7 +236,7 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image 2D", "[SimplnxCore][Co
 
     // Execute the filter and check the result
     auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
 
   // Expected Outputs:
@@ -287,7 +287,7 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image 2D with Element Sizes"
 
     // Execute the filter and check the result
     auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
 
   // Expected Outputs:
@@ -338,7 +338,7 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image Stack 3D", "[SimplnxCo
 
     // Execute the filter and check the result
     auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
 
   // Expected Outputs:
@@ -389,7 +389,7 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image Stack 3D with Element 
 
     // Execute the filter and check the result
     auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
 
   // Expected Outputs:
@@ -420,17 +420,19 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Image Stack 3D with Element 
 
 TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Rectilinear Grid", "[SimplnxCore][ComputeFeatureSizes]")
 {
+  DataStructure dataStructure = Test::CreateRectGridDataStructure();
+
   {
     ComputeFeatureSizesFilter filter;
     Arguments args;
 
-    args.insert(ComputeFeatureSizesFilter::k_GeometryPath_Key, std::make_any<DataPath>(smallIn100Group));
+    args.insert(ComputeFeatureSizesFilter::k_GeometryPath_Key, std::make_any<DataPath>(Test::k_ImageGeomPath));
     args.insert(ComputeFeatureSizesFilter::k_SaveElementSizes_Key, std::make_any<bool>(false));
-    args.insert(ComputeFeatureSizesFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(featureIdsPath));
-    args.insert(ComputeFeatureSizesFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(featureGroup));
-    args.insert(ComputeFeatureSizesFilter::k_VolumesName_Key, std::make_any<std::string>(volumesName));
-    args.insert(ComputeFeatureSizesFilter::k_EquivalentDiametersName_Key, std::make_any<std::string>(EquivalentDiametersName));
-    args.insert(ComputeFeatureSizesFilter::k_NumElementsName_Key, std::make_any<std::string>(numElementsName));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(Test::k_FeatureIdsPath));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(Test::k_FeatureAMPath));
+    args.insert(ComputeFeatureSizesFilter::k_VolumesName_Key, std::make_any<std::string>(Test::k_VolumesName));
+    args.insert(ComputeFeatureSizesFilter::k_EquivalentDiametersName_Key, std::make_any<std::string>(Test::k_EquivalentDiametersName));
+    args.insert(ComputeFeatureSizesFilter::k_NumElementsName_Key, std::make_any<std::string>(Test::k_NumElementsName));
 
     // Preflight the filter and check result
     auto preflightResult = filter.preflight(dataStructure, args);
@@ -440,6 +442,76 @@ TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Rectilinear Grid", "[Simplnx
     auto executeResult = filter.execute(dataStructure, args);
     SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
   }
+  // numElements: 0 39 15 10
+  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(Test::k_NumElementsPath);
+  REQUIRE(numElements.getValue(1) == 39);
+  REQUIRE(numElements.getValue(2) == 15);
+  REQUIRE(numElements.getValue(3) == 10);
+  // volumes: 0.0 2358.834 352.462 15.59
+  const auto& volumes = dataStructure.getDataRefAs<Float32Array>(Test::k_VolumesPath);
+  REQUIRE(volumes.getValue(1) == 2358.834f);
+  REQUIRE(volumes.getValue(2) == 352.462f);
+  REQUIRE(volumes.getValue(3) == 15.59f);
+  // eqDiameters: 0.0 16.516 8.764 3.0994
+  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(Test::k_EquivalentDiametersPath);
+  REQUIRE(equivalentDiameters.getValue(1) == 16.516f);
+  REQUIRE(equivalentDiameters.getValue(2) == 8.764f);
+  REQUIRE(equivalentDiameters.getValue(3) == 3.0994f);
+
+  // Write the DataStructure out to the file system
+#ifdef SIMPLNX_WRITE_TEST_OUTPUT
+  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/valid_rect_grid.dream3d", unit_test::k_BinaryTestOutputDir)));
+#endif
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ComputeFeatureSizes: Valid: Rectilinear Grid with Element Size", "[SimplnxCore][ComputeFeatureSizes]")
+{
+  DataStructure dataStructure = Test::CreateRectGridDataStructure();
+
+  {
+    ComputeFeatureSizesFilter filter;
+    Arguments args;
+
+    args.insert(ComputeFeatureSizesFilter::k_GeometryPath_Key, std::make_any<DataPath>(Test::k_ImageGeomPath));
+    args.insert(ComputeFeatureSizesFilter::k_SaveElementSizes_Key, std::make_any<bool>(true));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(Test::k_FeatureIdsPath));
+    args.insert(ComputeFeatureSizesFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(Test::k_FeatureAMPath));
+    args.insert(ComputeFeatureSizesFilter::k_VolumesName_Key, std::make_any<std::string>(Test::k_VolumesName));
+    args.insert(ComputeFeatureSizesFilter::k_EquivalentDiametersName_Key, std::make_any<std::string>(Test::k_EquivalentDiametersName));
+    args.insert(ComputeFeatureSizesFilter::k_NumElementsName_Key, std::make_any<std::string>(Test::k_NumElementsName));
+
+    // Preflight the filter and check result
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+    // Execute the filter and check the result
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+  }
+  // numElements: 0 39 15 10
+  const auto& numElements = dataStructure.getDataRefAs<Int32Array>(Test::k_NumElementsPath);
+  REQUIRE(numElements.getValue(1) == 39);
+  REQUIRE(numElements.getValue(2) == 15);
+  REQUIRE(numElements.getValue(3) == 10);
+  // volumes: 0.0 2358.834 352.462 15.59
+  const auto& volumes = dataStructure.getDataRefAs<Float32Array>(Test::k_VolumesPath);
+  REQUIRE(volumes.getValue(1) == 2358.834f);
+  REQUIRE(volumes.getValue(2) == 352.462f);
+  REQUIRE(volumes.getValue(3) == 15.59f);
+  // eqDiameters: 0.0 16.516 8.764 3.0994
+  const auto& equivalentDiameters = dataStructure.getDataRefAs<Float32Array>(Test::k_EquivalentDiametersPath);
+  REQUIRE(equivalentDiameters.getValue(1) == 16.516f);
+  REQUIRE(equivalentDiameters.getValue(2) == 8.764f);
+  REQUIRE(equivalentDiameters.getValue(3) == 3.0994f);
+
+  // Write the DataStructure out to the file system
+#ifdef SIMPLNX_WRITE_TEST_OUTPUT
+  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/calculate_feature_sizes/valid_rect_grid_w_elemnt_sizes.dream3d", unit_test::k_BinaryTestOutputDir)));
+#endif
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
 }
 
 TEST_CASE("SimplnxCore::ComputeFeatureSizes: Invalid: Execution Failure", "[SimplnxCore][ComputeFeatureSizes]")

--- a/src/simplnx/DataStructure/Geometry/EdgeGeom.cpp
+++ b/src/simplnx/DataStructure/Geometry/EdgeGeom.cpp
@@ -4,8 +4,6 @@
 #include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/Utilities/GeometryHelpers.hpp"
 
-#include <stdexcept>
-
 using namespace nx::core;
 
 EdgeGeom::EdgeGeom(DataStructure& dataStructure, std::string name)
@@ -259,7 +257,7 @@ Result<> EdgeGeom::findElementCentroids(bool recalculate)
     {
       m_CellCentroidsDataArrayId.reset();
       // Used to be error code `-1`
-      return MakeErrorResult(-2433, fmt::format("{}({}) TetrahedralGeom::{} Error: Unable to find or create a valid element centroids array or data store.", __FILE__, __LINE__, __func__));
+      return MakeErrorResult(-2433, fmt::format("{}({}) EdgeGeom::{} Error: Unable to find or create a valid element centroids array or data store.", __FILE__, __LINE__, __func__));
     }
   }
 

--- a/src/simplnx/DataStructure/Geometry/EdgeGeom.cpp
+++ b/src/simplnx/DataStructure/Geometry/EdgeGeom.cpp
@@ -139,23 +139,26 @@ std::shared_ptr<DataObject> EdgeGeom::deepCopy(const DataPath& copyPath)
   return nullptr;
 }
 
-IGeometry::StatusCode EdgeGeom::findElementSizes(bool recalculate)
+Result<> EdgeGeom::findElementSizes(bool recalculate)
 {
   auto* sizes = getDataStructureRef().getDataAsUnsafe<Float32Array>(m_ElementSizesId);
   if(sizes != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(sizes == nullptr)
   {
     auto dataStore = std::make_unique<DataStore<float32>>(getNumberOfCells(), 0.0f);
     sizes = DataArray<float32>::Create(*getDataStructure(), k_VoxelSizes, std::move(dataStore), getId());
+    if(sizes == nullptr)
+    {
+      m_ElementSizesId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2430, fmt::format("{}({}) EdgeGeom::{} Error: Unable to find or create a valid element sizes array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(sizes == nullptr)
-  {
-    m_ElementSizesId.reset();
-    return -1;
-  }
+
   m_ElementSizesId = sizes->getId();
 
   std::array<Point3Df, 2> verts = {Point3Df(0.0f, 0.0f, 0.0f), Point3Df(0.0f, 0.0f, 0.0f)};
@@ -171,7 +174,8 @@ IGeometry::StatusCode EdgeGeom::findElementSizes(bool recalculate)
     (*sizes)[i] = std::sqrt(length);
   }
 
-  return 1;
+  // Used to be error code `1`
+  return {};
 }
 
 usize EdgeGeom::getNumberOfVerticesPerEdge() const
@@ -179,80 +183,91 @@ usize EdgeGeom::getNumberOfVerticesPerEdge() const
   return k_NumEdgeVerts;
 }
 
-IGeometry::StatusCode EdgeGeom::findElementsContainingVert(bool recalculate)
+Result<> EdgeGeom::findElementsContainingVert(bool recalculate)
 {
   auto* edgesContainingVert = getDataStructureRef().getDataAsUnsafe<ElementDynamicList>(m_CellContainingVertDataArrayId);
   if(edgesContainingVert != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(edgesContainingVert == nullptr)
   {
     edgesContainingVert = DynamicListArray<uint16, MeshIndexType>::Create(*getDataStructure(), k_EltsContainingVert, getId());
+    if(edgesContainingVert == nullptr)
+    {
+      m_CellContainingVertDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2431, fmt::format("{}({}) EdgeGeom::{} Error: Unable to find or create a valid dynamic list array.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(edgesContainingVert == nullptr)
-  {
-    m_CellContainingVertDataArrayId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Connectivity::FindElementsContainingVert<uint16, MeshIndexType>(getEdges(), edgesContainingVert, getNumberOfVertices());
   m_CellContainingVertDataArrayId = edgesContainingVert->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode EdgeGeom::findElementNeighbors(bool recalculate)
+Result<> EdgeGeom::findElementNeighbors(bool recalculate)
 {
   auto* edgeNeighbors = getDataStructureRef().getDataAsUnsafe<ElementDynamicList>(m_CellNeighborsDataArrayId);
   if(edgeNeighbors != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
 
-  StatusCode err = findElementsContainingVert(recalculate);
-  if(err < 0)
+  Result<> result = findElementsContainingVert(recalculate);
+  if(result.invalid())
   {
     m_CellNeighborsDataArrayId.reset();
-    return err;
+    return result;
   }
   if(edgeNeighbors == nullptr)
   {
     edgeNeighbors = ElementDynamicList::Create(*getDataStructure(), k_EltNeighbors, getId());
+    if(edgeNeighbors == nullptr)
+    {
+      m_CellNeighborsDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2432, fmt::format("{}({}) EdgeGeom::{} Error: Unable to find or create a dynamic list array.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(edgeNeighbors == nullptr)
-  {
-    m_CellNeighborsDataArrayId.reset();
-    return -1;
-  }
+
   m_CellNeighborsDataArrayId = edgeNeighbors->getId();
-  err = GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getEdges(), getElementsContainingVert(), edgeNeighbors, IGeometry::Type::Edge);
-  if(edgeNeighbors == nullptr)
-  {
-    m_CellNeighborsDataArrayId.reset();
-    return -1;
-  }
-  return 1;
+
+  // No error value ( < 0) returned from below function ever
+  GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getEdges(), getElementsContainingVert(), edgeNeighbors, Type::Edge);
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode EdgeGeom::findElementCentroids(bool recalculate)
+Result<> EdgeGeom::findElementCentroids(bool recalculate)
 {
   auto* edgeCentroids = getDataStructureRef().getDataAsUnsafe<Float32Array>(m_CellCentroidsDataArrayId);
   if(edgeCentroids != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(edgeCentroids == nullptr)
   {
-    auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfCells()}, std::vector<usize>{3}, 0.0f);
+    auto dataStore = std::make_unique<DataStore<float32>>(std::vector{getNumberOfCells()}, std::vector<usize>{3}, 0.0f);
     edgeCentroids = DataArray<float32>::Create(*getDataStructure(), k_EltCentroids, std::move(dataStore), getId());
+    if(edgeCentroids == nullptr)
+    {
+      m_CellCentroidsDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2433, fmt::format("{}({}) TetrahedralGeom::{} Error: Unable to find or create a valid element centroids array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(edgeCentroids == nullptr)
-  {
-    m_CellCentroidsDataArrayId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Topology::FindElementCentroids(getEdges(), getVertices(), edgeCentroids);
   m_CellCentroidsDataArrayId = edgeCentroids->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
 Point3D<float64> EdgeGeom::getParametricCenter() const

--- a/src/simplnx/DataStructure/Geometry/EdgeGeom.hpp
+++ b/src/simplnx/DataStructure/Geometry/EdgeGeom.hpp
@@ -101,28 +101,39 @@ public:
   usize getNumberOfVerticesPerEdge() const override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief calculates the sizes of each edge in the geometry
+   * and store it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when
+   * an Element Sizes Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementSizes(bool recalculate) override;
+  Result<> findElementSizes(bool recalculate) override;
 
   /**
    * @brief
-   * @return StatusCode
+   * @param recalculate This will allow for skipping execution when an
+   * `ElementDynamicList` exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementsContainingVert(bool recalculate) override;
+  Result<> findElementsContainingVert(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the neighbors of each edge in the geometry
+   * and store it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * `ElementDynamicList` exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementNeighbors(bool recalculate) override;
+  Result<> findElementNeighbors(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief calculates the centroids of each edge in the geometry
+   * and store it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an Element
+   * Centroids Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementCentroids(bool recalculate) override;
+  Result<> findElementCentroids(bool recalculate) override;
 
   /**
    * @brief

--- a/src/simplnx/DataStructure/Geometry/HexahedralGeom.cpp
+++ b/src/simplnx/DataStructure/Geometry/HexahedralGeom.cpp
@@ -265,7 +265,7 @@ Result<> HexahedralGeom::findElementNeighbors(bool recalculate)
   }
   if(hexNeighbors == nullptr)
   {
-    hexNeighbors = DynamicListArray<uint16_t, MeshIndexType>::Create(*getDataStructure(), k_EltNeighbors, getId());
+    hexNeighbors = DynamicListArray<uint16, MeshIndexType>::Create(*getDataStructure(), k_EltNeighbors, getId());
     if(hexNeighbors == nullptr)
     {
       m_CellNeighborsDataArrayId.reset();
@@ -447,7 +447,7 @@ Result<> HexahedralGeom::findUnsharedFaces(bool recalculate)
     {
       m_UnsharedFaceListId.reset();
       // Used to be error code `-1`
-      return MakeErrorResult(-2137, fmt::format("{}({}) HexahedralGeom::{} Error: Unable to find or create a valid unshared faces array or data store.", __FILE__, __LINE__, __func__));
+      return MakeErrorResult(-2537, fmt::format("{}({}) HexahedralGeom::{} Error: Unable to find or create a valid unshared faces array or data store.", __FILE__, __LINE__, __func__));
     }
   }
 

--- a/src/simplnx/DataStructure/Geometry/HexahedralGeom.cpp
+++ b/src/simplnx/DataStructure/Geometry/HexahedralGeom.cpp
@@ -196,101 +196,118 @@ usize HexahedralGeom::getNumberOfCells() const
   return elements.getNumberOfTuples();
 }
 
-IGeometry::StatusCode HexahedralGeom::findElementSizes(bool recalculate)
+Result<> HexahedralGeom::findElementSizes(bool recalculate)
 {
   auto* hexSizes = getDataStructureRef().getDataAsUnsafe<Float32Array>(m_ElementSizesId);
   if(hexSizes != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(hexSizes == nullptr)
   {
     auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfCells()}, std::vector<usize>{1}, 0.0f);
     hexSizes = DataArray<float32>::Create(*getDataStructure(), k_VoxelSizes, std::move(dataStore), getId());
+    if(hexSizes == nullptr)
+    {
+      m_ElementSizesId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2530, fmt::format("{}({}) HexahedralGeom::{} Error: Unable to find or create a valid element sizes array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(hexSizes == nullptr)
-  {
-    m_ElementSizesId.reset();
-    return -1;
-  }
+
   m_ElementSizesId = hexSizes->getId();
-  GeometryHelpers::Topology::FindHexVolumes<uint64_t>(getPolyhedra(), getVertices(), hexSizes);
-  return 1;
+  GeometryHelpers::Topology::FindHexVolumes<uint64>(getPolyhedra(), getVertices(), hexSizes);
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode HexahedralGeom::findElementsContainingVert(bool recalculate)
+Result<> HexahedralGeom::findElementsContainingVert(bool recalculate)
 {
   auto* hexasControllingVert = getDataStructureRef().getDataAsUnsafe<ElementDynamicList>(m_CellContainingVertDataArrayId);
   if(hexasControllingVert != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(hexasControllingVert == nullptr)
   {
-    hexasControllingVert = DynamicListArray<uint16_t, MeshIndexType>::Create(*getDataStructure(), k_EltsContainingVert, getId());
+    hexasControllingVert = DynamicListArray<uint16, MeshIndexType>::Create(*getDataStructure(), k_EltsContainingVert, getId());
+    if(hexasControllingVert == nullptr)
+    {
+      m_CellContainingVertDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2531, fmt::format("{}({}) HexahedralGeom::{} Error: Unable to find or create a valid dynamic list array.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(hexasControllingVert == nullptr)
-  {
-    m_CellContainingVertDataArrayId.reset();
-    return -1;
-  }
+
   m_CellContainingVertDataArrayId = hexasControllingVert->getId();
   GeometryHelpers::Connectivity::FindElementsContainingVert<uint16, MeshIndexType>(getPolyhedra(), hexasControllingVert, getNumberOfVertices());
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode HexahedralGeom::findElementNeighbors(bool recalculate)
+Result<> HexahedralGeom::findElementNeighbors(bool recalculate)
 {
   auto* hexNeighbors = getDataStructureRef().getDataAsUnsafe<ElementDynamicList>(m_CellNeighborsDataArrayId);
   if(hexNeighbors != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
 
-  StatusCode err = findElementsContainingVert(recalculate);
-  if(err < 0)
+  Result<> result = findElementsContainingVert(recalculate);
+  if(result.invalid())
   {
     m_CellNeighborsDataArrayId.reset();
-    return err;
+    return result;
   }
   if(hexNeighbors == nullptr)
   {
     hexNeighbors = DynamicListArray<uint16_t, MeshIndexType>::Create(*getDataStructure(), k_EltNeighbors, getId());
+    if(hexNeighbors == nullptr)
+    {
+      m_CellNeighborsDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2532, fmt::format("{}({}) HexahedralGeom::{} Error: Unable to find or create a dynamic list array.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(hexNeighbors == nullptr)
-  {
-    m_CellNeighborsDataArrayId.reset();
-    return -1;
-  }
+
   m_CellNeighborsDataArrayId = hexNeighbors->getId();
-  err = GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getPolyhedra(), getElementsContainingVert(), hexNeighbors, IGeometry::Type::Hexahedral);
-  if(err < 0)
-  {
-    return err;
-  }
-  return 1;
+
+  // No error value ( < 0) returned from below function ever
+  GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getPolyhedra(), getElementsContainingVert(), hexNeighbors, Type::Hexahedral);
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode HexahedralGeom::findElementCentroids(bool recalculate)
+Result<> HexahedralGeom::findElementCentroids(bool recalculate)
 {
   auto* hexCentroids = getDataStructureRef().getDataAsUnsafe<Float32Array>(m_CellCentroidsDataArrayId);
   if(hexCentroids != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(hexCentroids == nullptr)
   {
     auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfCells()}, std::vector<usize>{3}, 0.0f);
     hexCentroids = DataArray<float32>::Create(*getDataStructure(), k_EltCentroids, std::move(dataStore), getId());
+    if(hexCentroids == nullptr)
+    {
+      m_CellCentroidsDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2533, fmt::format("{}({}) HexahedralGeom::{} Error: Unable to find or create a valid element centroids array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(hexCentroids == nullptr)
-  {
-    m_CellCentroidsDataArrayId.reset();
-    return -1;
-  }
+
   m_CellCentroidsDataArrayId = hexCentroids->getId();
-  GeometryHelpers::Topology::FindElementCentroids<uint64_t>(getPolyhedra(), getVertices(), hexCentroids);
-  return 1;
+  GeometryHelpers::Topology::FindElementCentroids<uint64>(getPolyhedra(), getVertices(), hexCentroids);
+
+  // Used to be error code `1`
+  return {};
 }
 
 Point3D<float64> HexahedralGeom::getParametricCenter() const
@@ -335,88 +352,108 @@ void HexahedralGeom::getShapeFunctions(const Point3D<float64>& pCoords, float64*
   shape[23] = rm * pCoords[1];
 }
 
-IGeometry::StatusCode HexahedralGeom::findEdges(bool recalculate)
+Result<> HexahedralGeom::findEdges(bool recalculate)
 {
   auto* edgeList = getDataStructureRef().getDataAsUnsafe<DataArray<MeshIndexType>>(m_EdgeDataArrayId);
   if(edgeList != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(edgeList == nullptr)
   {
     edgeList = createSharedEdgeList(0);
+    if(edgeList == nullptr)
+    {
+      m_EdgeDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2534, fmt::format("{}({}) HexahedralGeom::{} Error: Unable to find or create a valid shared edges array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(edgeList == nullptr)
-  {
-    m_EdgeDataArrayId.reset();
-    return -1;
-  }
-  GeometryHelpers::Connectivity::FindHexEdges<uint64_t>(getPolyhedra(), edgeList);
+
+  GeometryHelpers::Connectivity::FindHexEdges<uint64>(getPolyhedra(), edgeList);
   m_EdgeDataArrayId = edgeList->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode HexahedralGeom::findFaces(bool recalculate)
+Result<> HexahedralGeom::findFaces(bool recalculate)
 {
   auto* quadList = getDataStructureRef().getDataAsUnsafe<DataArray<MeshIndexType>>(m_FaceListId);
   if(quadList != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(quadList == nullptr)
   {
     quadList = createSharedQuadList(0);
+    if(quadList == nullptr)
+    {
+      m_FaceListId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2535, fmt::format("{}({}) HexahedralGeom::{} Error: Unable to find or create a valid shared faces array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(quadList == nullptr)
-  {
-    m_FaceListId.reset();
-    return -1;
-  }
-  GeometryHelpers::Connectivity::FindHexFaces<uint64_t>(getPolyhedra(), quadList);
+
+  GeometryHelpers::Connectivity::FindHexFaces<uint64>(getPolyhedra(), quadList);
   m_FaceListId = quadList->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode HexahedralGeom::findUnsharedEdges(bool recalculate)
+Result<> HexahedralGeom::findUnsharedEdges(bool recalculate)
 {
   auto* unsharedEdgeList = getDataStructureRef().getDataAsUnsafe<DataArray<MeshIndexType>>(m_UnsharedEdgeListId);
   if(unsharedEdgeList != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(unsharedEdgeList == nullptr)
   {
     auto dataStore = std::make_unique<DataStore<MeshIndexType>>(std::vector<usize>{0}, std::vector<usize>{2}, 0);
     unsharedEdgeList = DataArray<MeshIndexType>::Create(*getDataStructure(), k_UnsharedEdgesListName, std::move(dataStore), getId());
+    if(unsharedEdgeList == nullptr)
+    {
+      m_UnsharedEdgeListId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2536, fmt::format("{}({}) HexahedralGeom::{} Error: Unable to find or create a valid unshared edges array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(unsharedEdgeList == nullptr)
-  {
-    m_UnsharedEdgeListId.reset();
-    return -1;
-  }
-  GeometryHelpers::Connectivity::FindUnsharedHexEdges<uint64_t>(getPolyhedra(), unsharedEdgeList);
+
+  GeometryHelpers::Connectivity::FindUnsharedHexEdges<uint64>(getPolyhedra(), unsharedEdgeList);
   m_UnsharedEdgeListId = unsharedEdgeList->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode HexahedralGeom::findUnsharedFaces(bool recalculate)
+Result<> HexahedralGeom::findUnsharedFaces(bool recalculate)
 {
   auto* unsharedQuadList = getDataStructureRef().getDataAsUnsafe<DataArray<MeshIndexType>>(m_UnsharedFaceListId);
   if(unsharedQuadList != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(unsharedQuadList == nullptr)
   {
     auto dataStore = std::make_unique<DataStore<MeshIndexType>>(std::vector<usize>{0}, std::vector<usize>{4}, 0);
     unsharedQuadList = DataArray<MeshIndexType>::Create(*getDataStructure(), k_UnsharedFacesListName, std::move(dataStore), getId());
+    if(unsharedQuadList == nullptr)
+    {
+      m_UnsharedFaceListId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2137, fmt::format("{}({}) HexahedralGeom::{} Error: Unable to find or create a valid unshared faces array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(unsharedQuadList == nullptr)
-  {
-    m_UnsharedFaceListId.reset();
-    return -1;
-  }
-  GeometryHelpers::Connectivity::FindUnsharedHexFaces<uint64_t>(getPolyhedra(), unsharedQuadList);
+
+  GeometryHelpers::Connectivity::FindUnsharedHexFaces<uint64>(getPolyhedra(), unsharedQuadList);
   m_UnsharedFaceListId = unsharedQuadList->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }

--- a/src/simplnx/DataStructure/Geometry/HexahedralGeom.hpp
+++ b/src/simplnx/DataStructure/Geometry/HexahedralGeom.hpp
@@ -120,27 +120,39 @@ public:
   usize getNumberOfCells() const override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief calculates the sizes of each hexahedron in the geometry
+   * and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Element Sizes Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementSizes(bool recalculate) override;
+  Result<> findElementSizes(bool recalculate) override;
 
   /**
    * @brief
-   * @return StatusCode
+   * @param recalculate This will allow for skipping execution when an
+   * `ElementDynamicList` exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementsContainingVert(bool recalculate) override;
+  Result<> findElementsContainingVert(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the neighbors of each hexahedron in the geometry
+   * and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * `ElementDynamicList` exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementNeighbors(bool recalculate) override;
+  Result<> findElementNeighbors(bool recalculate) override;
 
   /**
-   * @return StatusCode
+   * @brief calculates the centroid of each hexahedron in the geometry
+   * and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Element Centroids Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementCentroids(bool recalculate) override;
+  Result<> findElementCentroids(bool recalculate) override;
 
   /**
    * @brief
@@ -156,28 +168,40 @@ public:
   void getShapeFunctions(const Point3D<float64>& pCoords, float64* shape) const override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the shared edges (no duplicates) of each hexahedron in the
+   * geometry and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when a
+   * Shared Edge Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findEdges(bool recalculate) override;
+  Result<> findEdges(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the shared faces (no duplicates) of each hexahedron in the
+   * geometry and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when a
+   * Shared Faces Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findFaces(bool recalculate) override;
+  Result<> findFaces(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the edges (including duplicates) of each hexahedron in the
+   * geometry and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Unshared Edges Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findUnsharedEdges(bool recalculate) override;
+  Result<> findUnsharedEdges(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the faces (including duplicates) of each hexahedron in the
+   * geometry and store it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Unshared Faces Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findUnsharedFaces(bool recalculate) override;
+  Result<> findUnsharedFaces(bool recalculate) override;
 
 protected:
   /**

--- a/src/simplnx/DataStructure/Geometry/IGeometry.hpp
+++ b/src/simplnx/DataStructure/Geometry/IGeometry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "simplnx/Common/Array.hpp"
+#include "simplnx/Common/Result.hpp"
 #include "simplnx/DataStructure/BaseGroup.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataStructure.hpp"
@@ -12,8 +13,6 @@ class SIMPLNX_EXPORT IGeometry : public BaseGroup
 {
 public:
   friend class DataStructure;
-
-  using StatusCode = int32;
 
   using MeshIndexType = uint64;
   using MeshIndexArrayType = DataArray<MeshIndexType>;
@@ -107,10 +106,13 @@ public:
   virtual usize getNumberOfCells() const = 0;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief Pure-Virtual intended to calculate the sizes of each element
+   * in the geometry and store it in a new or existing array in the datastructure
+   * @param recalculate This will allow for skipping execution when an Element Sizes
+   * Array exists and recalculate is `false`
+   * @return Result<>
    */
-  virtual StatusCode findElementSizes(bool recalculate) = 0;
+  virtual Result<> findElementSizes(bool recalculate) = 0;
 
   /**
    * @brief

--- a/src/simplnx/DataStructure/Geometry/IGridGeometry.hpp
+++ b/src/simplnx/DataStructure/Geometry/IGridGeometry.hpp
@@ -12,8 +12,8 @@ namespace nx::core
 class SIMPLNX_EXPORT IGridGeometry : public IGeometry
 {
 public:
-  static inline constexpr StringLiteral k_CellAttributeMatrixName = "Cell Data";
-  static inline constexpr StringLiteral k_TypeName = "IGridGeometry";
+  static constexpr StringLiteral k_CellAttributeMatrixName = "Cell Data";
+  static constexpr StringLiteral k_TypeName = "IGridGeometry";
 
   IGridGeometry() = delete;
   IGridGeometry(const IGridGeometry&) = default;

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry0D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry0D.hpp
@@ -14,9 +14,9 @@ namespace nx::core
 class SIMPLNX_EXPORT INodeGeometry0D : public IGeometry
 {
 public:
-  static inline constexpr StringLiteral k_TypeName = "INodeGeometry0D";
-  static inline constexpr StringLiteral k_SharedVertexListName = "Shared Vertex List";
-  static inline constexpr StringLiteral k_VertexAttributeMatrixName = "Vertex Data";
+  static constexpr StringLiteral k_TypeName = "INodeGeometry0D";
+  static constexpr StringLiteral k_SharedVertexListName = "Shared Vertex List";
+  static constexpr StringLiteral k_VertexAttributeMatrixName = "Vertex Data";
 
   INodeGeometry0D() = delete;
   INodeGeometry0D(const INodeGeometry0D&) = default;
@@ -85,21 +85,21 @@ public:
   BoundingBox3Df getBoundingBox() const;
 
   /**
-   * @brief Returns whether or not this geometry is in a YZ plane.
+   * @brief Returns whether this geometry is in a YZ plane.
    * Returns empty if the vertex list does not exist.
    * @return
    */
   Result<bool> isYZPlane() const;
 
   /**
-   * @brief Returns whether or not this geometry is in a XY plane
+   * @brief Returns whether this geometry is in a XY plane
    * Returns empty if the vertex list does not exist.
    * @return
    */
   Result<bool> isXYPlane() const;
 
   /**
-   * @brief Returns whether or not this geometry is in a XZ plane
+   * @brief Returns whether this geometry is in a XZ plane
    * Returns empty if the vertex list does not exist.
    * @return
    */

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry1D.cpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry1D.cpp
@@ -233,11 +233,6 @@ std::optional<DataObject::IdType> INodeGeometry1D::getElementCentroidsId() const
   return m_CellCentroidsDataArrayId;
 }
 
-std::optional<DataObject::IdType> INodeGeometry1D::getElementSizesId() const
-{
-  return m_ElementSizesId;
-}
-
 void INodeGeometry1D::setElementContainingVertId(const std::optional<IdType>& elementsContainingVertId)
 {
   m_CellContainingVertDataArrayId = elementsContainingVertId;
@@ -251,11 +246,6 @@ void INodeGeometry1D::setElementNeighborsId(const std::optional<IdType>& element
 void INodeGeometry1D::setElementCentroidsId(const std::optional<IdType>& centroidsId)
 {
   m_CellCentroidsDataArrayId = centroidsId;
-}
-
-void INodeGeometry1D::setElementSizesId(const std::optional<IdType>& sizesId)
-{
-  m_ElementSizesId = sizesId;
 }
 
 void INodeGeometry1D::checkUpdatedIdsImpl(const std::unordered_map<DataObject::IdType, DataObject::IdType>& updatedIdsMap)

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry1D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry1D.hpp
@@ -102,8 +102,7 @@ public:
   void getEdgeCoordinates(usize edgeId, nonstd::span<Point3Df> coords) const;
 
   /**
-   * @brief Pure-Virtual intended to calculate the sizes of each element
-   * in the geometry and store it in a new or existing array in the datastructure
+   * @brief Pure-Virtual
    * @param recalculate This will allow for skipping execution when an
    * `ElementDynamicList` exists and recalculate is `false`
    * @return Result<>
@@ -122,7 +121,7 @@ public:
   void deleteElementsContainingVert();
 
   /**
-   * @brief Pure-Virtual intended to calculate the sizes of each element
+   * @brief Pure-Virtual intended to find the neighbors of each element
    * in the geometry and store it in a new or existing array in the datastructure
    * @param recalculate This will allow for skipping execution when an
    * `ElementDynamicList` exists and recalculate is `false`
@@ -215,12 +214,10 @@ public:
   std::optional<IdType> getElementContainingVertId() const;
   std::optional<IdType> getElementNeighborsId() const;
   std::optional<IdType> getElementCentroidsId() const;
-  std::optional<IdType> getElementSizesId() const;
 
   void setElementContainingVertId(const std::optional<IdType>& elementsContainingVertId);
   void setElementNeighborsId(const std::optional<IdType>& elementNeighborsId);
   void setElementCentroidsId(const std::optional<IdType>& centroidsId);
-  void setElementSizesId(const std::optional<IdType>& sizesId);
 
   /**
    * @brief validates that linkages between shared node lists and their associated Attribute Matrix is correct.

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry1D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry1D.hpp
@@ -7,15 +7,15 @@ namespace nx::core
 class SIMPLNX_EXPORT INodeGeometry1D : public INodeGeometry0D
 {
 public:
-  static inline constexpr StringLiteral k_EdgeAttributeMatrixName = "Edge Data";
-  static inline constexpr StringLiteral k_EdgeFeatureAttributeMatrix = "Edge Feature Data";
-  static inline constexpr StringLiteral k_SharedEdgeListName = "Shared Edge List";
-  static inline constexpr StringLiteral k_UnsharedEdgesListName = "Unshared Edge List";
-  static inline constexpr StringLiteral k_UnsharedFacesListName = "Unshared Face List";
+  static constexpr StringLiteral k_EdgeAttributeMatrixName = "Edge Data";
+  static constexpr StringLiteral k_EdgeFeatureAttributeMatrix = "Edge Feature Data";
+  static constexpr StringLiteral k_SharedEdgeListName = "Shared Edge List";
+  static constexpr StringLiteral k_UnsharedEdgesListName = "Unshared Edge List";
+  static constexpr StringLiteral k_UnsharedFacesListName = "Unshared Face List";
 
-  static inline constexpr StringLiteral k_TypeName = "INodeGeometry1D";
+  static constexpr StringLiteral k_TypeName = "INodeGeometry1D";
 
-  static inline constexpr usize k_NumEdgeVerts = 2;
+  static constexpr usize k_NumEdgeVerts = 2;
 
   ~INodeGeometry1D() noexcept override = default;
 
@@ -102,11 +102,13 @@ public:
   void getEdgeCoordinates(usize edgeId, nonstd::span<Point3Df> coords) const;
 
   /**
-   * @brief
-   * recalculate If true, this function will recalculate the array. Otherwise, it will leave the array as is.
-   * @return StatusCode
+   * @brief Pure-Virtual intended to calculate the sizes of each element
+   * in the geometry and store it in a new or existing array in the datastructure
+   * @param recalculate This will allow for skipping execution when an
+   * `ElementDynamicList` exists and recalculate is `false`
+   * @return Result<>
    */
-  virtual StatusCode findElementsContainingVert(bool recalculate) = 0;
+  virtual Result<> findElementsContainingVert(bool recalculate) = 0;
 
   /**
    * @brief
@@ -120,10 +122,13 @@ public:
   void deleteElementsContainingVert();
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief Pure-Virtual intended to calculate the sizes of each element
+   * in the geometry and store it in a new or existing array in the datastructure
+   * @param recalculate This will allow for skipping execution when an
+   * `ElementDynamicList` exists and recalculate is `false`
+   * @return Result<>
    */
-  virtual StatusCode findElementNeighbors(bool recalculate) = 0;
+  virtual Result<> findElementNeighbors(bool recalculate) = 0;
 
   /**
    * @brief
@@ -137,10 +142,13 @@ public:
   void deleteElementNeighbors();
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief Pure-Virtual intended to calculate the centroids of each element
+   * in the geometry and store it in a new or existing array in the datastructure
+   * @param recalculate This will allow for skipping execution when an Element Centroids
+   * Array exists and recalculate is `false`
+   * @return Result<>
    */
-  virtual StatusCode findElementCentroids(bool recalculate) = 0;
+  virtual Result<> findElementCentroids(bool recalculate) = 0;
 
   /**
    * @brief

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry2D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry2D.hpp
@@ -105,10 +105,13 @@ public:
   void getFaceCoordinates(usize faceId, nonstd::span<Point3Df> coords) const;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief Pure-Virtual intended to find the shared edges of each element
+   * in the geometry and store it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an Edge
+   * Array exists and recalculate is `false`
+   * @return Result<>
    */
-  virtual StatusCode findEdges(bool recalculate) = 0;
+  virtual Result<> findEdges(bool recalculate) = 0;
 
   /**
    * @brief Deletes the shared edge list and removes it from the DataStructure.
@@ -124,10 +127,13 @@ public:
   void setUnsharedEdgesId(const OptionalId& unsharedEdgesId);
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief Pure-Virtual intended to find the unshared edges of each element
+   * in the geometry and store it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an Unshared Edge
+   * Array exists and recalculate is `false`
+   * @return Result<>
    */
-  virtual StatusCode findUnsharedEdges(bool recalculate) = 0;
+  virtual Result<> findUnsharedEdges(bool recalculate) = 0;
 
   /**
    * @brief Returns a const pointer to the unshared edge list. Returns nullptr

--- a/src/simplnx/DataStructure/Geometry/INodeGeometry3D.hpp
+++ b/src/simplnx/DataStructure/Geometry/INodeGeometry3D.hpp
@@ -67,10 +67,13 @@ public:
   usize getNumberOfPolyhedra() const;
 
   /**
-   * @brief Creates and assigns the face list array for the current values.
-   * @return StatusCode
+   * @brief Pure-Virtual intended to find the shared faces of each element
+   * in the geometry and store it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when a Shared Face
+   * Array exists and recalculate is `false`
+   * @return Result<>
    */
-  virtual StatusCode findFaces(bool recalculate) = 0;
+  virtual Result<> findFaces(bool recalculate) = 0;
 
   /**
    * @brief Deletes the current face list array.
@@ -90,9 +93,13 @@ public:
   void setUnsharedFacedId(const OptionalId& id);
 
   /**
-   * @brief Creates and assigns the unshared face list array for the current values.
+   * @brief Pure-Virtual intended to find the unshared faces of each element
+   * in the geometry and store it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an Unshared Faces
+   * Array exists and recalculate is `false`
+   * @return Result<>
    */
-  virtual StatusCode findUnsharedFaces(bool recalculate) = 0;
+  virtual Result<> findUnsharedFaces(bool recalculate) = 0;
 
   /**
    * @brief Returns a pointer to the unshared face list array.

--- a/src/simplnx/DataStructure/Geometry/ImageGeom.cpp
+++ b/src/simplnx/DataStructure/Geometry/ImageGeom.cpp
@@ -142,38 +142,66 @@ BoundingBox<float64> ImageGeom::getBoundingBox() const
 
 usize ImageGeom::getNumberOfCells() const
 {
-  return (m_Dimensions[0] * m_Dimensions[1] * m_Dimensions[2]);
+  return m_Dimensions[0] * m_Dimensions[1] * m_Dimensions[2];
 }
 
-IGeometry::StatusCode ImageGeom::findElementSizes(bool recalculate)
+Result<> ImageGeom::findElementSizes(bool recalculate)
 {
   auto* voxelSizes = getDataStructureRef().getDataAsUnsafe<Float32Array>(m_ElementSizesId);
   if(voxelSizes != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
 
-  FloatVec3 res = getSpacing();
-
-  if(res[0] <= 0.0f || res[1] <= 0.0f || res[2] <= 0.0f)
+  if(m_Spacing[0] <= 0.0f || m_Spacing[1] <= 0.0f || m_Spacing[2] <= 0.0f)
   {
     m_ElementSizesId.reset();
-    return -1;
+    // Used to be error code `-1`
+    return MakeErrorResult(-1530, fmt::format("{}({}) ImageGeom::{} Error: Invalid spacing detected. X-Spacing: {}, Y-Spacing: {}, Z-Spacing: {}", __FILE__, __LINE__, __func__, m_Spacing[0],
+                                              m_Spacing[1], m_Spacing[2]));
   }
 
+  uint32 emptyDimsCount = 0;
+  emptyDimsCount += static_cast<int32>(m_Dimensions[0] == 1);
+  emptyDimsCount += static_cast<int32>(m_Dimensions[1] == 1);
+  emptyDimsCount += static_cast<int32>(m_Dimensions[2] == 1);
+  if(emptyDimsCount > 1)
+  {
+    return MakeErrorResult(
+        -1531, fmt::format("{}({}) ImageGeom::{} Error: Unable to calculate element sizes.\nImage have more than 2 dimensions greater than 1.\nX-Dimension: {}, Y-Dimension: {}, Z-Dimension: {}",
+                           __FILE__, __LINE__, __func__, m_Dimensions[0], m_Dimensions[1], m_Dimensions[2]));
+  }
+
+  // if x dimension has a size of 1 then xSpacing = 1; else xSpacing = spacing[0]
+  const float32 xSpacing = (m_Spacing[0] * static_cast<float32>(m_Dimensions[0] > 1ULL)) + (1.0f * static_cast<float32>(m_Dimensions[0] < 2ULL));
+  // if y dimension has a size of 1 then ySpacing = 1; else ySpacing = spacing[1]
+  const float32 ySpacing = (m_Spacing[1] * static_cast<float32>(m_Dimensions[1] > 1ULL)) + (1.0f * static_cast<float32>(m_Dimensions[1] < 2ULL));
+  // if z dimension has a size of 1 then zSpacing = 1; else zSpacing = spacing[2]
+  const float32 zSpacing = (m_Spacing[2] * static_cast<float32>(m_Dimensions[2] > 1ULL)) + (1.0f * static_cast<float32>(m_Dimensions[2] < 2ULL));
+
+  // This value will be filled with area if 2D or volume if 3D
+  const float32 singleVoxelSize = xSpacing * ySpacing * zSpacing;
+
+  // if true first instance, else recalculate
   if(voxelSizes == nullptr)
   {
-    float32 initValue = res[0] * res[1] * res[2];
-    auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfCells()}, std::vector<usize>{1}, initValue);
+    auto dataStore = std::make_unique<DataStore<float32>>(std::vector{getNumberOfCells()}, std::vector<usize>{1}, singleVoxelSize);
     voxelSizes = DataArray<float32>::Create(*getDataStructure(), k_VoxelSizes, std::move(dataStore), getId());
+    if(voxelSizes == nullptr)
+    {
+      m_ElementSizesId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-1532, fmt::format("{}({}) ImageGeom::{} Error: Unable to find or create a valid element sizes array or data store.", __FILE__, __LINE__, __func__));
+    }
+    m_ElementSizesId = voxelSizes->getId();
   }
-  if(voxelSizes == nullptr)
+  else
   {
-    m_ElementSizesId.reset();
-    return -1;
+    voxelSizes->fill(singleVoxelSize);
   }
-  m_ElementSizesId = voxelSizes->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
 Point3D<float64> ImageGeom::getParametricCenter() const

--- a/src/simplnx/DataStructure/Geometry/ImageGeom.cpp
+++ b/src/simplnx/DataStructure/Geometry/ImageGeom.cpp
@@ -167,9 +167,9 @@ Result<> ImageGeom::findElementSizes(bool recalculate)
   emptyDimsCount += static_cast<uint32>(m_Dimensions[2] == 1);
   if(emptyDimsCount > 1)
   {
-    return MakeErrorResult(
-        -1531, fmt::format("{}({}) ImageGeom::{} Error: Unable to calculate element sizes.\nImage has 2 or more dimensions equal to 1.\nX-Dimension: {}, Y-Dimension: {}, Z-Dimension: {}",
-                           __FILE__, __LINE__, __func__, m_Dimensions[0], m_Dimensions[1], m_Dimensions[2]));
+    return MakeErrorResult(-1531,
+                           fmt::format("{}({}) ImageGeom::{} Error: Unable to calculate element sizes.\nImage has 2 or more dimensions equal to 1.\nX-Dimension: {}, Y-Dimension: {}, Z-Dimension: {}",
+                                       __FILE__, __LINE__, __func__, m_Dimensions[0], m_Dimensions[1], m_Dimensions[2]));
   }
 
   // if x dimension has a size of 1 then xSpacing = 1; else xSpacing = spacing[0]

--- a/src/simplnx/DataStructure/Geometry/ImageGeom.cpp
+++ b/src/simplnx/DataStructure/Geometry/ImageGeom.cpp
@@ -162,13 +162,13 @@ Result<> ImageGeom::findElementSizes(bool recalculate)
   }
 
   uint32 emptyDimsCount = 0;
-  emptyDimsCount += static_cast<int32>(m_Dimensions[0] == 1);
-  emptyDimsCount += static_cast<int32>(m_Dimensions[1] == 1);
-  emptyDimsCount += static_cast<int32>(m_Dimensions[2] == 1);
+  emptyDimsCount += static_cast<uint32>(m_Dimensions[0] == 1);
+  emptyDimsCount += static_cast<uint32>(m_Dimensions[1] == 1);
+  emptyDimsCount += static_cast<uint32>(m_Dimensions[2] == 1);
   if(emptyDimsCount > 1)
   {
     return MakeErrorResult(
-        -1531, fmt::format("{}({}) ImageGeom::{} Error: Unable to calculate element sizes.\nImage have more than 2 dimensions greater than 1.\nX-Dimension: {}, Y-Dimension: {}, Z-Dimension: {}",
+        -1531, fmt::format("{}({}) ImageGeom::{} Error: Unable to calculate element sizes.\nImage has 2 or more dimensions equal to 1.\nX-Dimension: {}, Y-Dimension: {}, Z-Dimension: {}",
                            __FILE__, __LINE__, __func__, m_Dimensions[0], m_Dimensions[1], m_Dimensions[2]));
   }
 

--- a/src/simplnx/DataStructure/Geometry/ImageGeom.hpp
+++ b/src/simplnx/DataStructure/Geometry/ImageGeom.hpp
@@ -21,7 +21,7 @@ class SIMPLNX_EXPORT ImageGeom : public IGridGeometry
 public:
   friend class DataStructure;
 
-  static inline constexpr StringLiteral k_TypeName = "ImageGeom";
+  static constexpr StringLiteral k_TypeName = "ImageGeom";
 
   enum class ErrorType : EnumType
   {
@@ -163,10 +163,16 @@ public:
   usize getNumberOfCells() const override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief !!! NOTE: This function will return areas for "2D" and volume for "3D" !!!
+   * This function calculates the sizes of each voxel in the geometry and
+   * store it in a new or existing array in the DataStructure. This function
+   * will error out if more than two dimensions have a size of `1` aka are empty (think about
+   * a geometry XYZ 1x1x5, do you use X or Y spacing for area).
+   * @param recalculate This will allow for skipping execution when an
+   * Element Sizes Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementSizes(bool recalculate) override;
+  Result<> findElementSizes(bool recalculate) override;
 
   /**
    * @brief

--- a/src/simplnx/DataStructure/Geometry/QuadGeom.cpp
+++ b/src/simplnx/DataStructure/Geometry/QuadGeom.cpp
@@ -173,101 +173,121 @@ usize QuadGeom::getNumberOfVerticesPerFace() const
   return k_NumFaceVerts;
 }
 
-IGeometry::StatusCode QuadGeom::findElementSizes(bool recalculate)
+Result<> QuadGeom::findElementSizes(bool recalculate)
 {
   auto* quadSizes = getDataStructureRef().getDataAsUnsafe<Float32Array>(m_ElementSizesId);
   if(quadSizes != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(quadSizes == nullptr)
   {
     auto dataStore = std::make_unique<DataStore<float32>>(getNumberOfCells(), 0.0f);
     quadSizes = DataArray<float32>::Create(*getDataStructure(), k_VoxelSizes, std::move(dataStore), getId());
+
+    if(quadSizes == nullptr)
+    {
+      m_ElementSizesId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2630, fmt::format("{}({}) QuadGeom::{} Error: Unable to find or create a valid element sizes array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(quadSizes == nullptr)
-  {
-    m_ElementSizesId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Topology::Find2DElementAreas(getFaces(), getVertices(), quadSizes);
   m_ElementSizesId = quadSizes->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode QuadGeom::findElementsContainingVert(bool recalculate)
+Result<> QuadGeom::findElementsContainingVert(bool recalculate)
 {
   auto* quadsContainingVert = getDataStructureRef().getDataAsUnsafe<ElementDynamicList>(m_CellContainingVertDataArrayId);
   if(quadsContainingVert != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(quadsContainingVert == nullptr)
   {
     quadsContainingVert = DynamicListArray<uint16, MeshIndexType>::Create(*getDataStructure(), k_EltsContainingVert, getId());
+
+    if(quadsContainingVert == nullptr)
+    {
+      m_CellContainingVertDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2631, fmt::format("{}({}) QuadGeom::{} Error: Unable to find or create a valid dynamic list array.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(quadsContainingVert == nullptr)
-  {
-    m_CellContainingVertDataArrayId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Connectivity::FindElementsContainingVert<uint16, MeshIndexType>(getFaces(), quadsContainingVert, getNumberOfVertices());
   m_CellContainingVertDataArrayId = quadsContainingVert->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode QuadGeom::findElementNeighbors(bool recalculate)
+Result<> QuadGeom::findElementNeighbors(bool recalculate)
 {
   auto* quadNeighbors = getDataStructureRef().getDataAsUnsafe<ElementDynamicList>(m_CellNeighborsDataArrayId);
   if(quadNeighbors != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
 
-  StatusCode err = findElementsContainingVert(recalculate);
-  if(err < 0)
+  Result<> result = findElementsContainingVert(recalculate);
+  if(result.invalid())
   {
     m_CellNeighborsDataArrayId.reset();
-    return err;
+    return result;
   }
+
   if(quadNeighbors == nullptr)
   {
     quadNeighbors = DynamicListArray<uint16, MeshIndexType>::Create(*getDataStructure(), k_EltNeighbors, getId());
+    if(quadNeighbors == nullptr)
+    {
+      m_CellNeighborsDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2632, fmt::format("{}({}) QuadGeom::{} Error: Unable to find or create a dynamic list array.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(quadNeighbors == nullptr)
-  {
-    m_CellNeighborsDataArrayId.reset();
-    return -1;
-  }
+
   m_CellNeighborsDataArrayId = quadNeighbors->getId();
-  err = GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getFaces(), getElementsContainingVert(), quadNeighbors, IGeometry::Type::Quad);
-  if(err < 0)
-  {
-    return err;
-  }
-  return 1;
+
+  // No error value ( < 0) returned from below function ever
+  GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getFaces(), getElementsContainingVert(), quadNeighbors, Type::Quad);
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode QuadGeom::findElementCentroids(bool recalculate)
+Result<> QuadGeom::findElementCentroids(bool recalculate)
 {
   auto* quadCentroids = getDataStructureRef().getDataAsUnsafe<Float32Array>(m_CellCentroidsDataArrayId);
   if(quadCentroids != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(quadCentroids == nullptr)
   {
     auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfCells()}, std::vector<usize>{3}, 0.0f);
     quadCentroids = DataArray<float32>::Create(*getDataStructure(), k_EltCentroids, std::move(dataStore), getId());
+    if(quadCentroids == nullptr)
+    {
+      m_CellCentroidsDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2633, fmt::format("{}({}) QuadGeom::{} Error: Unable to find or create a valid element centroids array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(quadCentroids == nullptr)
-  {
-    m_CellCentroidsDataArrayId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Topology::FindElementCentroids(getFaces(), getVertices(), quadCentroids);
   m_CellCentroidsDataArrayId = quadCentroids->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
 Point3D<float64> QuadGeom::getParametricCenter() const
@@ -290,45 +310,56 @@ void QuadGeom::getShapeFunctions(const Point3D<float64>& pCoords, float64* shape
   shape[7] = rm;
 }
 
-IGeometry::StatusCode QuadGeom::findEdges(bool recalculate)
+Result<> QuadGeom::findEdges(bool recalculate)
 {
   auto* edgeList = getDataStructureRef().getDataAsUnsafe<DataArray<MeshIndexType>>(m_EdgeDataArrayId);
   if(edgeList != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(edgeList == nullptr)
   {
     edgeList = createSharedEdgeList(0);
+    if(edgeList == nullptr)
+    {
+      m_EdgeDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2634, fmt::format("{}({}) QuadGeom::{} Error: Unable to find or create a valid shared edges array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(edgeList == nullptr)
-  {
-    m_EdgeDataArrayId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Connectivity::Find2DElementEdges(getFaces(), edgeList);
   m_EdgeDataArrayId = edgeList->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode QuadGeom::findUnsharedEdges(bool recalculate)
+Result<> QuadGeom::findUnsharedEdges(bool recalculate)
 {
   auto* unsharedEdgeList = getDataStructureRef().getDataAsUnsafe<DataArray<MeshIndexType>>(m_UnsharedEdgeListId);
   if(unsharedEdgeList != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(unsharedEdgeList == nullptr)
   {
     auto dataStore = std::make_unique<DataStore<MeshIndexType>>(std::vector<usize>{0}, std::vector<usize>{2}, 0);
     unsharedEdgeList = DataArray<MeshIndexType>::Create(*getDataStructure(), k_UnsharedEdgesListName, std::move(dataStore), getId());
+
+    if(unsharedEdgeList == nullptr)
+    {
+      m_UnsharedEdgeListId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2635, fmt::format("{}({}) QuadGeom::{} Error: Unable to find or create a valid unshared edges array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(unsharedEdgeList == nullptr)
-  {
-    m_UnsharedEdgeListId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Connectivity::Find2DUnsharedEdges<MeshIndexType>(getFaces(), unsharedEdgeList);
   m_UnsharedEdgeListId = unsharedEdgeList->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }

--- a/src/simplnx/DataStructure/Geometry/QuadGeom.hpp
+++ b/src/simplnx/DataStructure/Geometry/QuadGeom.hpp
@@ -113,28 +113,39 @@ public:
   usize getNumberOfVerticesPerFace() const override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief calculates the sizes of each quad in the geometry
+   * and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Element Sizes Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementSizes(bool recalculate) override;
+  Result<> findElementSizes(bool recalculate) override;
 
   /**
    * @brief
-   * @return StatusCode
+   * @param recalculate This will allow for skipping execution when an
+   * `ElementDynamicList` exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementsContainingVert(bool recalculate) override;
+  Result<> findElementsContainingVert(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the neighbors of each quad in the geometry
+   * and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * `ElementDynamicList` exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementNeighbors(bool recalculate) override;
+  Result<> findElementNeighbors(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief calculates the centroid of each quad in the geometry
+   * and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Element Centroids Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementCentroids(bool recalculate) override;
+  Result<> findElementCentroids(bool recalculate) override;
 
   /**
    * @brief
@@ -150,16 +161,22 @@ public:
   void getShapeFunctions(const Point3D<float64>& pCoords, float64* shape) const override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the shared edges (no duplicates) of each quad in the
+   * geometry and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when a
+   * Shared Edge Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findEdges(bool recalculate) override;
+  Result<> findEdges(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the edges (including duplicates) of each quad in the
+   * geometry and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Unshared Edges Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findUnsharedEdges(bool recalculate) override;
+  Result<> findUnsharedEdges(bool recalculate) override;
 
 protected:
   /**

--- a/src/simplnx/DataStructure/Geometry/RectGridGeom.cpp
+++ b/src/simplnx/DataStructure/Geometry/RectGridGeom.cpp
@@ -304,18 +304,33 @@ usize RectGridGeom::getNumberOfCells() const
   return m_Dimensions.getX() * m_Dimensions.getY() * m_Dimensions.getZ();
 }
 
-IGeometry::StatusCode RectGridGeom::findElementSizes(bool recalculate)
+Result<> RectGridGeom::findElementSizes(bool recalculate)
 {
   auto* sizeArray = getDataStructureRef().getDataAsUnsafe<Float32Array>(m_ElementSizesId);
   if(sizeArray != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
 
-  auto sizes = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfCells()}, std::vector<usize>{1}, 0.0f);
-  auto xBnds = getXBounds();
-  auto yBnds = getYBounds();
-  auto zBnds = getZBounds();
+  auto sizes = std::make_unique<DataStore<float32>>(std::vector{getNumberOfCells()}, std::vector<usize>{1}, 0.0f);
+  const auto* xBnds = getXBounds();
+  if(xBnds == nullptr)
+  {
+    // Used to be error code `-1`
+    return MakeErrorResult(-1830, fmt::format("{}({}) RectGridGeom::{} Error: No valid X Bounds Array", __FILE__, __LINE__, __func__));
+  }
+  const auto* yBnds = getYBounds();
+  if(yBnds == nullptr)
+  {
+    // Used to be error code `-1`
+    return MakeErrorResult(-1831, fmt::format("{}({}) RectGridGeom::{} Error: No valid Y Bounds Array", __FILE__, __LINE__, __func__));
+  }
+  const auto* zBnds = getZBounds();
+  if(zBnds == nullptr)
+  {
+    // Used to be error code `-1`
+    return MakeErrorResult(-1832, fmt::format("{}({}) RectGridGeom::{} Error: No valid Z Bounds Array", __FILE__, __LINE__, __func__));
+  }
   float32 xRes = 0.0f;
   float32 yRes = 0.0f;
   float32 zRes = 0.0f;
@@ -332,25 +347,27 @@ IGeometry::StatusCode RectGridGeom::findElementSizes(bool recalculate)
         if(xRes <= 0.0f || yRes <= 0.0f || zRes <= 0.0f)
         {
           m_ElementSizesId.reset();
-          return -1;
+          // Used to be error code `-1`
+          return MakeErrorResult(
+              -1833, fmt::format("{}({}) RectGridGeom::{} Error: Found voxel with a spacing of zero or less.\nX-Index: {} | X-Spacing: {}\nY-Index: {} | Y-Spacing: {}\nZ-Index: {} | Z-Spacing: {}",
+                                 __FILE__, __LINE__, __func__, x, xRes, y, yRes, z, zRes));
         }
         (*sizes)[(m_Dimensions[0] * m_Dimensions[1] * z) + (m_Dimensions[0] * y) + x] = zRes * yRes * xRes;
       }
     }
   }
 
-  if(sizeArray == nullptr)
-  {
-    sizeArray = DataArray<float32>::Create(*getDataStructure(), k_VoxelSizes, std::move(sizes), getId());
-  }
+  sizeArray = DataArray<float32>::Create(*getDataStructure(), k_VoxelSizes, std::move(sizes), getId());
   if(sizeArray == nullptr)
   {
     m_ElementSizesId.reset();
-    return -1;
+    // Used to be error code `-1`
+    return MakeErrorResult(-1834, fmt::format("{}({}) RectGridGeom::{} Error: Unable to find or create a valid element sizes array or data store.", __FILE__, __LINE__, __func__));
   }
-
   m_ElementSizesId = sizeArray->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
 Point3D<float64> RectGridGeom::getParametricCenter() const

--- a/src/simplnx/DataStructure/Geometry/RectGridGeom.cpp
+++ b/src/simplnx/DataStructure/Geometry/RectGridGeom.cpp
@@ -312,7 +312,19 @@ Result<> RectGridGeom::findElementSizes(bool recalculate)
     return {};
   }
 
-  auto sizes = std::make_unique<DataStore<float32>>(std::vector{getNumberOfCells()}, std::vector<usize>{1}, 0.0f);
+  if(sizeArray == nullptr)
+  {
+    // If we are here we are not recalculating so create array
+    auto dataStore = std::make_unique<DataStore<float32>>(std::vector{getNumberOfCells()}, std::vector<usize>{1}, 0.0f);
+    sizeArray = DataArray<float32>::Create(*getDataStructure(), k_VoxelSizes, std::move(dataStore), getId());
+    if(sizeArray == nullptr)
+    {
+      m_ElementSizesId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-1834, fmt::format("{}({}) RectGridGeom::{} Error: Unable to find or create a valid element sizes array or data store.", __FILE__, __LINE__, __func__));
+    }
+  }
+
   const auto* xBnds = getXBounds();
   if(xBnds == nullptr)
   {
@@ -352,18 +364,11 @@ Result<> RectGridGeom::findElementSizes(bool recalculate)
               -1833, fmt::format("{}({}) RectGridGeom::{} Error: Found voxel with a spacing of zero or less.\nX-Index: {} | X-Spacing: {}\nY-Index: {} | Y-Spacing: {}\nZ-Index: {} | Z-Spacing: {}",
                                  __FILE__, __LINE__, __func__, x, xRes, y, yRes, z, zRes));
         }
-        (*sizes)[(m_Dimensions[0] * m_Dimensions[1] * z) + (m_Dimensions[0] * y) + x] = zRes * yRes * xRes;
+        sizeArray->setValue((m_Dimensions[0] * m_Dimensions[1] * z) + (m_Dimensions[0] * y) + x, zRes * yRes * xRes);
       }
     }
   }
 
-  sizeArray = DataArray<float32>::Create(*getDataStructure(), k_VoxelSizes, std::move(sizes), getId());
-  if(sizeArray == nullptr)
-  {
-    m_ElementSizesId.reset();
-    // Used to be error code `-1`
-    return MakeErrorResult(-1834, fmt::format("{}({}) RectGridGeom::{} Error: Unable to find or create a valid element sizes array or data store.", __FILE__, __LINE__, __func__));
-  }
   m_ElementSizesId = sizeArray->getId();
 
   // Used to be error code `1`

--- a/src/simplnx/DataStructure/Geometry/RectGridGeom.hpp
+++ b/src/simplnx/DataStructure/Geometry/RectGridGeom.hpp
@@ -205,10 +205,13 @@ public:
   usize getNumberOfCells() const override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief This function calculates the sizes of each voxel in the
+   * geometry and store it in a new or existing array in the datastructure
+   * @param recalculate This will allow for skipping execution when an
+   * Element Sizes Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementSizes(bool recalculate) override;
+  Result<> findElementSizes(bool recalculate) override;
 
   /**
    * @brief

--- a/src/simplnx/DataStructure/Geometry/TetrahedralGeom.cpp
+++ b/src/simplnx/DataStructure/Geometry/TetrahedralGeom.cpp
@@ -196,101 +196,120 @@ usize TetrahedralGeom::getNumberOfCells() const
   return tets.getNumberOfTuples();
 }
 
-IGeometry::StatusCode TetrahedralGeom::findElementSizes(bool recalculate)
+Result<> TetrahedralGeom::findElementSizes(bool recalculate)
 {
   auto* tetSizes = getDataStructureRef().getDataAsUnsafe<Float32Array>(m_ElementSizesId);
   if(tetSizes != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(tetSizes == nullptr)
   {
-    auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfCells()}, std::vector<usize>{1}, 0.0f);
+    auto dataStore = std::make_unique<DataStore<float32>>(std::vector{getNumberOfCells()}, std::vector<usize>{1}, 0.0f);
     tetSizes = DataArray<float32>::Create(*getDataStructure(), k_VoxelSizes, std::move(dataStore), getId());
+    if(tetSizes == nullptr)
+    {
+      m_ElementSizesId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2130, fmt::format("{}({}) TetrahedralGeom::{} Error: Unable to find or create a valid element sizes array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(tetSizes == nullptr)
-  {
-    m_ElementSizesId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Topology::FindTetVolumes(getPolyhedra(), getVertices(), tetSizes);
   m_ElementSizesId = tetSizes->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode TetrahedralGeom::findElementsContainingVert(bool recalculate)
+Result<> TetrahedralGeom::findElementsContainingVert(bool recalculate)
 {
   auto* tetsContainingVert = getDataStructureRef().getDataAsUnsafe<ElementDynamicList>(m_CellContainingVertDataArrayId);
   if(tetsContainingVert != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(tetsContainingVert == nullptr)
   {
     tetsContainingVert = DynamicListArray<uint16, MeshIndexType>::Create(*getDataStructure(), k_EltsContainingVert, getId());
+    if(tetsContainingVert == nullptr)
+    {
+      m_CellContainingVertDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2131, fmt::format("{}({}) TetrahedralGeom::{} Error: Unable to find or create a valid dynamic list array.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(tetsContainingVert == nullptr)
-  {
-    m_CellContainingVertDataArrayId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Connectivity::FindElementsContainingVert<uint16, MeshIndexType>(getPolyhedra(), tetsContainingVert, getNumberOfVertices());
   m_CellContainingVertDataArrayId = tetsContainingVert->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode TetrahedralGeom::findElementNeighbors(bool recalculate)
+Result<> TetrahedralGeom::findElementNeighbors(bool recalculate)
 {
   auto* tetNeighbors = getDataStructureRef().getDataAsUnsafe<ElementDynamicList>(m_CellNeighborsDataArrayId);
   if(tetNeighbors != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
 
-  StatusCode err = findElementsContainingVert(recalculate);
-  if(err < 0)
+  Result<> result = findElementsContainingVert(recalculate);
+  if(result.invalid())
   {
     m_CellNeighborsDataArrayId.reset();
-    return err;
+    return result;
   }
+
   if(tetNeighbors == nullptr)
   {
     tetNeighbors = DynamicListArray<uint16, MeshIndexType>::Create(*getDataStructure(), k_EltNeighbors, getId());
+    if(tetNeighbors == nullptr)
+    {
+      m_CellNeighborsDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2132, fmt::format("{}({}) TetrahedralGeom::{} Error: Unable to find or create a dynamic list array.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(tetNeighbors == nullptr)
-  {
-    m_CellNeighborsDataArrayId.reset();
-    return -1;
-  }
+
   m_CellNeighborsDataArrayId = tetNeighbors->getId();
-  err = GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getPolyhedra(), getElementsContainingVert(), tetNeighbors, IGeometry::Type::Tetrahedral);
-  if(err < 0)
-  {
-    return err;
-  }
-  return 1;
+
+  // No error value ( < 0) returned from below function ever
+  GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getPolyhedra(), getElementsContainingVert(), tetNeighbors, Type::Tetrahedral);
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode TetrahedralGeom::findElementCentroids(bool recalculate)
+Result<> TetrahedralGeom::findElementCentroids(bool recalculate)
 {
   auto* tetCentroids = getDataStructureRef().getDataAsUnsafe<Float32Array>(m_CellCentroidsDataArrayId);
   if(tetCentroids != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(tetCentroids == nullptr)
   {
-    auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfCells()}, std::vector<usize>{3}, 0.0f);
+    auto dataStore = std::make_unique<DataStore<float32>>(std::vector{getNumberOfCells()}, std::vector<usize>{3}, 0.0f);
     tetCentroids = DataArray<float32>::Create(*getDataStructure(), k_EltCentroids, std::move(dataStore), getId());
+
+    if(tetCentroids == nullptr)
+    {
+      m_CellCentroidsDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2133, fmt::format("{}({}) TetrahedralGeom::{} Error: Unable to find or create a valid element centroids array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(tetCentroids == nullptr)
-  {
-    m_CellCentroidsDataArrayId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Topology::FindElementCentroids(getPolyhedra(), getVertices(), tetCentroids);
   m_CellCentroidsDataArrayId = tetCentroids->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
 Point3D<float64> TetrahedralGeom::getParametricCenter() const
@@ -319,88 +338,108 @@ void TetrahedralGeom::getShapeFunctions([[maybe_unused]] const Point3D<float64>&
   shape[11] = 1.0;
 }
 
-IGeometry::StatusCode TetrahedralGeom::findEdges(bool recalculate)
+Result<> TetrahedralGeom::findEdges(bool recalculate)
 {
   auto* edgeList = getDataStructureRef().getDataAsUnsafe<DataArray<MeshIndexType>>(m_EdgeDataArrayId);
   if(edgeList != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(edgeList == nullptr)
   {
     edgeList = createSharedEdgeList(0);
+    if(edgeList == nullptr)
+    {
+      m_EdgeDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2134, fmt::format("{}({}) TetrahedralGeom::{} Error: Unable to find or create a valid shared edges array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(edgeList == nullptr)
-  {
-    m_EdgeDataArrayId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Connectivity::FindTetEdges(getPolyhedra(), edgeList);
   m_EdgeDataArrayId = edgeList->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode TetrahedralGeom::findFaces(bool recalculate)
+Result<> TetrahedralGeom::findFaces(bool recalculate)
 {
   auto* triList = getDataStructureRef().getDataAsUnsafe<DataArray<MeshIndexType>>(m_FaceListId);
   if(triList != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(triList == nullptr)
   {
     triList = createSharedTriList(0);
+    if(triList == nullptr)
+    {
+      m_FaceListId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2135, fmt::format("{}({}) TetrahedralGeom::{} Error: Unable to find or create a valid shared faces array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(triList == nullptr)
-  {
-    m_FaceListId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Connectivity::FindTetFaces(getPolyhedra(), triList);
   m_FaceListId = triList->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode TetrahedralGeom::findUnsharedEdges(bool recalculate)
+Result<> TetrahedralGeom::findUnsharedEdges(bool recalculate)
 {
   auto* unsharedEdgeList = getDataStructureRef().getDataAsUnsafe<DataArray<MeshIndexType>>(m_UnsharedEdgeListId);
   if(unsharedEdgeList != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(unsharedEdgeList == nullptr)
   {
     auto dataStore = std::make_unique<DataStore<MeshIndexType>>(std::vector<usize>{0}, std::vector<usize>{2}, 0);
     unsharedEdgeList = DataArray<MeshIndexType>::Create(*getDataStructure(), k_UnsharedEdgesListName, std::move(dataStore), getId());
+    if(unsharedEdgeList == nullptr)
+    {
+      m_UnsharedEdgeListId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2136, fmt::format("{}({}) TetrahedralGeom::{} Error: Unable to find or create a valid unshared edges array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(unsharedEdgeList == nullptr)
-  {
-    m_UnsharedEdgeListId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Connectivity::FindUnsharedTetEdges<MeshIndexType>(getPolyhedra(), unsharedEdgeList);
   m_UnsharedEdgeListId = unsharedEdgeList->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode TetrahedralGeom::findUnsharedFaces(bool recalculate)
+Result<> TetrahedralGeom::findUnsharedFaces(bool recalculate)
 {
   auto* unsharedTriList = getDataStructureRef().getDataAsUnsafe<DataArray<MeshIndexType>>(m_UnsharedFaceListId);
   if(unsharedTriList != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(unsharedTriList == nullptr)
   {
     auto dataStore = std::make_unique<DataStore<MeshIndexType>>(std::vector<usize>{0}, std::vector<usize>{3}, 0);
     unsharedTriList = DataArray<MeshIndexType>::Create(*getDataStructure(), k_UnsharedFacesListName, std::move(dataStore), getId());
+    if(unsharedTriList == nullptr)
+    {
+      m_UnsharedFaceListId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2137, fmt::format("{}({}) TetrahedralGeom::{} Error: Unable to find or create a valid unshared faces array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(unsharedTriList == nullptr)
-  {
-    m_UnsharedFaceListId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Connectivity::FindUnsharedTetFaces<MeshIndexType>(getPolyhedra(), unsharedTriList);
   m_UnsharedFaceListId = unsharedTriList->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }

--- a/src/simplnx/DataStructure/Geometry/TetrahedralGeom.hpp
+++ b/src/simplnx/DataStructure/Geometry/TetrahedralGeom.hpp
@@ -120,28 +120,39 @@ public:
   usize getNumberOfCells() const override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief calculates the sizes of each tetrahedron in the geometry
+   * and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Element Sizes Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementSizes(bool recalculate) override;
+  Result<> findElementSizes(bool recalculate) override;
 
   /**
    * @brief
-   * @return StatusCode
+   * @param recalculate This will allow for skipping execution when an
+   * `ElementDynamicList` exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementsContainingVert(bool recalculate) override;
+  Result<> findElementsContainingVert(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the neighbors of each tetrahedron in the geometry
+   * and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * `ElementDynamicList` exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementNeighbors(bool recalculate) override;
+  Result<> findElementNeighbors(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief calculates the centroid of each tetrahedron in the geometry
+   * and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Element Centroids Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementCentroids(bool recalculate) override;
+  Result<> findElementCentroids(bool recalculate) override;
 
   /**
    * @brief
@@ -157,28 +168,40 @@ public:
   void getShapeFunctions(const Point3D<float64>& pCoords, float64* shape) const override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the shared edges (no duplicates) of each tetrahedron in the
+   * geometry and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when a
+   * Shared Edge Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findEdges(bool recalculate) override;
+  Result<> findEdges(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the shared faces (no duplicates) of each tetrahedron in the
+   * geometry and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when a
+   * Shared Faces Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findFaces(bool recalculate) override;
+  Result<> findFaces(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the edges (including duplicates) of each tetrahedron in the
+   * geometry and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Unshared Edges Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findUnsharedEdges(bool recalculate) override;
+  Result<> findUnsharedEdges(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the faces (including duplicates) of each tetrahedron in the
+   * geometry and store it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Unshared Faces Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findUnsharedFaces(bool recalculate) override;
+  Result<> findUnsharedFaces(bool recalculate) override;
 
 protected:
   /**

--- a/src/simplnx/DataStructure/Geometry/TriangleGeom.cpp
+++ b/src/simplnx/DataStructure/Geometry/TriangleGeom.cpp
@@ -174,104 +174,121 @@ usize TriangleGeom::getNumberOfVerticesPerFace() const
   return k_NumFaceVerts;
 }
 
-IGeometry::StatusCode TriangleGeom::findElementSizes(bool recalculate)
+Result<> TriangleGeom::findElementSizes(bool recalculate)
 {
   auto* triangleSizes = getDataStructureRef().getDataAsUnsafe<Float32Array>(m_ElementSizesId);
   if(triangleSizes != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(triangleSizes == nullptr)
   {
-    auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfFaces()}, std::vector<usize>{1}, 0.0f);
+    auto dataStore = std::make_unique<DataStore<float32>>(std::vector{getNumberOfFaces()}, std::vector<usize>{1}, 0.0f);
     triangleSizes = DataArray<float32>::Create(*getDataStructure(), k_VoxelSizes, std::move(dataStore), getId());
+    if(triangleSizes == nullptr)
+    {
+      m_ElementSizesId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2230, fmt::format("{}({}) TriangleGeom::{} Error: Unable to find or create a valid element sizes array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(triangleSizes == nullptr)
-  {
-    m_ElementSizesId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Topology::Find2DElementAreas(getFaces(), getVertices(), triangleSizes);
   m_ElementSizesId = triangleSizes->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode TriangleGeom::findElementsContainingVert(bool recalculate)
+Result<> TriangleGeom::findElementsContainingVert(bool recalculate)
 {
   auto* trianglesContainingVert = getDataStructureRef().getDataAsUnsafe<ElementDynamicList>(m_CellContainingVertDataArrayId);
   if(trianglesContainingVert != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(trianglesContainingVert == nullptr)
   {
     trianglesContainingVert = DynamicListArray<uint16, MeshIndexType>::Create(*getDataStructure(), k_EltsContainingVert, getId());
+    if(trianglesContainingVert == nullptr)
+    {
+      m_CellContainingVertDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2231, fmt::format("{}({}) TriangleGeom::{} Error: Unable to find or create a valid dynamic list array.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(trianglesContainingVert == nullptr)
-  {
-    m_CellContainingVertDataArrayId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Connectivity::FindElementsContainingVert<uint16, MeshIndexType>(getFaces(), trianglesContainingVert, getNumberOfVertices());
   m_CellContainingVertDataArrayId = trianglesContainingVert->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode TriangleGeom::findElementNeighbors(bool recalculate)
+Result<> TriangleGeom::findElementNeighbors(bool recalculate)
 {
   auto* triangleNeighbors = getDataStructureRef().getDataAsUnsafe<ElementDynamicList>(m_CellNeighborsDataArrayId);
   if(triangleNeighbors != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
 
-  StatusCode err = findElementsContainingVert(recalculate);
-  if(err < 0)
+  Result<> result = findElementsContainingVert(recalculate);
+  if(result.invalid())
   {
     m_CellNeighborsDataArrayId.reset();
-    return err;
+    return result;
   }
   if(triangleNeighbors == nullptr)
   {
     triangleNeighbors = ElementDynamicList::Create(*getDataStructure(), k_EltNeighbors, getId());
+    if(triangleNeighbors == nullptr)
+    {
+      m_CellNeighborsDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2232, fmt::format("{}({}) TriangleGeom::{} Error: Unable to find or create a dynamic list array.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(triangleNeighbors == nullptr)
-  {
-    m_CellNeighborsDataArrayId.reset();
-    return -1;
-  }
+
   m_CellNeighborsDataArrayId = triangleNeighbors->getId();
-  err = GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getFaces(), getElementsContainingVert(), triangleNeighbors, IGeometry::Type::Triangle);
-  if(err < 0)
-  {
-    return err;
-  }
-  return 1;
+
+  // No error value ( < 0) returned from below function ever
+  GeometryHelpers::Connectivity::FindElementNeighbors<uint16, MeshIndexType>(getFaces(), getElementsContainingVert(), triangleNeighbors, Type::Triangle);
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode TriangleGeom::findElementCentroids(bool recalculate)
+Result<> TriangleGeom::findElementCentroids(bool recalculate)
 {
   auto* triangleCentroids = getDataStructureRef().getDataAsUnsafe<Float32Array>(m_CellCentroidsDataArrayId);
   if(triangleCentroids != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(triangleCentroids == nullptr)
   {
-    auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfFaces()}, std::vector<usize>{3}, 0.0f);
+    auto dataStore = std::make_unique<DataStore<float32>>(std::vector{getNumberOfFaces()}, std::vector<usize>{3}, 0.0f);
     triangleCentroids = DataArray<float32>::Create(*getDataStructure(), k_EltCentroids, std::move(dataStore), getId());
   }
   if(triangleCentroids == nullptr)
   {
     m_CellCentroidsDataArrayId.reset();
-    return -1;
+    // Used to be error code `-1`
+    return MakeErrorResult(-2233, fmt::format("{}({}) TriangleGeom::{} Error: Unable to find or create a valid element centroids array or data store.", __FILE__, __LINE__, __func__));
   }
+
   GeometryHelpers::Topology::FindElementCentroids(getFaces(), getVertices(), triangleCentroids);
   m_CellCentroidsDataArrayId = triangleCentroids->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-::Point3D<float64> TriangleGeom::getParametricCenter() const
+Point3D<float64> TriangleGeom::getParametricCenter() const
 {
   return {1.0 / 3.0, 1.0 / 3.0, 0.0};
 }
@@ -289,35 +306,41 @@ void TriangleGeom::getShapeFunctions([[maybe_unused]] const Point3D<float64>& pC
   shape[5] = 1.0;
 }
 
-IGeometry::StatusCode TriangleGeom::findEdges(bool recalculate)
+Result<> TriangleGeom::findEdges(bool recalculate)
 {
   auto* edgeList = getDataStructureRef().getDataAsUnsafe<UInt64Array>(m_EdgeDataArrayId);
   if(edgeList != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(edgeList == nullptr)
   {
     auto dataStore = std::make_unique<DataStore<uint64>>(std::vector<usize>{0}, std::vector<usize>{2}, 0);
     edgeList = DataArray<uint64>::Create(*getDataStructure(), k_SharedEdgeListName, std::move(dataStore), getId());
+    if(edgeList == nullptr)
+    {
+      m_EdgeDataArrayId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2234, fmt::format("{}({}) TriangleGeom::{} Error: Unable to find or create a valid shared edges array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(edgeList == nullptr)
-  {
-    m_EdgeDataArrayId.reset();
-    return -1;
-  }
+
   GeometryHelpers::Connectivity::Find2DElementEdges(getFaces(), edgeList);
   m_EdgeDataArrayId = edgeList->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
-IGeometry::StatusCode TriangleGeom::findUnsharedEdges(bool recalculate)
+Result<> TriangleGeom::findUnsharedEdges(bool recalculate)
 {
   auto* unsharedEdgeList = getDataStructureRef().getDataAsUnsafe<DataArray<MeshIndexType>>(m_UnsharedEdgeListId);
   if(unsharedEdgeList != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   if(unsharedEdgeList == nullptr)
   {
     auto dataStore = std::make_unique<DataStore<MeshIndexType>>(std::vector<usize>{0}, std::vector<usize>{2}, 0);
@@ -326,9 +349,12 @@ IGeometry::StatusCode TriangleGeom::findUnsharedEdges(bool recalculate)
   if(unsharedEdgeList == nullptr)
   {
     m_UnsharedEdgeListId.reset();
-    return -1;
+    // Used to be error code `-1`
+    return MakeErrorResult(-2235, fmt::format("{}({}) TriangleGeom::{} Error: Unable to find or create a valid unshared edges array or data store.", __FILE__, __LINE__, __func__));
   }
+
   GeometryHelpers::Connectivity::Find2DUnsharedEdges(getFaces(), unsharedEdgeList);
   m_UnsharedEdgeListId = unsharedEdgeList->getId();
-  return 1;
+
+  return {};
 }

--- a/src/simplnx/DataStructure/Geometry/TriangleGeom.hpp
+++ b/src/simplnx/DataStructure/Geometry/TriangleGeom.hpp
@@ -116,27 +116,39 @@ public:
   usize getNumberOfVerticesPerFace() const override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief calculates the sizes of each triangle in the geometry
+   * and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Element Sizes Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementSizes(bool recalculate) override;
+  Result<> findElementSizes(bool recalculate) override;
 
   /**
    * @brief
-   * @return StatusCode
+   * @param recalculate This will allow for skipping execution when an
+   * `ElementDynamicList` exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementsContainingVert(bool recalculate) override;
+  Result<> findElementsContainingVert(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the neighbors of each triangle in the geometry
+   * and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * `ElementDynamicList` exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementNeighbors(bool recalculate) override;
+  Result<> findElementNeighbors(bool recalculate) override;
+
   /**
-   * @brief
-   * @return StatusCode
+   * @brief calculates the centroid of each triangle in the geometry
+   * and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Element Centroids Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementCentroids(bool recalculate) override;
+  Result<> findElementCentroids(bool recalculate) override;
 
   /**
    * @brief
@@ -153,16 +165,22 @@ public:
   void getShapeFunctions(const Point3D<float64>& pCoords, float64* shape) const override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the shared edges (no duplicates) of each triangle in the
+   * geometry and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when a
+   * Shared Edge Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findEdges(bool recalculate) override;
+  Result<> findEdges(bool recalculate) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief finds the edges (including duplicates) of each triangle in the
+   * geometry and stores it in a new or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Unshared Edges Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findUnsharedEdges(bool recalculate) override;
+  Result<> findUnsharedEdges(bool recalculate) override;
 
 protected:
   /**

--- a/src/simplnx/DataStructure/Geometry/VertexGeom.cpp
+++ b/src/simplnx/DataStructure/Geometry/VertexGeom.cpp
@@ -112,27 +112,32 @@ std::shared_ptr<DataObject> VertexGeom::deepCopy(const DataPath& copyPath)
   return nullptr;
 }
 
-IGeometry::StatusCode VertexGeom::findElementSizes(bool recalculate)
+Result<> VertexGeom::findElementSizes(bool recalculate)
 {
   auto* vertexSizes = getDataStructureRef().getDataAsUnsafe<Float32Array>(m_ElementSizesId);
   if(vertexSizes != nullptr && !recalculate)
   {
-    return 0;
+    return {};
   }
+
   // Vertices are 0-dimensional (they have no getSize),
   // so simply splat 0 over the sizes array
   if(vertexSizes == nullptr)
   {
     auto dataStore = std::make_unique<DataStore<float32>>(std::vector<usize>{getNumberOfCells()}, std::vector<usize>{1}, 0.0f);
     vertexSizes = DataArray<float32>::Create(getDataStructureRef(), k_VoxelSizes, std::move(dataStore), getId());
+    if(vertexSizes == nullptr)
+    {
+      m_ElementSizesId.reset();
+      // Used to be error code `-1`
+      return MakeErrorResult(-2730, fmt::format("{}({}) VertexGeom::{} Error: Unable to find or create a valid element sizes array or data store.", __FILE__, __LINE__, __func__));
+    }
   }
-  if(vertexSizes == nullptr)
-  {
-    m_ElementSizesId.reset();
-    return -1;
-  }
+
   m_ElementSizesId = vertexSizes->getId();
-  return 1;
+
+  // Used to be error code `1`
+  return {};
 }
 
 Point3D<float64> VertexGeom::getParametricCenter() const

--- a/src/simplnx/DataStructure/Geometry/VertexGeom.hpp
+++ b/src/simplnx/DataStructure/Geometry/VertexGeom.hpp
@@ -91,10 +91,13 @@ public:
   std::shared_ptr<DataObject> deepCopy(const DataPath& copyPath) override;
 
   /**
-   * @brief
-   * @return StatusCode
+   * @brief Points have no space, so this function stores `0`s in a new
+   * or existing array in the DataStructure
+   * @param recalculate This will allow for skipping execution when an
+   * Element Sizes Array exists and recalculate is `false`
+   * @return Result<>
    */
-  StatusCode findElementSizes(bool recalculate) override;
+  Result<> findElementSizes(bool recalculate) override;
 
   /**
    * @brief

--- a/test/DataStructTest.cpp
+++ b/test/DataStructTest.cpp
@@ -1396,12 +1396,12 @@ TEST_CASE("NodeBasedGeometryFindElementsTest")
     const DataPath srcImageGeoPath({Constants::k_ImageGeometry});
     auto* geom = dataStruct.getDataAs<ImageGeom>(srcImageGeoPath);
 
-    IGeometry::StatusCode status = geom->findElementSizes(false);
-    REQUIRE(status == 1);
+    Result<> status = geom->findElementSizes(false);
+    REQUIRE(status.valid());
     status = geom->findElementSizes(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementSizes(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
   }
 
   SECTION("Rectilinear Grid Geometry")
@@ -1409,10 +1409,10 @@ TEST_CASE("NodeBasedGeometryFindElementsTest")
     const DataPath srcRectGeoPath({k_RectGridGeo});
     auto* geom = dataStruct.getDataAs<RectGridGeom>(srcRectGeoPath);
 
-    IGeometry::StatusCode status = geom->findElementSizes(false);
-    REQUIRE(status == 0);
+    Result<> status = geom->findElementSizes(false);
+    REQUIRE(status.valid());
     status = geom->findElementSizes(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
   }
 
   SECTION("Vertex Geometry")
@@ -1420,10 +1420,10 @@ TEST_CASE("NodeBasedGeometryFindElementsTest")
     const DataPath srcGeoPath({Constants::k_VertexGeometry});
     auto* geom = dataStruct.getDataAs<VertexGeom>(srcGeoPath);
 
-    IGeometry::StatusCode status = geom->findElementSizes(false);
-    REQUIRE(status == 0);
+    Result<> status = geom->findElementSizes(false);
+    REQUIRE(status.valid());
     status = geom->findElementSizes(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
   }
 
   SECTION("Edge Geometry")
@@ -1431,25 +1431,25 @@ TEST_CASE("NodeBasedGeometryFindElementsTest")
     const DataPath srcGeoPath({k_EdgeGeo});
     auto* geom = dataStruct.getDataAs<EdgeGeom>(srcGeoPath);
 
-    IGeometry::StatusCode status = geom->findElementSizes(false);
-    REQUIRE(status == 0);
+    Result<> status = geom->findElementSizes(false);
+    REQUIRE(status.valid());
     status = geom->findElementSizes(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementsContainingVert(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementsContainingVert(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementNeighbors(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementNeighbors(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementCentroids(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementCentroids(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
   }
 
   SECTION("Triangle Geometry")
@@ -1457,37 +1457,37 @@ TEST_CASE("NodeBasedGeometryFindElementsTest")
     const DataPath srcGeoPath({Constants::k_TriangleGeometryName});
     auto* geom = dataStruct.getDataAs<TriangleGeom>(srcGeoPath);
 
-    IGeometry::StatusCode status = geom->findElementSizes(false);
-    REQUIRE(status == 1);
+    Result<> status = geom->findElementSizes(false);
+    REQUIRE(status.valid());
     status = geom->findElementSizes(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementSizes(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementsContainingVert(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementsContainingVert(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementNeighbors(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementNeighbors(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementCentroids(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementCentroids(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findEdges(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findEdges(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findUnsharedEdges(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findUnsharedEdges(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
   }
 
   SECTION("Quad Geometry")
@@ -1495,37 +1495,37 @@ TEST_CASE("NodeBasedGeometryFindElementsTest")
     const DataPath srcGeoPath({k_QuadGeo});
     auto* geom = dataStruct.getDataAs<QuadGeom>(srcGeoPath);
 
-    IGeometry::StatusCode status = geom->findElementSizes(false);
-    REQUIRE(status == 1);
+    Result<> status = geom->findElementSizes(false);
+    REQUIRE(status.valid());
     status = geom->findElementSizes(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementSizes(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementsContainingVert(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementsContainingVert(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementNeighbors(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementNeighbors(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementCentroids(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementCentroids(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findEdges(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findEdges(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findUnsharedEdges(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findUnsharedEdges(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
   }
 
   SECTION("Tetrahedral Geometry")
@@ -1533,45 +1533,45 @@ TEST_CASE("NodeBasedGeometryFindElementsTest")
     const DataPath srcGeoPath({k_TetGeo});
     auto* geom = dataStruct.getDataAs<TetrahedralGeom>(srcGeoPath);
 
-    IGeometry::StatusCode status = geom->findElementSizes(false);
-    REQUIRE(status == 0);
+    Result<> status = geom->findElementSizes(false);
+    REQUIRE(status.valid());
     status = geom->findElementSizes(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementsContainingVert(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementsContainingVert(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementNeighbors(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementNeighbors(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementCentroids(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementCentroids(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findEdges(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findEdges(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findUnsharedEdges(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findUnsharedEdges(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findFaces(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findFaces(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findUnsharedFaces(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findUnsharedFaces(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
   }
 
   SECTION("Hexahedral Geometry")
@@ -1579,45 +1579,45 @@ TEST_CASE("NodeBasedGeometryFindElementsTest")
     const DataPath srcGeoPath({k_HexGeo});
     auto* geom = dataStruct.getDataAs<HexahedralGeom>(srcGeoPath);
 
-    IGeometry::StatusCode status = geom->findElementSizes(false);
-    REQUIRE(status == 0);
+    Result<> status = geom->findElementSizes(false);
+    REQUIRE(status.valid());
     status = geom->findElementSizes(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementsContainingVert(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementsContainingVert(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementNeighbors(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementNeighbors(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findElementCentroids(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findElementCentroids(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findEdges(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findEdges(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findUnsharedEdges(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findUnsharedEdges(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findFaces(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findFaces(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
 
     status = geom->findUnsharedFaces(false);
-    REQUIRE(status == 0);
+    REQUIRE(status.valid());
     status = geom->findUnsharedFaces(true);
-    REQUIRE(status == 1);
+    REQUIRE(status.valid());
   }
 }
 


### PR DESCRIPTION
- Enabled RectGrid in the Filter
- Updated Geometries to use Result<> instead of status code
- Fixed findElementSizes() bugs in `ImageGeom` and `RectGridGeom`
- Move to Kahan Summation for less variance in RectGeom volume calculation
- Documentation of `ImageGeom` behavior 2D/3D
- Cleaned up redefinition functions for INodeGeom1D
- New test cases
- Extensive Refactoring 
- Logic Cleanup
- Space and Branch Cutting Optimizations
- Restricted Input Typing in Algorithm
- Help text cleanup
- New Preflight Checks
- Extensive Code Documentation
- progress feedback
- cancel checks