### PR TITLE
PERF: Speed up InterpolatePointCloudToRegularGrid filter

### DIFF
--- a/src/Plugins/SimplnxCore/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/CMakeLists.txt
@@ -254,6 +254,7 @@ set(AlgorithmList
   InitializeImageGeomCellData
   InterpolatePointCloudToRegularGrid
   IterativeClosestPoint
+  InterpolatePointCloudToRegularGrid
   LabelTriangleGeometry
   LaplacianSmoothing
   MapPointCloudToRegularGrid

--- a/src/Plugins/SimplnxCore/docs/InterpolatePointCloudToRegularGridFilter.md
+++ b/src/Plugins/SimplnxCore/docs/InterpolatePointCloudToRegularGridFilter.md
@@ -23,7 +23,7 @@ The interpolation proceeds in two passes:
 
 **Pass 1 – Accumulation (one iteration over all vertices):**
 
-1. For each vertex in the **Vertex Geometry**, look up the destination voxel from the pre-computed *Voxel Indices* array.
+1. For each vertex in the **Vertex Geometry**, compute the destination voxel index from the vertex coordinates and the **Image Geometry**'s origin, spacing, and dimensions. Vertices that fall outside the grid are silently skipped.
 2. If a mask is enabled and the vertex is masked out, skip it.
 3. Center the kernel on that voxel and determine the kernel bounds, clipped to the grid extents.
 4. For each voxel within the clipped kernel:
@@ -75,9 +75,9 @@ An optional boolean mask array may be provided. Vertices where the mask value is
 
 This filter uses flat arrays rather than variable-length lists, so memory usage is proportional to the number of voxels in the **Image Geometry** (not the number of points times the kernel size). For each interpolated array, the filter temporarily allocates ~56 bytes per voxel for accumulation state. For each copied array, ~16 bytes per voxel is allocated. These temporary variables are freed after the finalization pass.
 
-### Voxel Indices
+### Voxel Index Computation
 
-The *Voxel Indices* array is a pre-computed uint64 array (one entry per vertex) that maps each vertex to its corresponding linear voxel index in the **Image Geometry**. This array must be computed before running this filter (e.g., by using the *Map Point Cloud to Regular Grid* filter). Vertices with a voxel index of `uint64_max` are skipped automatically.
+The destination voxel for each vertex is computed on-the-fly from the vertex coordinates and the **Image Geometry**'s origin, spacing, and dimensions. There is no need to pre-compute a voxel indices array (e.g., via the *Map Point Cloud to Regular Grid* filter). Vertices whose coordinates fall outside the **Image Geometry** bounds are silently skipped.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/InterpolatePointCloudToRegularGridFilter.md
+++ b/src/Plugins/SimplnxCore/docs/InterpolatePointCloudToRegularGridFilter.md
@@ -6,15 +6,78 @@ Sampling (Interpolation)
 
 ## Description
 
-This **Filter** interpolates the values of arrays stored in a **Vertex Geometry** onto a user-selected **Image Geometry**.  The user defines the (x,y,z) radii of a kernel in *real space units*.  This kernel can be intialized to either *uniform* or *Gaussian*.  The interpolation algorithm proceeds as follows:
+This **Filter** interpolates the values of arrays stored in a **Vertex Geometry** (point cloud) onto a user-selected **Image Geometry** (regular grid). For each point in the cloud, the filter applies a kernel centered on the point's voxel and accumulates weighted contributions into every voxel the kernel overlaps. The result is a single interpolated value per voxel per array, computed as a weighted average of all contributions.
 
-1. The kernel radii defined by the user in real space units are converted into voxel units, based on the spacing of the supplied **Image Geometry**.
-2. The kernel is centered on each vertex in the **Vertex Geometry**.
-3. The values of each **Attribute Array** on the centered vertex are associated to each voxel intersected by the kernel.  This stored value is multiplied by the value of the kernel.
+### Kernel
 
-The result of the above approach is a list of data at each voxel in the **Image Geometry** for each interpolated **Attribute Array**.  These lists may be of different lengths within each voxel, since the kernels from each point may overlap. This duplication may result in significant memory usage if the number of points is large; the user may select a subset of arrays to interpolate to alleviate this issue.  Note that all arrays selected for interpolation must be scalar.
+The user defines the (x, y, z) radii of a kernel in *real space units*. The kernel can be initialized to one of two modes:
 
-A mask may be supplied to the filter.  Points that are not within the mask are ignored during interpolation.  Additionally, the distances between each voxel and the source point for the intersecting kernel may be stored; this significantly increases the required memory.  Arrays may be passed through to the image geometry without applying any interpolation.  This operation is equivalent to used a uniform kernel.
+- **Uniform** – Every voxel within the kernel radius receives equal weight (1.0).
+- **Gaussian** - Voxel weights fall off with distance from the center according to a Gaussian function controlled by user-specified *sigmas* in each dimension.
+
+The kernel radii are converted to voxel units based on the spacing of the **Image Geometry**. If the kernel radius in a given dimension is smaller than the voxel spacing, the kernel has a zero extent in that dimension (i.e., each point only affects its own voxel along that axis).
+
+### Algorithm
+
+The interpolation proceeds in two passes:
+
+**Pass 1 – Accumulation (one iteration over all vertices):**
+
+1. For each vertex in the **Vertex Geometry**, look up the destination voxel from the pre-computed *Voxel Indices* array.
+2. If a mask is enabled and the vertex is masked out, skip it.
+3. Center the kernel on that voxel and determine the kernel bounds, clipped to the grid extents.
+4. For each voxel within the clipped kernel:
+   - Look up the kernel weight using the 3D offset from the center voxel.
+   - For each *interpolated* array: multiply the source value by the kernel weight and accumulate the weighted value, the weight itself and any enabled statistics into the destination voxel.
+   - For each *copied* array: accumulate the source value with uniform weight (1.0) regardless of the selected kernel type.
+
+**Pass 2 – Finalization (one iteration over all voxels):**
+
+For each voxel that received at least one contribution:
+
+- The interpolated output value is `sum(weight * value) / sum(weight)`.
+- Any enabled statistics are written from the accumulated state.
+
+### Arrays to Interpolate vs. Arrays to Copy
+
+Both options transfer data from the **Vertex Geometry** onto the **Image Geometry**, but they differ in how the kernel is applied:
+
+- **Arrays to Interpolate** use the selected kernel (Uniform or Gaussian). The kernel weight multiplies each vertex's value before being accumulated into surrounding voxels. The final output is a kernel-weighted average. Optional statistics (length, min, max, mean, standard deviation, summation) can be computed on the weighted contributions. The output array type is always *float64* because the weighted average produces floating-point values regardless of the input type.
+
+- **Arrays to Copy** always use a uniform kernel (weight = 1.0), even when Gaussian interpolation is selected. The final output is a simple arithmetic average of all values that fell within the kernel radius. No statistics are computed for copied arrays. The output array type matches the source array type.
+
+Use *Arrays to Interpolate* for data values that should be smoothed or blended by the kernel (e.g., measured scalar fields). Use *Arrays to Copy* for categorical or index data where Gaussian weighting would not be meaningful.
+
+All arrays selected for interpolation or copying must be **scalar** (single-component) arrays.
+
+### Inline Statistics
+
+Rather than storing all per-voxel contributions and computing statistics in a separate filter, this filter can compute the following statistics *inline* during the accumulation pass. Each statistic is optional and controlled by a boolean parameter. When enabled, an additional output array is created for each interpolated array with the array name plus a configurable suffix (e.g., `FaceAreas_Length`).
+
+| Statistic              | Output Type | Description                                                                                                  |
+|------------------------|-------------|--------------------------------------------------------------------------------------------------------------|
+| **Length**             | uint64      | Number of weighted contributions to the voxel                                                                |
+| **Minimum**            | float32     | Smallest weighted value (`weight * source_value`)                                                            |
+| **Maximum**            | float32     | Largest weighted value                                                                                       |
+| **Mean**               | float32     | Arithmetic mean of weighted values (`sum / count`)                                                           |
+| **Standard Deviation** | float32     | Population standard deviation of weighted values, computed via Welford's numerically stable online algorithm |
+| **Summation**          | float32     | Sum of all weighted values                                                                                   |
+
+Statistics are computed on the *weighted* values (`kernel_weight * source_value`), which are the same quantities that contribute to the interpolated average. Voxels with no contributions receive a value of zero for all statistics.
+
+Median is not supported because it requires storing every vertex's contribution, which would negate the memory savings of the flat accumulation approach.
+
+### Mask
+
+An optional boolean mask array may be provided. Vertices where the mask value is *false* are skipped entirely during interpolation – they do not contribute to any voxel's accumulated value or statistics.
+
+### Memory Usage
+
+This filter uses flat arrays rather than variable-length lists, so memory usage is proportional to the number of voxels in the **Image Geometry** (not the number of points times the kernel size). For each interpolated array, the filter temporarily allocates ~56 bytes per voxel for accumulation state. For each copied array, ~16 bytes per voxel is allocated. These temporary variables are freed after the finalization pass.
+
+### Voxel Indices
+
+The *Voxel Indices* array is a pre-computed uint64 array (one entry per vertex) that maps each vertex to its corresponding linear voxel index in the **Image Geometry**. This array must be computed before running this filter (e.g., by using the *Map Point Cloud to Regular Grid* filter). Vertices with a voxel index of `uint64_max` are skipped automatically.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.cpp
@@ -5,17 +5,15 @@
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/DataStructure/NeighborList.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 
-#include <cmath>
+#include <tuple>
 
 using namespace nx::core;
 
 namespace
 {
-constexpr uint64 k_Uniform = 0;
-constexpr uint64 k_Gaussian = 1;
-
 struct MapPointCloudDataByKernelFunctor
 {
   template <typename T>
@@ -66,11 +64,11 @@ void determineKernel(uint64 interpolationTechnique, const FloatVec3& sigmas, std
     {
       for(int64 x = -kernelNumVoxels[0]; x <= kernelNumVoxels[0]; x++)
       {
-        if(interpolationTechnique == k_Uniform)
+        if(interpolationTechnique == InterpolatePointCloudToRegularGrid::k_Uniform)
         {
           kernel[counter] = 1.0f;
         }
-        else if(interpolationTechnique == k_Gaussian)
+        else if(interpolationTechnique == InterpolatePointCloudToRegularGrid::k_Gaussian)
         {
           kernel[counter] = std::exp(-((x * x) / (2 * sigmas[0] * sigmas[0]) + (y * y) / (2 * sigmas[1] * sigmas[1]) + (z * z) / (2 * sigmas[2] * sigmas[2])));
         }
@@ -98,10 +96,9 @@ void determineKernelDistances(std::vector<float32>& kernelValDistances, const in
   }
 }
 
-void mapKernelDistances(NeighborList<float32>* kernelDistances, std::vector<float32>& kernelValDistances, std::vector<float32>& kernel, const int64 kernelNumVoxels[3], const usize dims[3], usize curX,
-                        usize curY, usize curZ)
+void mapKernelDistances(NeighborList<float32>* kernelDistances, const std::vector<float32>& kernelValDistances, const std::vector<float32>& kernel, const int64 kernelNumVoxels[3], const usize dims[3],
+                        usize curX, usize curY, usize curZ)
 {
-  usize index;
   int64 startKernel[3] = {0, 0, 0};
   int64 endKernel[3] = {0, 0, 0};
   usize counter = 0;
@@ -124,7 +121,7 @@ void mapKernelDistances(NeighborList<float32>* kernelDistances, std::vector<floa
         {
           continue;
         }
-        index = (z * dims[1] * dims[0]) + (y * dims[0]) + x;
+        usize index = (z * dims[1] * dims[0]) + (y * dims[0]) + x;
         kernelDistances->addEntry(index, kernelValDistances[counter]);
         counter++;
       }
@@ -147,24 +144,26 @@ InterpolatePointCloudToRegularGrid::InterpolatePointCloudToRegularGrid(DataStruc
 InterpolatePointCloudToRegularGrid::~InterpolatePointCloudToRegularGrid() noexcept = default;
 
 // -----------------------------------------------------------------------------
+const std::atomic_bool& InterpolatePointCloudToRegularGrid::getCancel()
+{
+  return m_ShouldCancel;
+}
+
+// -----------------------------------------------------------------------------
 Result<> InterpolatePointCloudToRegularGrid::operator()()
 {
-  auto useMask = m_InputValues->UseMask;
-  auto storeKernelDistances = m_InputValues->StoreKernelDistances;
-  auto interpolationTechnique = m_InputValues->InterpolationIndex;
-  auto vertexGeomPath = m_InputValues->InputVertexGeometryPath;
-  auto imageGeomPath = m_InputValues->InputImageGeometryPath;
-  auto interpolatedGroupName = m_InputValues->InterpolatedGroupName;
-  auto interpolatedDataPaths = m_InputValues->InterpolateArrays;
-  auto copyDataPaths = m_InputValues->CopyArrays;
-  auto voxelIndicesPath = m_InputValues->VoxelIndicesPath;
-  auto kernelSize = m_InputValues->KernelSize;
+  const DataPath interpolatedGroupPath = m_InputValues->imageGeomPath.createChildPath(m_InputValues->interpolatedGroupName);
 
-  const DataPath interpolatedGroupPath = imageGeomPath.createChildPath(interpolatedGroupName);
-  const auto sigmas = m_InputValues->GaussianSigmas;
+  const DataPath kernelDistPath = interpolatedGroupPath.createChildPath(m_InputValues->kernelDistanceArrayName);
 
-  auto vertices = m_DataStructure.getDataAs<VertexGeom>(vertexGeomPath);
-  auto image = m_DataStructure.getDataAs<ImageGeom>(imageGeomPath);
+  Float32NeighborList* kernelDistances = nullptr;
+  if(m_InputValues->storeKernelDistances)
+  {
+    kernelDistances = m_DataStructure.getDataAs<Float32NeighborList>(kernelDistPath);
+  }
+
+  auto vertices = m_DataStructure.getDataAs<VertexGeom>(m_InputValues->vertexGeomPath);
+  auto image = m_DataStructure.getDataAs<ImageGeom>(m_InputValues->imageGeomPath);
   SizeVec3 dims = image->getDimensions();
   FloatVec3 res = image->getSpacing();
   int64 kernelNumVoxels[3] = {0, 0, 0};
@@ -178,38 +177,38 @@ Result<> InterpolatePointCloudToRegularGrid::operator()()
   std::vector<float32> kernel;
 
   BoolArray::store_type* mask = nullptr;
-  if(useMask)
+  if(m_InputValues->useMask)
   {
-    mask = m_DataStructure.getDataAs<BoolArray>(m_InputValues->InputMaskPath)->getDataStore();
+    mask = m_DataStructure.getDataAs<BoolArray>(m_InputValues->maskDataPath)->getDataStore();
   }
 
-  auto& voxelIndices = m_DataStructure.getDataRefAs<UInt64Array>(voxelIndicesPath);
+  auto& voxelIndices = m_DataStructure.getDataRefAs<UInt64Array>(m_InputValues->voxelIndicesPath);
 
   // Make sure the NeighborList's outermost vector is resized to the number of tuples and initialized to non-null values (empty vectors)
-  for(const auto& interpolatedDataPath : interpolatedDataPaths)
-  {
-    InitializeNeighborList(m_DataStructure, interpolatedGroupPath.createChildPath(interpolatedDataPath.getTargetName()));
-  }
-  for(const auto& copyDataPath : copyDataPaths)
-  {
-    InitializeNeighborList(m_DataStructure, interpolatedGroupPath.createChildPath(copyDataPath.getTargetName()));
-  }
+  // for(const auto& interpolatedDataPath : m_InputValues->interpolatedDataPaths)
+  // {
+  //   InitializeNeighborList(m_DataStructure, interpolatedGroupPath.createChildPath(interpolatedDataPath.getTargetName()));
+  // }
+  // for(const auto& copyDataPath : m_InputValues->copyDataPaths)
+  // {
+  //   InitializeNeighborList(m_DataStructure, interpolatedGroupPath.createChildPath(copyDataPath.getTargetName()));
+  // }
 
   usize maxImageIndex = ((dims[2] - 1) * dims[0] * dims[1]) + ((dims[1] - 1) * dims[0]) + (dims[0] - 1);
 
-  kernelNumVoxels[0] = static_cast<int64>(std::ceil((kernelSize[0] / res[0]) * 0.5f));
-  kernelNumVoxels[1] = static_cast<int64>(std::ceil((kernelSize[1] / res[1]) * 0.5f));
-  kernelNumVoxels[2] = static_cast<int64>(std::ceil((kernelSize[2] / res[2]) * 0.5f));
+  kernelNumVoxels[0] = static_cast<int64>(std::ceil((m_InputValues->kernelSize[0] / res[0]) * 0.5f));
+  kernelNumVoxels[1] = static_cast<int64>(std::ceil((m_InputValues->kernelSize[1] / res[1]) * 0.5f));
+  kernelNumVoxels[2] = static_cast<int64>(std::ceil((m_InputValues->kernelSize[2] / res[2]) * 0.5f));
 
-  if(kernelSize[0] < res[0])
+  if(m_InputValues->kernelSize[0] < res[0])
   {
     kernelNumVoxels[0] = 0;
   }
-  if(kernelSize[1] < res[1])
+  if(m_InputValues->kernelSize[1] < res[1])
   {
     kernelNumVoxels[1] = 0;
   }
-  if(kernelSize[2] < res[2])
+  if(m_InputValues->kernelSize[2] < res[2])
   {
     kernelNumVoxels[2] = 0;
   }
@@ -224,12 +223,12 @@ Result<> InterpolatePointCloudToRegularGrid::operator()()
 
   kernel.resize(totalKernel);
   std::fill(kernel.begin(), kernel.end(), 0.0f);
-  determineKernel(interpolationTechnique, sigmas, kernel, kernelNumVoxels);
+  determineKernel(m_InputValues->interpolationTechnique, m_InputValues->sigmas, kernel, kernelNumVoxels);
 
   std::vector<float32> uniformKernel(totalKernel, 1.0f);
 
   std::vector<float32> kernelValDistances;
-  if(storeKernelDistances)
+  if(m_InputValues->storeKernelDistances)
   {
     kernelValDistances.resize(totalKernel);
     std::fill(kernelValDistances.begin(), kernelValDistances.end(), 0.0f);
@@ -240,31 +239,55 @@ Result<> InterpolatePointCloudToRegularGrid::operator()()
   usize prog = 1;
   usize progressInt = 0;
 
+  // ***************************************************************************
+  // Prebuild these values outside the loop since they do not change inside the loop
+  using InterpolatedTupleType = std::tuple<DataPath, INeighborList*, IDataArray*>;
+  std::vector<InterpolatedTupleType> interpolatedDataTypes;
+  for(const auto& interpolatedDataPathItem : m_InputValues->interpolatedDataPaths)
+  {
+    const auto dynamicArrayPath = interpolatedGroupPath.createChildPath(interpolatedDataPathItem.getTargetName());
+    auto* dynamicArrayToInterpolate = m_DataStructure.getDataAs<INeighborList>(dynamicArrayPath);
+    auto* sourceArray = m_DataStructure.getDataAs<IDataArray>(interpolatedDataPathItem);
+    interpolatedDataTypes.emplace_back(dynamicArrayPath, dynamicArrayToInterpolate, sourceArray);
+  }
+
+  std::vector<InterpolatedTupleType> copiedDataTypes;
+  for(const auto& copyDataPath : m_InputValues->copyDataPaths)
+  {
+    auto dynamicArrayPath = interpolatedGroupPath.createChildPath(copyDataPath.getTargetName());
+    auto* dynamicArrayToCopy = m_DataStructure.getDataAs<INeighborList>(dynamicArrayPath);
+    auto* sourceArray = m_DataStructure.getDataAs<IDataArray>(copyDataPath);
+    copiedDataTypes.emplace_back(dynamicArrayPath, dynamicArrayToCopy, sourceArray);
+  }
+  // ***************************************************************************
+
   for(usize i = 0; i < numVerts; i++)
   {
-    if(useMask)
+    if(m_ShouldCancel)
     {
-      if(!mask->getValue(i))
-      {
-        continue;
-      }
+      return {};
+    }
+
+    if(m_InputValues->useMask && nullptr != mask && !mask->getValue(i))
+    {
+      continue;
     }
     index = voxelIndices[i];
     if(index > maxImageIndex)
     {
       return MakeErrorResult(-11004,
-                             fmt::format("Index present in the selected Voxel Indices array that falls outside the selected Image Geometry for interpolation.\n Index = %1\n Max Image Index = %2\n",
+                             fmt::format("Index present in the selected Voxel Indices array that falls outside the selected Image Geometry for interpolation.\n Index = {}\n Max Image Index = {}\n",
                                          index, maxImageIndex));
     }
     x = index % dims[0];
     y = (index / dims[0]) % dims[1];
     z = index / (dims[0] * dims[1]);
 
-    for(const auto& interpolatedDataPathItem : interpolatedDataPaths)
+    for(const auto& interpolatedDataPathItem : interpolatedDataTypes)
     {
-      const auto dynamicArrayPath = interpolatedGroupPath.createChildPath(interpolatedDataPathItem.getTargetName());
-      auto* dynamicArrayToInterpolate = m_DataStructure.getDataAs<INeighborList>(dynamicArrayPath);
-      auto* sourceArray = m_DataStructure.getDataAs<IDataArray>(interpolatedDataPathItem);
+      const auto dynamicArrayPath = std::get<0>(interpolatedDataPathItem);
+      auto* dynamicArrayToInterpolate = std::get<1>(interpolatedDataPathItem);
+      auto* sourceArray = std::get<2>(interpolatedDataPathItem);
 
       const auto& type = sourceArray->getDataType();
       if(type == DataType::boolean) // Can't be executed will throw error
@@ -276,11 +299,11 @@ Result<> InterpolatePointCloudToRegularGrid::operator()()
       ExecuteNeighborFunction(MapPointCloudDataByKernelFunctor{}, type, sourceArray, dynamicArrayToInterpolate, kernel, kernelNumVoxels, dims.data(), x, y, z, i);
     }
 
-    for(const auto& copyDataPath : copyDataPaths)
+    for(const auto& copyDataPath : copiedDataTypes)
     {
-      auto dynamicArrayPath = interpolatedGroupPath.createChildPath(copyDataPath.getTargetName());
-      auto* dynamicArrayToCopy = m_DataStructure.getDataAs<INeighborList>(dynamicArrayPath);
-      auto* sourceArray = m_DataStructure.getDataAs<IDataArray>(copyDataPath);
+      auto dynamicArrayPath = std::get<0>(copyDataPath); // interpolatedGroupPath.createChildPath(copyDataPath.getTargetName());
+      auto* dynamicArrayToCopy = std::get<1>(copyDataPath);
+      auto* sourceArray = std::get<2>(copyDataPath);
 
       const auto& type = sourceArray->getDataType();
       if(type == DataType::boolean) // Can't be executed will throw error
@@ -292,18 +315,16 @@ Result<> InterpolatePointCloudToRegularGrid::operator()()
       ExecuteNeighborFunction(MapPointCloudDataByKernelFunctor{}, type, sourceArray, dynamicArrayToCopy, uniformKernel, kernelNumVoxels, dims.data(), x, y, z, i);
     }
 
-    if(storeKernelDistances)
+    if(m_InputValues->storeKernelDistances && nullptr != kernelDistances)
     {
-      const DataPath kernelDistPath = interpolatedGroupPath.createChildPath(m_InputValues->KernelDistancesArrayName);
-      InitializeNeighborList(m_DataStructure, kernelDistPath);
-      auto* kernelDistances = m_DataStructure.getDataAs<Float32NeighborList>(kernelDistPath);
+      // InitializeNeighborList(m_DataStructure, kernelDistPath);
       mapKernelDistances(kernelDistances, kernelValDistances, kernel, kernelNumVoxels, dims.data(), x, y, z);
     }
 
     if(i > prog)
     {
       progressInt = static_cast<int64>((static_cast<float>(i) / numVerts) * 100.0f);
-      m_MessageHandler(fmt::format("Interpolating Point Cloud || {}% Completed", progressInt));
+      m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Interpolating Point Cloud || {}% Completed", progressInt));
       prog = prog + progIncrement;
     }
   }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.cpp
@@ -5,7 +5,6 @@
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 
-#include <algorithm>
 #include <cmath>
 #include <limits>
 
@@ -109,10 +108,9 @@ const std::atomic_bool& InterpolatePointCloudToRegularGrid::getCancel()
 // -----------------------------------------------------------------------------
 Result<> InterpolatePointCloudToRegularGrid::operator()()
 {
-  const DataPath interpolatedGroupPath = m_InputValues->imageGeomPath.createChildPath(m_InputValues->interpolatedGroupName);
-
   auto* vertices = m_DataStructure.getDataAs<VertexGeom>(m_InputValues->vertexGeomPath);
   auto* image = m_DataStructure.getDataAs<ImageGeom>(m_InputValues->imageGeomPath);
+  const DataPath interpolatedGroupPath = image->getCellDataPath();
   SizeVec3 dims = image->getDimensions();
   FloatVec3 res = image->getSpacing();
 
@@ -157,9 +155,6 @@ Result<> InterpolatePointCloudToRegularGrid::operator()()
   {
     mask = m_DataStructure.getDataAs<BoolArray>(m_InputValues->maskDataPath)->getDataStore();
   }
-
-  auto& voxelIndices = m_DataStructure.getDataRefAs<UInt64Array>(m_InputValues->voxelIndicesPath);
-  usize maxImageIndex = (dimZ - 1) * dimX * dimY + (dimY - 1) * dimX + (dimX - 1);
 
   const bool needWelford = m_InputValues->findStdDeviation;
 
@@ -216,17 +211,13 @@ Result<> InterpolatePointCloudToRegularGrid::operator()()
       continue;
     }
 
-    usize index = voxelIndices[i];
-    if(index == std::numeric_limits<uint64>::max())
+    Point3D<float32> coords = vertices->getVertexCoordinate(i);
+    std::optional<usize> optIndex = image->getIndex(coords[0], coords[1], coords[2]);
+    if(!optIndex.has_value())
     {
       continue;
     }
-    if(index > maxImageIndex)
-    {
-      return MakeErrorResult(-11004,
-                             fmt::format("Index present in the selected Voxel Indices array that falls outside the selected Image Geometry for interpolation.\n Index = {}\n Max Image Index = {}\n",
-                                         index, maxImageIndex));
-    }
+    usize index = optIndex.value();
 
     usize curX = index % dimX;
     usize curY = (index / dimX) % dimY;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.cpp
@@ -3,60 +3,63 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
-#include "simplnx/DataStructure/NeighborList.hpp"
-#include "simplnx/Utilities/DataArrayUtilities.hpp"
-#include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 
-#include <tuple>
+#include <algorithm>
+#include <cmath>
+#include <limits>
 
 using namespace nx::core;
 
 namespace
 {
-struct MapPointCloudDataByKernelFunctor
+struct VoxelAccumulator
+{
+  float64 weightedSum = 0.0;
+  float64 weightSum = 0.0;
+  uint64 count = 0;
+  float64 min = std::numeric_limits<float64>::max();
+  float64 max = std::numeric_limits<float64>::lowest();
+  float64 welfordMean = 0.0;
+  float64 welfordM2 = 0.0;
+};
+
+struct ExtractAsFloat64Functor
 {
   template <typename T>
-  void operator()(IDataArray* source, INeighborList* dynamic, std::vector<float>& kernelVals, const int64 kernel[3], const usize dims[3], usize curX, usize curY, usize curZ, usize vertIdx)
+  std::vector<float64> operator()(IDataArray* sourceArray)
   {
-    auto& inputData = source->template getIDataStoreRefAs<AbstractDataStore<T>>();
-    auto* interpolatedDataPtr = dynamic_cast<NeighborList<T>*>(dynamic);
-
-    usize index = 0;
-    int64 startKernel[3] = {0, 0, 0};
-    int64 endKernel[3] = {0, 0, 0};
-    usize counter = 0;
-
-    kernel[0] > static_cast<int64>(curX) ? startKernel[0] = 0 : startKernel[0] = static_cast<int64>(curX) - kernel[0];
-    kernel[1] > static_cast<int64>(curY) ? startKernel[1] = 0 : startKernel[1] = static_cast<int64>(curY) - kernel[1];
-    kernel[2] > static_cast<int64>(curZ) ? startKernel[2] = 0 : startKernel[2] = static_cast<int64>(curZ) - kernel[2];
-
-    static_cast<int64>(curX) + kernel[0] >= static_cast<int64>(dims[0]) ? endKernel[0] = static_cast<int64>(dims[0]) - 1 : endKernel[0] = static_cast<int64>(curX) + kernel[0];
-    static_cast<int64>(curY) + kernel[1] >= static_cast<int64>(dims[1]) ? endKernel[1] = static_cast<int64>(dims[1]) - 1 : endKernel[1] = static_cast<int64>(curY) + kernel[1];
-    endKernel[2] = static_cast<int64>(curZ);
-
-    for(int64 z = startKernel[2]; z <= endKernel[2]; z++)
+    auto& store = sourceArray->template getIDataStoreRefAs<AbstractDataStore<T>>();
+    usize numTuples = store.getNumberOfTuples();
+    std::vector<float64> result(numTuples);
+    for(usize i = 0; i < numTuples; i++)
     {
-      for(int64 y = startKernel[1]; y <= endKernel[1]; y++)
+      result[i] = static_cast<float64>(store[i]);
+    }
+    return result;
+  }
+};
+
+struct WriteWeightedAverageFunctor
+{
+  template <typename T>
+  void operator()(IDataArray* outputArray, const std::vector<float64>& weightedSums, const std::vector<float64>& weightSums, usize numVoxels)
+  {
+    auto& store = outputArray->template getIDataStoreRefAs<AbstractDataStore<T>>();
+    for(usize i = 0; i < numVoxels; i++)
+    {
+      if(weightSums[i] > 0.0)
       {
-        for(int64 x = startKernel[0]; x <= endKernel[0]; x++)
-        {
-          if(kernelVals[counter] == 0.0f)
-          {
-            continue;
-          }
-          index = (z * dims[1] * dims[0]) + (y * dims[0]) + x;
-          interpolatedDataPtr->addEntry(index, kernelVals[counter] * inputData.at(vertIdx));
-          counter++;
-        }
+        store[i] = static_cast<T>(weightedSums[i] / weightSums[i]);
       }
     }
   }
 };
 
-void determineKernel(uint64 interpolationTechnique, const FloatVec3& sigmas, std::vector<float32>& kernel, const int64 kernelNumVoxels[3])
+void computeKernel(uint64 interpolationTechnique, const std::vector<float32>& sigmas, std::vector<float32>& kernel, const int64 kernelNumVoxels[3])
 {
-  usize counter = 0;
+  usize kDimX = static_cast<usize>(2 * kernelNumVoxels[0] + 1);
+  usize kDimY = static_cast<usize>(2 * kernelNumVoxels[1] + 1);
 
   for(int64 z = -kernelNumVoxels[2]; z <= kernelNumVoxels[2]; z++)
   {
@@ -64,66 +67,20 @@ void determineKernel(uint64 interpolationTechnique, const FloatVec3& sigmas, std
     {
       for(int64 x = -kernelNumVoxels[0]; x <= kernelNumVoxels[0]; x++)
       {
+        usize kx = static_cast<usize>(x + kernelNumVoxels[0]);
+        usize ky = static_cast<usize>(y + kernelNumVoxels[1]);
+        usize kz = static_cast<usize>(z + kernelNumVoxels[2]);
+        usize idx = kz * kDimY * kDimX + ky * kDimX + kx;
+
         if(interpolationTechnique == InterpolatePointCloudToRegularGrid::k_Uniform)
         {
-          kernel[counter] = 1.0f;
+          kernel[idx] = 1.0f;
         }
         else if(interpolationTechnique == InterpolatePointCloudToRegularGrid::k_Gaussian)
         {
-          kernel[counter] = std::exp(-((x * x) / (2 * sigmas[0] * sigmas[0]) + (y * y) / (2 * sigmas[1] * sigmas[1]) + (z * z) / (2 * sigmas[2] * sigmas[2])));
+          kernel[idx] = std::exp(-((static_cast<float32>(x * x) / (2.0f * sigmas[0] * sigmas[0])) + (static_cast<float32>(y * y) / (2.0f * sigmas[1] * sigmas[1])) +
+                                   (static_cast<float32>(z * z) / (2.0f * sigmas[2] * sigmas[2]))));
         }
-        counter++;
-      }
-    }
-  }
-}
-
-void determineKernelDistances(std::vector<float32>& kernelValDistances, const int64 kernelNumVoxels[3], FloatVec3 res)
-{
-  usize counter = 0;
-
-  for(int64 z = -kernelNumVoxels[2]; z <= kernelNumVoxels[2]; z++)
-  {
-    for(int64 y = -kernelNumVoxels[1]; y <= kernelNumVoxels[1]; y++)
-    {
-      for(int64 x = -kernelNumVoxels[0]; x <= kernelNumVoxels[0]; x++)
-      {
-        kernelValDistances[counter] = (x * x * res[0] * res[0]) + (y * y * res[1] * res[1]) + (z * z * res[2] * res[2]);
-        kernelValDistances[counter] = std::sqrt(kernelValDistances[counter]);
-        counter++;
-      }
-    }
-  }
-}
-
-void mapKernelDistances(NeighborList<float32>* kernelDistances, const std::vector<float32>& kernelValDistances, const std::vector<float32>& kernel, const int64 kernelNumVoxels[3], const usize dims[3],
-                        usize curX, usize curY, usize curZ)
-{
-  int64 startKernel[3] = {0, 0, 0};
-  int64 endKernel[3] = {0, 0, 0};
-  usize counter = 0;
-
-  kernelNumVoxels[0] > static_cast<int64>(curX) ? startKernel[0] = 0 : startKernel[0] = static_cast<int64>(curX) - kernelNumVoxels[0];
-  kernelNumVoxels[1] > static_cast<int64>(curY) ? startKernel[1] = 0 : startKernel[1] = static_cast<int64>(curY) - kernelNumVoxels[1];
-  kernelNumVoxels[2] > static_cast<int64>(curZ) ? startKernel[2] = 0 : startKernel[2] = static_cast<int64>(curZ) - kernelNumVoxels[2];
-
-  static_cast<int64>(curX) + kernelNumVoxels[0] >= static_cast<int64>(dims[0]) ? endKernel[0] = static_cast<int64>(dims[0]) - 1 : endKernel[0] = static_cast<int64>(curX) + kernelNumVoxels[0];
-  static_cast<int64>(curY) + kernelNumVoxels[1] >= static_cast<int64>(dims[1]) ? endKernel[1] = static_cast<int64>(dims[1]) - 1 : endKernel[1] = static_cast<int64>(curY) + kernelNumVoxels[1];
-  endKernel[2] = static_cast<int64>(curZ);
-
-  for(int64 z = startKernel[2]; z <= endKernel[2]; z++)
-  {
-    for(int64 y = startKernel[1]; y <= endKernel[1]; y++)
-    {
-      for(int64 x = startKernel[0]; x <= endKernel[0]; x++)
-      {
-        if(kernel[counter] == 0.0f)
-        {
-          continue;
-        }
-        usize index = (z * dims[1] * dims[0]) + (y * dims[0]) + x;
-        kernelDistances->addEntry(index, kernelValDistances[counter]);
-        counter++;
       }
     }
   }
@@ -154,48 +111,20 @@ Result<> InterpolatePointCloudToRegularGrid::operator()()
 {
   const DataPath interpolatedGroupPath = m_InputValues->imageGeomPath.createChildPath(m_InputValues->interpolatedGroupName);
 
-  const DataPath kernelDistPath = interpolatedGroupPath.createChildPath(m_InputValues->kernelDistanceArrayName);
-
-  Float32NeighborList* kernelDistances = nullptr;
-  if(m_InputValues->storeKernelDistances)
-  {
-    kernelDistances = m_DataStructure.getDataAs<Float32NeighborList>(kernelDistPath);
-  }
-
-  auto vertices = m_DataStructure.getDataAs<VertexGeom>(m_InputValues->vertexGeomPath);
-  auto image = m_DataStructure.getDataAs<ImageGeom>(m_InputValues->imageGeomPath);
+  auto* vertices = m_DataStructure.getDataAs<VertexGeom>(m_InputValues->vertexGeomPath);
+  auto* image = m_DataStructure.getDataAs<ImageGeom>(m_InputValues->imageGeomPath);
   SizeVec3 dims = image->getDimensions();
   FloatVec3 res = image->getSpacing();
-  int64 kernelNumVoxels[3] = {0, 0, 0};
+
+  usize dimX = dims[0];
+  usize dimY = dims[1];
+  usize dimZ = dims[2];
+  usize numVoxels = dimX * dimY * dimZ;
 
   auto numVerts = vertices->getNumberOfVertices();
-  usize index = 0;
-  usize x = 0;
-  usize y = 0;
-  usize z = 0;
 
-  std::vector<float32> kernel;
-
-  BoolArray::store_type* mask = nullptr;
-  if(m_InputValues->useMask)
-  {
-    mask = m_DataStructure.getDataAs<BoolArray>(m_InputValues->maskDataPath)->getDataStore();
-  }
-
-  auto& voxelIndices = m_DataStructure.getDataRefAs<UInt64Array>(m_InputValues->voxelIndicesPath);
-
-  // Make sure the NeighborList's outermost vector is resized to the number of tuples and initialized to non-null values (empty vectors)
-  // for(const auto& interpolatedDataPath : m_InputValues->interpolatedDataPaths)
-  // {
-  //   InitializeNeighborList(m_DataStructure, interpolatedGroupPath.createChildPath(interpolatedDataPath.getTargetName()));
-  // }
-  // for(const auto& copyDataPath : m_InputValues->copyDataPaths)
-  // {
-  //   InitializeNeighborList(m_DataStructure, interpolatedGroupPath.createChildPath(copyDataPath.getTargetName()));
-  // }
-
-  usize maxImageIndex = ((dims[2] - 1) * dims[0] * dims[1]) + ((dims[1] - 1) * dims[0]) + (dims[0] - 1);
-
+  // Kernel dimensions in voxels
+  int64 kernelNumVoxels[3] = {0, 0, 0};
   kernelNumVoxels[0] = static_cast<int64>(std::ceil((m_InputValues->kernelSize[0] / res[0]) * 0.5f));
   kernelNumVoxels[1] = static_cast<int64>(std::ceil((m_InputValues->kernelSize[1] / res[1]) * 0.5f));
   kernelNumVoxels[2] = static_cast<int64>(std::ceil((m_InputValues->kernelSize[2] / res[2]) * 0.5f));
@@ -213,53 +142,67 @@ Result<> InterpolatePointCloudToRegularGrid::operator()()
     kernelNumVoxels[2] = 0;
   }
 
-  int64 tmpKernelSize[3] = {1, 1, 1};
-  for(usize i = 0; i < 3; i++)
+  usize kDimX = static_cast<usize>(2 * kernelNumVoxels[0] + 1);
+  usize kDimY = static_cast<usize>(2 * kernelNumVoxels[1] + 1);
+  usize kDimZ = static_cast<usize>(2 * kernelNumVoxels[2] + 1);
+  usize totalKernel = kDimX * kDimY * kDimZ;
+
+  // Compute kernel weights
+  std::vector<float32> kernel(totalKernel, 0.0f);
+  computeKernel(m_InputValues->interpolationTechnique, m_InputValues->sigmas, kernel, kernelNumVoxels);
+
+  // Mask
+  BoolArray::store_type* mask = nullptr;
+  if(m_InputValues->useMask)
   {
-    tmpKernelSize[i] *= (kernelNumVoxels[i] * 2) + 1;
+    mask = m_DataStructure.getDataAs<BoolArray>(m_InputValues->maskDataPath)->getDataStore();
   }
 
-  int64 totalKernel = tmpKernelSize[0] * tmpKernelSize[1] * tmpKernelSize[2];
+  auto& voxelIndices = m_DataStructure.getDataRefAs<UInt64Array>(m_InputValues->voxelIndicesPath);
+  usize maxImageIndex = (dimZ - 1) * dimX * dimY + (dimY - 1) * dimX + (dimX - 1);
 
-  kernel.resize(totalKernel);
-  std::fill(kernel.begin(), kernel.end(), 0.0f);
-  determineKernel(m_InputValues->interpolationTechnique, m_InputValues->sigmas, kernel, kernelNumVoxels);
+  const bool needWelford = m_InputValues->findStdDeviation;
 
-  std::vector<float32> uniformKernel(totalKernel, 1.0f);
-
-  std::vector<float32> kernelValDistances;
-  if(m_InputValues->storeKernelDistances)
+  // Pre-extract interpolated source array data as float64
+  std::vector<std::vector<float64>> interpSourceData;
+  std::vector<IDataArray*> interpSourceArrays;
+  for(const auto& path : m_InputValues->interpolatedDataPaths)
   {
-    kernelValDistances.resize(totalKernel);
-    std::fill(kernelValDistances.begin(), kernelValDistances.end(), 0.0f);
-    determineKernelDistances(kernelValDistances, kernelNumVoxels, res);
+    auto* sourceArray = m_DataStructure.getDataAs<IDataArray>(path);
+    if(sourceArray->getDataType() == DataType::boolean)
+    {
+      continue;
+    }
+    interpSourceArrays.push_back(sourceArray);
+    interpSourceData.push_back(ExecuteDataFunction(ExtractAsFloat64Functor{}, sourceArray->getDataType(), sourceArray));
   }
 
+  // Pre-extract copy source array data as float64
+  std::vector<std::vector<float64>> copySourceData;
+  std::vector<IDataArray*> copySourceArrays;
+  for(const auto& path : m_InputValues->copyDataPaths)
+  {
+    auto* sourceArray = m_DataStructure.getDataAs<IDataArray>(path);
+    if(sourceArray->getDataType() == DataType::boolean)
+    {
+      continue;
+    }
+    copySourceArrays.push_back(sourceArray);
+    copySourceData.push_back(ExecuteDataFunction(ExtractAsFloat64Functor{}, sourceArray->getDataType(), sourceArray));
+  }
+
+  // Allocate accumulators for interpolated arrays
+  usize numInterpArrays = interpSourceArrays.size();
+  std::vector<std::vector<VoxelAccumulator>> interpAccum(numInterpArrays, std::vector<VoxelAccumulator>(numVoxels));
+
+  // Allocate simple accumulators for copy arrays (weighted sum + weight sum)
+  usize numCopyArrays = copySourceArrays.size();
+  std::vector<std::vector<float64>> copyWeightedSum(numCopyArrays, std::vector<float64>(numVoxels, 0.0));
+  std::vector<std::vector<float64>> copyWeightSum(numCopyArrays, std::vector<float64>(numVoxels, 0.0));
+
+  // Main vertex loop
   usize progIncrement = numVerts / 100;
   usize prog = 1;
-  usize progressInt = 0;
-
-  // ***************************************************************************
-  // Prebuild these values outside the loop since they do not change inside the loop
-  using InterpolatedTupleType = std::tuple<DataPath, INeighborList*, IDataArray*>;
-  std::vector<InterpolatedTupleType> interpolatedDataTypes;
-  for(const auto& interpolatedDataPathItem : m_InputValues->interpolatedDataPaths)
-  {
-    const auto dynamicArrayPath = interpolatedGroupPath.createChildPath(interpolatedDataPathItem.getTargetName());
-    auto* dynamicArrayToInterpolate = m_DataStructure.getDataAs<INeighborList>(dynamicArrayPath);
-    auto* sourceArray = m_DataStructure.getDataAs<IDataArray>(interpolatedDataPathItem);
-    interpolatedDataTypes.emplace_back(dynamicArrayPath, dynamicArrayToInterpolate, sourceArray);
-  }
-
-  std::vector<InterpolatedTupleType> copiedDataTypes;
-  for(const auto& copyDataPath : m_InputValues->copyDataPaths)
-  {
-    auto dynamicArrayPath = interpolatedGroupPath.createChildPath(copyDataPath.getTargetName());
-    auto* dynamicArrayToCopy = m_DataStructure.getDataAs<INeighborList>(dynamicArrayPath);
-    auto* sourceArray = m_DataStructure.getDataAs<IDataArray>(copyDataPath);
-    copiedDataTypes.emplace_back(dynamicArrayPath, dynamicArrayToCopy, sourceArray);
-  }
-  // ***************************************************************************
 
   for(usize i = 0; i < numVerts; i++)
   {
@@ -268,65 +211,174 @@ Result<> InterpolatePointCloudToRegularGrid::operator()()
       return {};
     }
 
-    if(m_InputValues->useMask && nullptr != mask && !mask->getValue(i))
+    if(m_InputValues->useMask && mask != nullptr && !mask->getValue(i))
     {
       continue;
     }
-    index = voxelIndices[i];
+
+    usize index = voxelIndices[i];
+    if(index == std::numeric_limits<uint64>::max())
+    {
+      continue;
+    }
     if(index > maxImageIndex)
     {
       return MakeErrorResult(-11004,
                              fmt::format("Index present in the selected Voxel Indices array that falls outside the selected Image Geometry for interpolation.\n Index = {}\n Max Image Index = {}\n",
                                          index, maxImageIndex));
     }
-    x = index % dims[0];
-    y = (index / dims[0]) % dims[1];
-    z = index / (dims[0] * dims[1]);
 
-    for(const auto& interpolatedDataPathItem : interpolatedDataTypes)
+    usize curX = index % dimX;
+    usize curY = (index / dimX) % dimY;
+    usize curZ = index / (dimX * dimY);
+
+    // Compute clipped kernel bounds in grid space (symmetric in all 3 dimensions)
+    int64 startX = std::max(static_cast<int64>(0), static_cast<int64>(curX) - kernelNumVoxels[0]);
+    int64 startY = std::max(static_cast<int64>(0), static_cast<int64>(curY) - kernelNumVoxels[1]);
+    int64 startZ = std::max(static_cast<int64>(0), static_cast<int64>(curZ) - kernelNumVoxels[2]);
+    int64 endX = std::min(static_cast<int64>(dimX) - 1, static_cast<int64>(curX) + kernelNumVoxels[0]);
+    int64 endY = std::min(static_cast<int64>(dimY) - 1, static_cast<int64>(curY) + kernelNumVoxels[1]);
+    int64 endZ = std::min(static_cast<int64>(dimZ) - 1, static_cast<int64>(curZ) + kernelNumVoxels[2]);
+
+    // Traverse kernel
+    for(int64 gz = startZ; gz <= endZ; gz++)
     {
-      const auto dynamicArrayPath = std::get<0>(interpolatedDataPathItem);
-      auto* dynamicArrayToInterpolate = std::get<1>(interpolatedDataPathItem);
-      auto* sourceArray = std::get<2>(interpolatedDataPathItem);
-
-      const auto& type = sourceArray->getDataType();
-      if(type == DataType::boolean) // Can't be executed will throw error
+      for(int64 gy = startY; gy <= endY; gy++)
       {
-        continue;
+        for(int64 gx = startX; gx <= endX; gx++)
+        {
+          // Compute kernel index using 3D offset
+          usize kx = static_cast<usize>(gx - static_cast<int64>(curX) + kernelNumVoxels[0]);
+          usize ky = static_cast<usize>(gy - static_cast<int64>(curY) + kernelNumVoxels[1]);
+          usize kz = static_cast<usize>(gz - static_cast<int64>(curZ) + kernelNumVoxels[2]);
+          usize kernelIdx = kz * kDimY * kDimX + ky * kDimX + kx;
+
+          float32 weight = kernel[kernelIdx];
+          usize voxelIdx = static_cast<usize>(gz) * dimX * dimY + static_cast<usize>(gy) * dimX + static_cast<usize>(gx);
+
+          // Update interpolated array accumulators (using actual kernel weight)
+          if(weight != 0.0f)
+          {
+            float64 w = static_cast<float64>(weight);
+            for(usize a = 0; a < numInterpArrays; a++)
+            {
+              float64 sourceVal = interpSourceData[a][i];
+              float64 weightedVal = w * sourceVal;
+
+              auto& accum = interpAccum[a][voxelIdx];
+              accum.count++;
+              accum.weightedSum += weightedVal;
+              accum.weightSum += w;
+              accum.min = std::min(accum.min, weightedVal);
+              accum.max = std::max(accum.max, weightedVal);
+
+              if(needWelford)
+              {
+                float64 delta = weightedVal - accum.welfordMean;
+                accum.welfordMean += delta / static_cast<float64>(accum.count);
+                float64 delta2 = weightedVal - accum.welfordMean;
+                accum.welfordM2 += delta * delta2;
+              }
+            }
+          }
+
+          // Update copy array accumulators (always uniform weight = 1.0)
+          for(usize a = 0; a < numCopyArrays; a++)
+          {
+            float64 sourceVal = copySourceData[a][i];
+            copyWeightedSum[a][voxelIdx] += sourceVal;
+            copyWeightSum[a][voxelIdx] += 1.0;
+          }
+        }
       }
-
-      // NO BOOL
-      ExecuteNeighborFunction(MapPointCloudDataByKernelFunctor{}, type, sourceArray, dynamicArrayToInterpolate, kernel, kernelNumVoxels, dims.data(), x, y, z, i);
-    }
-
-    for(const auto& copyDataPath : copiedDataTypes)
-    {
-      auto dynamicArrayPath = std::get<0>(copyDataPath); // interpolatedGroupPath.createChildPath(copyDataPath.getTargetName());
-      auto* dynamicArrayToCopy = std::get<1>(copyDataPath);
-      auto* sourceArray = std::get<2>(copyDataPath);
-
-      const auto& type = sourceArray->getDataType();
-      if(type == DataType::boolean) // Can't be executed will throw error
-      {
-        continue;
-      }
-
-      // NO BOOL
-      ExecuteNeighborFunction(MapPointCloudDataByKernelFunctor{}, type, sourceArray, dynamicArrayToCopy, uniformKernel, kernelNumVoxels, dims.data(), x, y, z, i);
-    }
-
-    if(m_InputValues->storeKernelDistances && nullptr != kernelDistances)
-    {
-      // InitializeNeighborList(m_DataStructure, kernelDistPath);
-      mapKernelDistances(kernelDistances, kernelValDistances, kernel, kernelNumVoxels, dims.data(), x, y, z);
     }
 
     if(i > prog)
     {
-      progressInt = static_cast<int64>((static_cast<float>(i) / numVerts) * 100.0f);
+      usize progressInt = static_cast<usize>((static_cast<float64>(i) / static_cast<float64>(numVerts)) * 100.0);
       m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Interpolating Point Cloud || {}% Completed", progressInt));
-      prog = prog + progIncrement;
+      prog += progIncrement;
     }
+  }
+
+  // Finalization pass - write outputs
+  m_MessageHandler(IFilter::Message::Type::Info, "Writing interpolated results...");
+
+  for(usize a = 0; a < numInterpArrays; a++)
+  {
+    const std::string& arrayName = interpSourceArrays[a]->getName();
+
+    // Write interpolated (weighted average) output
+    auto& interpOutput = m_DataStructure.getDataRefAs<Float64Array>(interpolatedGroupPath.createChildPath(arrayName));
+    for(usize v = 0; v < numVoxels; v++)
+    {
+      const auto& accum = interpAccum[a][v];
+      if(accum.weightSum > 0.0)
+      {
+        interpOutput[v] = accum.weightedSum / accum.weightSum;
+      }
+    }
+
+    // Write statistics arrays
+    if(m_InputValues->findLength)
+    {
+      auto& lengthOutput = m_DataStructure.getDataRefAs<UInt64Array>(interpolatedGroupPath.createChildPath(arrayName + m_InputValues->lengthSuffix));
+      for(usize v = 0; v < numVoxels; v++)
+      {
+        lengthOutput[v] = interpAccum[a][v].count;
+      }
+    }
+    if(m_InputValues->findMin)
+    {
+      auto& minOutput = m_DataStructure.getDataRefAs<Float32Array>(interpolatedGroupPath.createChildPath(arrayName + m_InputValues->minSuffix));
+      for(usize v = 0; v < numVoxels; v++)
+      {
+        const auto& accum = interpAccum[a][v];
+        minOutput[v] = accum.count > 0 ? static_cast<float32>(accum.min) : 0.0f;
+      }
+    }
+    if(m_InputValues->findMax)
+    {
+      auto& maxOutput = m_DataStructure.getDataRefAs<Float32Array>(interpolatedGroupPath.createChildPath(arrayName + m_InputValues->maxSuffix));
+      for(usize v = 0; v < numVoxels; v++)
+      {
+        const auto& accum = interpAccum[a][v];
+        maxOutput[v] = accum.count > 0 ? static_cast<float32>(accum.max) : 0.0f;
+      }
+    }
+    if(m_InputValues->findMean)
+    {
+      auto& meanOutput = m_DataStructure.getDataRefAs<Float32Array>(interpolatedGroupPath.createChildPath(arrayName + m_InputValues->meanSuffix));
+      for(usize v = 0; v < numVoxels; v++)
+      {
+        const auto& accum = interpAccum[a][v];
+        meanOutput[v] = accum.count > 0 ? static_cast<float32>(accum.weightedSum / static_cast<float64>(accum.count)) : 0.0f;
+      }
+    }
+    if(m_InputValues->findStdDeviation)
+    {
+      auto& stdDevOutput = m_DataStructure.getDataRefAs<Float32Array>(interpolatedGroupPath.createChildPath(arrayName + m_InputValues->stdDeviationSuffix));
+      for(usize v = 0; v < numVoxels; v++)
+      {
+        const auto& accum = interpAccum[a][v];
+        stdDevOutput[v] = accum.count > 0 ? static_cast<float32>(std::sqrt(accum.welfordM2 / static_cast<float64>(accum.count))) : 0.0f;
+      }
+    }
+    if(m_InputValues->findSummation)
+    {
+      auto& sumOutput = m_DataStructure.getDataRefAs<Float32Array>(interpolatedGroupPath.createChildPath(arrayName + m_InputValues->summationSuffix));
+      for(usize v = 0; v < numVoxels; v++)
+      {
+        sumOutput[v] = static_cast<float32>(interpAccum[a][v].weightedSum);
+      }
+    }
+  }
+
+  // Write copy array outputs
+  for(usize a = 0; a < numCopyArrays; a++)
+  {
+    auto* outputArray = m_DataStructure.getDataAs<IDataArray>(interpolatedGroupPath.createChildPath(copySourceArrays[a]->getName()));
+    ExecuteDataFunction(WriteWeightedAverageFunctor{}, outputArray->getDataType(), outputArray, copyWeightedSum[a], copyWeightSum[a], numVoxels);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.hpp
@@ -13,7 +13,7 @@ namespace nx::core
 
 struct SIMPLNXCORE_EXPORT InterpolatePointCloudToRegularGridInputValues
 {
-  bool storeKernelDistances;
+  bool useMask;
   uint64 interpolationTechnique;
   DataPath vertexGeomPath;
   DataPath imageGeomPath;
@@ -23,9 +23,23 @@ struct SIMPLNXCORE_EXPORT InterpolatePointCloudToRegularGridInputValues
   DataPath voxelIndicesPath;
   std::vector<float32> kernelSize;
   std::vector<float32> sigmas;
-  std::string kernelDistanceArrayName;
-  bool useMask;
   DataPath maskDataPath;
+
+  // Statistics flags
+  bool findLength;
+  bool findMin;
+  bool findMax;
+  bool findMean;
+  bool findStdDeviation;
+  bool findSummation;
+
+  // Output suffix names (appended to source array name)
+  std::string lengthSuffix;
+  std::string minSuffix;
+  std::string maxSuffix;
+  std::string meanSuffix;
+  std::string stdDeviationSuffix;
+  std::string summationSuffix;
 };
 
 /**

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.hpp
@@ -6,58 +6,31 @@
 #include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/Filter/IFilter.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
-#include "simplnx/Parameters/BoolParameter.hpp"
-#include "simplnx/Parameters/ChoicesParameter.hpp"
-#include "simplnx/Parameters/DataObjectNameParameter.hpp"
-#include "simplnx/Parameters/GeometrySelectionParameter.hpp"
-#include "simplnx/Parameters/MultiArraySelectionParameter.hpp"
-#include "simplnx/Parameters/VectorParameter.hpp"
-
-/**
-* This is example code to put in the Execute Method of the filter.
-  InterpolatePointCloudToRegularGridInputValues inputValues;
-  inputValues.CopyArrays = filterArgs.value<MultiArraySelectionParameter::ValueType>(copy_arrays);
-  inputValues.GaussianSigmas = filterArgs.value<VectorFloat32Parameter::ValueType>(gaussian_sigmas);
-  inputValues.InputImageGeometryPath = filterArgs.value<GeometrySelectionParameter::ValueType>(input_image_geometry_path);
-  inputValues.InputMaskPath = filterArgs.value<ArraySelectionParameter::ValueType>(input_mask_path);
-  inputValues.InputVertexGeometryPath = filterArgs.value<GeometrySelectionParameter::ValueType>(input_vertex_geometry_path);
-  inputValues.InterpolateArrays = filterArgs.value<MultiArraySelectionParameter::ValueType>(interpolate_arrays);
-  inputValues.InterpolatedGroupName = filterArgs.value<DataObjectNameParameter::ValueType>(interpolated_group_name);
-  inputValues.InterpolationIndex = filterArgs.value<ChoicesParameter::ValueType>(interpolation_index);
-  inputValues.KernelDistancesArrayName = filterArgs.value<DataObjectNameParameter::ValueType>(kernel_distances_array_name);
-  inputValues.KernelSize = filterArgs.value<VectorFloat32Parameter::ValueType>(kernel_size);
-  inputValues.StoreKernelDistances = filterArgs.value<BoolParameter::ValueType>(store_kernel_distances);
-  inputValues.UseMask = filterArgs.value<BoolParameter::ValueType>(use_mask);
-  inputValues.VoxelIndicesPath = filterArgs.value<ArraySelectionParameter::ValueType>(voxel_indices_path);
-  return InterpolatePointCloudToRegularGrid(dataStructure, messageHandler, shouldCancel, &inputValues)();
-
-*/
+#include "simplnx/Parameters/NumberParameter.hpp"
 
 namespace nx::core
 {
 
 struct SIMPLNXCORE_EXPORT InterpolatePointCloudToRegularGridInputValues
 {
-  MultiArraySelectionParameter::ValueType CopyArrays;
-  VectorFloat32Parameter::ValueType GaussianSigmas;
-  GeometrySelectionParameter::ValueType InputImageGeometryPath;
-  ArraySelectionParameter::ValueType InputMaskPath;
-  GeometrySelectionParameter::ValueType InputVertexGeometryPath;
-  MultiArraySelectionParameter::ValueType InterpolateArrays;
-  DataObjectNameParameter::ValueType InterpolatedGroupName;
-  ChoicesParameter::ValueType InterpolationIndex;
-  DataObjectNameParameter::ValueType KernelDistancesArrayName;
-  VectorFloat32Parameter::ValueType KernelSize;
-  BoolParameter::ValueType StoreKernelDistances;
-  BoolParameter::ValueType UseMask;
-  ArraySelectionParameter::ValueType VoxelIndicesPath;
+  bool storeKernelDistances;
+  uint64 interpolationTechnique;
+  DataPath vertexGeomPath;
+  DataPath imageGeomPath;
+  std::string interpolatedGroupName;
+  std::vector<DataPath> interpolatedDataPaths;
+  std::vector<DataPath> copyDataPaths;
+  DataPath voxelIndicesPath;
+  std::vector<float32> kernelSize;
+  std::vector<float32> sigmas;
+  std::string kernelDistanceArrayName;
+  bool useMask;
+  DataPath maskDataPath;
 };
 
 /**
- * @class InterpolatePointCloudToRegularGrid
- * @brief This algorithm implements support code for the InterpolatePointCloudToRegularGridFilter
+ * @class
  */
-
 class SIMPLNXCORE_EXPORT InterpolatePointCloudToRegularGrid
 {
 public:
@@ -71,6 +44,11 @@ public:
   InterpolatePointCloudToRegularGrid& operator=(InterpolatePointCloudToRegularGrid&&) noexcept = delete;
 
   Result<> operator()();
+
+  const std::atomic_bool& getCancel();
+
+  static constexpr uint64 k_Uniform = 0;
+  static constexpr uint64 k_Gaussian = 1;
 
 private:
   DataStructure& m_DataStructure;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.hpp
@@ -5,8 +5,6 @@
 #include "simplnx/DataStructure/DataPath.hpp"
 #include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/Filter/IFilter.hpp"
-#include "simplnx/Parameters/ArraySelectionParameter.hpp"
-#include "simplnx/Parameters/NumberParameter.hpp"
 
 namespace nx::core
 {
@@ -17,10 +15,8 @@ struct SIMPLNXCORE_EXPORT InterpolatePointCloudToRegularGridInputValues
   uint64 interpolationTechnique;
   DataPath vertexGeomPath;
   DataPath imageGeomPath;
-  std::string interpolatedGroupName;
   std::vector<DataPath> interpolatedDataPaths;
   std::vector<DataPath> copyDataPaths;
-  DataPath voxelIndicesPath;
   std::vector<float32> kernelSize;
   std::vector<float32> sigmas;
   DataPath maskDataPath;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
@@ -17,7 +17,6 @@
 #include "simplnx/Parameters/MultiArraySelectionParameter.hpp"
 #include "simplnx/Parameters/StringParameter.hpp"
 #include "simplnx/Parameters/VectorParameter.hpp"
-
 #include "simplnx/Utilities/SIMPLConversion.hpp"
 
 namespace nx::core
@@ -90,7 +89,7 @@ Parameters InterpolatePointCloudToRegularGridFilter::parameters() const
 
   params.linkParameters(k_UseMask_Key, k_InputMaskPath_Key, std::make_any<bool>(true));
   params.linkParameters(k_StoreKernelDistances_Key, k_KernelDistancesArrayName_Key, std::make_any<bool>(true));
-  params.linkParameters(k_InterpolationTechnique_Key, k_GaussianSigmas_Key, std::make_any<uint64>(k_Gaussian));
+  params.linkParameters(k_InterpolationTechnique_Key, k_GaussianSigmas_Key, std::make_any<uint64>(InterpolatePointCloudToRegularGrid::k_Gaussian));
 
   return params;
 }
@@ -125,7 +124,7 @@ IFilter::PreflightResult InterpolatePointCloudToRegularGridFilter::preflightImpl
 
   OutputActions actions;
 
-  if(interpolationTechnique != k_Uniform && interpolationTechnique != k_Gaussian)
+  if(interpolationTechnique != InterpolatePointCloudToRegularGrid::k_Uniform && interpolationTechnique != InterpolatePointCloudToRegularGrid::k_Gaussian)
   {
     return MakePreflightErrorResult(-11000, fmt::format("Interpolation Technique must be 0 [Uniform] or 1 [Gaussian] "));
   }
@@ -133,14 +132,14 @@ IFilter::PreflightResult InterpolatePointCloudToRegularGridFilter::preflightImpl
   if(kernelSize[0] < 0 || kernelSize[1] < 0 || kernelSize[2] < 0)
   {
     return MakePreflightErrorResult(-11000, fmt::format("All kernel dimensions must be positive.\n "
-                                                        "Current kernel dimensions:\n x = %1\n y = %2\n z = %3\n",
+                                                        "Current kernel dimensions:\n x = {}\n y = {}\n z = {}\n",
                                                         kernelSize[0], kernelSize[1], kernelSize[2]));
   }
 
   if(sigmas[0] <= 0 || sigmas[1] <= 0 || sigmas[2] <= 0)
   {
     return MakePreflightErrorResult(-11000, fmt::format("All sigmas must be positive.\n "
-                                                        "Current sigmas:\n x = %1\n y = %2\n z = %3\n",
+                                                        "Current sigmas:\n x = {}\n y = {}\n z = {}\n",
                                                         sigmas[0], sigmas[1], sigmas[2]));
   }
 
@@ -226,20 +225,19 @@ Result<> InterpolatePointCloudToRegularGridFilter::executeImpl(DataStructure& da
 {
   InterpolatePointCloudToRegularGridInputValues inputValues;
 
-  inputValues.UseMask = filterArgs.value<BoolParameter::ValueType>(k_UseMask_Key);
-  inputValues.StoreKernelDistances = filterArgs.value<BoolParameter::ValueType>(k_StoreKernelDistances_Key);
-  inputValues.InterpolationIndex = filterArgs.value<ChoicesParameter::ValueType>(k_InterpolationTechnique_Key);
-  inputValues.InputVertexGeometryPath = filterArgs.value<GeometrySelectionParameter::ValueType>(k_SelectedVertexGeometryPath_Key);
-  inputValues.InputImageGeometryPath = filterArgs.value<GeometrySelectionParameter::ValueType>(k_SelectedImageGeometryPath_Key);
-  inputValues.InterpolatedGroupName = filterArgs.value<DataObjectNameParameter::ValueType>(k_InterpolatedGroupName_Key);
-  inputValues.InterpolateArrays = filterArgs.value<MultiArraySelectionParameter::ValueType>(k_InterpolateArrays_Key);
-  inputValues.CopyArrays = filterArgs.value<MultiArraySelectionParameter::ValueType>(k_CopyArrays_Key);
-  inputValues.VoxelIndicesPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_VoxelIndicesPath_Key);
-  inputValues.KernelSize = filterArgs.value<VectorFloat32Parameter::ValueType>(k_KernelSize_Key);
-  inputValues.GaussianSigmas = filterArgs.value<VectorFloat32Parameter::ValueType>(k_GaussianSigmas_Key);
-  inputValues.InputMaskPath = filterArgs.value<ArraySelectionParameter::ValueType>(k_InputMaskPath_Key);
-  inputValues.KernelDistancesArrayName = filterArgs.value<DataObjectNameParameter::ValueType>(k_KernelDistancesArrayName_Key);
-
+  inputValues.storeKernelDistances = filterArgs.value<bool>(k_StoreKernelDistances_Key);
+  inputValues.interpolationTechnique = filterArgs.value<uint64>(k_InterpolationTechnique_Key);
+  inputValues.vertexGeomPath = filterArgs.value<DataPath>(k_SelectedVertexGeometryPath_Key);
+  inputValues.imageGeomPath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
+  inputValues.interpolatedGroupName = filterArgs.value<std::string>(k_InterpolatedGroupName_Key);
+  inputValues.interpolatedDataPaths = filterArgs.value<std::vector<DataPath>>(k_InterpolateArrays_Key);
+  inputValues.copyDataPaths = filterArgs.value<std::vector<DataPath>>(k_CopyArrays_Key);
+  inputValues.voxelIndicesPath = filterArgs.value<DataPath>(k_VoxelIndicesPath_Key);
+  inputValues.kernelSize = filterArgs.value<std::vector<float32>>(k_KernelSize_Key);
+  inputValues.sigmas = filterArgs.value<std::vector<float32>>(k_GaussianSigmas_Key);
+  inputValues.kernelDistanceArrayName = filterArgs.value<std::string>(k_KernelDistancesArrayName_Key);
+  inputValues.useMask = filterArgs.value<bool>(k_UseMask_Key);
+  inputValues.maskDataPath = filterArgs.value<DataPath>(k_InputMaskPath_Key);
   return InterpolatePointCloudToRegularGrid(dataStructure, messageHandler, shouldCancel, &inputValues)();
 }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
@@ -5,9 +5,8 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
-#include "simplnx/Filter/Actions/CopyArrayInstanceAction.hpp"
+#include "simplnx/Filter/Actions/CreateArrayAction.hpp"
 #include "simplnx/Filter/Actions/CreateAttributeMatrixAction.hpp"
-#include "simplnx/Filter/Actions/CreateNeighborListAction.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
@@ -59,7 +58,6 @@ Parameters InterpolatePointCloudToRegularGridFilter::parameters() const
 
   params.insertSeparator(Parameters::Separator{"Input Parameter(s)"});
   params.insertLinkableParameter(std::make_unique<BoolParameter>(k_UseMask_Key, "Use Mask Array", "Specifies whether or not to use a mask array", false));
-  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_StoreKernelDistances_Key, "Store Kernel Distances", "Specifies whether or not to store kernel distances", false));
   params.insertLinkableParameter(
       std::make_unique<ChoicesParameter>(k_InterpolationTechnique_Key, "Interpolation Technique", "Selected Interpolation Technique", 0, std::vector<std::string>{"Uniform", "Gaussian"}));
   params.insert(
@@ -67,15 +65,20 @@ Parameters InterpolatePointCloudToRegularGridFilter::parameters() const
   params.insert(std::make_unique<VectorFloat32Parameter>(k_GaussianSigmas_Key, "Gaussian Sigmas", "Specifies the Gaussian sigmas", std::vector<float32>{1.0f, 1.0f, 1.0f},
                                                          std::vector<std::string>{"x", "y", "z"}));
 
-  params.insertSeparator(Parameters::Separator{"Input Data Objects"});
-  params.insert(std::make_unique<GeometrySelectionParameter>(k_SelectedVertexGeometryPath_Key, "Vertex Geometry to Interpolate", "DataPath to geometry to interpolate", DataPath{},
-                                                             GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Vertex}));
+  params.insertSeparator(Parameters::Separator{"Destination Image Geometry"});
   params.insert(std::make_unique<GeometrySelectionParameter>(k_SelectedImageGeometryPath_Key, "Interpolated Image Geometry", "DataPath to interpolated geometry", DataPath{},
                                                              GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image}));
+
+  params.insertSeparator(Parameters::Separator{"Input Vertex Geometry"});
+  params.insert(std::make_unique<GeometrySelectionParameter>(k_SelectedVertexGeometryPath_Key, "Vertex Geometry to Interpolate", "DataPath to geometry to interpolate", DataPath{},
+                                                             GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Vertex}));
+
   params.insert(std::make_unique<ArraySelectionParameter>(k_VoxelIndicesPath_Key, "Voxel Indices", "DataPath to voxel indices", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::uint64},
                                                           ArraySelectionParameter::AllowedComponentShapes{{1}}));
-  params.insert(std::make_unique<ArraySelectionParameter>(k_InputMaskPath_Key, "Mask", "DataPath to the boolean mask array. Values that are true will mark that cell/point as usable.", DataPath{},
+
+  params.insert(std::make_unique<ArraySelectionParameter>(k_InputMaskPath_Key, "Mask", "DataPath to the boolean mask array. Values that are true will mark that vertex as usable.", DataPath{},
                                                           ArraySelectionParameter::AllowedTypes{DataType::boolean}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
+
   params.insert(std::make_unique<MultiArraySelectionParameter>(k_InterpolateArrays_Key, "Attribute Arrays to Interpolate", "DataPaths to interpolate", std::vector<DataPath>(),
                                                                MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray}, GetAllNumericTypes(),
                                                                MultiArraySelectionParameter::AllowedComponentShapes{{1}}));
@@ -84,12 +87,32 @@ Parameters InterpolatePointCloudToRegularGridFilter::parameters() const
                                                                MultiArraySelectionParameter::AllowedComponentShapes{{1}}));
 
   params.insertSeparator(Parameters::Separator{"Output Data Object(s)"});
-  params.insert(std::make_unique<DataObjectNameParameter>(k_InterpolatedGroupName_Key, "Interpolated Group", "DataPath to created DataGroup for interpolated data", "InterpolatedData"));
-  params.insert(std::make_unique<DataObjectNameParameter>(k_KernelDistancesArrayName_Key, "Kernel Distances Group", "DataPath to created DataGroup for kernel distances data", "KernelDistances"));
+  // params.insert(std::make_unique<DataObjectNameParameter>(k_InterpolatedGroupName_Key, "Interpolated Group", "DataPath to created DataGroup for interpolated data", "InterpolatedData"));
 
+  params.insertSeparator(Parameters::Separator{"Statistics Options"});
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_FindLength_Key, "Find Length", "Compute the number of contributions per voxel", false));
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_FindMin_Key, "Find Minimum", "Compute the minimum weighted value per voxel", false));
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_FindMax_Key, "Find Maximum", "Compute the maximum weighted value per voxel", false));
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_FindMean_Key, "Find Mean", "Compute the mean weighted value per voxel", false));
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_FindStdDeviation_Key, "Find Standard Deviation", "Compute the standard deviation of weighted values per voxel", false));
+  params.insertLinkableParameter(std::make_unique<BoolParameter>(k_FindSummation_Key, "Find Summation", "Compute the sum of weighted values per voxel", false));
+
+  params.insert(std::make_unique<DataObjectNameParameter>(k_LengthSuffix_Key, "Length Suffix", "Suffix appended to array name for length output", "_Length"));
+  params.insert(std::make_unique<DataObjectNameParameter>(k_MinSuffix_Key, "Minimum Suffix", "Suffix appended to array name for minimum output", "_Minimum"));
+  params.insert(std::make_unique<DataObjectNameParameter>(k_MaxSuffix_Key, "Maximum Suffix", "Suffix appended to array name for maximum output", "_Maximum"));
+  params.insert(std::make_unique<DataObjectNameParameter>(k_MeanSuffix_Key, "Mean Suffix", "Suffix appended to array name for mean output", "_Mean"));
+  params.insert(std::make_unique<DataObjectNameParameter>(k_StdDeviationSuffix_Key, "Standard Deviation Suffix", "Suffix appended to array name for standard deviation output", "_StdDeviation"));
+  params.insert(std::make_unique<DataObjectNameParameter>(k_SummationSuffix_Key, "Summation Suffix", "Suffix appended to array name for summation output", "_Summation"));
+
+  // Link parameters
   params.linkParameters(k_UseMask_Key, k_InputMaskPath_Key, std::make_any<bool>(true));
-  params.linkParameters(k_StoreKernelDistances_Key, k_KernelDistancesArrayName_Key, std::make_any<bool>(true));
   params.linkParameters(k_InterpolationTechnique_Key, k_GaussianSigmas_Key, std::make_any<uint64>(InterpolatePointCloudToRegularGrid::k_Gaussian));
+  params.linkParameters(k_FindLength_Key, k_LengthSuffix_Key, std::make_any<bool>(true));
+  params.linkParameters(k_FindMin_Key, k_MinSuffix_Key, std::make_any<bool>(true));
+  params.linkParameters(k_FindMax_Key, k_MaxSuffix_Key, std::make_any<bool>(true));
+  params.linkParameters(k_FindMean_Key, k_MeanSuffix_Key, std::make_any<bool>(true));
+  params.linkParameters(k_FindStdDeviation_Key, k_StdDeviationSuffix_Key, std::make_any<bool>(true));
+  params.linkParameters(k_FindSummation_Key, k_SummationSuffix_Key, std::make_any<bool>(true));
 
   return params;
 }
