### PR TITLE
ENH: Add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
+CLAUDE.md
 .claude/
 .cproject
 .ctags


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` to `.gitignore` so that users can have a local CLAUDE.md file for Claude Code sessions without it being tracked by git

## Test plan
- [ ] Verify `.gitignore` correctly ignores `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)