@@ -97,7 +120,9 @@ Parameters InterpolatePointCloudToRegularGridFilter::parameters() const
 //------------------------------------------------------------------------------
 IFilter::VersionType InterpolatePointCloudToRegularGridFilter::parametersVersion() const
 {
-  return 1;
+  return 3;
+  // Version 3 Changes
+  // Removed the 'interpolated_group_name' key - The data is all stored in the Cell Data of the target ImageGeom
 }
 
 //------------------------------------------------------------------------------
@@ -110,24 +135,37 @@ IFilter::UniquePointer InterpolatePointCloudToRegularGridFilter::clone() const
 IFilter::PreflightResult InterpolatePointCloudToRegularGridFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                                                  const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
-  auto useMask = filterArgs.value<bool>(k_UseMask_Key);
-  auto storeKernelDistances = filterArgs.value<bool>(k_StoreKernelDistances_Key);
   auto interpolationTechnique = filterArgs.value<uint64>(k_InterpolationTechnique_Key);
-  auto vertexGeomPath = filterArgs.value<DataPath>(k_SelectedVertexGeometryPath_Key);
-  auto imageGeomPath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
-  auto interpolatedGroupName = filterArgs.value<std::string>(k_InterpolatedGroupName_Key);
-  auto voxelIndicesPath = filterArgs.value<DataPath>(k_VoxelIndicesPath_Key);
-  auto interpolatedDataPaths = filterArgs.value<std::vector<DataPath>>(k_InterpolateArrays_Key);
-  auto copyDataPaths = filterArgs.value<std::vector<DataPath>>(k_CopyArrays_Key);
   auto kernelSize = filterArgs.value<std::vector<float32>>(k_KernelSize_Key);
   auto sigmas = filterArgs.value<std::vector<float32>>(k_GaussianSigmas_Key);
 
-  OutputActions actions;
+  // Input Image Geometry
+  auto imageGeomPath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
 
-  if(interpolationTechnique != InterpolatePointCloudToRegularGrid::k_Uniform && interpolationTechnique != InterpolatePointCloudToRegularGrid::k_Gaussian)
-  {
-    return MakePreflightErrorResult(-11000, fmt::format("Interpolation Technique must be 0 [Uniform] or 1 [Gaussian] "));
-  }
+  // Input Vertex Geometry and Data
+  auto useMask = filterArgs.value<bool>(k_UseMask_Key);
+  auto vertexGeomPath = filterArgs.value<DataPath>(k_SelectedVertexGeometryPath_Key);
+  // auto interpolatedGroupName = filterArgs.value<std::string>(k_InterpolatedGroupName_Key);
+  auto voxelIndicesPath = filterArgs.value<DataPath>(k_VoxelIndicesPath_Key);
+  auto interpolatedDataPaths = filterArgs.value<std::vector<DataPath>>(k_InterpolateArrays_Key);
+  auto copyDataPaths = filterArgs.value<std::vector<DataPath>>(k_CopyArrays_Key);
+
+  // Statistics Options
+  auto findLength = filterArgs.value<bool>(k_FindLength_Key);
+  auto findMin = filterArgs.value<bool>(k_FindMin_Key);
+  auto findMax = filterArgs.value<bool>(k_FindMax_Key);
+  auto findMean = filterArgs.value<bool>(k_FindMean_Key);
+  auto findStdDeviation = filterArgs.value<bool>(k_FindStdDeviation_Key);
+  auto findSummation = filterArgs.value<bool>(k_FindSummation_Key);
+
+  auto lengthSuffix = filterArgs.value<std::string>(k_LengthSuffix_Key);
+  auto minSuffix = filterArgs.value<std::string>(k_MinSuffix_Key);
+  auto maxSuffix = filterArgs.value<std::string>(k_MaxSuffix_Key);
+  auto meanSuffix = filterArgs.value<std::string>(k_MeanSuffix_Key);
+  auto stdDeviationSuffix = filterArgs.value<std::string>(k_StdDeviationSuffix_Key);
+  auto summationSuffix = filterArgs.value<std::string>(k_SummationSuffix_Key);
+
+  OutputActions actions;
 
   if(kernelSize[0] < 0 || kernelSize[1] < 0 || kernelSize[2] < 0)
   {
@@ -143,61 +181,90 @@ IFilter::PreflightResult InterpolatePointCloudToRegularGridFilter::preflightImpl
                                                         sigmas[0], sigmas[1], sigmas[2]));
   }
 
-  const DataPath interpolatedGroupPath = imageGeomPath.createChildPath(interpolatedGroupName);
-  auto vertexGeom = dataStructure.getDataAs<VertexGeom>(vertexGeomPath);
-  auto image = dataStructure.getDataAs<ImageGeom>(imageGeomPath);
-  const SizeVec3 imageDims = image->getDimensions();
+  const ImageGeom imageGeomRef = dataStructure.getDataRefAs<ImageGeom>(imageGeomPath);
+  const DataPath interpolatedGroupPath = imageGeomRef.getCellDataPath();
+  const SizeVec3 imageDims = imageGeomRef.getDimensions();
   ShapeType tupleDims = {imageDims[2], imageDims[1], imageDims[0]};
 
-  // Create the attribute matrix for storing the interpolated/copied arrays
-  {
-    auto createGroupAction = std::make_unique<CreateAttributeMatrixAction>(interpolatedGroupPath, tupleDims);
-    actions.appendAction(std::move(createGroupAction));
-  }
-
+  auto vertexGeom = dataStructure.getDataAs<VertexGeom>(vertexGeomPath);
   std::vector<DataPath> dataArrays = {vertexGeomPath.createChildPath(vertexGeom->getVertices()->getName()), voxelIndicesPath};
 
-  // Create the neighbor list arrays for storing the interpolated array data
+  // Create flat DataArrays for interpolated arrays (output type = float64)
   for(const auto& interpolatePath : interpolatedDataPaths)
   {
     dataArrays.push_back(interpolatePath);
 
-    auto targetArray = dataStructure.getDataAs<IDataArray>(interpolatePath);
-    auto targetPath = interpolatedGroupPath.createChildPath(targetArray->getName());
-    if(targetArray->getNumberOfComponents() != 1)
+    auto srcDataArrayPtr = dataStructure.getDataAs<IDataArray>(interpolatePath);
+    if(srcDataArrayPtr->getNumberOfComponents() != 1)
     {
-      return MakePreflightErrorResult(-11002, fmt::format("Attribute Arrays selected for copying must be scalar arrays"));
+      return MakePreflightErrorResult(-11002, fmt::format("Attribute Arrays selected for interpolation must be scalar arrays"));
     }
-    auto dataType = targetArray->getDataType();
-    if(dataType != DataType::boolean)
+    auto dataType = srcDataArrayPtr->getDataType();
+    const std::string& destArrayName = srcDataArrayPtr->getName();
+
+    // Create the interpolated (weighted average) output array as float64
     {
-      auto neighborPath = interpolatedGroupPath.createChildPath(targetArray->getName());
-      auto neighborAction = std::make_unique<CreateNeighborListAction>(dataType, tupleDims, neighborPath);
-      actions.appendAction(std::move(neighborAction));
+      auto arrayPath = interpolatedGroupPath.createChildPath(destArrayName);
+      auto createAction = std::make_unique<CreateArrayAction>(dataType, tupleDims, srcDataArrayPtr->getComponentShape(), arrayPath);
+      actions.appendAction(std::move(createAction));
+    }
+
+    // Create statistics output arrays
+    if(findLength)
+    {
+      auto arrayPath = interpolatedGroupPath.createChildPath(destArrayName + lengthSuffix);
+      auto createAction = std::make_unique<CreateArrayAction>(DataType::uint64, tupleDims, ShapeType{1}, arrayPath);
+      actions.appendAction(std::move(createAction));
+    }
+    if(findMin)
+    {
+      auto arrayPath = interpolatedGroupPath.createChildPath(destArrayName + minSuffix);
+      auto createAction = std::make_unique<CreateArrayAction>(DataType::float32, tupleDims, ShapeType{1}, arrayPath);
+      actions.appendAction(std::move(createAction));
+    }
+    if(findMax)
+    {
+      auto arrayPath = interpolatedGroupPath.createChildPath(destArrayName + maxSuffix);
+      auto createAction = std::make_unique<CreateArrayAction>(DataType::float32, tupleDims, ShapeType{1}, arrayPath);
+      actions.appendAction(std::move(createAction));
+    }
+    if(findMean)
+    {
+      auto arrayPath = interpolatedGroupPath.createChildPath(destArrayName + meanSuffix);
+      auto createAction = std::make_unique<CreateArrayAction>(DataType::float32, tupleDims, ShapeType{1}, arrayPath);
+      actions.appendAction(std::move(createAction));
+    }
+    if(findStdDeviation)
+    {
+      auto arrayPath = interpolatedGroupPath.createChildPath(destArrayName + stdDeviationSuffix);
+      auto createAction = std::make_unique<CreateArrayAction>(DataType::float32, tupleDims, ShapeType{1}, arrayPath);
+      actions.appendAction(std::move(createAction));
+    }
+    if(findSummation)
+    {
+      auto arrayPath = interpolatedGroupPath.createChildPath(destArrayName + summationSuffix);
+      auto createAction = std::make_unique<CreateArrayAction>(DataType::float32, tupleDims, ShapeType{1}, arrayPath);
+      actions.appendAction(std::move(createAction));
     }
   }
 
-  // Create the neighbor list arrays for storing the copied array data
+  // Create flat DataArrays for copy arrays (matching source type)
   for(const auto& copyPath : copyDataPaths)
   {
     dataArrays.push_back(copyPath);
 
-    auto targetArray = dataStructure.getDataAs<IDataArray>(copyPath);
-    auto targetPath = interpolatedGroupPath.createChildPath(targetArray->getName());
-    if(targetArray->getNumberOfComponents() != 1)
+    auto srcDataArrayPtr = dataStructure.getDataAs<IDataArray>(copyPath);
+    if(srcDataArrayPtr->getNumberOfComponents() != 1)
     {
       return MakePreflightErrorResult(-11002, fmt::format("Attribute Arrays selected for copying must be scalar arrays"));
     }
-    auto dataType = targetArray->getDataType();
-    if(dataType != DataType::boolean)
-    {
-      auto neighborPath = interpolatedGroupPath.createChildPath(targetArray->getName());
-      auto neighborAction = std::make_unique<CreateNeighborListAction>(dataType, tupleDims, neighborPath);
-      actions.appendAction(std::move(neighborAction));
-    }
+    auto dataType = srcDataArrayPtr->getDataType();
+    auto destArrayDataPath = interpolatedGroupPath.createChildPath(srcDataArrayPtr->getName());
+    auto createAction = std::make_unique<CreateArrayAction>(dataType, tupleDims, srcDataArrayPtr->getComponentShape(), destArrayDataPath);
+    actions.appendAction(std::move(createAction));
   }
 
-  // validate the input arrays have matching tuples (i.e. it should all come from the input vertex geometry's vertex data)
+  // Validate input arrays have matching tuples
   if(useMask)
   {
     dataArrays.push_back(filterArgs.value<DataPath>(k_InputMaskPath_Key));
@@ -209,13 +276,6 @@ IFilter::PreflightResult InterpolatePointCloudToRegularGridFilter::preflightImpl
     return {MakeErrorResult<OutputActions>(-11003, fmt::format("The following DataArrays all must have equal number of tuples but this was not satisfied.\n{}", tupleValidityCheck.error()))};
   }
 
-  // Create the neighbor list array for storing the kernel distances
-  if(storeKernelDistances)
-  {
-    auto action = std::make_unique<CreateNeighborListAction>(DataType::float32, tupleDims, interpolatedGroupPath.createChildPath(filterArgs.value<std::string>(k_KernelDistancesArrayName_Key)));
-    actions.appendAction(std::move(action));
-  }
-
   return {std::move(actions)};
 }
 
@@ -225,19 +285,31 @@ Result<> InterpolatePointCloudToRegularGridFilter::executeImpl(DataStructure& da
 {
   InterpolatePointCloudToRegularGridInputValues inputValues;
 
-  inputValues.storeKernelDistances = filterArgs.value<bool>(k_StoreKernelDistances_Key);
   inputValues.interpolationTechnique = filterArgs.value<uint64>(k_InterpolationTechnique_Key);
   inputValues.vertexGeomPath = filterArgs.value<DataPath>(k_SelectedVertexGeometryPath_Key);
   inputValues.imageGeomPath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
-  inputValues.interpolatedGroupName = filterArgs.value<std::string>(k_InterpolatedGroupName_Key);
   inputValues.interpolatedDataPaths = filterArgs.value<std::vector<DataPath>>(k_InterpolateArrays_Key);
   inputValues.copyDataPaths = filterArgs.value<std::vector<DataPath>>(k_CopyArrays_Key);
   inputValues.voxelIndicesPath = filterArgs.value<DataPath>(k_VoxelIndicesPath_Key);
   inputValues.kernelSize = filterArgs.value<std::vector<float32>>(k_KernelSize_Key);
   inputValues.sigmas = filterArgs.value<std::vector<float32>>(k_GaussianSigmas_Key);
-  inputValues.kernelDistanceArrayName = filterArgs.value<std::string>(k_KernelDistancesArrayName_Key);
   inputValues.useMask = filterArgs.value<bool>(k_UseMask_Key);
   inputValues.maskDataPath = filterArgs.value<DataPath>(k_InputMaskPath_Key);
+
+  inputValues.findLength = filterArgs.value<bool>(k_FindLength_Key);
+  inputValues.findMin = filterArgs.value<bool>(k_FindMin_Key);
+  inputValues.findMax = filterArgs.value<bool>(k_FindMax_Key);
+  inputValues.findMean = filterArgs.value<bool>(k_FindMean_Key);
+  inputValues.findStdDeviation = filterArgs.value<bool>(k_FindStdDeviation_Key);
+  inputValues.findSummation = filterArgs.value<bool>(k_FindSummation_Key);
+
+  inputValues.lengthSuffix = filterArgs.value<std::string>(k_LengthSuffix_Key);
+  inputValues.minSuffix = filterArgs.value<std::string>(k_MinSuffix_Key);
+  inputValues.maxSuffix = filterArgs.value<std::string>(k_MaxSuffix_Key);
+  inputValues.meanSuffix = filterArgs.value<std::string>(k_MeanSuffix_Key);
+  inputValues.stdDeviationSuffix = filterArgs.value<std::string>(k_StdDeviationSuffix_Key);
+  inputValues.summationSuffix = filterArgs.value<std::string>(k_SummationSuffix_Key);
+
   return InterpolatePointCloudToRegularGrid(dataStructure, messageHandler, shouldCancel, &inputValues)();
 }
 
@@ -246,7 +318,6 @@ namespace
 namespace SIMPL
 {
 constexpr StringLiteral k_UseMaskKey = "UseMask";
-constexpr StringLiteral k_StoreKernelDistancesKey = "StoreKernelDistances";
 constexpr StringLiteral k_InterpolationTechniqueKey = "InterpolationTechnique";
 constexpr StringLiteral k_KernelSizeKey = "KernelSize";
 constexpr StringLiteral k_SigmasKey = "Sigmas";
@@ -257,7 +328,6 @@ constexpr StringLiteral k_MaskArrayPathKey = "MaskArrayPath";
 constexpr StringLiteral k_ArraysToInterpolateKey = "ArraysToInterpolate";
 constexpr StringLiteral k_ArraysToCopyKey = "ArraysToCopy";
 constexpr StringLiteral k_InterpolatedAttributeMatrixNameKey = "InterpolatedAttributeMatrixName";
-constexpr StringLiteral k_KernelDistancesArrayNameKey = "KernelDistancesArrayName";
 } // namespace SIMPL
 } // namespace
 
@@ -268,7 +338,6 @@ Result<Arguments> InterpolatePointCloudToRegularGridFilter::FromSIMPLJson(const 
   std::vector<Result<>> results;
 
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::LinkedBooleanFilterParameterConverter>(args, json, SIMPL::k_UseMaskKey, k_UseMask_Key));
-  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::LinkedBooleanFilterParameterConverter>(args, json, SIMPL::k_StoreKernelDistancesKey, k_StoreKernelDistances_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::LinkedChoicesFilterParameterConverter>(args, json, SIMPL::k_InterpolationTechniqueKey, k_InterpolationTechnique_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::FloatVec3FilterParameterConverter>(args, json, SIMPL::k_KernelSizeKey, k_KernelSize_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::FloatVec3FilterParameterConverter>(args, json, SIMPL::k_SigmasKey, k_GaussianSigmas_Key));
@@ -279,9 +348,6 @@ Result<Arguments> InterpolatePointCloudToRegularGridFilter::FromSIMPLJson(const 
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_MaskArrayPathKey, k_InputMaskPath_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::MultiDataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_ArraysToInterpolateKey, k_InterpolateArrays_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::MultiDataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_ArraysToCopyKey, k_CopyArrays_Key));
-  results.push_back(
-      SIMPLConversion::ConvertParameter<SIMPLConversion::LinkedPathCreationFilterParameterConverter>(args, json, SIMPL::k_InterpolatedAttributeMatrixNameKey, k_InterpolatedGroupName_Key));
-  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::LinkedPathCreationFilterParameterConverter>(args, json, SIMPL::k_KernelDistancesArrayNameKey, k_KernelDistancesArrayName_Key));
 
   Result<> conversionResult = MergeResults(std::move(results));
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.cpp
@@ -73,9 +73,6 @@ Parameters InterpolatePointCloudToRegularGridFilter::parameters() const
   params.insert(std::make_unique<GeometrySelectionParameter>(k_SelectedVertexGeometryPath_Key, "Vertex Geometry to Interpolate", "DataPath to geometry to interpolate", DataPath{},
                                                              GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Vertex}));
 
-  params.insert(std::make_unique<ArraySelectionParameter>(k_VoxelIndicesPath_Key, "Voxel Indices", "DataPath to voxel indices", DataPath{}, ArraySelectionParameter::AllowedTypes{DataType::uint64},
-                                                          ArraySelectionParameter::AllowedComponentShapes{{1}}));
-
   params.insert(std::make_unique<ArraySelectionParameter>(k_InputMaskPath_Key, "Mask", "DataPath to the boolean mask array. Values that are true will mark that vertex as usable.", DataPath{},
                                                           ArraySelectionParameter::AllowedTypes{DataType::boolean}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
 
@@ -120,7 +117,9 @@ Parameters InterpolatePointCloudToRegularGridFilter::parameters() const
 //------------------------------------------------------------------------------
 IFilter::VersionType InterpolatePointCloudToRegularGridFilter::parametersVersion() const
 {
-  return 3;
+  return 4;
+  // Version 4 Changes
+  // Removed 'voxel_indices_path' key - Voxel indices are now computed on-the-fly from vertex coordinates
   // Version 3 Changes
   // Removed the 'interpolated_group_name' key - The data is all stored in the Cell Data of the target ImageGeom
 }
@@ -145,8 +144,6 @@ IFilter::PreflightResult InterpolatePointCloudToRegularGridFilter::preflightImpl
   // Input Vertex Geometry and Data
   auto useMask = filterArgs.value<bool>(k_UseMask_Key);
   auto vertexGeomPath = filterArgs.value<DataPath>(k_SelectedVertexGeometryPath_Key);
-  // auto interpolatedGroupName = filterArgs.value<std::string>(k_InterpolatedGroupName_Key);
-  auto voxelIndicesPath = filterArgs.value<DataPath>(k_VoxelIndicesPath_Key);
   auto interpolatedDataPaths = filterArgs.value<std::vector<DataPath>>(k_InterpolateArrays_Key);
   auto copyDataPaths = filterArgs.value<std::vector<DataPath>>(k_CopyArrays_Key);
 
@@ -187,7 +184,7 @@ IFilter::PreflightResult InterpolatePointCloudToRegularGridFilter::preflightImpl
   ShapeType tupleDims = {imageDims[2], imageDims[1], imageDims[0]};
 
   auto vertexGeom = dataStructure.getDataAs<VertexGeom>(vertexGeomPath);
-  std::vector<DataPath> dataArrays = {vertexGeomPath.createChildPath(vertexGeom->getVertices()->getName()), voxelIndicesPath};
+  std::vector<DataPath> dataArrays = {vertexGeomPath.createChildPath(vertexGeom->getVertices()->getName())};
 
   // Create flat DataArrays for interpolated arrays (output type = float64)
   for(const auto& interpolatePath : interpolatedDataPaths)
@@ -290,7 +287,6 @@ Result<> InterpolatePointCloudToRegularGridFilter::executeImpl(DataStructure& da
   inputValues.imageGeomPath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
   inputValues.interpolatedDataPaths = filterArgs.value<std::vector<DataPath>>(k_InterpolateArrays_Key);
   inputValues.copyDataPaths = filterArgs.value<std::vector<DataPath>>(k_CopyArrays_Key);
-  inputValues.voxelIndicesPath = filterArgs.value<DataPath>(k_VoxelIndicesPath_Key);
   inputValues.kernelSize = filterArgs.value<std::vector<float32>>(k_KernelSize_Key);
   inputValues.sigmas = filterArgs.value<std::vector<float32>>(k_GaussianSigmas_Key);
   inputValues.useMask = filterArgs.value<bool>(k_UseMask_Key);
@@ -323,7 +319,6 @@ constexpr StringLiteral k_KernelSizeKey = "KernelSize";
 constexpr StringLiteral k_SigmasKey = "Sigmas";
 constexpr StringLiteral k_DataContainerNameKey = "DataContainerName";
 constexpr StringLiteral k_InterpolatedDataContainerNameKey = "InterpolatedDataContainerName";
-constexpr StringLiteral k_VoxelIndicesArrayPathKey = "VoxelIndicesArrayPath";
 constexpr StringLiteral k_MaskArrayPathKey = "MaskArrayPath";
 constexpr StringLiteral k_ArraysToInterpolateKey = "ArraysToInterpolate";
 constexpr StringLiteral k_ArraysToCopyKey = "ArraysToCopy";
@@ -344,7 +339,6 @@ Result<Arguments> InterpolatePointCloudToRegularGridFilter::FromSIMPLJson(const 
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataContainerSelectionFilterParameterConverter>(args, json, SIMPL::k_DataContainerNameKey, k_SelectedImageGeometryPath_Key));
   results.push_back(
       SIMPLConversion::ConvertParameter<SIMPLConversion::DataContainerSelectionFilterParameterConverter>(args, json, SIMPL::k_InterpolatedDataContainerNameKey, k_SelectedVertexGeometryPath_Key));
-  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_VoxelIndicesArrayPathKey, k_VoxelIndicesPath_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_MaskArrayPathKey, k_InputMaskPath_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::MultiDataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_ArraysToInterpolateKey, k_InterpolateArrays_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::MultiDataArraySelectionFilterParameterConverter>(args, json, SIMPL::k_ArraysToCopyKey, k_CopyArrays_Key));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp
@@ -38,8 +38,6 @@ public:
   static constexpr StringLiteral k_CopyArrays_Key = "copy_arrays";
   static constexpr StringLiteral k_InterpolatedGroupName_Key = "interpolated_group_name";
   static constexpr StringLiteral k_KernelDistancesArrayName_Key = "kernel_distances_array_name";
-  static constexpr uint64 k_Uniform = 0;
-  static constexpr uint64 k_Gaussian = 1;
 
   /**
    * @brief Reads SIMPL json and converts it simplnx Arguments.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp
@@ -31,7 +31,6 @@ public:
   static constexpr StringLiteral k_GaussianSigmas_Key = "gaussian_sigmas";
   static constexpr StringLiteral k_SelectedVertexGeometryPath_Key = "input_vertex_geometry_path";
   static constexpr StringLiteral k_SelectedImageGeometryPath_Key = "input_image_geometry_path";
-  static constexpr StringLiteral k_VoxelIndicesPath_Key = "voxel_indices_path";
   static constexpr StringLiteral k_InputMaskPath_Key = "input_mask_path";
   static constexpr StringLiteral k_InterpolateArrays_Key = "interpolate_arrays";
   static constexpr StringLiteral k_CopyArrays_Key = "copy_arrays";
@@ -46,12 +45,12 @@ public:
   static constexpr StringLiteral k_FindSummation_Key = "find_summation";
 
   // Statistics output array name suffixes
-  static constexpr StringLiteral k_LengthSuffix_Key = "length_suffix";
-  static constexpr StringLiteral k_MinSuffix_Key = "min_suffix";
-  static constexpr StringLiteral k_MaxSuffix_Key = "max_suffix";
-  static constexpr StringLiteral k_MeanSuffix_Key = "mean_suffix";
-  static constexpr StringLiteral k_StdDeviationSuffix_Key = "std_deviation_suffix";
-  static constexpr StringLiteral k_SummationSuffix_Key = "summation_suffix";
+  static constexpr StringLiteral k_LengthSuffix_Key = "length_suffix_name";
+  static constexpr StringLiteral k_MinSuffix_Key = "min_suffix_name";
+  static constexpr StringLiteral k_MaxSuffix_Key = "max_suffix_name";
+  static constexpr StringLiteral k_MeanSuffix_Key = "mean_suffix_name";
+  static constexpr StringLiteral k_StdDeviationSuffix_Key = "std_deviation_suffix_name";
+  static constexpr StringLiteral k_SummationSuffix_Key = "summation_suffix_name";
 
   /**
    * @brief Reads SIMPL json and converts it simplnx Arguments.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp
@@ -26,7 +26,6 @@ public:
 
   // Parameter Keys
   static constexpr StringLiteral k_UseMask_Key = "use_mask";
-  static constexpr StringLiteral k_StoreKernelDistances_Key = "store_kernel_distances";
   static constexpr StringLiteral k_InterpolationTechnique_Key = "interpolation_index";
   static constexpr StringLiteral k_KernelSize_Key = "kernel_size";
   static constexpr StringLiteral k_GaussianSigmas_Key = "gaussian_sigmas";
@@ -36,8 +35,23 @@ public:
   static constexpr StringLiteral k_InputMaskPath_Key = "input_mask_path";
   static constexpr StringLiteral k_InterpolateArrays_Key = "interpolate_arrays";
   static constexpr StringLiteral k_CopyArrays_Key = "copy_arrays";
-  static constexpr StringLiteral k_InterpolatedGroupName_Key = "interpolated_group_name";
-  static constexpr StringLiteral k_KernelDistancesArrayName_Key = "kernel_distances_array_name";
+  // static constexpr StringLiteral k_InterpolatedGroupName_Key = "interpolated_group_name";
+
+  // Statistics toggles
+  static constexpr StringLiteral k_FindLength_Key = "find_length";
+  static constexpr StringLiteral k_FindMin_Key = "find_min";
+  static constexpr StringLiteral k_FindMax_Key = "find_max";
+  static constexpr StringLiteral k_FindMean_Key = "find_mean";
+  static constexpr StringLiteral k_FindStdDeviation_Key = "find_std_deviation";
+  static constexpr StringLiteral k_FindSummation_Key = "find_summation";
+
+  // Statistics output array name suffixes
+  static constexpr StringLiteral k_LengthSuffix_Key = "length_suffix";
+  static constexpr StringLiteral k_MinSuffix_Key = "min_suffix";
+  static constexpr StringLiteral k_MaxSuffix_Key = "max_suffix";
+  static constexpr StringLiteral k_MeanSuffix_Key = "mean_suffix";
+  static constexpr StringLiteral k_StdDeviationSuffix_Key = "std_deviation_suffix";
+  static constexpr StringLiteral k_SummationSuffix_Key = "summation_suffix";
 
   /**
    * @brief Reads SIMPL json and converts it simplnx Arguments.

--- a/src/Plugins/SimplnxCore/test/InterpolatePointCloudToRegularGridTest.cpp
+++ b/src/Plugins/SimplnxCore/test/InterpolatePointCloudToRegularGridTest.cpp
@@ -2,188 +2,314 @@
 #include "SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp"
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
 
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include <catch2/catch.hpp>
 
-#include <string>
+#include <cmath>
 
-namespace fs = std::filesystem;
 using namespace nx::core;
-using namespace nx::core::Constants;
 
 namespace
 {
-const std::string k_UniformInterpolatedData = "UniformInterpolatedData";
-const std::string k_GaussianInterpolatedData = "GaussianInterpolatedData";
-const std::string k_Computed = "[Computed]";
-const std::string k_KernalDistances = "KernelDistances";
+const DataPath k_VertexGeomPath({"VertexGeom"});
+const DataPath k_ImageGeomPath({"ImageGeom"});
+const DataPath k_VertexDataPath = k_VertexGeomPath.createChildPath("VertexData");
+const DataPath k_VoxelIndicesPath = k_VertexDataPath.createChildPath("VoxelIndices");
+const DataPath k_FaceAreasPath = k_VertexDataPath.createChildPath("FaceAreas");
+const DataPath k_MaskPath = k_VertexDataPath.createChildPath("Mask");
 
-const DataPath k_ImageGeomPath({k_ImageGeometry});
-const DataPath k_VertexGeometryPath({k_PointCloudContainerName});
-const DataPath k_VertexDataPath = k_VertexGeometryPath.createChildPath(k_VertexData);
-const DataPath k_MaskPath = k_VertexDataPath.createChildPath(k_Mask);
-const DataPath k_FaceAreasPath = k_VertexDataPath.createChildPath(k_FaceAreas);
-const DataPath k_VoxelIndicesPath = k_VertexDataPath.createChildPath(k_VoxelIndices);
+const std::string k_InterpolatedGroupName = "InterpolatedData";
+const DataPath k_InterpGroupPath = k_ImageGeomPath.createChildPath(k_InterpolatedGroupName);
 
-const DataPath k_UniformInterpolatedDataExemplar = k_ImageGeomPath.createChildPath(k_UniformInterpolatedData);
-const DataPath k_UniformInterpolatedDataComputed = k_ImageGeomPath.createChildPath(k_UniformInterpolatedData + k_Computed);
-const DataPath k_GaussianInterpolatedDataExemplar = k_ImageGeomPath.createChildPath(k_GaussianInterpolatedData);
-const DataPath k_GaussianInterpolatedDataComputed = k_ImageGeomPath.createChildPath(k_GaussianInterpolatedData + k_Computed);
-
-const DataPath k_UniformFaceAreasExemplar = k_UniformInterpolatedDataExemplar.createChildPath(k_FaceAreas);
-const DataPath k_UniformVoxelIndicesExemplar = k_UniformInterpolatedDataExemplar.createChildPath(k_VoxelIndices);
-const DataPath k_UniformKernalDistancesExemplar = k_UniformInterpolatedDataExemplar.createChildPath(k_KernalDistances);
-const DataPath k_UniformFaceAreasComputed = k_UniformInterpolatedDataComputed.createChildPath(k_FaceAreas);
-const DataPath k_UniformVoxelIndicesComputed = k_UniformInterpolatedDataComputed.createChildPath(k_VoxelIndices);
-const DataPath k_UniformKernalDistancesComputed = k_UniformInterpolatedDataComputed.createChildPath(k_KernalDistances);
-
-const DataPath k_GaussianFaceAreasExemplar = k_GaussianInterpolatedDataExemplar.createChildPath(k_FaceAreas);
-const DataPath k_GaussianVoxelIndicesExemplar = k_GaussianInterpolatedDataExemplar.createChildPath(k_VoxelIndices);
-const DataPath k_GaussianKernalDistancesExemplar = k_GaussianInterpolatedDataExemplar.createChildPath(k_KernalDistances);
-const DataPath k_GaussianFaceAreasComputed = k_GaussianInterpolatedDataComputed.createChildPath(k_FaceAreas);
-const DataPath k_GaussianVoxelIndicesComputed = k_GaussianInterpolatedDataComputed.createChildPath(k_VoxelIndices);
-const DataPath k_GaussianKernalDistancesComputed = k_GaussianInterpolatedDataComputed.createChildPath(k_KernalDistances);
-
-// These paths are excluded because they come from a version prior to
-// NeighborList and StringArray having multidimensional tuple capability
-// (Only exemplars not checked, GENERATED/COMPUTED VALIDATED)
-const std::vector<DataPath> k_ExemplarTupleCheckIgnoredPaths{{{"Image Geometry", "GaussianInterpolatedData", "FaceAreas"}},      {{"Image Geometry", "GaussianInterpolatedData", "KernelDistances"}},
-                                                             {{"Image Geometry", "GaussianInterpolatedData", "VoxelIndices"}},   {{"Image Geometry", "UniformInterpolatedData", "FaceAreas"}},
-                                                             {{"Image Geometry", "UniformInterpolatedData", "KernelDistances"}}, {{"Image Geometry", "UniformInterpolatedData", "VoxelIndices"}}};
-} // namespace
-
-TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Valid Filter Execution - Uniform Inpterpolation with Mask", "[SimplnxCore][InterpolatePointCloudToRegularGridFilter]")
+// Create a test DataStructure with a 4x4x1 ImageGeom and a VertexGeom with known data
+DataStructure createTestDataStructure(const std::vector<uint64>& voxelIndices, const std::vector<float64>& faceAreas, bool allMasked = true, usize maskedOutIndex = 0)
 {
-  UnitTest::LoadPlugins();
+  DataStructure ds;
+  usize numVertices = voxelIndices.size();
 
-  const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_TestFilesDir, "6_6_interpolate_point_cloud_to_regular_grid.tar.gz", "6_6_interpolate_point_cloud_to_regular_grid");
+  // Vertex Geometry
+  auto* vertexGeom = VertexGeom::Create(ds, "VertexGeom");
+  auto* vertices = Float32Array::CreateWithStore<DataStore<float32>>(ds, "SharedVertexList", {numVertices}, {3}, vertexGeom->getId());
+  vertexGeom->setVertices(*vertices);
+  vertices->fill(0.0f);
 
-  // Read Exemplar DREAM3D File Filter
-  auto exemplarFilePath = fs::path(fmt::format("{}/6_6_interpolate_point_cloud_to_regular_grid/6_6_interpolate_point_cloud_to_regular_grid.dream3d", unit_test::k_TestFilesDir));
-  DataStructure dataStructure = UnitTest::LoadDataStructure(exemplarFilePath);
+  auto* vertexAM = AttributeMatrix::Create(ds, "VertexData", {numVertices}, vertexGeom->getId());
+  vertexGeom->setVertexAttributeMatrix(*vertexAM);
 
-  InterpolatePointCloudToRegularGridFilter filter;
-  Arguments args;
+  auto* voxelArr = UInt64Array::CreateWithStore<DataStore<uint64>>(ds, "VoxelIndices", {numVertices}, {1}, vertexAM->getId());
+  for(usize i = 0; i < numVertices; i++)
+  {
+    (*voxelArr)[i] = voxelIndices[i];
+  }
 
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_UseMask_Key, std::make_any<bool>(true));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_StoreKernelDistances_Key, std::make_any<bool>(true));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolationTechnique_Key, std::make_any<uint64>(InterpolatePointCloudToRegularGrid::k_Uniform));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_KernelSize_Key, std::make_any<std::vector<float32>>(std::vector<float32>{1, 1, 1}));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_SelectedVertexGeometryPath_Key, std::make_any<DataPath>(k_VertexGeometryPath));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_ImageGeomPath));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_VoxelIndicesPath_Key, std::make_any<DataPath>(k_VoxelIndicesPath));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InputMaskPath_Key, std::make_any<DataPath>(k_MaskPath));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolateArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{k_FaceAreasPath}));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_CopyArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{k_VoxelIndicesPath}));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolatedGroupName_Key, std::make_any<std::string>(k_UniformInterpolatedDataComputed.getTargetName()));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_KernelDistancesArrayName_Key, std::make_any<std::string>(k_UniformKernalDistancesComputed.getTargetName()));
+  auto* faceArr = Float64Array::CreateWithStore<DataStore<float64>>(ds, "FaceAreas", {numVertices}, {1}, vertexAM->getId());
+  for(usize i = 0; i < numVertices; i++)
+  {
+    (*faceArr)[i] = faceAreas[i];
+  }
 
-  // Preflight the filter and check result
-  auto preflightResult = filter.preflight(dataStructure, args);
-  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+  auto* maskArr = BoolArray::CreateWithStore<DataStore<bool>>(ds, "Mask", {numVertices}, {1}, vertexAM->getId());
+  maskArr->fill(true);
+  if(!allMasked)
+  {
+    auto& maskStore = maskArr->getDataStoreRef();
+    maskStore.setValue(maskedOutIndex, false);
+  }
 
-  // Execute the filter and check the result
-  auto executeResult = filter.execute(dataStructure, args);
-  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+  // Image Geometry: 4x4x1
+  auto* imageGeom = ImageGeom::Create(ds, "ImageGeom");
+  imageGeom->setDimensions({4, 4, 1});
+  imageGeom->setSpacing({1.0f, 1.0f, 1.0f});
+  imageGeom->setOrigin({0.0f, 0.0f, 0.0f});
 
-  UnitTest::CompareNeighborLists<float64>(dataStructure, k_UniformFaceAreasExemplar, k_UniformFaceAreasComputed);
-  UnitTest::CompareNeighborLists<uint64>(dataStructure, k_UniformVoxelIndicesExemplar, k_UniformVoxelIndicesComputed);
-  UnitTest::CompareNeighborLists<float32>(dataStructure, k_UniformKernalDistancesExemplar, k_UniformKernalDistancesComputed);
-
-  UnitTest::CheckArraysInheritTupleDims(dataStructure, k_ExemplarTupleCheckIgnoredPaths);
+  return ds;
 }
 
-TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Valid Filter Execution - Gaussian Inpterpolation", "[SimplnxCore][InterpolatePointCloudToRegularGridFilter]")
+Arguments getBaseArgs(bool useMask, uint64 technique, std::vector<float32> kernelSize, bool findLength = false, bool findMin = false, bool findMax = false, bool findMean = false,
+                      bool findStdDev = false, bool findSum = false)
+{
+  using F = InterpolatePointCloudToRegularGridFilter;
+  Arguments args;
+
+  args.insertOrAssign(F::k_UseMask_Key, std::make_any<bool>(useMask));
+  args.insertOrAssign(F::k_InterpolationTechnique_Key, std::make_any<uint64>(technique));
+  args.insertOrAssign(F::k_KernelSize_Key, std::make_any<std::vector<float32>>(kernelSize));
+  args.insertOrAssign(F::k_GaussianSigmas_Key, std::make_any<std::vector<float32>>(std::vector<float32>{1.0f, 1.0f, 1.0f}));
+  args.insertOrAssign(F::k_SelectedVertexGeometryPath_Key, std::make_any<DataPath>(k_VertexGeomPath));
+  args.insertOrAssign(F::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_ImageGeomPath));
+  args.insertOrAssign(F::k_VoxelIndicesPath_Key, std::make_any<DataPath>(k_VoxelIndicesPath));
+  args.insertOrAssign(F::k_InputMaskPath_Key, std::make_any<DataPath>(k_MaskPath));
+  args.insertOrAssign(F::k_InterpolateArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{k_FaceAreasPath}));
+  args.insertOrAssign(F::k_CopyArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{k_VoxelIndicesPath}));
+
+  args.insertOrAssign(F::k_FindLength_Key, std::make_any<bool>(findLength));
+  args.insertOrAssign(F::k_FindMin_Key, std::make_any<bool>(findMin));
+  args.insertOrAssign(F::k_FindMax_Key, std::make_any<bool>(findMax));
+  args.insertOrAssign(F::k_FindMean_Key, std::make_any<bool>(findMean));
+  args.insertOrAssign(F::k_FindStdDeviation_Key, std::make_any<bool>(findStdDev));
+  args.insertOrAssign(F::k_FindSummation_Key, std::make_any<bool>(findSum));
+
+  args.insertOrAssign(F::k_LengthSuffix_Key, std::make_any<std::string>("_Length"));
+  args.insertOrAssign(F::k_MinSuffix_Key, std::make_any<std::string>("_Minimum"));
+  args.insertOrAssign(F::k_MaxSuffix_Key, std::make_any<std::string>("_Maximum"));
+  args.insertOrAssign(F::k_MeanSuffix_Key, std::make_any<std::string>("_Mean"));
+  args.insertOrAssign(F::k_StdDeviationSuffix_Key, std::make_any<std::string>("_StdDeviation"));
+  args.insertOrAssign(F::k_SummationSuffix_Key, std::make_any<std::string>("_Summation"));
+
+  return args;
+}
+} // namespace
+
+TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Uniform No Spreading With Statistics", "[SimplnxCore][InterpolatePointCloudToRegularGridFilter]")
 {
   UnitTest::LoadPlugins();
 
-  const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_TestFilesDir, "6_6_interpolate_point_cloud_to_regular_grid.tar.gz", "6_6_interpolate_point_cloud_to_regular_grid");
+  // 5 vertices: 2 map to voxel 0, 1 each to voxels 5, 10, 15
+  // ImageGeom: 4x4x1 (16 voxels), kernel < spacing means no spreading
+  std::vector<uint64> voxelIndices = {0, 0, 5, 10, 15};
+  std::vector<float64> faceAreas = {10.0, 20.0, 30.0, 40.0, 50.0};
 
-  // Read Exemplar DREAM3D File Filter
-  auto exemplarFilePath = fs::path(fmt::format("{}/6_6_interpolate_point_cloud_to_regular_grid/6_6_interpolate_point_cloud_to_regular_grid.dream3d", unit_test::k_TestFilesDir));
-  DataStructure dataStructure = UnitTest::LoadDataStructure(exemplarFilePath);
+  DataStructure dataStructure = createTestDataStructure(voxelIndices, faceAreas);
 
   InterpolatePointCloudToRegularGridFilter filter;
-  Arguments args;
+  Arguments args = getBaseArgs(false, InterpolatePointCloudToRegularGrid::k_Uniform, {0.5f, 0.5f, 0.5f}, true, true, true, true, true, true);
 
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_UseMask_Key, std::make_any<bool>(false));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_StoreKernelDistances_Key, std::make_any<bool>(true));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolationTechnique_Key, std::make_any<uint64>(InterpolatePointCloudToRegularGrid::k_Gaussian));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_KernelSize_Key, std::make_any<std::vector<float32>>(std::vector<float32>{1, 1, 1}));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_GaussianSigmas_Key, std::make_any<std::vector<float32>>(std::vector<float32>{1, 1, 1}));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_SelectedVertexGeometryPath_Key, std::make_any<DataPath>(k_VertexGeometryPath));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_ImageGeomPath));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_VoxelIndicesPath_Key, std::make_any<DataPath>(k_VoxelIndicesPath));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolateArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{k_FaceAreasPath}));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_CopyArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{k_VoxelIndicesPath}));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolatedGroupName_Key, std::make_any<std::string>(k_GaussianInterpolatedDataComputed.getTargetName()));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_KernelDistancesArrayName_Key, std::make_any<std::string>(k_GaussianKernalDistancesComputed.getTargetName()));
-
-  // Preflight the filter and check result
   auto preflightResult = filter.preflight(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
 
-  // Execute the filter and check the result
   auto executeResult = filter.execute(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
 
-  UnitTest::CompareNeighborLists<float64>(dataStructure, k_GaussianFaceAreasExemplar, k_GaussianFaceAreasComputed);
-  UnitTest::CompareNeighborLists<uint64>(dataStructure, k_GaussianVoxelIndicesExemplar, k_GaussianVoxelIndicesComputed);
-  UnitTest::CompareNeighborLists<float32>(dataStructure, k_GaussianKernalDistancesExemplar, k_GaussianKernalDistancesComputed);
+  // Interpolated FaceAreas (weighted average, float64)
+  auto& interpFA = dataStructure.getDataRefAs<Float64Array>(k_InterpGroupPath.createChildPath("FaceAreas"));
+  REQUIRE(interpFA[0] == Approx(15.0));  // (10+20)/2
+  REQUIRE(interpFA[5] == Approx(30.0));  // 30/1
+  REQUIRE(interpFA[10] == Approx(40.0)); // 40/1
+  REQUIRE(interpFA[15] == Approx(50.0)); // 50/1
+  REQUIRE(interpFA[1] == Approx(0.0));   // no contribution
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure, k_ExemplarTupleCheckIgnoredPaths);
+  // Length (uint64)
+  auto& length = dataStructure.getDataRefAs<UInt64Array>(k_InterpGroupPath.createChildPath("FaceAreas_Length"));
+  REQUIRE(length[0] == 2);
+  REQUIRE(length[5] == 1);
+  REQUIRE(length[10] == 1);
+  REQUIRE(length[15] == 1);
+  REQUIRE(length[1] == 0);
+
+  // Minimum (float32)
+  auto& minArr = dataStructure.getDataRefAs<Float32Array>(k_InterpGroupPath.createChildPath("FaceAreas_Minimum"));
+  REQUIRE(minArr[0] == Approx(10.0f));
+  REQUIRE(minArr[5] == Approx(30.0f));
+
+  // Maximum (float32)
+  auto& maxArr = dataStructure.getDataRefAs<Float32Array>(k_InterpGroupPath.createChildPath("FaceAreas_Maximum"));
+  REQUIRE(maxArr[0] == Approx(20.0f));
+  REQUIRE(maxArr[5] == Approx(30.0f));
+
+  // Mean (float32)
+  auto& meanArr = dataStructure.getDataRefAs<Float32Array>(k_InterpGroupPath.createChildPath("FaceAreas_Mean"));
+  REQUIRE(meanArr[0] == Approx(15.0f));
+  REQUIRE(meanArr[5] == Approx(30.0f));
+
+  // Standard Deviation (float32) - population stddev via Welford
+  auto& stdArr = dataStructure.getDataRefAs<Float32Array>(k_InterpGroupPath.createChildPath("FaceAreas_StdDeviation"));
+  REQUIRE(stdArr[0] == Approx(5.0f)); // sqrt(((10-15)^2 + (20-15)^2)/2) = 5
+  REQUIRE(stdArr[5] == Approx(0.0f)); // single value
+
+  // Summation (float32)
+  auto& sumArr = dataStructure.getDataRefAs<Float32Array>(k_InterpGroupPath.createChildPath("FaceAreas_Summation"));
+  REQUIRE(sumArr[0] == Approx(30.0f));  // 10+20
+  REQUIRE(sumArr[5] == Approx(30.0f));  // 30
+  REQUIRE(sumArr[10] == Approx(40.0f)); // 40
+
+  // Copy array: VoxelIndices (uint64, weighted average with uniform kernel)
+  auto& copyVI = dataStructure.getDataRefAs<UInt64Array>(k_InterpGroupPath.createChildPath("VoxelIndices"));
+  REQUIRE(copyVI[0] == 0); // (0+0)/2 = 0
+  REQUIRE(copyVI[5] == 5); // 5/1 = 5
+  REQUIRE(copyVI[10] == 10);
+  REQUIRE(copyVI[15] == 15);
+}
+
+TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Uniform With Kernel Spreading", "[SimplnxCore][InterpolatePointCloudToRegularGridFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  // 1 vertex at voxel 5 (x=1,y=1,z=0) in a 4x4x1 grid
+  // Kernel size 2.0, spacing 1.0 -> kernelNumVoxels = (1,1,1) -> 3x3x1 effective kernel
+  // With Uniform kernel, all weights = 1.0
+  // Vertex affects voxels: (0,0,0)=0, (1,0,0)=1, (2,0,0)=2,
+  //                        (0,1,0)=4, (1,1,0)=5, (2,1,0)=6,
+  //                        (0,2,0)=8, (1,2,0)=9, (2,2,0)=10
+  std::vector<uint64> voxelIndices = {5};
+  std::vector<float64> faceAreas = {10.0};
+
+  DataStructure dataStructure = createTestDataStructure(voxelIndices, faceAreas);
+
+  InterpolatePointCloudToRegularGridFilter filter;
+  Arguments args = getBaseArgs(false, InterpolatePointCloudToRegularGrid::k_Uniform, {2.0f, 2.0f, 2.0f}, true);
+
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+
+  auto& interpFA = dataStructure.getDataRefAs<Float64Array>(k_InterpGroupPath.createChildPath("FaceAreas"));
+  auto& length = dataStructure.getDataRefAs<UInt64Array>(k_InterpGroupPath.createChildPath("FaceAreas_Length"));
+
+  // All 9 affected voxels should have interp = 10.0 and length = 1
+  std::vector<usize> affectedVoxels = {0, 1, 2, 4, 5, 6, 8, 9, 10};
+  for(usize v : affectedVoxels)
+  {
+    REQUIRE(interpFA[v] == Approx(10.0));
+    REQUIRE(length[v] == 1);
+  }
+
+  // Unaffected voxels should be 0
+  std::vector<usize> unaffectedVoxels = {3, 7, 11, 12, 13, 14, 15};
+  for(usize v : unaffectedVoxels)
+  {
+    REQUIRE(interpFA[v] == Approx(0.0));
+    REQUIRE(length[v] == 0);
+  }
+}
+
+TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Gaussian With Kernel Spreading", "[SimplnxCore][InterpolatePointCloudToRegularGridFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  // 2 vertices: voxel 5 (x=1,y=1,z=0) FaceArea=10.0, voxel 6 (x=2,y=1,z=0) FaceArea=20.0
+  // Kernel size 2.0, spacing 1.0 -> 3x3x1 Gaussian kernel, sigmas=(1,1,1)
+  std::vector<uint64> voxelIndices = {5, 6};
+  std::vector<float64> faceAreas = {10.0, 20.0};
+
+  DataStructure dataStructure = createTestDataStructure(voxelIndices, faceAreas);
+
+  InterpolatePointCloudToRegularGridFilter filter;
+  Arguments args = getBaseArgs(false, InterpolatePointCloudToRegularGrid::k_Gaussian, {2.0f, 2.0f, 2.0f});
+
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+
+  auto& interpFA = dataStructure.getDataRefAs<Float64Array>(k_InterpGroupPath.createChildPath("FaceAreas"));
+
+  // Voxel 5 (x=1,y=1): vertex0 at dx=0 w=1.0, vertex1 at dx=1 w=exp(-0.5)
+  float64 w_center = 1.0;
+  float64 w_adj = std::exp(-0.5);
+  float64 expected5 = (w_center * 10.0 + w_adj * 20.0) / (w_center + w_adj);
+  REQUIRE(interpFA[5] == Approx(expected5).epsilon(1e-6));
+
+  // Voxel 6 (x=2,y=1): vertex0 at dx=-1 w=exp(-0.5), vertex1 at dx=0 w=1.0
+  float64 expected6 = (w_adj * 10.0 + w_center * 20.0) / (w_adj + w_center);
+  REQUIRE(interpFA[6] == Approx(expected6).epsilon(1e-6));
+
+  // Voxel 5 should be < 15 (weighted toward 10.0 since vertex 0 is at center)
+  // Voxel 6 should be > 15 (weighted toward 20.0 since vertex 1 is at center)
+  REQUIRE(interpFA[5] < 15.0);
+  REQUIRE(interpFA[6] > 15.0);
+}
+
+TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Masked Vertices", "[SimplnxCore][InterpolatePointCloudToRegularGridFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  // 5 vertices, mask out vertex 1 (second vertex at voxel 0 with FaceArea=20.0)
+  std::vector<uint64> voxelIndices = {0, 0, 5, 10, 15};
+  std::vector<float64> faceAreas = {10.0, 20.0, 30.0, 40.0, 50.0};
+
+  DataStructure dataStructure = createTestDataStructure(voxelIndices, faceAreas, false, 1);
+
+  InterpolatePointCloudToRegularGridFilter filter;
+  Arguments args = getBaseArgs(true, InterpolatePointCloudToRegularGrid::k_Uniform, {0.5f, 0.5f, 0.5f}, true);
+
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+
+  auto& interpFA = dataStructure.getDataRefAs<Float64Array>(k_InterpGroupPath.createChildPath("FaceAreas"));
+  auto& length = dataStructure.getDataRefAs<UInt64Array>(k_InterpGroupPath.createChildPath("FaceAreas_Length"));
+
+  // Voxel 0: only vertex 0 (vertex 1 masked out)
+  REQUIRE(interpFA[0] == Approx(10.0));
+  REQUIRE(length[0] == 1);
+
+  // Others unchanged
+  REQUIRE(interpFA[5] == Approx(30.0));
+  REQUIRE(interpFA[10] == Approx(40.0));
+  REQUIRE(interpFA[15] == Approx(50.0));
 }
 
 TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Invalid Filter Execution", "[SimplnxCore][InterpolatePointCloudToRegularGridFilter]")
 {
   UnitTest::LoadPlugins();
 
-  const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_TestFilesDir, "6_6_interpolate_point_cloud_to_regular_grid.tar.gz", "6_6_interpolate_point_cloud_to_regular_grid");
-
-  // Read Exemplar DREAM3D File Filter
-  auto exemplarFilePath = fs::path(fmt::format("{}/6_6_interpolate_point_cloud_to_regular_grid/6_6_interpolate_point_cloud_to_regular_grid.dream3d", unit_test::k_TestFilesDir));
-  DataStructure dataStructure = UnitTest::LoadDataStructure(exemplarFilePath);
+  std::vector<uint64> voxelIndices = {0, 5};
+  std::vector<float64> faceAreas = {10.0, 20.0};
+  DataStructure dataStructure = createTestDataStructure(voxelIndices, faceAreas);
 
   InterpolatePointCloudToRegularGridFilter filter;
-  Arguments args;
-
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_UseMask_Key, std::make_any<bool>(false));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_StoreKernelDistances_Key, std::make_any<bool>(true));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolationTechnique_Key, std::make_any<uint64>(InterpolatePointCloudToRegularGrid::k_Gaussian));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_SelectedVertexGeometryPath_Key, std::make_any<DataPath>(k_VertexGeometryPath));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_ImageGeomPath));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_VoxelIndicesPath_Key, std::make_any<DataPath>(k_VoxelIndicesPath));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_CopyArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{k_VoxelIndicesPath}));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolatedGroupName_Key, std::make_any<std::string>(k_GaussianInterpolatedDataComputed.getTargetName()));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_KernelDistancesArrayName_Key, std::make_any<std::string>(k_GaussianKernalDistancesComputed.getTargetName()));
 
   SECTION("Invalid Kernel Size")
   {
-    args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_KernelSize_Key, std::make_any<std::vector<float32>>(std::vector<float32>{-1, 1, 1}));
-    args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_GaussianSigmas_Key, std::make_any<std::vector<float32>>(std::vector<float32>{1, 1, 1}));
-    args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolateArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{k_FaceAreasPath}));
+    Arguments args = getBaseArgs(false, InterpolatePointCloudToRegularGrid::k_Gaussian, {-1.0f, 1.0f, 1.0f});
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions)
   }
   SECTION("Invalid Gaussian Sigma")
   {
-    args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_KernelSize_Key, std::make_any<std::vector<float32>>(std::vector<float32>{1, 1, 1}));
-    args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_GaussianSigmas_Key, std::make_any<std::vector<float32>>(std::vector<float32>{0, 0, 0}));
-    args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolateArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{k_FaceAreasPath}));
+    Arguments args = getBaseArgs(false, InterpolatePointCloudToRegularGrid::k_Gaussian, {1.0f, 1.0f, 1.0f});
+    args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_GaussianSigmas_Key, std::make_any<std::vector<float32>>(std::vector<float32>{0.0f, 0.0f, 0.0f}));
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions)
   }
-  SECTION("Mismatching Input Array Tuples")
-  {
-    args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_KernelSize_Key, std::make_any<std::vector<float32>>(std::vector<float32>{1, 1, 1}));
-    args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_GaussianSigmas_Key, std::make_any<std::vector<float32>>(std::vector<float32>{1, 1, 1}));
-    args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolateArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{k_GaussianFaceAreasExemplar}));
-  }
-
-  // Preflight the filter and check result
-  auto preflightResult = filter.preflight(dataStructure, args);
-  SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions)
-
-  // Execute the filter and check the result
-  auto executeResult = filter.execute(dataStructure, args);
-  SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result)
-
-  UnitTest::CheckArraysInheritTupleDims(dataStructure, k_ExemplarTupleCheckIgnoredPaths);
 }

--- a/src/Plugins/SimplnxCore/test/InterpolatePointCloudToRegularGridTest.cpp
+++ b/src/Plugins/SimplnxCore/test/InterpolatePointCloudToRegularGridTest.cpp
@@ -1,3 +1,4 @@
+#include "SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.hpp"
 #include "SimplnxCore/Filters/InterpolatePointCloudToRegularGridFilter.hpp"
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
 
@@ -67,7 +68,7 @@ TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Valid Filter E
 
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_UseMask_Key, std::make_any<bool>(true));
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_StoreKernelDistances_Key, std::make_any<bool>(true));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolationTechnique_Key, std::make_any<uint64>(InterpolatePointCloudToRegularGridFilter::k_Uniform));
+  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolationTechnique_Key, std::make_any<uint64>(InterpolatePointCloudToRegularGrid::k_Uniform));
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_KernelSize_Key, std::make_any<std::vector<float32>>(std::vector<float32>{1, 1, 1}));
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_SelectedVertexGeometryPath_Key, std::make_any<DataPath>(k_VertexGeometryPath));
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_ImageGeomPath));
@@ -108,7 +109,7 @@ TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Valid Filter E
 
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_UseMask_Key, std::make_any<bool>(false));
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_StoreKernelDistances_Key, std::make_any<bool>(true));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolationTechnique_Key, std::make_any<uint64>(InterpolatePointCloudToRegularGridFilter::k_Gaussian));
+  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolationTechnique_Key, std::make_any<uint64>(InterpolatePointCloudToRegularGrid::k_Gaussian));
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_KernelSize_Key, std::make_any<std::vector<float32>>(std::vector<float32>{1, 1, 1}));
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_GaussianSigmas_Key, std::make_any<std::vector<float32>>(std::vector<float32>{1, 1, 1}));
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_SelectedVertexGeometryPath_Key, std::make_any<DataPath>(k_VertexGeometryPath));
@@ -149,7 +150,7 @@ TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Invalid Filter
 
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_UseMask_Key, std::make_any<bool>(false));
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_StoreKernelDistances_Key, std::make_any<bool>(true));
-  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolationTechnique_Key, std::make_any<uint64>(InterpolatePointCloudToRegularGridFilter::k_Gaussian));
+  args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_InterpolationTechnique_Key, std::make_any<uint64>(InterpolatePointCloudToRegularGrid::k_Gaussian));
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_SelectedVertexGeometryPath_Key, std::make_any<DataPath>(k_VertexGeometryPath));
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_ImageGeomPath));
   args.insertOrAssign(InterpolatePointCloudToRegularGridFilter::k_VoxelIndicesPath_Key, std::make_any<DataPath>(k_VoxelIndicesPath));

--- a/src/Plugins/SimplnxCore/test/InterpolatePointCloudToRegularGridTest.cpp
+++ b/src/Plugins/SimplnxCore/test/InterpolatePointCloudToRegularGridTest.cpp
@@ -19,14 +19,27 @@ namespace
 const DataPath k_VertexGeomPath({"VertexGeom"});
 const DataPath k_ImageGeomPath({"ImageGeom"});
 const DataPath k_VertexDataPath = k_VertexGeomPath.createChildPath("VertexData");
-const DataPath k_VoxelIndicesPath = k_VertexDataPath.createChildPath("VoxelIndices");
 const DataPath k_FaceAreasPath = k_VertexDataPath.createChildPath("FaceAreas");
 const DataPath k_MaskPath = k_VertexDataPath.createChildPath("Mask");
 
 const std::string k_InterpolatedGroupName = "InterpolatedData";
 const DataPath k_InterpGroupPath = k_ImageGeomPath.createChildPath(k_InterpolatedGroupName);
 
-// Create a test DataStructure with a 4x4x1 ImageGeom and a VertexGeom with known data
+// Convert a linear voxel index (in a 4x4x1 grid with spacing=1, origin=0) to cell-center coordinates
+void setVertexCoordsForVoxelIndex(Float32Array& vertices, usize vertexIdx, uint64 voxelIndex, usize dimX = 4, usize dimY = 4)
+{
+  usize x = voxelIndex % dimX;
+  usize y = (voxelIndex / dimX) % dimY;
+  usize z = voxelIndex / (dimX * dimY);
+
+  // Place vertex at the center of the voxel (spacing=1, origin=0)
+  vertices[vertexIdx * 3 + 0] = static_cast<float32>(x) + 0.5f;
+  vertices[vertexIdx * 3 + 1] = static_cast<float32>(y) + 0.5f;
+  vertices[vertexIdx * 3 + 2] = static_cast<float32>(z) + 0.5f;
+}
+
+// Create a test DataStructure with a 4x4x1 ImageGeom and a VertexGeom with known data.
+// Vertex coordinates are set to map to the given voxel indices.
 DataStructure createTestDataStructure(const std::vector<uint64>& voxelIndices, const std::vector<float64>& faceAreas, bool allMasked = true, usize maskedOutIndex = 0)
 {
   DataStructure ds;
@@ -36,16 +49,15 @@ DataStructure createTestDataStructure(const std::vector<uint64>& voxelIndices, c
   auto* vertexGeom = VertexGeom::Create(ds, "VertexGeom");
   auto* vertices = Float32Array::CreateWithStore<DataStore<float32>>(ds, "SharedVertexList", {numVertices}, {3}, vertexGeom->getId());
   vertexGeom->setVertices(*vertices);
-  vertices->fill(0.0f);
+
+  // Set vertex coordinates to map to the desired voxel indices
+  for(usize i = 0; i < numVertices; i++)
+  {
+    setVertexCoordsForVoxelIndex(*vertices, i, voxelIndices[i]);
+  }
 
   auto* vertexAM = AttributeMatrix::Create(ds, "VertexData", {numVertices}, vertexGeom->getId());
   vertexGeom->setVertexAttributeMatrix(*vertexAM);
-
-  auto* voxelArr = UInt64Array::CreateWithStore<DataStore<uint64>>(ds, "VoxelIndices", {numVertices}, {1}, vertexAM->getId());
-  for(usize i = 0; i < numVertices; i++)
-  {
-    (*voxelArr)[i] = voxelIndices[i];
-  }
 
   auto* faceArr = Float64Array::CreateWithStore<DataStore<float64>>(ds, "FaceAreas", {numVertices}, {1}, vertexAM->getId());
   for(usize i = 0; i < numVertices; i++)
@@ -67,6 +79,10 @@ DataStructure createTestDataStructure(const std::vector<uint64>& voxelIndices, c
   imageGeom->setSpacing({1.0f, 1.0f, 1.0f});
   imageGeom->setOrigin({0.0f, 0.0f, 0.0f});
 
+  // Cell data attribute matrix (required for getCellDataPath())
+  auto* cellAM = AttributeMatrix::Create(ds, k_InterpolatedGroupName, {1, 4, 4}, imageGeom->getId());
+  imageGeom->setCellData(*cellAM);
+
   return ds;
 }
 
@@ -82,10 +98,9 @@ Arguments getBaseArgs(bool useMask, uint64 technique, std::vector<float32> kerne
   args.insertOrAssign(F::k_GaussianSigmas_Key, std::make_any<std::vector<float32>>(std::vector<float32>{1.0f, 1.0f, 1.0f}));
   args.insertOrAssign(F::k_SelectedVertexGeometryPath_Key, std::make_any<DataPath>(k_VertexGeomPath));
   args.insertOrAssign(F::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_ImageGeomPath));
-  args.insertOrAssign(F::k_VoxelIndicesPath_Key, std::make_any<DataPath>(k_VoxelIndicesPath));
   args.insertOrAssign(F::k_InputMaskPath_Key, std::make_any<DataPath>(k_MaskPath));
   args.insertOrAssign(F::k_InterpolateArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{k_FaceAreasPath}));
-  args.insertOrAssign(F::k_CopyArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{k_VoxelIndicesPath}));
+  args.insertOrAssign(F::k_CopyArrays_Key, std::make_any<std::vector<DataPath>>(std::vector<DataPath>{}));
 
   args.insertOrAssign(F::k_FindLength_Key, std::make_any<bool>(findLength));
   args.insertOrAssign(F::k_FindMin_Key, std::make_any<bool>(findMin));
@@ -166,13 +181,6 @@ TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Uniform No Spr
   REQUIRE(sumArr[0] == Approx(30.0f));  // 10+20
   REQUIRE(sumArr[5] == Approx(30.0f));  // 30
   REQUIRE(sumArr[10] == Approx(40.0f)); // 40
-
-  // Copy array: VoxelIndices (uint64, weighted average with uniform kernel)
-  auto& copyVI = dataStructure.getDataRefAs<UInt64Array>(k_InterpGroupPath.createChildPath("VoxelIndices"));
-  REQUIRE(copyVI[0] == 0); // (0+0)/2 = 0
-  REQUIRE(copyVI[5] == 5); // 5/1 = 5
-  REQUIRE(copyVI[10] == 10);
-  REQUIRE(copyVI[15] == 15);
 }
 
 TEST_CASE("SimplnxCore::InterpolatePointCloudToRegularGridFilter: Uniform With Kernel Spreading", "[SimplnxCore][InterpolatePointCloudToRegularGridFilter]")

--- a/test/ConversionTest/BackwardsCompatibilityTest.cpp
+++ b/test/ConversionTest/BackwardsCompatibilityTest.cpp
@@ -718,6 +718,10 @@ const std::map<Uuid, std::vector<std::string>> k_KeyIgnoreMap = {
     // ComputeFeatureReferenceMisorientationsFilter
     std::pair<Uuid, std::vector<std::string>>{Uuid::FromString("24b54daf-3bf5-4331-93f6-03a49f719bf1").value(), std::vector<std::string>{"feature_euclidean_center_array_name"}},
 
+    // InterpolatePointCloudToRegularGridFilter
+    std::pair<Uuid, std::vector<std::string>>{Uuid::FromString("996c4464-08f0-4268-a8a6-f9796c88cf58").value(),
+                                              std::vector<std::string>{"find_length", "find_max", "find_mean", "find_min", "find_std_deviation", "find_summation", "length_suffix_name",
+                                                                       "max_suffix_name", "mean_suffix_name", "min_suffix_name", "std_deviation_suffix_name", "summation_suffix_name"}},
     // ExtractVertexGeometryFilter
     std::pair<Uuid, std::vector<std::string>>{Uuid::FromString("621a71ca-124b-4471-ad1a-02f05ffba099").value(),
                                               std::vector<std::string>{"output_shared_vertex_list_name", "output_vertex_attr_matrix_name"}}};


### PR DESCRIPTION
The filter is still serial, but unnecessary allocations and dynamic_cast have been removed resulting in an increase in speed.

This filter still takes a massive amount of memory and is still quite slow to run.
