### PR TITLE
PERF: NeighborOrientationCorrelation and Morphological Filters OoC Optimizations

### DIFF
--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/NeighborOrientationCorrelation.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/NeighborOrientationCorrelation.cpp
@@ -19,12 +19,25 @@
 
 using namespace nx::core;
 
+/**
+ * @class NeighborOrientationCorrelationTransferDataImpl
+ * @brief Functor that copies tuple data from best-neighbor voxels into low-confidence voxels
+ * for a single DataArray. Designed to be executed in parallel across multiple DataArrays
+ * via ParallelTaskAlgorithm.
+ */
 class NeighborOrientationCorrelationTransferDataImpl
 {
 public:
   NeighborOrientationCorrelationTransferDataImpl() = delete;
   NeighborOrientationCorrelationTransferDataImpl(const NeighborOrientationCorrelationTransferDataImpl&) = default;
 
+  /**
+   * @brief Constructs the transfer functor for a single DataArray.
+   * @param messageHelper Reference to the MessageHelper for progress reporting
+   * @param totalPoints Total number of voxels in the volume
+   * @param bestNeighbor Vector mapping each voxel index to its best neighbor's index (-1 if none)
+   * @param dataArrayPtr Shared pointer to the DataArray whose tuples will be copied
+   */
   NeighborOrientationCorrelationTransferDataImpl(MessageHelper& messageHelper, size_t totalPoints, const std::vector<int64>& bestNeighbor, std::shared_ptr<IDataArray> dataArrayPtr)
   : m_MessageHelper(messageHelper)
   , m_TotalPoints(totalPoints)
@@ -38,6 +51,9 @@ public:
 
   ~NeighborOrientationCorrelationTransferDataImpl() = default;
 
+  /**
+   * @brief Iterates all voxels and copies tuple data from the best neighbor where applicable.
+   */
   void operator()() const
   {
     ThrottledMessenger throttledMessenger = m_MessageHelper.createThrottledMessenger();
@@ -74,17 +90,37 @@ NeighborOrientationCorrelation::NeighborOrientationCorrelation(DataStructure& da
 NeighborOrientationCorrelation::~NeighborOrientationCorrelation() noexcept = default;
 
 // -----------------------------------------------------------------------------
+/**
+ * @brief Executes the neighbor orientation correlation cleanup algorithm.
+ *
+ * The algorithm proceeds through cleanup levels from 6 down to Level (inclusive),
+ * decrementing by 2 each iteration (due to the additional decrement at the end of
+ * the loop body). At each level, the algorithm:
+ *
+ * 1. **Z-slice buffering**: Maintains a rolling window of 3 Z-slices for quaternion
+ *    and phase data, plus 1 slice for confidence index. This avoids random chunk
+ *    access in out-of-core mode where arrays may be stored as compressed Zarr chunks.
+ *
+ * 2. **Neighbor correlation**: For each low-confidence voxel, examines its 6 face
+ *    neighbors. Valid neighbor pairs with the same nonzero phase are compared via
+ *    misorientation. Neighbors within the angular tolerance accumulate similarity
+ *    counts. The last face neighbor with a positive similarity count is selected
+ *    as the best replacement source.
+ *
+ * 3. **Data transfer**: All cell DataArrays (except ignored ones) are updated in
+ *    parallel, copying tuple data from each voxel's best neighbor.
+ *
+ * @return Result<> Empty result on success, or containing errors if any occurred
+ */
 Result<> NeighborOrientationCorrelation::operator()()
 {
-  size_t progress = 0;
-  size_t totalProgress = 0;
-
   std::vector<ebsdlib::LaueOps::Pointer> orientationOps = ebsdlib::LaueOps::GetAllOrientationOps();
 
-  const auto& confidenceIndex = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->ConfidenceIndexArrayPath);
-  const auto& cellPhases = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->CellPhasesArrayPath);
-  const auto& quats = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->QuatsArrayPath);
+  auto& confidenceIndex = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->ConfidenceIndexArrayPath);
+  auto& cellPhases = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->CellPhasesArrayPath);
+  auto& quats = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->QuatsArrayPath);
   const auto& crystalStructures = m_DataStructure.getDataRefAs<UInt32Array>(m_InputValues->CrystalStructuresArrayPath);
+
   size_t totalPoints = confidenceIndex.getNumberOfTuples();
 
   float misorientationToleranceR = m_InputValues->MisorientationTolerance * numbers::pi_v<float> / 180.0f;
@@ -98,106 +134,190 @@ Result<> NeighborOrientationCorrelation::operator()()
       static_cast<int64>(udims[2]),
   };
 
-  int32 best = 0;
-  int64 neighborPoint2 = 0;
-
   std::array<int64, 6> neighborVoxelIndexOffsets = initializeFaceNeighborOffsets(dims);
   std::array<FaceNeighborType, 6> faceNeighborInternalIdx = initializeFaceNeighborInternalIdx();
 
-  std::vector<int32> neighborDiffCount(totalPoints, 0);
-  std::vector<int32> neighborSimCount(6, 0);
+  std::array<int32, 6> neighborSimCount = {};
   std::vector<int64> bestNeighbor(totalPoints, -1);
   const int32 startLevel = 6;
 
   MessageHelper messageHelper(m_MessageHandler);
-
   ThrottledMessenger throttledMessenger = messageHelper.createThrottledMessenger();
+
+  // Z-slice buffering: read 3 adjacent Z-slices of the most-accessed arrays
+  // into local memory to eliminate OOC chunk thrashing. The algorithm accesses
+  // each voxel's 6 face neighbors, requiring data from z-1, z, and z+1 slices.
+  // By buffering these slices, all neighbor lookups become local memory reads.
+  const usize sliceSize = static_cast<usize>(dims[0]) * static_cast<usize>(dims[1]);
+
+  // Rolling window: slot 0 = z-1, slot 1 = z (current), slot 2 = z+1
+  std::array<std::vector<float32>, 3> quatSlices;
+  std::array<std::vector<int32>, 3> phaseSlices;
+  std::vector<float32> ciSlice(sliceSize);
+
+  for(auto& qs : quatSlices)
+  {
+    qs.resize(sliceSize * 4);
+  }
+  for(auto& ps : phaseSlices)
+  {
+    ps.resize(sliceSize);
+  }
+
+  // Read a Z-slice of quats into a buffer slot (sequential access for OOC)
+  auto readQuatSlice = [&](int64 z, usize slot) {
+    for(int64 y = 0; y < dims[1]; y++)
+    {
+      for(int64 x = 0; x < dims[0]; x++)
+      {
+        usize inSlice = static_cast<usize>(y * dims[0] + x);
+        int64 vi = x + y * dims[0] + z * static_cast<int64>(sliceSize);
+        quatSlices[slot][inSlice * 4] = quats[vi * 4];
+        quatSlices[slot][inSlice * 4 + 1] = quats[vi * 4 + 1];
+        quatSlices[slot][inSlice * 4 + 2] = quats[vi * 4 + 2];
+        quatSlices[slot][inSlice * 4 + 3] = quats[vi * 4 + 3];
+      }
+    }
+  };
+
+  auto readPhaseSlice = [&](int64 z, usize slot) {
+    for(int64 y = 0; y < dims[1]; y++)
+    {
+      for(int64 x = 0; x < dims[0]; x++)
+      {
+        usize inSlice = static_cast<usize>(y * dims[0] + x);
+        int64 vi = x + y * dims[0] + z * static_cast<int64>(sliceSize);
+        phaseSlices[slot][inSlice] = cellPhases[vi];
+      }
+    }
+  };
+
+  auto readCISlice = [&](int64 z) {
+    for(int64 y = 0; y < dims[1]; y++)
+    {
+      for(int64 x = 0; x < dims[0]; x++)
+      {
+        usize inSlice = static_cast<usize>(y * dims[0] + x);
+        int64 vi = x + y * dims[0] + z * static_cast<int64>(sliceSize);
+        ciSlice[inSlice] = confidenceIndex[vi];
+      }
+    }
+  };
 
   for(int32 currentLevel = startLevel; currentLevel > m_InputValues->Level; currentLevel--)
   {
-    for(int64 voxelIndex = 0; voxelIndex < totalPoints; voxelIndex++)
-    {
-      throttledMessenger.sendThrottledMessage([&]() {
-        return fmt::format("Level '{}' of '{}' || Processing Data {:.2f}% completed", (startLevel - currentLevel) + 1, startLevel - m_InputValues->Level,
-                           CalculatePercentComplete(voxelIndex, totalPoints));
-      });
+    usize processedVoxels = 0;
 
-      if(m_ShouldCancel)
+    // Initialize rolling window: load z=0 into slot 1, z=1 into slot 2
+    readQuatSlice(0, 1);
+    readPhaseSlice(0, 1);
+    if(dims[2] > 1)
+    {
+      readQuatSlice(1, 2);
+      readPhaseSlice(1, 2);
+    }
+
+    for(int64 zIdx = 0; zIdx < dims[2] && !m_ShouldCancel; zIdx++)
+    {
+      // Advance rolling window for z > 0
+      if(zIdx > 0)
       {
-        break;
+        std::swap(quatSlices[0], quatSlices[1]);
+        std::swap(quatSlices[1], quatSlices[2]);
+        std::swap(phaseSlices[0], phaseSlices[1]);
+        std::swap(phaseSlices[1], phaseSlices[2]);
+        if(zIdx + 1 < dims[2])
+        {
+          readQuatSlice(zIdx + 1, 2);
+          readPhaseSlice(zIdx + 1, 2);
+        }
       }
 
-      if(confidenceIndex[voxelIndex] < m_InputValues->MinConfidence)
+      readCISlice(zIdx);
+
+      for(int64 yIdx = 0; yIdx < dims[1]; yIdx++)
       {
-        int64 xIdx = voxelIndex % dims[0];
-        int64 yIdx = (voxelIndex / dims[0]) % dims[1];
-        int64 zIdx = voxelIndex / (dims[0] * dims[1]);
-        // Loop over the 6 face neighbors of the voxel
-        std::array<bool, 6> isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
-        for(const auto& faceIndexJ : faceNeighborInternalIdx)
+        for(int64 xIdx = 0; xIdx < dims[0]; xIdx++)
         {
-          if(!isValidFaceNeighbor[faceIndexJ])
-          {
-            continue;
-          }
-          const int64 neighborPoint = voxelIndex + neighborVoxelIndexOffsets[faceIndexJ];
+          int64 voxelIndex = xIdx + yIdx * dims[0] + zIdx * static_cast<int64>(sliceSize);
+          usize inSlice = static_cast<usize>(yIdx * dims[0] + xIdx);
 
-          uint32 laueClass = crystalStructures[cellPhases[voxelIndex]];
-          ebsdlib::QuatD quat1(quats[voxelIndex * 4], quats[voxelIndex * 4 + 1], quats[voxelIndex * 4 + 2], quats[voxelIndex * 4 + 3]);
-          ebsdlib::QuatD quat2(quats[neighborPoint * 4], quats[neighborPoint * 4 + 1], quats[neighborPoint * 4 + 2], quats[neighborPoint * 4 + 3]);
-          ebsdlib::AxisAngleDType axisAngle(0.0, 0.0, 0.0, std::numeric_limits<double>::max());
-          if(cellPhases[voxelIndex] == cellPhases[neighborPoint] && cellPhases[voxelIndex] > 0)
-          {
-            axisAngle = orientationOps[laueClass]->calculateMisorientation(quat1, quat2);
-          }
-          if(axisAngle[3] > misorientationToleranceR)
-          {
-            neighborDiffCount[voxelIndex]++;
-          }
+          throttledMessenger.sendThrottledMessage([&]() {
+            return fmt::format("Level '{}' of '{}' || Processing Data {:.2f}% completed", (startLevel - currentLevel) + 1, startLevel - m_InputValues->Level,
+                               CalculatePercentComplete(processedVoxels, totalPoints));
+          });
 
-          isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
-          for(size_t faceIndexK = faceIndexJ + 1; faceIndexK < k_FaceNeighborCount; faceIndexK++)
+          if(ciSlice[inSlice] < m_InputValues->MinConfidence)
           {
-            if(!isValidFaceNeighbor[faceIndexK])
+            std::array<bool, 6> isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
+
+            // Pre-read all valid neighbor quats and phases into local arrays.
+            // Neighbor buffer slots: 0=-Z, 1=-Y(same z), 2=-X(same z), 3=+X(same z), 4=+Y(same z), 5=+Z
+            // slot mapping: -Z→0, same-z→1, +Z→2
+            constexpr std::array<usize, 6> neighborSlot = {0, 1, 1, 1, 1, 2};
+            const std::array<int64, 6> neighborBufX = {xIdx, xIdx, xIdx - 1, xIdx + 1, xIdx, xIdx};
+            const std::array<int64, 6> neighborBufY = {yIdx, yIdx - 1, yIdx, yIdx, yIdx + 1, yIdx};
+
+            std::array<ebsdlib::QuatD, 6> nQuats;
+            std::array<int32, 6> nPhases = {};
+
+            for(usize f = 0; f < k_FaceNeighborCount; f++)
             {
-              continue;
+              if(isValidFaceNeighbor[f])
+              {
+                usize nIdx = static_cast<usize>(neighborBufY[f] * dims[0] + neighborBufX[f]);
+                usize nIdx4 = nIdx * 4;
+                nPhases[f] = phaseSlices[neighborSlot[f]][nIdx];
+                nQuats[f] = ebsdlib::QuatD(quatSlices[neighborSlot[f]][nIdx4], quatSlices[neighborSlot[f]][nIdx4 + 1], quatSlices[neighborSlot[f]][nIdx4 + 2], quatSlices[neighborSlot[f]][nIdx4 + 3]);
+              }
             }
-            neighborPoint2 = voxelIndex + neighborVoxelIndexOffsets[faceIndexK];
 
-            laueClass = crystalStructures[cellPhases[neighborPoint2]];
-            quat1 = ebsdlib::QuatD(quats[neighborPoint2 * 4], quats[neighborPoint2 * 4 + 1], quats[neighborPoint2 * 4 + 2], quats[neighborPoint2 * 4 + 3]);
-            quat2 = ebsdlib::QuatD(quats[neighborPoint * 4], quats[neighborPoint * 4 + 1], quats[neighborPoint * 4 + 2], quats[neighborPoint * 4 + 3]);
-            axisAngle = ebsdlib::AxisAngleDType(0.0, 0.0, 0.0, std::numeric_limits<double>::max());
-            if(cellPhases[neighborPoint2] == cellPhases[neighborPoint] && cellPhases[neighborPoint2] > 0)
+            // Compute neighbor-neighbor similarity counts
+            neighborSimCount.fill(0);
+
+            for(usize faceIndexJ = 0; faceIndexJ < k_FaceNeighborCount; faceIndexJ++)
             {
-              axisAngle = orientationOps[laueClass]->calculateMisorientation(quat1, quat2);
+              if(!isValidFaceNeighbor[faceIndexJ])
+              {
+                continue;
+              }
+
+              for(usize faceIndexK = faceIndexJ + 1; faceIndexK < k_FaceNeighborCount; faceIndexK++)
+              {
+                if(!isValidFaceNeighbor[faceIndexK])
+                {
+                  continue;
+                }
+
+                if(nPhases[faceIndexK] == nPhases[faceIndexJ] && nPhases[faceIndexK] > 0)
+                {
+                  uint32 laueClass = crystalStructures[nPhases[faceIndexK]];
+                  ebsdlib::AxisAngleDType axisAngle = orientationOps[laueClass]->calculateMisorientation(nQuats[faceIndexK], nQuats[faceIndexJ]);
+                  if(axisAngle[3] < misorientationToleranceR)
+                  {
+                    neighborSimCount[faceIndexJ]++;
+                    neighborSimCount[faceIndexK]++;
+                  }
+                }
+              }
             }
-            if(axisAngle[3] < misorientationToleranceR)
+
+            // Find the best neighbor (last valid face with highest similarity count)
+            for(usize faceIndex = 0; faceIndex < k_FaceNeighborCount; faceIndex++)
             {
-              neighborSimCount[faceIndexJ]++;
-              neighborSimCount[faceIndexK]++;
+              if(!isValidFaceNeighbor[faceIndex])
+              {
+                continue;
+              }
+
+              if(neighborSimCount[faceIndex] > 0)
+              {
+                bestNeighbor[voxelIndex] = voxelIndex + neighborVoxelIndexOffsets[faceIndex];
+              }
             }
           }
-        }
 
-        // Loop over the 6 face neighbors of the voxel
-        isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
-        for(const auto& faceIndex : faceNeighborInternalIdx)
-        {
-          if(!isValidFaceNeighbor[faceIndex])
-          {
-            continue;
-          }
-          best = 0;
-
-          const int64 neighborPoint = voxelIndex + neighborVoxelIndexOffsets[faceIndex];
-
-          if(neighborSimCount[faceIndex] > best)
-          {
-            best = neighborSimCount[faceIndex];
-            bestNeighbor[voxelIndex] = neighborPoint;
-          }
-          neighborSimCount[faceIndex] = 0;
+          processedVoxels++;
         }
       }
     }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/NeighborOrientationCorrelation.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/NeighborOrientationCorrelation.cpp
@@ -9,12 +9,6 @@
 #include "simplnx/Utilities/NeighborUtilities.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
-#ifdef SIMPLNX_ENABLE_MULTICORE
-#define RUN_TASK g->run
-#else
-#define RUN_TASK
-#endif
-
 #include <EbsdLib/LaueOps/LaueOps.h>
 
 using namespace nx::core;
@@ -98,7 +92,6 @@ Result<> NeighborOrientationCorrelation::operator()()
   };
 
   std::array<int64, 6> neighborVoxelIndexOffsets = initializeFaceNeighborOffsets(dims);
-  std::array<FaceNeighborType, 6> faceNeighborInternalIdx = initializeFaceNeighborInternalIdx();
 
   std::array<int32, 6> neighborSimCount = {};
   std::vector<int64> bestNeighbor(totalPoints, -1);
@@ -294,9 +287,9 @@ Result<> NeighborOrientationCorrelation::operator()()
 
     // Build up a list of the DataArrays that we are going to operate on.
     std::vector<std::shared_ptr<IDataArray>> voxelArrays = nx::core::GenerateDataArrayList(m_DataStructure, m_InputValues->ConfidenceIndexArrayPath, m_InputValues->IgnoredDataArrayPaths);
-    // The idea for this parallel section is to parallelize over each Data Array that
-    // will need it's data adjusted. This should go faster than before by about 2x.
-    // Better speed up could be achieved if we had better data locality.
+    // Parallel per-array transfer: each task processes one entire array sequentially,
+    // which keeps OOC chunk access patterns coherent within each array. Multiple arrays
+    // run concurrently via ParallelTaskAlgorithm.
     ParallelTaskAlgorithm parallelTask;
     for(const auto& dataArrayPtr : voxelArrays)
     {

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/NeighborOrientationCorrelation.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/NeighborOrientationCorrelation.cpp
@@ -25,6 +25,7 @@ public:
   NeighborOrientationCorrelationTransferDataImpl() = delete;
   NeighborOrientationCorrelationTransferDataImpl(const NeighborOrientationCorrelationTransferDataImpl&) = default;
 
+  // SAFETY: bestNeighbor must outlive the ParallelTaskAlgorithm that executes this functor.
   NeighborOrientationCorrelationTransferDataImpl(MessageHelper& messageHelper, size_t totalPoints, const std::vector<int64>& bestNeighbor, std::shared_ptr<IDataArray> dataArrayPtr)
   : m_MessageHelper(messageHelper)
   , m_TotalPoints(totalPoints)
@@ -217,7 +218,7 @@ Result<> NeighborOrientationCorrelation::operator()()
             // Pre-read all valid neighbor quats and phases into local arrays.
             // Neighbor buffer slots: 0=-Z, 1=-Y(same z), 2=-X(same z), 3=+X(same z), 4=+Y(same z), 5=+Z
             // slot mapping: -Z→0, same-z→1, +Z→2
-            constexpr std::array<usize, 6> neighborSlot = {0, 1, 1, 1, 1, 2};
+            constexpr std::array<usize, 6> k_NeighborSlot = {0, 1, 1, 1, 1, 2};
             const std::array<int64, 6> neighborBufX = {xIdx, xIdx, xIdx - 1, xIdx + 1, xIdx, xIdx};
             const std::array<int64, 6> neighborBufY = {yIdx, yIdx - 1, yIdx, yIdx, yIdx + 1, yIdx};
 
@@ -230,8 +231,9 @@ Result<> NeighborOrientationCorrelation::operator()()
               {
                 usize nIdx = static_cast<usize>(neighborBufY[f] * dims[0] + neighborBufX[f]);
                 usize nIdx4 = nIdx * 4;
-                nPhases[f] = phaseSlices[neighborSlot[f]][nIdx];
-                nQuats[f] = ebsdlib::QuatD(quatSlices[neighborSlot[f]][nIdx4], quatSlices[neighborSlot[f]][nIdx4 + 1], quatSlices[neighborSlot[f]][nIdx4 + 2], quatSlices[neighborSlot[f]][nIdx4 + 3]);
+                nPhases[f] = phaseSlices[k_NeighborSlot[f]][nIdx];
+                nQuats[f] =
+                    ebsdlib::QuatD(quatSlices[k_NeighborSlot[f]][nIdx4], quatSlices[k_NeighborSlot[f]][nIdx4 + 1], quatSlices[k_NeighborSlot[f]][nIdx4 + 2], quatSlices[k_NeighborSlot[f]][nIdx4 + 3]);
               }
             }
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/NeighborOrientationCorrelation.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/NeighborOrientationCorrelation.cpp
@@ -19,25 +19,12 @@
 
 using namespace nx::core;
 
-/**
- * @class NeighborOrientationCorrelationTransferDataImpl
- * @brief Functor that copies tuple data from best-neighbor voxels into low-confidence voxels
- * for a single DataArray. Designed to be executed in parallel across multiple DataArrays
- * via ParallelTaskAlgorithm.
- */
 class NeighborOrientationCorrelationTransferDataImpl
 {
 public:
   NeighborOrientationCorrelationTransferDataImpl() = delete;
   NeighborOrientationCorrelationTransferDataImpl(const NeighborOrientationCorrelationTransferDataImpl&) = default;
 
-  /**
-   * @brief Constructs the transfer functor for a single DataArray.
-   * @param messageHelper Reference to the MessageHelper for progress reporting
-   * @param totalPoints Total number of voxels in the volume
-   * @param bestNeighbor Vector mapping each voxel index to its best neighbor's index (-1 if none)
-   * @param dataArrayPtr Shared pointer to the DataArray whose tuples will be copied
-   */
   NeighborOrientationCorrelationTransferDataImpl(MessageHelper& messageHelper, size_t totalPoints, const std::vector<int64>& bestNeighbor, std::shared_ptr<IDataArray> dataArrayPtr)
   : m_MessageHelper(messageHelper)
   , m_TotalPoints(totalPoints)
@@ -51,9 +38,6 @@ public:
 
   ~NeighborOrientationCorrelationTransferDataImpl() = default;
 
-  /**
-   * @brief Iterates all voxels and copies tuple data from the best neighbor where applicable.
-   */
   void operator()() const
   {
     ThrottledMessenger throttledMessenger = m_MessageHelper.createThrottledMessenger();
@@ -72,7 +56,7 @@ public:
 private:
   MessageHelper& m_MessageHelper;
   size_t m_TotalPoints = 0;
-  std::vector<int64> m_BestNeighbor;
+  const std::vector<int64>& m_BestNeighbor;
   std::shared_ptr<IDataArray> m_DataArrayPtr;
 };
 
@@ -90,28 +74,6 @@ NeighborOrientationCorrelation::NeighborOrientationCorrelation(DataStructure& da
 NeighborOrientationCorrelation::~NeighborOrientationCorrelation() noexcept = default;
 
 // -----------------------------------------------------------------------------
-/**
- * @brief Executes the neighbor orientation correlation cleanup algorithm.
- *
- * The algorithm proceeds through cleanup levels from 6 down to Level (inclusive),
- * decrementing by 2 each iteration (due to the additional decrement at the end of
- * the loop body). At each level, the algorithm:
- *
- * 1. **Z-slice buffering**: Maintains a rolling window of 3 Z-slices for quaternion
- *    and phase data, plus 1 slice for confidence index. This avoids random chunk
- *    access in out-of-core mode where arrays may be stored as compressed Zarr chunks.
- *
- * 2. **Neighbor correlation**: For each low-confidence voxel, examines its 6 face
- *    neighbors. Valid neighbor pairs with the same nonzero phase are compared via
- *    misorientation. Neighbors within the angular tolerance accumulate similarity
- *    counts. The last face neighbor with a positive similarity count is selected
- *    as the best replacement source.
- *
- * 3. **Data transfer**: All cell DataArrays (except ignored ones) are updated in
- *    parallel, copying tuple data from each voxel's best neighbor.
- *
- * @return Result<> Empty result on success, or containing errors if any occurred
- */
 Result<> NeighborOrientationCorrelation::operator()()
 {
   std::vector<ebsdlib::LaueOps::Pointer> orientationOps = ebsdlib::LaueOps::GetAllOrientationOps();
@@ -206,6 +168,7 @@ Result<> NeighborOrientationCorrelation::operator()()
 
   for(int32 currentLevel = startLevel; currentLevel > m_InputValues->Level; currentLevel--)
   {
+    std::fill(bestNeighbor.begin(), bestNeighbor.end(), -1);
     usize processedVoxels = 0;
 
     // Initialize rolling window: load z=0 into slot 1, z=1 into slot 2
@@ -302,7 +265,7 @@ Result<> NeighborOrientationCorrelation::operator()()
               }
             }
 
-            // Find the best neighbor (last valid face with highest similarity count)
+            // Find the best neighbor (last valid face with positive similarity count)
             for(usize faceIndex = 0; faceIndex < k_FaceNeighborCount; faceIndex++)
             {
               if(!isValidFaceNeighbor[faceIndex])

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/NeighborOrientationCorrelation.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/NeighborOrientationCorrelation.hpp
@@ -10,27 +10,63 @@
 namespace nx::core
 {
 
+/**
+ * @struct NeighborOrientationCorrelationInputValues
+ * @brief Holds all user-supplied parameters for the NeighborOrientationCorrelation algorithm.
+ */
 struct ORIENTATIONANALYSIS_EXPORT NeighborOrientationCorrelationInputValues
 {
-  DataPath ImageGeomPath;
-  float32 MinConfidence;
-  float32 MisorientationTolerance;
-  int32 Level;
-  DataPath ConfidenceIndexArrayPath;
-  DataPath CellPhasesArrayPath;
-  DataPath QuatsArrayPath;
-  DataPath CrystalStructuresArrayPath;
-  MultiArraySelectionParameter::ValueType IgnoredDataArrayPaths;
+  DataPath ImageGeomPath;                                        ///< Path to the ImageGeom that defines the voxel grid dimensions
+  float32 MinConfidence;                                         ///< Cells with confidence index below this value are candidates for replacement
+  float32 MisorientationTolerance;                               ///< Angular tolerance (degrees) for comparing neighbor orientations
+  int32 Level;                                                   ///< Minimum neighbor agreement count required to replace a cell (cleanup level)
+  DataPath ConfidenceIndexArrayPath;                             ///< Path to the float32 confidence index array
+  DataPath CellPhasesArrayPath;                                  ///< Path to the int32 cell phases array
+  DataPath QuatsArrayPath;                                       ///< Path to the float32 quaternion array (4 components per tuple)
+  DataPath CrystalStructuresArrayPath;                           ///< Path to the uint32 crystal structures ensemble array
+  MultiArraySelectionParameter::ValueType IgnoredDataArrayPaths; ///< Data arrays excluded from the neighbor-copy transfer step
 };
 
 /**
- * @class
+ * @class NeighborOrientationCorrelation
+ * @brief Corrects low-confidence EBSD voxels by replacing their cell data with
+ * data from the most orientation-correlated face neighbor.
+ *
+ * The algorithm iterates through multiple "cleanup levels" (from 6 down to the
+ * user-specified Level). At each level, every voxel whose confidence index is
+ * below MinConfidence is examined. For that voxel, the 6 face neighbors are
+ * compared pairwise: two neighbors "agree" if they share the same nonzero phase
+ * and their misorientation is within MisorientationTolerance. Each neighbor
+ * accumulates a similarity count (how many other neighbors agree with it). The
+ * neighbor with the highest agreement is chosen as the replacement source.
+ *
+ * ## Z-Slice Buffering (Out-of-Core Optimization)
+ *
+ * To avoid random-access thrashing of out-of-core (OOC) compressed chunk stores,
+ * the algorithm maintains a rolling window of 3 adjacent Z-slices for the
+ * quaternion and phase arrays, plus 1 Z-slice for the confidence index. At each
+ * Z-step, the window advances by swapping buffer slots and reading only the new
+ * z+1 slice. All neighbor lookups then read from these local buffers instead of
+ * the backing DataArray, eliminating repeated chunk decompressions.
+ *
+ * After identifying the best neighbor for every low-confidence voxel in a level,
+ * all cell-level DataArrays (except ignored ones) are updated in parallel using
+ * ParallelTaskAlgorithm, copying tuple data from each best neighbor.
  */
 class ORIENTATIONANALYSIS_EXPORT NeighborOrientationCorrelation
 {
 public:
+  /**
+   * @brief Constructs the algorithm with all required references and parameters.
+   * @param dataStructure The DataStructure containing all input/output arrays
+   * @param mesgHandler Handler for sending progress messages to the UI
+   * @param shouldCancel Atomic flag checked between iterations to support cancellation
+   * @param inputValues User-supplied parameters controlling the algorithm behavior
+   */
   NeighborOrientationCorrelation(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel,
                                  NeighborOrientationCorrelationInputValues* inputValues);
+
+  /** @brief Default destructor. */
   ~NeighborOrientationCorrelation() noexcept;
 
   NeighborOrientationCorrelation(const NeighborOrientationCorrelation&) = delete;
@@ -38,6 +74,10 @@ public:
   NeighborOrientationCorrelation& operator=(const NeighborOrientationCorrelation&) = delete;
   NeighborOrientationCorrelation& operator=(NeighborOrientationCorrelation&&) noexcept = delete;
 
+  /**
+   * @brief Executes the neighbor orientation correlation algorithm.
+   * @return Result<> indicating success or any errors encountered during execution
+   */
   Result<> operator()();
 
 private:

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/NeighborOrientationCorrelation.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/NeighborOrientationCorrelation.hpp
@@ -66,7 +66,9 @@ public:
   NeighborOrientationCorrelation(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel,
                                  NeighborOrientationCorrelationInputValues* inputValues);
 
-  /** @brief Default destructor. */
+  /**
+   * @brief Default destructor.
+   */
   ~NeighborOrientationCorrelation() noexcept;
 
   NeighborOrientationCorrelation(const NeighborOrientationCorrelation&) = delete;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.cpp
@@ -22,60 +22,36 @@ constexpr int32 k_InvalidNumTuples = -580093;
 
 namespace nx::core
 {
-/**
- * @brief Returns the internal programmatic name of the filter.
- * @return The filter name string
- */
 //------------------------------------------------------------------------------
 std::string NeighborOrientationCorrelationFilter::name() const
 {
   return FilterTraits<NeighborOrientationCorrelationFilter>::name.str();
 }
 
-/**
- * @brief Returns the C++ class name of the filter.
- * @return The class name string
- */
 //------------------------------------------------------------------------------
 std::string NeighborOrientationCorrelationFilter::className() const
 {
   return FilterTraits<NeighborOrientationCorrelationFilter>::className;
 }
 
-/**
- * @brief Returns the universally unique identifier for this filter.
- * @return The filter's UUID
- */
 //------------------------------------------------------------------------------
 Uuid NeighborOrientationCorrelationFilter::uuid() const
 {
   return FilterTraits<NeighborOrientationCorrelationFilter>::uuid;
 }
 
-/**
- * @brief Returns the user-facing display name for this filter.
- * @return The human-readable filter name
- */
 //------------------------------------------------------------------------------
 std::string NeighborOrientationCorrelationFilter::humanName() const
 {
   return "Neighbor Orientation Correlation";
 }
 
-/**
- * @brief Returns the default tags used for searching and categorizing this filter.
- * @return A vector of tag strings
- */
 //------------------------------------------------------------------------------
 std::vector<std::string> NeighborOrientationCorrelationFilter::defaultTags() const
 {
   return {className(), "Processing", "Cleanup"};
 }
 
-/**
- * @brief Defines all user-configurable parameters for this filter.
- * @return A Parameters object containing all parameter definitions
- */
 //------------------------------------------------------------------------------
 Parameters NeighborOrientationCorrelationFilter::parameters() const
 {
@@ -105,39 +81,18 @@ Parameters NeighborOrientationCorrelationFilter::parameters() const
   return params;
 }
 
-/**
- * @brief Returns the version number of the filter's parameter schema.
- * @return The parameters version (incremented when parameters change)
- */
 //------------------------------------------------------------------------------
 IFilter::VersionType NeighborOrientationCorrelationFilter::parametersVersion() const
 {
   return 1;
 }
 
-/**
- * @brief Creates and returns a deep copy of this filter instance.
- * @return A unique pointer to the cloned filter
- */
 //------------------------------------------------------------------------------
 IFilter::UniquePointer NeighborOrientationCorrelationFilter::clone() const
 {
   return std::make_unique<NeighborOrientationCorrelationFilter>();
 }
 
-/**
- * @brief Validates filter inputs and reports what modifications the filter will make.
- *
- * Checks that all required DataArrays exist, have matching tuple counts, and are
- * compatible types. Reports that cell data arrays will be modified in place.
- *
- * @param dataStructure The input DataStructure to validate against
- * @param filterArgs The user-supplied filter arguments
- * @param messageHandler Handler for sending messages to the UI
- * @param shouldCancel Atomic flag for cancellation support
- * @param executionContext The execution context for path resolution
- * @return PreflightResult containing output actions and any warnings/errors
- */
 //------------------------------------------------------------------------------
 IFilter::PreflightResult NeighborOrientationCorrelationFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
@@ -208,22 +163,6 @@ IFilter::PreflightResult NeighborOrientationCorrelationFilter::preflightImpl(con
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
 }
 
-/**
- * @brief Executes the neighbor orientation correlation algorithm on the DataStructure.
- *
- * Extracts all input values from the filter arguments, constructs a
- * NeighborOrientationCorrelation algorithm instance, and runs it. The algorithm
- * modifies cell data arrays in place by replacing low-confidence voxels with data
- * from their most orientation-correlated face neighbor.
- *
- * @param dataStructure The DataStructure containing all input arrays (modified in place)
- * @param filterArgs The user-supplied filter arguments
- * @param pipelineNode The pipeline node executing this filter (unused)
- * @param messageHandler Handler for sending progress messages to the UI
- * @param shouldCancel Atomic flag for cancellation support
- * @param executionContext The execution context for path resolution
- * @return Result<> indicating success or any errors from the algorithm
- */
 //------------------------------------------------------------------------------
 Result<> NeighborOrientationCorrelationFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
@@ -258,11 +197,6 @@ constexpr StringLiteral k_IgnoredDataArrayPathsKey = "IgnoredDataArrayPaths";
 } // namespace SIMPL
 } // namespace
 
-/**
- * @brief Converts a SIMPL-format JSON object into simplnx Arguments for this filter.
- * @param json The SIMPL JSON object containing legacy filter parameters
- * @return Result<Arguments> containing the converted arguments, or errors if conversion fails
- */
 Result<Arguments> NeighborOrientationCorrelationFilter::FromSIMPLJson(const nlohmann::json& json)
 {
   Arguments args = NeighborOrientationCorrelationFilter().getDefaultArguments();

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.cpp
@@ -22,36 +22,60 @@ constexpr int32 k_InvalidNumTuples = -580093;
 
 namespace nx::core
 {
+/**
+ * @brief Returns the internal programmatic name of the filter.
+ * @return The filter name string
+ */
 //------------------------------------------------------------------------------
 std::string NeighborOrientationCorrelationFilter::name() const
 {
   return FilterTraits<NeighborOrientationCorrelationFilter>::name.str();
 }
 
+/**
+ * @brief Returns the C++ class name of the filter.
+ * @return The class name string
+ */
 //------------------------------------------------------------------------------
 std::string NeighborOrientationCorrelationFilter::className() const
 {
   return FilterTraits<NeighborOrientationCorrelationFilter>::className;
 }
 
+/**
+ * @brief Returns the universally unique identifier for this filter.
+ * @return The filter's UUID
+ */
 //------------------------------------------------------------------------------
 Uuid NeighborOrientationCorrelationFilter::uuid() const
 {
   return FilterTraits<NeighborOrientationCorrelationFilter>::uuid;
 }
 
+/**
+ * @brief Returns the user-facing display name for this filter.
+ * @return The human-readable filter name
+ */
 //------------------------------------------------------------------------------
 std::string NeighborOrientationCorrelationFilter::humanName() const
 {
   return "Neighbor Orientation Correlation";
 }
 
+/**
+ * @brief Returns the default tags used for searching and categorizing this filter.
+ * @return A vector of tag strings
+ */
 //------------------------------------------------------------------------------
 std::vector<std::string> NeighborOrientationCorrelationFilter::defaultTags() const
 {
   return {className(), "Processing", "Cleanup"};
 }
 
+/**
+ * @brief Defines all user-configurable parameters for this filter.
+ * @return A Parameters object containing all parameter definitions
+ */
 //------------------------------------------------------------------------------
 Parameters NeighborOrientationCorrelationFilter::parameters() const
 {
@@ -81,18 +105,39 @@ Parameters NeighborOrientationCorrelationFilter::parameters() const
   return params;
 }
 
+/**
+ * @brief Returns the version number of the filter's parameter schema.
+ * @return The parameters version (incremented when parameters change)
+ */
 //------------------------------------------------------------------------------
 IFilter::VersionType NeighborOrientationCorrelationFilter::parametersVersion() const
 {
   return 1;
 }
 
+/**
+ * @brief Creates and returns a deep copy of this filter instance.
+ * @return A unique pointer to the cloned filter
+ */
 //------------------------------------------------------------------------------
 IFilter::UniquePointer NeighborOrientationCorrelationFilter::clone() const
 {
   return std::make_unique<NeighborOrientationCorrelationFilter>();
 }
 
+/**
+ * @brief Validates filter inputs and reports what modifications the filter will make.
+ *
+ * Checks that all required DataArrays exist, have matching tuple counts, and are
+ * compatible types. Reports that cell data arrays will be modified in place.
+ *
+ * @param dataStructure The input DataStructure to validate against
+ * @param filterArgs The user-supplied filter arguments
+ * @param messageHandler Handler for sending messages to the UI
+ * @param shouldCancel Atomic flag for cancellation support
+ * @param executionContext The execution context for path resolution
+ * @return PreflightResult containing output actions and any warnings/errors
+ */
 //------------------------------------------------------------------------------
 IFilter::PreflightResult NeighborOrientationCorrelationFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
                                                                              const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
@@ -163,6 +208,22 @@ IFilter::PreflightResult NeighborOrientationCorrelationFilter::preflightImpl(con
   return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
 }
 
+/**
+ * @brief Executes the neighbor orientation correlation algorithm on the DataStructure.
+ *
+ * Extracts all input values from the filter arguments, constructs a
+ * NeighborOrientationCorrelation algorithm instance, and runs it. The algorithm
+ * modifies cell data arrays in place by replacing low-confidence voxels with data
+ * from their most orientation-correlated face neighbor.
+ *
+ * @param dataStructure The DataStructure containing all input arrays (modified in place)
+ * @param filterArgs The user-supplied filter arguments
+ * @param pipelineNode The pipeline node executing this filter (unused)
+ * @param messageHandler Handler for sending progress messages to the UI
+ * @param shouldCancel Atomic flag for cancellation support
+ * @param executionContext The execution context for path resolution
+ * @return Result<> indicating success or any errors from the algorithm
+ */
 //------------------------------------------------------------------------------
 Result<> NeighborOrientationCorrelationFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                                            const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
@@ -197,6 +258,11 @@ constexpr StringLiteral k_IgnoredDataArrayPathsKey = "IgnoredDataArrayPaths";
 } // namespace SIMPL
 } // namespace
 
+/**
+ * @brief Converts a SIMPL-format JSON object into simplnx Arguments for this filter.
+ * @param json The SIMPL JSON object containing legacy filter parameters
+ * @return Result<Arguments> containing the converted arguments, or errors if conversion fails
+ */
 Result<Arguments> NeighborOrientationCorrelationFilter::FromSIMPLJson(const nlohmann::json& json)
 {
   Arguments args = NeighborOrientationCorrelationFilter().getDefaultArguments();

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/NeighborOrientationCorrelationFilter.hpp
@@ -9,7 +9,21 @@ namespace nx::core
 {
 /**
  * @class NeighborOrientationCorrelationFilter
- * @brief This filter will ....
+ * @brief Cleans up EBSD data by replacing low-confidence voxels with data from
+ * the most orientation-correlated face neighbor.
+ *
+ * This filter identifies voxels whose confidence index falls below a
+ * user-specified threshold, then examines the 6 face neighbors of each such
+ * voxel. Neighbor pairs are compared using crystallographic misorientation;
+ * the neighbor that agrees most with the other neighbors (within a given
+ * angular tolerance) is selected as the replacement source. All cell-level
+ * DataArrays are updated to reflect the replacement. The process repeats
+ * across multiple cleanup levels, progressively relaxing the required neighbor
+ * agreement count.
+ *
+ * The underlying algorithm uses Z-slice buffering to maintain efficient
+ * sequential access patterns, which is critical for out-of-core (OOC) data
+ * where arrays are stored as compressed Zarr chunks on disk.
  */
 class ORIENTATIONANALYSIS_EXPORT NeighborOrientationCorrelationFilter : public IFilter
 {

--- a/src/Plugins/OrientationAnalysis/test/NeighborOrientationCorrelationTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/NeighborOrientationCorrelationTest.cpp
@@ -38,6 +38,8 @@ using namespace nx::core::UnitTest;
 TEST_CASE("OrientationAnalysis::NeighborOrientationCorrelationFilter: Small IN100 Pipeline", "[OrientationAnalysis][NeighborOrientationCorrelationFilter]")
 {
   UnitTest::LoadPlugins();
+  // 1 Z-slice of quats (largest array): 189*201*4*4 = 607824 bytes
+  const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 600000, true);
 
   const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_TestFilesDir, "neighbor_orientation_correlation.tar.gz", "neighbor_orientation_correlation.dream3d");
 

--- a/src/Plugins/OrientationAnalysis/test/NeighborOrientationCorrelationTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/NeighborOrientationCorrelationTest.cpp
@@ -207,18 +207,18 @@ TEST_CASE("OrientationAnalysis::NeighborOrientationCorrelationFilter: Benchmark 
   // 200x200x200, Quats (float32, 4-comp) => 200*200*4*4 = 640,000 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 640000, true);
 
-  constexpr usize kDimX = 200;
-  constexpr usize kDimY = 200;
-  constexpr usize kDimZ = 200;
-  constexpr usize kTotalVoxels = kDimX * kDimY * kDimZ;
-  const ShapeType cellTupleShape = {kDimZ, kDimY, kDimX};
+  constexpr usize k_DimX = 200;
+  constexpr usize k_DimY = 200;
+  constexpr usize k_DimZ = 200;
+  constexpr usize k_TotalVoxels = k_DimX * k_DimY * k_DimZ;
+  const ShapeType cellTupleShape = {k_DimZ, k_DimY, k_DimX};
   const auto benchmarkFile = fs::path(fmt::format("{}/neighbor_orientation_correlation_benchmark.dream3d", unit_test::k_BinaryTestOutputDir));
 
   // Stage 1: Build data programmatically and write to .dream3d
   {
     DataStructure buildDS;
     auto* imageGeom = ImageGeom::Create(buildDS, "Image Geometry");
-    imageGeom->setDimensions({kDimX, kDimY, kDimZ});
+    imageGeom->setDimensions({k_DimX, k_DimY, k_DimZ});
     imageGeom->setSpacing({1.0f, 1.0f, 1.0f});
     imageGeom->setOrigin({0.0f, 0.0f, 0.0f});
 
@@ -237,22 +237,22 @@ TEST_CASE("OrientationAnalysis::NeighborOrientationCorrelationFilter: Benchmark 
     auto* ciArray = UnitTest::CreateTestDataArray<float32>(buildDS, "Confidence Index", cellTupleShape, {1}, cellAM->getId());
     auto& ciStore = ciArray->getDataStoreRef();
 
-    constexpr usize kBlockSize = 25;
-    constexpr usize kBlocksPerDim = kDimX / kBlockSize;
-    for(usize z = 0; z < kDimZ; z++)
+    constexpr usize k_BlockSize = 25;
+    constexpr usize k_BlocksPerDim = k_DimX / k_BlockSize;
+    for(usize z = 0; z < k_DimZ; z++)
     {
-      for(usize y = 0; y < kDimY; y++)
+      for(usize y = 0; y < k_DimY; y++)
       {
-        for(usize x = 0; x < kDimX; x++)
+        for(usize x = 0; x < k_DimX; x++)
         {
-          const usize idx = z * kDimX * kDimY + y * kDimX + x;
+          const usize idx = z * k_DimX * k_DimY + y * k_DimX + x;
           phasesStore[idx] = 1;
 
           // Block-based orientation: each 25^3 block gets a distinct quaternion
-          usize bx = x / kBlockSize;
-          usize by = y / kBlockSize;
-          usize bz = z / kBlockSize;
-          float32 angle = static_cast<float32>(bz * kBlocksPerDim * kBlocksPerDim + by * kBlocksPerDim + bx) * 0.1f;
+          usize bx = x / k_BlockSize;
+          usize by = y / k_BlockSize;
+          usize bz = z / k_BlockSize;
+          float32 angle = static_cast<float32>(bz * k_BlocksPerDim * k_BlocksPerDim + by * k_BlocksPerDim + bx) * 0.1f;
           float32 sinHalf = std::sin(angle * 0.5f);
           float32 cosHalf = std::cos(angle * 0.5f);
 
@@ -263,7 +263,7 @@ TEST_CASE("OrientationAnalysis::NeighborOrientationCorrelationFilter: Benchmark 
           quatsStore[qIdx + 3] = sinHalf * 0.577350269f;
 
           // Low CI at block boundaries (~10% of voxels), high CI inside
-          bool isBoundary = (x % kBlockSize == 0) || (y % kBlockSize == 0) || (z % kBlockSize == 0);
+          bool isBoundary = (x % k_BlockSize == 0) || (y % k_BlockSize == 0) || (z % k_BlockSize == 0);
           bool isNoisy = ((x * 7 + y * 13 + z * 29) % 10 == 0);
           ciStore[idx] = (isBoundary || isNoisy) ? 0.05f : 0.9f;
         }

--- a/src/Plugins/OrientationAnalysis/test/NeighborOrientationCorrelationTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/NeighborOrientationCorrelationTest.cpp
@@ -210,7 +210,6 @@ TEST_CASE("OrientationAnalysis::NeighborOrientationCorrelationFilter: Benchmark 
   constexpr usize k_DimX = 200;
   constexpr usize k_DimY = 200;
   constexpr usize k_DimZ = 200;
-  constexpr usize k_TotalVoxels = k_DimX * k_DimY * k_DimZ;
   const ShapeType cellTupleShape = {k_DimZ, k_DimY, k_DimX};
   const auto benchmarkFile = fs::path(fmt::format("{}/neighbor_orientation_correlation_benchmark.dream3d", unit_test::k_BinaryTestOutputDir));
 

--- a/src/Plugins/OrientationAnalysis/test/NeighborOrientationCorrelationTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/NeighborOrientationCorrelationTest.cpp
@@ -3,14 +3,18 @@
 #include "OrientationAnalysisTestUtils.hpp"
 
 #include "simplnx/Core/Application.hpp"
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/Dream3dImportParameter.hpp"
 #include "simplnx/Parameters/GeometrySelectionParameter.hpp"
+#include "simplnx/Parameters/MultiArraySelectionParameter.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include <catch2/catch.hpp>
 
+#include <cmath>
 #include <filesystem>
 
 namespace fs = std::filesystem;
@@ -195,4 +199,109 @@ TEST_CASE("OrientationAnalysis::NeighborOrientationCorrelationFilter: Small IN10
 #endif
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure, SmallIn100::k_TupleCheckIgnoredPaths);
+}
+
+TEST_CASE("OrientationAnalysis::NeighborOrientationCorrelationFilter: Benchmark 200x200x200", "[OrientationAnalysis][NeighborOrientationCorrelationFilter][Benchmark]")
+{
+  UnitTest::LoadPlugins();
+  // 200x200x200, Quats (float32, 4-comp) => 200*200*4*4 = 640,000 bytes/slice
+  const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 640000, true);
+
+  constexpr usize kDimX = 200;
+  constexpr usize kDimY = 200;
+  constexpr usize kDimZ = 200;
+  constexpr usize kTotalVoxels = kDimX * kDimY * kDimZ;
+  const ShapeType cellTupleShape = {kDimZ, kDimY, kDimX};
+  const auto benchmarkFile = fs::path(fmt::format("{}/neighbor_orientation_correlation_benchmark.dream3d", unit_test::k_BinaryTestOutputDir));
+
+  // Stage 1: Build data programmatically and write to .dream3d
+  {
+    DataStructure buildDS;
+    auto* imageGeom = ImageGeom::Create(buildDS, "Image Geometry");
+    imageGeom->setDimensions({kDimX, kDimY, kDimZ});
+    imageGeom->setSpacing({1.0f, 1.0f, 1.0f});
+    imageGeom->setOrigin({0.0f, 0.0f, 0.0f});
+
+    auto* cellAM = AttributeMatrix::Create(buildDS, "Cell Data", cellTupleShape, imageGeom->getId());
+    imageGeom->setCellData(*cellAM);
+
+    // Quaternions: block-based orientations with noise at boundaries
+    auto* quatsArray = UnitTest::CreateTestDataArray<float32>(buildDS, "Quats", cellTupleShape, {4}, cellAM->getId());
+    auto& quatsStore = quatsArray->getDataStoreRef();
+
+    // Phases: all phase 1 (cubic)
+    auto* phasesArray = UnitTest::CreateTestDataArray<int32>(buildDS, "Phases", cellTupleShape, {1}, cellAM->getId());
+    auto& phasesStore = phasesArray->getDataStoreRef();
+
+    // Confidence Index: low at block boundaries, high inside blocks
+    auto* ciArray = UnitTest::CreateTestDataArray<float32>(buildDS, "Confidence Index", cellTupleShape, {1}, cellAM->getId());
+    auto& ciStore = ciArray->getDataStoreRef();
+
+    constexpr usize kBlockSize = 25;
+    constexpr usize kBlocksPerDim = kDimX / kBlockSize;
+    for(usize z = 0; z < kDimZ; z++)
+    {
+      for(usize y = 0; y < kDimY; y++)
+      {
+        for(usize x = 0; x < kDimX; x++)
+        {
+          const usize idx = z * kDimX * kDimY + y * kDimX + x;
+          phasesStore[idx] = 1;
+
+          // Block-based orientation: each 25^3 block gets a distinct quaternion
+          usize bx = x / kBlockSize;
+          usize by = y / kBlockSize;
+          usize bz = z / kBlockSize;
+          float32 angle = static_cast<float32>(bz * kBlocksPerDim * kBlocksPerDim + by * kBlocksPerDim + bx) * 0.1f;
+          float32 sinHalf = std::sin(angle * 0.5f);
+          float32 cosHalf = std::cos(angle * 0.5f);
+
+          const usize qIdx = idx * 4;
+          quatsStore[qIdx] = cosHalf;
+          quatsStore[qIdx + 1] = sinHalf * 0.577350269f; // 1/sqrt(3)
+          quatsStore[qIdx + 2] = sinHalf * 0.577350269f;
+          quatsStore[qIdx + 3] = sinHalf * 0.577350269f;
+
+          // Low CI at block boundaries (~10% of voxels), high CI inside
+          bool isBoundary = (x % kBlockSize == 0) || (y % kBlockSize == 0) || (z % kBlockSize == 0);
+          bool isNoisy = ((x * 7 + y * 13 + z * 29) % 10 == 0);
+          ciStore[idx] = (isBoundary || isNoisy) ? 0.05f : 0.9f;
+        }
+      }
+    }
+
+    // Ensemble data: Crystal Structures (1 entry for phase 0 = unknown, 1 entry for phase 1 = cubic)
+    auto* ensembleAM = AttributeMatrix::Create(buildDS, "Ensemble Data", {2}, imageGeom->getId());
+    auto* crystalStructuresArray = UnitTest::CreateTestDataArray<uint32>(buildDS, "CrystalStructures", {2}, {1}, ensembleAM->getId());
+    auto& crystalStructuresStore = crystalStructuresArray->getDataStoreRef();
+    crystalStructuresStore[0] = 999; // Unknown
+    crystalStructuresStore[1] = 1;   // Cubic-High (m-3m)
+
+    UnitTest::WriteTestDataStructure(buildDS, benchmarkFile);
+  }
+
+  // Stage 2: Reload (arrays become ZarrStore in OOC) and run filter
+  DataStructure dataStructure = UnitTest::LoadDataStructure(benchmarkFile);
+
+  {
+    const NeighborOrientationCorrelationFilter filter;
+    Arguments args;
+
+    args.insertOrAssign(NeighborOrientationCorrelationFilter::k_ImageGeometryPath_Key, std::make_any<DataPath>(DataPath({"Image Geometry"})));
+    args.insertOrAssign(NeighborOrientationCorrelationFilter::k_MinConfidence_Key, std::make_any<float32>(0.2f));
+    args.insertOrAssign(NeighborOrientationCorrelationFilter::k_MisorientationTolerance_Key, std::make_any<float32>(5.0f));
+    args.insertOrAssign(NeighborOrientationCorrelationFilter::k_Level_Key, std::make_any<int32>(2));
+    args.insertOrAssign(NeighborOrientationCorrelationFilter::k_CorrelationArrayPath_Key, std::make_any<DataPath>(DataPath({"Image Geometry", "Cell Data", "Confidence Index"})));
+    args.insertOrAssign(NeighborOrientationCorrelationFilter::k_CellPhasesArrayPath_Key, std::make_any<DataPath>(DataPath({"Image Geometry", "Cell Data", "Phases"})));
+    args.insertOrAssign(NeighborOrientationCorrelationFilter::k_QuatsArrayPath_Key, std::make_any<DataPath>(DataPath({"Image Geometry", "Cell Data", "Quats"})));
+    args.insertOrAssign(NeighborOrientationCorrelationFilter::k_CrystalStructuresArrayPath_Key, std::make_any<DataPath>(DataPath({"Image Geometry", "Ensemble Data", "CrystalStructures"})));
+    args.insertOrAssign(NeighborOrientationCorrelationFilter::k_IgnoredDataArrayPaths_Key, std::make_any<MultiArraySelectionParameter::ValueType>(MultiArraySelectionParameter::ValueType{}));
+
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+    auto executeResult = filter.execute(dataStructure, args, nullptr, IFilter::MessageHandler{[](const IFilter::Message& message) { fmt::print("{}\n", message.message); }});
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+  }
+
+  fs::remove(benchmarkFile);
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.cpp
@@ -21,7 +21,7 @@ ErodeDilateBadData::ErodeDilateBadData(DataStructure& dataStructure, const IFilt
 ErodeDilateBadData::~ErodeDilateBadData() noexcept = default;
 
 // -----------------------------------------------------------------------------
-const std::atomic_bool& ErodeDilateBadData::getCancel()
+const std::atomic_bool& ErodeDilateBadData::getCancel() const
 {
   return m_ShouldCancel;
 }
@@ -29,7 +29,7 @@ const std::atomic_bool& ErodeDilateBadData::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ErodeDilateBadData::operator()()
 {
-  const auto& featureIds = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsArrayPath)->getDataStoreRef();
+  const auto& featureIds = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->FeatureIdsArrayPath).getDataStoreRef();
   const usize totalPoints = featureIds.getNumberOfTuples();
 
   std::vector<int64> neighbors(totalPoints, -1);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.cpp
@@ -4,66 +4,9 @@
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
-#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/NeighborUtilities.hpp"
-#include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
 using namespace nx::core;
-namespace
-{
-class ErodeDilateBadDataTransferDataImpl
-{
-public:
-  ErodeDilateBadDataTransferDataImpl() = delete;
-  ErodeDilateBadDataTransferDataImpl(const ErodeDilateBadDataTransferDataImpl&) = default;
-
-  ErodeDilateBadDataTransferDataImpl(ErodeDilateBadData* filterAlg, usize totalPoints, ChoicesParameter::ValueType operation, const Int32AbstractDataStore& featureIds,
-                                     const std::vector<int64>& neighbors, const std::shared_ptr<IDataArray>& dataArrayPtr, MessageHelper& messageHelper)
-  : m_FilterAlg(filterAlg)
-  , m_TotalPoints(totalPoints)
-  , m_Operation(operation)
-  , m_Neighbors(neighbors)
-  , m_DataArrayPtr(dataArrayPtr)
-  , m_FeatureIds(featureIds)
-  , m_MessageHelper(messageHelper)
-  {
-  }
-  ErodeDilateBadDataTransferDataImpl(ErodeDilateBadDataTransferDataImpl&&) = default;                // Move Constructor Not Implemented
-  ErodeDilateBadDataTransferDataImpl& operator=(const ErodeDilateBadDataTransferDataImpl&) = delete; // Copy Assignment Not Implemented
-  ErodeDilateBadDataTransferDataImpl& operator=(ErodeDilateBadDataTransferDataImpl&&) = delete;      // Move Assignment Not Implemented
-
-  ~ErodeDilateBadDataTransferDataImpl() = default;
-
-  void operator()() const
-  {
-    ThrottledMessenger throttledMessenger = m_MessageHelper.createThrottledMessenger();
-    std::string arrayName = m_DataArrayPtr->getName();
-    for(usize i = 0; i < m_TotalPoints; i++)
-    {
-      throttledMessenger.sendThrottledMessage([&]() { return fmt::format("Processing {}: {:.2f}% completed", arrayName, CalculatePercentComplete(i, m_TotalPoints)); });
-
-      const int32 featureName = m_FeatureIds[i];
-      const int64 neighbor = m_Neighbors[i];
-      if(neighbor >= 0)
-      {
-        if((featureName == 0 && m_FeatureIds[neighbor] > 0 && m_Operation == detail::k_ErodeIndex) || (featureName > 0 && m_FeatureIds[neighbor] == 0 && m_Operation == detail::k_DilateIndex))
-        {
-          m_DataArrayPtr->copyTuple(neighbor, i);
-        }
-      }
-    }
-  }
-
-private:
-  ErodeDilateBadData* m_FilterAlg = nullptr;
-  usize m_TotalPoints = 0;
-  ChoicesParameter::ValueType m_Operation = 0;
-  std::vector<int64> m_Neighbors;
-  const std::shared_ptr<IDataArray> m_DataArrayPtr;
-  const Int32AbstractDataStore& m_FeatureIds;
-  MessageHelper& m_MessageHelper;
-};
-} // namespace
 
 // -----------------------------------------------------------------------------
 ErodeDilateBadData::ErodeDilateBadData(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ErodeDilateBadDataInputValues* inputValues)
@@ -225,30 +168,47 @@ Result<> ErodeDilateBadData::operator()()
       }
     }
 
-    // Build up a list of the DataArrays that we are going to operate on.
+    // Sequential per-array transfer: process one array at a time so only one array's
+    // chunks compete for the OOC cache. This avoids the chunk thrashing that occurs
+    // when ParallelTaskAlgorithm processes multiple arrays simultaneously.
     const std::vector<std::shared_ptr<IDataArray>> voxelArrays = nx::core::GenerateDataArrayList(m_DataStructure, m_InputValues->FeatureIdsArrayPath, m_InputValues->IgnoredDataArrayPaths);
 
-    MessageHelper messageHelper(m_MessageHandler);
-
-    ParallelTaskAlgorithm taskRunner;
-    taskRunner.setParallelizationEnabled(true);
     for(const auto& voxelArray : voxelArrays)
     {
-      // We need to skip updating the FeatureIds until all the other arrays are updated
-      // since we actually depend on the feature Ids values.
       if(voxelArray->getName() == m_InputValues->FeatureIdsArrayPath.getTargetName())
       {
         continue;
       }
-
-      taskRunner.execute(ErodeDilateBadDataTransferDataImpl(this, totalPoints, m_InputValues->Operation, featureIds, neighbors, voxelArray, messageHelper));
+      for(usize i = 0; i < totalPoints; i++)
+      {
+        const int64 neighbor = neighbors[i];
+        if(neighbor >= 0)
+        {
+          const int32 featureName = featureIds[i];
+          if((featureName == 0 && featureIds[neighbor] > 0 && m_InputValues->Operation == detail::k_ErodeIndex) ||
+             (featureName > 0 && featureIds[neighbor] == 0 && m_InputValues->Operation == detail::k_DilateIndex))
+          {
+            voxelArray->copyTuple(neighbor, i);
+          }
+        }
+      }
     }
-    taskRunner.wait(); // This will spill over if the number of DataArrays to process does not divide evenly by the number of threads.
 
-    // Now update the feature Ids
+    // Update FeatureIds last since the condition check depends on the original values
     auto featureIDataArray = m_DataStructure.getSharedDataAs<IDataArray>(m_InputValues->FeatureIdsArrayPath);
-    taskRunner.setParallelizationEnabled(false); // Do this to make the next call synchronous
-    taskRunner.execute(ErodeDilateBadDataTransferDataImpl(this, totalPoints, m_InputValues->Operation, featureIds, neighbors, featureIDataArray, messageHelper));
+    for(usize i = 0; i < totalPoints; i++)
+    {
+      const int64 neighbor = neighbors[i];
+      if(neighbor >= 0)
+      {
+        const int32 featureName = featureIds[i];
+        if((featureName == 0 && featureIds[neighbor] > 0 && m_InputValues->Operation == detail::k_ErodeIndex) ||
+           (featureName > 0 && featureIds[neighbor] == 0 && m_InputValues->Operation == detail::k_DilateIndex))
+        {
+          featureIDataArray->copyTuple(neighbor, i);
+        }
+      }
+    }
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.cpp
@@ -116,23 +116,74 @@ Result<> ErodeDilateBadData::operator()()
 
   std::vector<int32> featureCount(numFeatures + 1, 0);
 
+  // Z-slice buffering: maintain a rolling window of 3 adjacent Z-slices for
+  // FeatureIds to avoid random OOC chunk access during neighbor lookups.
+  const usize sliceSize = static_cast<usize>(dims[0]) * static_cast<usize>(dims[1]);
+
+  // Rolling window: slot 0 = z-1, slot 1 = z (current), slot 2 = z+1
+  std::array<std::vector<int32>, 3> featureIdSlices;
+  for(auto& fis : featureIdSlices)
+  {
+    fis.resize(sliceSize);
+  }
+
+  auto readFeatureIdSlice = [&](int64 z, usize slot) {
+    const usize zOffset = static_cast<usize>(z) * sliceSize;
+    for(usize i = 0; i < sliceSize; i++)
+    {
+      featureIdSlices[slot][i] = featureIds[zOffset + i];
+    }
+  };
+
+  // Helper to read a FeatureId from the rolling buffer.
+  // neighborSlot: 0 = z-1, 1 = z (current), 2 = z+1
+  // Face neighbor ordering: 0=-Z, 1=-Y, 2=-X, 3=+X, 4=+Y, 5=+Z
+  constexpr std::array<usize, 6> k_NeighborSlot = {0, 1, 1, 1, 1, 2};
+
   for(int32 iteration = 0; iteration < m_InputValues->NumIterations; iteration++)
   {
+    // Initialize rolling window: load z=0 into slot 1, z=1 into slot 2
+    readFeatureIdSlice(0, 1);
+    if(dims[2] > 1)
+    {
+      readFeatureIdSlice(1, 2);
+    }
+
     for(int64 zIdx = 0; zIdx < dims[2]; zIdx++)
     {
-      const int64 zStride = dims[0] * dims[1] * zIdx;
+      // Advance rolling window for z > 0
+      if(zIdx > 0)
+      {
+        std::swap(featureIdSlices[0], featureIdSlices[1]);
+        std::swap(featureIdSlices[1], featureIdSlices[2]);
+        if(zIdx + 1 < dims[2])
+        {
+          readFeatureIdSlice(zIdx + 1, 2);
+        }
+      }
+
       for(int64 yIdx = 0; yIdx < dims[1]; yIdx++)
       {
-        const int64 yStride = dims[0] * yIdx;
         for(int64 xIdx = 0; xIdx < dims[0]; xIdx++)
         {
-          const int64 voxelIndex = zStride + yStride + xIdx;
-          const int32 featureName = featureIds[voxelIndex];
+          const int64 voxelIndex = xIdx + yIdx * dims[0] + zIdx * static_cast<int64>(sliceSize);
+          const usize inSlice = static_cast<usize>(yIdx * dims[0] + xIdx);
+          const int32 featureName = featureIdSlices[1][inSlice];
           if(featureName == 0)
           {
             int32 most = 0;
-            // Loop over the 6 face neighbors of the voxel
             std::array<bool, 6> isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
+
+            // Precompute neighbor in-slice indices for buffer lookups
+            const std::array<usize, 6> neighborInSlice = {
+                inSlice,                                           // -Z: same xy position in prev slice
+                static_cast<usize>((yIdx - 1) * dims[0] + xIdx),  // -Y
+                static_cast<usize>(yIdx * dims[0] + (xIdx - 1)),  // -X
+                static_cast<usize>(yIdx * dims[0] + (xIdx + 1)),  // +X
+                static_cast<usize>((yIdx + 1) * dims[0] + xIdx),  // +Y
+                inSlice                                            // +Z: same xy position in next slice
+            };
+
             for(const auto& faceIndex : faceNeighborInternalIdx)
             {
               if(!isValidFaceNeighbor[faceIndex])
@@ -140,8 +191,8 @@ Result<> ErodeDilateBadData::operator()()
                 continue;
               }
               const int64 neighborPoint = voxelIndex + neighborVoxelIndexOffsets[faceIndex];
+              const int32 feature = featureIdSlices[k_NeighborSlot[faceIndex]][neighborInSlice[faceIndex]];
 
-              const int32 feature = featureIds[neighborPoint];
               if(m_InputValues->Operation == detail::k_DilateIndex && feature > 0)
               {
                 neighbors[neighborPoint] = voxelIndex;
@@ -159,17 +210,13 @@ Result<> ErodeDilateBadData::operator()()
             }
             if(m_InputValues->Operation == detail::k_ErodeIndex)
             {
-              // Loop over the 6 face neighbors of the voxel
-              isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
               for(const auto& faceIndex : faceNeighborInternalIdx)
               {
                 if(!isValidFaceNeighbor[faceIndex])
                 {
                   continue;
                 }
-                const int64 neighborPoint = voxelIndex + neighborVoxelIndexOffsets[faceIndex];
-
-                const int32 feature = featureIds[neighborPoint];
+                const int32 feature = featureIdSlices[k_NeighborSlot[faceIndex]][neighborInSlice[faceIndex]];
                 featureCount[feature] = 0;
               }
             }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.cpp
@@ -119,12 +119,12 @@ Result<> ErodeDilateBadData::operator()()
 
             // Precompute neighbor in-slice indices for buffer lookups
             const std::array<usize, 6> neighborInSlice = {
-                inSlice,                                           // -Z: same xy position in prev slice
-                static_cast<usize>((yIdx - 1) * dims[0] + xIdx),  // -Y
-                static_cast<usize>(yIdx * dims[0] + (xIdx - 1)),  // -X
-                static_cast<usize>(yIdx * dims[0] + (xIdx + 1)),  // +X
-                static_cast<usize>((yIdx + 1) * dims[0] + xIdx),  // +Y
-                inSlice                                            // +Z: same xy position in next slice
+                inSlice,                                         // -Z: same xy position in prev slice
+                static_cast<usize>((yIdx - 1) * dims[0] + xIdx), // -Y
+                static_cast<usize>(yIdx * dims[0] + (xIdx - 1)), // -X
+                static_cast<usize>(yIdx * dims[0] + (xIdx + 1)), // +X
+                static_cast<usize>((yIdx + 1) * dims[0] + xIdx), // +Y
+                inSlice                                          // +Z: same xy position in next slice
             };
 
             for(const auto& faceIndex : faceNeighborInternalIdx)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.hpp
@@ -43,7 +43,18 @@ struct SIMPLNXCORE_EXPORT ErodeDilateBadDataInputValues
 class SIMPLNXCORE_EXPORT ErodeDilateBadData
 {
 public:
+  /**
+   * @brief Constructs the algorithm with all required references and parameters.
+   * @param dataStructure The DataStructure containing all input/output arrays
+   * @param mesgHandler Handler for sending progress messages to the UI
+   * @param shouldCancel Atomic flag checked between iterations to support cancellation
+   * @param inputValues User-supplied parameters controlling the algorithm behavior
+   */
   ErodeDilateBadData(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ErodeDilateBadDataInputValues* inputValues);
+
+  /**
+   * @brief Default destructor.
+   */
   ~ErodeDilateBadData() noexcept;
 
   ErodeDilateBadData(const ErodeDilateBadData&) = delete;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.hpp
@@ -20,6 +20,10 @@ static inline constexpr ChoicesParameter::ValueType k_DilateIndex = 0ULL;
 static inline constexpr ChoicesParameter::ValueType k_ErodeIndex = 1ULL;
 } // namespace detail
 
+/**
+ * @struct ErodeDilateBadDataInputValues
+ * @brief Holds all user-supplied parameters for the ErodeDilateBadData algorithm.
+ */
 struct SIMPLNXCORE_EXPORT ErodeDilateBadDataInputValues
 {
   ChoicesParameter::ValueType Operation;
@@ -33,8 +37,8 @@ struct SIMPLNXCORE_EXPORT ErodeDilateBadDataInputValues
 };
 
 /**
- * @class ConditionalSetValueFilter
-
+ * @class ErodeDilateBadData
+ * @brief Erodes or dilates bad (FeatureId == 0) voxels by replacing them with the most common neighbor feature.
  */
 class SIMPLNXCORE_EXPORT ErodeDilateBadData
 {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.hpp
@@ -62,9 +62,13 @@ public:
   ErodeDilateBadData& operator=(const ErodeDilateBadData&) = delete;
   ErodeDilateBadData& operator=(ErodeDilateBadData&&) noexcept = delete;
 
+  /**
+   * @brief Executes the erode/dilate bad data algorithm.
+   * @return Result<> indicating success or any errors encountered during execution
+   */
   Result<> operator()();
 
-  const std::atomic_bool& getCancel();
+  const std::atomic_bool& getCancel() const;
 
 private:
   DataStructure& m_DataStructure;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.cpp
@@ -15,7 +15,7 @@ struct DataArrayCopyTupleFunctor
   void operator()(IDataArray& outputIDataArray, size_t sourceIndex, size_t targetIndex)
   {
     using DataArrayType = DataArray<T>;
-    DataArrayType outputArray = dynamic_cast<DataArrayType&>(outputIDataArray);
+    DataArrayType& outputArray = dynamic_cast<DataArrayType&>(outputIDataArray);
     outputArray.copyTuple(sourceIndex, targetIndex);
   }
 };
@@ -195,7 +195,6 @@ Result<> ErodeDilateCoordinationNumber::operator()()
           }
 
           // Reset featureCount for neighbors
-          isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
           for(const auto& faceIndex : faceNeighborInternalIdx)
           {
             if(!isValidFaceNeighbor[faceIndex])

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.cpp
@@ -35,7 +35,7 @@ ErodeDilateCoordinationNumber::ErodeDilateCoordinationNumber(DataStructure& data
 ErodeDilateCoordinationNumber::~ErodeDilateCoordinationNumber() noexcept = default;
 
 // -----------------------------------------------------------------------------
-const std::atomic_bool& ErodeDilateCoordinationNumber::getCancel()
+const std::atomic_bool& ErodeDilateCoordinationNumber::getCancel() const
 {
   return m_ShouldCancel;
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.cpp
@@ -81,6 +81,28 @@ Result<> ErodeDilateCoordinationNumber::operator()()
   bool keepGoing = true;
   int32 counter = 1;
 
+  // Z-slice buffering: maintain rolling window of 3 adjacent Z-slices for FeatureIds
+  // to avoid random OOC chunk access during neighbor lookups.
+  const usize sliceSize = static_cast<usize>(dims[0]) * static_cast<usize>(dims[1]);
+
+  // Rolling window: slot 0 = z-1, slot 1 = z (current), slot 2 = z+1
+  std::array<std::vector<int32>, 3> featureIdSlices;
+  for(auto& fis : featureIdSlices)
+  {
+    fis.resize(sliceSize);
+  }
+
+  auto readFeatureIdSlice = [&](int64 z, usize slot) {
+    const usize zOffset = static_cast<usize>(z) * sliceSize;
+    for(usize i = 0; i < sliceSize; i++)
+    {
+      featureIdSlices[slot][i] = featureIds[zOffset + i];
+    }
+  };
+
+  // Face neighbor ordering: 0=-Z, 1=-Y, 2=-X, 3=+X, 4=+Y, 5=+Z
+  constexpr std::array<usize, 6> k_NeighborSlot = {0, 1, 1, 1, 1, 2};
+
   while(counter > 0 && keepGoing)
   {
     counter = 0;
@@ -89,20 +111,47 @@ Result<> ErodeDilateCoordinationNumber::operator()()
       keepGoing = false;
     }
 
+    // Initialize rolling window: load z=0 into slot 1, z=1 into slot 2
+    readFeatureIdSlice(0, 1);
+    if(dims[2] > 1)
+    {
+      readFeatureIdSlice(1, 2);
+    }
+
     for(int64 zIdx = 0; zIdx < dims[2]; zIdx++)
     {
-      const int64 zStride = dims[0] * dims[1] * zIdx;
+      // Advance rolling window for z > 0
+      if(zIdx > 0)
+      {
+        std::swap(featureIdSlices[0], featureIdSlices[1]);
+        std::swap(featureIdSlices[1], featureIdSlices[2]);
+        if(zIdx + 1 < dims[2])
+        {
+          readFeatureIdSlice(zIdx + 1, 2);
+        }
+      }
+
       for(int64 yIdx = 0; yIdx < dims[1]; yIdx++)
       {
-        const int64 yStride = dims[0] * yIdx;
         for(int64 xIdx = 0; xIdx < dims[0]; xIdx++)
         {
-          const int64 voxelIndex = zStride + yStride + xIdx;
-          const int32 featureName = featureIds[voxelIndex];
+          const int64 voxelIndex = dims[0] * dims[1] * zIdx + dims[0] * yIdx + xIdx;
+          const usize inSlice = static_cast<usize>(yIdx * dims[0] + xIdx);
+          const int32 featureName = featureIdSlices[1][inSlice];
           int32 coordination = 0;
           int32 most = 0;
-          // Loop over the 6 face neighbors of the voxel
+
           std::array<bool, 6> isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
+
+          const std::array<usize, 6> neighborInSlice = {
+              inSlice,                                          // -Z
+              static_cast<usize>((yIdx - 1) * dims[0] + xIdx), // -Y
+              static_cast<usize>(yIdx * dims[0] + (xIdx - 1)), // -X
+              static_cast<usize>(yIdx * dims[0] + (xIdx + 1)), // +X
+              static_cast<usize>((yIdx + 1) * dims[0] + xIdx), // +Y
+              inSlice                                           // +Z
+          };
+
           for(const auto& faceIndex : faceNeighborInternalIdx)
           {
             if(!isValidFaceNeighbor[faceIndex])
@@ -111,8 +160,8 @@ Result<> ErodeDilateCoordinationNumber::operator()()
             }
 
             const int64 neighborPoint = voxelIndex + neighborVoxelIndexOffsets[faceIndex];
+            const int32 feature = featureIdSlices[k_NeighborSlot[faceIndex]][neighborInSlice[faceIndex]];
 
-            const int32 feature = featureIds[neighborPoint];
             if((featureName > 0 && feature == 0) || (featureName == 0 && feature > 0))
             {
               coordination = coordination + 1;
@@ -139,8 +188,13 @@ Result<> ErodeDilateCoordinationNumber::operator()()
             {
               ExecuteDataFunction(DataArrayCopyTupleFunctor{}, voxelArray->getDataType(), *voxelArray, neighbor, voxelIndex);
             }
+            // Update the buffer to reflect the in-place modification
+            // Since featureIds is in voxelArrays, the copyTuple above updated
+            // the backing store. Re-read the modified voxel into our buffer.
+            featureIdSlices[1][inSlice] = featureIds[voxelIndex];
           }
-          // Loop over the 6 face neighbors of the voxel
+
+          // Reset featureCount for neighbors
           isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
           for(const auto& faceIndex : faceNeighborInternalIdx)
           {
@@ -149,8 +203,7 @@ Result<> ErodeDilateCoordinationNumber::operator()()
               continue;
             }
 
-            const int64 neighborPoint = voxelIndex + neighborVoxelIndexOffsets[faceIndex];
-            const int32 feature = featureIds[neighborPoint];
+            const int32 feature = featureIdSlices[k_NeighborSlot[faceIndex]][neighborInSlice[faceIndex]];
             if(feature > 0)
             {
               featureCount[feature] = 0;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.cpp
@@ -144,12 +144,12 @@ Result<> ErodeDilateCoordinationNumber::operator()()
           std::array<bool, 6> isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
 
           const std::array<usize, 6> neighborInSlice = {
-              inSlice,                                          // -Z
+              inSlice,                                         // -Z
               static_cast<usize>((yIdx - 1) * dims[0] + xIdx), // -Y
               static_cast<usize>(yIdx * dims[0] + (xIdx - 1)), // -X
               static_cast<usize>(yIdx * dims[0] + (xIdx + 1)), // +X
               static_cast<usize>((yIdx + 1) * dims[0] + xIdx), // +Y
-              inSlice                                           // +Z
+              inSlice                                          // +Z
           };
 
           for(const auto& faceIndex : faceNeighborInternalIdx)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.hpp
@@ -13,6 +13,10 @@
 namespace nx::core
 {
 
+/**
+ * @struct ErodeDilateCoordinationNumberInputValues
+ * @brief Holds all user-supplied parameters for the ErodeDilateCoordinationNumber algorithm.
+ */
 struct SIMPLNXCORE_EXPORT ErodeDilateCoordinationNumberInputValues
 {
   int32 CoordinationNumber;
@@ -23,7 +27,8 @@ struct SIMPLNXCORE_EXPORT ErodeDilateCoordinationNumberInputValues
 };
 
 /**
- * @class
+ * @class ErodeDilateCoordinationNumber
+ * @brief Smooths voxel boundaries by eroding or dilating based on coordination number thresholds.
  */
 class SIMPLNXCORE_EXPORT ErodeDilateCoordinationNumber
 {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.hpp
@@ -33,7 +33,18 @@ struct SIMPLNXCORE_EXPORT ErodeDilateCoordinationNumberInputValues
 class SIMPLNXCORE_EXPORT ErodeDilateCoordinationNumber
 {
 public:
+  /**
+   * @brief Constructs the algorithm with all required references and parameters.
+   * @param dataStructure The DataStructure containing all input/output arrays
+   * @param mesgHandler Handler for sending progress messages to the UI
+   * @param shouldCancel Atomic flag checked between iterations to support cancellation
+   * @param inputValues User-supplied parameters controlling the algorithm behavior
+   */
   ErodeDilateCoordinationNumber(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ErodeDilateCoordinationNumberInputValues* inputValues);
+
+  /**
+   * @brief Default destructor.
+   */
   ~ErodeDilateCoordinationNumber() noexcept;
 
   ErodeDilateCoordinationNumber(const ErodeDilateCoordinationNumber&) = delete;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.hpp
@@ -52,9 +52,13 @@ public:
   ErodeDilateCoordinationNumber& operator=(const ErodeDilateCoordinationNumber&) = delete;
   ErodeDilateCoordinationNumber& operator=(ErodeDilateCoordinationNumber&&) noexcept = delete;
 
+  /**
+   * @brief Executes the erode/dilate coordination number algorithm.
+   * @return Result<> indicating success or any errors encountered during execution
+   */
   Result<> operator()();
 
-  const std::atomic_bool& getCancel();
+  const std::atomic_bool& getCancel() const;
 
 private:
   DataStructure& m_DataStructure;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp
@@ -20,7 +20,7 @@ ErodeDilateMask::ErodeDilateMask(DataStructure& dataStructure, const IFilter::Me
 ErodeDilateMask::~ErodeDilateMask() noexcept = default;
 
 // -----------------------------------------------------------------------------
-const std::atomic_bool& ErodeDilateMask::getCancel()
+const std::atomic_bool& ErodeDilateMask::getCancel() const
 {
   return m_ShouldCancel;
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp
@@ -50,13 +50,13 @@ Result<> ErodeDilateMask::operator()()
   const usize sliceSize = static_cast<usize>(dims[0]) * static_cast<usize>(dims[1]);
 
   // Rolling window: slot 0 = z-1, slot 1 = z (current), slot 2 = z+1
-  std::array<std::vector<bool>, 3> maskSlices;
+  std::array<std::vector<uint8>, 3> maskSlices;
   for(auto& ms : maskSlices)
   {
     ms.resize(sliceSize);
   }
   // maskCopy uses same rolling window structure for output
-  std::array<std::vector<bool>, 3> maskCopySlices;
+  std::array<std::vector<uint8>, 3> maskCopySlices;
   for(auto& ms : maskCopySlices)
   {
     ms.resize(sliceSize);
@@ -106,7 +106,7 @@ Result<> ErodeDilateMask::operator()()
         {
           const usize inSlice = static_cast<usize>(yIdx * dims[0] + xIdx);
 
-          if(!maskSlices[1][inSlice])
+          if(maskSlices[1][inSlice] == 0)
           {
             std::array<bool, 6> isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
 
@@ -126,13 +126,13 @@ Result<> ErodeDilateMask::operator()()
                 continue;
               }
 
-              if(m_InputValues->Operation == detail::k_DilateIndex && maskSlices[k_NeighborSlot[faceIndex]][neighborInSlice[faceIndex]])
+              if(m_InputValues->Operation == detail::k_DilateIndex && maskSlices[k_NeighborSlot[faceIndex]][neighborInSlice[faceIndex]] != 0)
               {
-                maskCopySlices[1][inSlice] = true;
+                maskCopySlices[1][inSlice] = 1;
               }
-              if(m_InputValues->Operation == detail::k_ErodeIndex && maskSlices[k_NeighborSlot[faceIndex]][neighborInSlice[faceIndex]])
+              if(m_InputValues->Operation == detail::k_ErodeIndex && maskSlices[k_NeighborSlot[faceIndex]][neighborInSlice[faceIndex]] != 0)
               {
-                maskCopySlices[k_NeighborSlot[faceIndex]][neighborInSlice[faceIndex]] = false;
+                maskCopySlices[k_NeighborSlot[faceIndex]][neighborInSlice[faceIndex]] = 0;
               }
             }
           }
@@ -145,7 +145,7 @@ Result<> ErodeDilateMask::operator()()
         const usize prevZOffset = static_cast<usize>(zIdx - 1) * sliceSize;
         for(usize i = 0; i < sliceSize; i++)
         {
-          mask[prevZOffset + i] = maskCopySlices[0][i];
+          mask[prevZOffset + i] = (maskCopySlices[0][i] != 0);
         }
       }
     }
@@ -155,7 +155,7 @@ Result<> ErodeDilateMask::operator()()
     {
       for(usize i = 0; i < sliceSize; i++)
       {
-        mask[i] = maskCopySlices[1][i];
+        mask[i] = (maskCopySlices[1][i] != 0);
       }
     }
     else
@@ -163,7 +163,7 @@ Result<> ErodeDilateMask::operator()()
       const usize lastZOffset = static_cast<usize>(dims[2] - 1) * sliceSize;
       for(usize i = 0; i < sliceSize; i++)
       {
-        mask[lastZOffset + i] = maskCopySlices[1][i];
+        mask[lastZOffset + i] = (maskCopySlices[1][i] != 0);
       }
     }
   }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp
@@ -32,8 +32,6 @@ Result<> ErodeDilateMask::operator()()
   auto& mask = m_DataStructure.getDataRefAs<BoolArray>(m_InputValues->MaskArrayPath);
   const size_t totalPoints = mask.getNumberOfTuples();
 
-  std::vector<bool> maskCopy(totalPoints, false);
-
   const auto& selectedImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->InputImageGeometry);
 
   SizeVec3 udims = selectedImageGeom.getDimensions();
@@ -47,28 +45,80 @@ Result<> ErodeDilateMask::operator()()
   std::array<int64, 6> neighborVoxelIndexOffsets = initializeFaceNeighborOffsets(dims);
   std::array<FaceNeighborType, 6> faceNeighborInternalIdx = initializeFaceNeighborInternalIdx();
 
+  // Z-slice buffering: maintain rolling window of 3 adjacent Z-slices for mask
+  // to avoid random OOC chunk access during neighbor lookups.
+  const usize sliceSize = static_cast<usize>(dims[0]) * static_cast<usize>(dims[1]);
+
+  // Rolling window: slot 0 = z-1, slot 1 = z (current), slot 2 = z+1
+  std::array<std::vector<bool>, 3> maskSlices;
+  for(auto& ms : maskSlices)
+  {
+    ms.resize(sliceSize);
+  }
+  // maskCopy uses same rolling window structure for output
+  std::array<std::vector<bool>, 3> maskCopySlices;
+  for(auto& ms : maskCopySlices)
+  {
+    ms.resize(sliceSize);
+  }
+
+  auto readMaskSlice = [&](int64 z, usize slot) {
+    const usize zOffset = static_cast<usize>(z) * sliceSize;
+    for(usize i = 0; i < sliceSize; i++)
+    {
+      maskSlices[slot][i] = mask[zOffset + i];
+      maskCopySlices[slot][i] = maskSlices[slot][i];
+    }
+  };
+
+  // Face neighbor ordering: 0=-Z, 1=-Y, 2=-X, 3=+X, 4=+Y, 5=+Z
+  constexpr std::array<usize, 6> k_NeighborSlot = {0, 1, 1, 1, 1, 2};
+
   for(int32_t iteration = 0; iteration < m_InputValues->NumIterations; iteration++)
   {
     m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Iteration {}", iteration));
 
-    for(size_t j = 0; j < totalPoints; j++)
+    // Initialize rolling window: load z=0 into slot 1, z=1 into slot 2
+    readMaskSlice(0, 1);
+    if(dims[2] > 1)
     {
-      maskCopy[j] = mask[j];
+      readMaskSlice(1, 2);
     }
+
     for(int64 zIdx = 0; zIdx < dims[2]; zIdx++)
     {
-      const int64 zStride = dims[0] * dims[1] * zIdx;
+      // Advance rolling window for z > 0
+      if(zIdx > 0)
+      {
+        std::swap(maskSlices[0], maskSlices[1]);
+        std::swap(maskSlices[1], maskSlices[2]);
+        std::swap(maskCopySlices[0], maskCopySlices[1]);
+        std::swap(maskCopySlices[1], maskCopySlices[2]);
+        if(zIdx + 1 < dims[2])
+        {
+          readMaskSlice(zIdx + 1, 2);
+        }
+      }
+
       for(int64 yIdx = 0; yIdx < dims[1]; yIdx++)
       {
-        const int64 yStride = dims[0] * yIdx;
         for(int64 xIdx = 0; xIdx < dims[0]; xIdx++)
         {
-          const int64 voxelIndex = zStride + yStride + xIdx;
+          const usize inSlice = static_cast<usize>(yIdx * dims[0] + xIdx);
 
-          if(!mask[voxelIndex])
+          if(!maskSlices[1][inSlice])
           {
-            // Loop over the 6 face neighbors of the voxel
             std::array<bool, 6> isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
+
+            const std::array<usize, 6> neighborInSlice = {
+                inSlice,                                          // -Z: same xy position in prev slice
+                static_cast<usize>((yIdx - 1) * dims[0] + xIdx), // -Y
+                static_cast<usize>(yIdx * dims[0] + (xIdx - 1)), // -X
+                static_cast<usize>(yIdx * dims[0] + (xIdx + 1)), // +X
+                static_cast<usize>((yIdx + 1) * dims[0] + xIdx), // +Y
+                inSlice                                           // +Z: same xy position in next slice
+            };
+
             for(const auto& faceIndex : faceNeighborInternalIdx)
             {
               if(!isValidFaceNeighbor[faceIndex])
@@ -76,24 +126,45 @@ Result<> ErodeDilateMask::operator()()
                 continue;
               }
 
-              const int64 neighpoint = voxelIndex + neighborVoxelIndexOffsets[faceIndex];
-
-              if(m_InputValues->Operation == detail::k_DilateIndex && mask[neighpoint])
+              if(m_InputValues->Operation == detail::k_DilateIndex && maskSlices[k_NeighborSlot[faceIndex]][neighborInSlice[faceIndex]])
               {
-                maskCopy[voxelIndex] = true;
+                maskCopySlices[1][inSlice] = true;
               }
-              if(m_InputValues->Operation == detail::k_ErodeIndex && mask[neighpoint])
+              if(m_InputValues->Operation == detail::k_ErodeIndex && maskSlices[k_NeighborSlot[faceIndex]][neighborInSlice[faceIndex]])
               {
-                maskCopy[neighpoint] = false;
+                maskCopySlices[k_NeighborSlot[faceIndex]][neighborInSlice[faceIndex]] = false;
               }
             }
           }
         }
       }
+
+      // Write back the completed z-1 slice (or current if last z)
+      if(zIdx > 0)
+      {
+        const usize prevZOffset = static_cast<usize>(zIdx - 1) * sliceSize;
+        for(usize i = 0; i < sliceSize; i++)
+        {
+          mask[prevZOffset + i] = maskCopySlices[0][i];
+        }
+      }
     }
-    for(size_t j = 0; j < totalPoints; j++)
+
+    // Write back the last slice(s)
+    if(dims[2] == 1)
     {
-      mask[j] = maskCopy[j];
+      for(usize i = 0; i < sliceSize; i++)
+      {
+        mask[i] = maskCopySlices[1][i];
+      }
+    }
+    else
+    {
+      const usize lastZOffset = static_cast<usize>(dims[2] - 1) * sliceSize;
+      for(usize i = 0; i < sliceSize; i++)
+      {
+        mask[lastZOffset + i] = maskCopySlices[1][i];
+      }
     }
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp
@@ -111,12 +111,12 @@ Result<> ErodeDilateMask::operator()()
             std::array<bool, 6> isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
 
             const std::array<usize, 6> neighborInSlice = {
-                inSlice,                                          // -Z: same xy position in prev slice
+                inSlice,                                         // -Z: same xy position in prev slice
                 static_cast<usize>((yIdx - 1) * dims[0] + xIdx), // -Y
                 static_cast<usize>(yIdx * dims[0] + (xIdx - 1)), // -X
                 static_cast<usize>(yIdx * dims[0] + (xIdx + 1)), // +X
                 static_cast<usize>((yIdx + 1) * dims[0] + xIdx), // +Y
-                inSlice                                           // +Z: same xy position in next slice
+                inSlice                                          // +Z: same xy position in next slice
             };
 
             for(const auto& faceIndex : faceNeighborInternalIdx)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.hpp
@@ -22,6 +22,10 @@ static inline constexpr ChoicesParameter::ValueType k_DilateIndex = 0ULL;
 static inline constexpr ChoicesParameter::ValueType k_ErodeIndex = 1ULL;
 } // namespace detail
 
+/**
+ * @struct ErodeDilateMaskInputValues
+ * @brief Holds all user-supplied parameters for the ErodeDilateMask algorithm.
+ */
 struct SIMPLNXCORE_EXPORT ErodeDilateMaskInputValues
 {
   ChoicesParameter::ValueType Operation;
@@ -34,7 +38,8 @@ struct SIMPLNXCORE_EXPORT ErodeDilateMaskInputValues
 };
 
 /**
- * @class
+ * @class ErodeDilateMask
+ * @brief Erodes or dilates a boolean mask array using face-neighbor connectivity.
  */
 class SIMPLNXCORE_EXPORT ErodeDilateMask
 {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.hpp
@@ -44,7 +44,18 @@ struct SIMPLNXCORE_EXPORT ErodeDilateMaskInputValues
 class SIMPLNXCORE_EXPORT ErodeDilateMask
 {
 public:
+  /**
+   * @brief Constructs the algorithm with all required references and parameters.
+   * @param dataStructure The DataStructure containing all input/output arrays
+   * @param mesgHandler Handler for sending progress messages to the UI
+   * @param shouldCancel Atomic flag checked between iterations to support cancellation
+   * @param inputValues User-supplied parameters controlling the algorithm behavior
+   */
   ErodeDilateMask(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ErodeDilateMaskInputValues* inputValues);
+
+  /**
+   * @brief Default destructor.
+   */
   ~ErodeDilateMask() noexcept;
 
   ErodeDilateMask(const ErodeDilateMask&) = delete;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.hpp
@@ -63,9 +63,13 @@ public:
   ErodeDilateMask& operator=(const ErodeDilateMask&) = delete;
   ErodeDilateMask& operator=(ErodeDilateMask&&) noexcept = delete;
 
+  /**
+   * @brief Executes the erode/dilate mask algorithm.
+   * @return Result<> indicating success or any errors encountered during execution
+   */
   Result<> operator()();
 
-  const std::atomic_bool& getCancel();
+  const std::atomic_bool& getCancel() const;
 
 private:
   DataStructure& m_DataStructure;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.cpp
@@ -233,7 +233,12 @@ struct ExecuteTemplate
       // thrashing when multiple arrays' chunks evict each other between voxel iterations.
       for(const auto& [dataId, dataObject] : *attrMatrix)
       {
-        auto& dataArray = dynamic_cast<IDataArray&>(*dataObject);
+        auto* dataArrayPtr = dynamic_cast<IDataArray*>(dataObject.get());
+        if(dataArrayPtr == nullptr)
+        {
+          continue;
+        }
+        auto& dataArray = *dataArrayPtr;
         for(int64 voxelIndex = 0; voxelIndex < totalPoints; voxelIndex++)
         {
           const int64 neighbor = bestNeighbor[voxelIndex];

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.cpp
@@ -82,13 +82,13 @@ public:
 struct ExecuteTemplate
 {
   template <typename T>
-  void CompareValues(std::shared_ptr<IComparisonFunctor<T>>& comparator, const AbstractDataStore<T>& inputArray, int64 neighbor, float thresholdValue, float32& best,
-                     std::vector<int64_t>& bestNeighbor, size_t i) const
+  void CompareValues(std::shared_ptr<IComparisonFunctor<T>>& comparator, T neighborValue, float thresholdValue, float32& best, std::vector<int64_t>& bestNeighbor, size_t i,
+                     int64 neighborPoint) const
   {
-    if(comparator->compare1(inputArray[neighbor], thresholdValue) && comparator->compare2(inputArray[neighbor], best))
+    if(comparator->compare1(neighborValue, thresholdValue) && comparator->compare2(neighborValue, best))
     {
-      best = inputArray[neighbor];
-      bestNeighbor[i] = neighbor;
+      best = neighborValue;
+      bestNeighbor[i] = neighborPoint;
     }
   }
 
@@ -107,13 +107,8 @@ struct ExecuteTemplate
         static_cast<int64>(udims[2]),
     };
 
-    // bool good = true;
-    int64 neighbor = 0;
-    int64 column = 0;
-    int64 row = 0;
-    int64 plane = 0;
-
     std::array<int64, 6> neighborVoxelIndexOffsets = initializeFaceNeighborOffsets(dims);
+    std::array<FaceNeighborType, 6> faceNeighborInternalIdx = initializeFaceNeighborInternalIdx();
     std::vector<int64_t> bestNeighbor(totalPoints, -1);
 
     size_t count = 0;
@@ -127,6 +122,28 @@ struct ExecuteTemplate
 
     const AttributeMatrix* attrMatrix = imageGeom.getCellData();
 
+    // Z-slice buffering: maintain rolling window of 3 adjacent Z-slices for input array
+    // to avoid random OOC chunk access during neighbor lookups.
+    const usize sliceSize = static_cast<usize>(dims[0]) * static_cast<usize>(dims[1]);
+
+    // Rolling window: slot 0 = z-1, slot 1 = z (current), slot 2 = z+1
+    std::array<std::vector<T>, 3> inputSlices;
+    for(auto& is : inputSlices)
+    {
+      is.resize(sliceSize);
+    }
+
+    auto readInputSlice = [&](int64 z, usize slot) {
+      const usize zOffset = static_cast<usize>(z) * sliceSize;
+      for(usize i = 0; i < sliceSize; i++)
+      {
+        inputSlices[slot][i] = inputStore[zOffset + i];
+      }
+    };
+
+    // Face neighbor ordering: 0=-Z, 1=-Y, 2=-X, 3=+X, 4=+Y, 5=+Z
+    constexpr std::array<usize, 6> k_NeighborSlot = {0, 1, 1, 1, 1, 2};
+
     while(keepGoing)
     {
       keepGoing = false;
@@ -136,56 +153,73 @@ struct ExecuteTemplate
         break;
       }
 
+      // Initialize rolling window: load z=0 into slot 1, z=1 into slot 2
+      readInputSlice(0, 1);
+      if(dims[2] > 1)
+      {
+        readInputSlice(1, 2);
+      }
+
       auto progIncrement = static_cast<int64_t>(totalPoints / 50);
       int64 prog = 1;
       int64 progressInt = 0;
-      for(size_t voxelIndex = 0; voxelIndex < totalPoints; voxelIndex++)
-      {
-        if(comparator->compare(inputStore[voxelIndex], thresholdValue))
-        {
-          column = voxelIndex % dims[0];
-          row = (voxelIndex / dims[0]) % dims[1];
-          plane = voxelIndex / (dims[0] * dims[1]);
-          count++;
-          float32 best = inputStore[voxelIndex];
 
-          neighbor = static_cast<int64>(voxelIndex) + neighborVoxelIndexOffsets[0];
-          if(plane != 0)
+      for(int64 zIdx = 0; zIdx < dims[2]; zIdx++)
+      {
+        // Advance rolling window for z > 0
+        if(zIdx > 0)
+        {
+          std::swap(inputSlices[0], inputSlices[1]);
+          std::swap(inputSlices[1], inputSlices[2]);
+          if(zIdx + 1 < dims[2])
           {
-            CompareValues<T>(comparator, inputStore, neighbor, thresholdValue, best, bestNeighbor, voxelIndex);
-          }
-          neighbor = static_cast<int64>(voxelIndex) + neighborVoxelIndexOffsets[1];
-          if(row != 0)
-          {
-            CompareValues<T>(comparator, inputStore, neighbor, thresholdValue, best, bestNeighbor, voxelIndex);
-          }
-          neighbor = static_cast<int64>(voxelIndex) + neighborVoxelIndexOffsets[2];
-          if(column != 0)
-          {
-            CompareValues<T>(comparator, inputStore, neighbor, thresholdValue, best, bestNeighbor, voxelIndex);
-          }
-          neighbor = static_cast<int64>(voxelIndex) + neighborVoxelIndexOffsets[3];
-          if(column != (dims[0] - 1))
-          {
-            CompareValues<T>(comparator, inputStore, neighbor, thresholdValue, best, bestNeighbor, voxelIndex);
-          }
-          neighbor = static_cast<int64>(voxelIndex) + neighborVoxelIndexOffsets[4];
-          if(row != (dims[1] - 1))
-          {
-            CompareValues<T>(comparator, inputStore, neighbor, thresholdValue, best, bestNeighbor, voxelIndex);
-          }
-          neighbor = static_cast<int64>(voxelIndex) + neighborVoxelIndexOffsets[5];
-          if(plane != (dims[2] - 1))
-          {
-            CompareValues<T>(comparator, inputStore, neighbor, thresholdValue, best, bestNeighbor, voxelIndex);
+            readInputSlice(zIdx + 1, 2);
           }
         }
-        if(voxelIndex > prog)
+
+        for(int64 yIdx = 0; yIdx < dims[1]; yIdx++)
         {
-          progressInt = static_cast<int64_t>(((float)voxelIndex / totalPoints) * 100.0f);
-          const std::string progressMessage = fmt::format("Processing Loop({}) Progress: {}% Complete", count, progressInt);
-          messageHandler(IFilter::ProgressMessage{IFilter::Message::Type::Progress, progressMessage, static_cast<int32_t>(progressInt)});
-          prog += progIncrement;
+          for(int64 xIdx = 0; xIdx < dims[0]; xIdx++)
+          {
+            const int64 voxelIndex = zIdx * static_cast<int64>(sliceSize) + yIdx * dims[0] + xIdx;
+            const usize inSlice = static_cast<usize>(yIdx * dims[0] + xIdx);
+
+            if(comparator->compare(inputSlices[1][inSlice], thresholdValue))
+            {
+              count++;
+              float32 best = inputSlices[1][inSlice];
+
+              std::array<bool, 6> isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
+
+              const std::array<usize, 6> neighborInSlice = {
+                  inSlice,                                          // -Z
+                  static_cast<usize>((yIdx - 1) * dims[0] + xIdx), // -Y
+                  static_cast<usize>(yIdx * dims[0] + (xIdx - 1)), // -X
+                  static_cast<usize>(yIdx * dims[0] + (xIdx + 1)), // +X
+                  static_cast<usize>((yIdx + 1) * dims[0] + xIdx), // +Y
+                  inSlice                                           // +Z
+              };
+
+              for(const auto& faceIndex : faceNeighborInternalIdx)
+              {
+                if(!isValidFaceNeighbor[faceIndex])
+                {
+                  continue;
+                }
+
+                const int64 neighborPoint = voxelIndex + neighborVoxelIndexOffsets[faceIndex];
+                const T neighborValue = inputSlices[k_NeighborSlot[faceIndex]][neighborInSlice[faceIndex]];
+                CompareValues<T>(comparator, neighborValue, thresholdValue, best, bestNeighbor, voxelIndex, neighborPoint);
+              }
+            }
+            if(voxelIndex > prog)
+            {
+              progressInt = static_cast<int64_t>(((float)voxelIndex / totalPoints) * 100.0f);
+              const std::string progressMessage = fmt::format("Processing Loop({}) Progress: {}% Complete", count, progressInt);
+              messageHandler(IFilter::ProgressMessage{IFilter::Message::Type::Progress, progressMessage, static_cast<int32_t>(progressInt)});
+              prog += progIncrement;
+            }
+          }
         }
       }
 
@@ -207,7 +241,7 @@ struct ExecuteTemplate
           prog = prog + progIncrement;
         }
 
-        neighbor = bestNeighbor[voxelIndex];
+        const int64 neighbor = bestNeighbor[voxelIndex];
         if(neighbor != -1)
         {
           for(const auto& [dataId, dataObject] : *attrMatrix)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.cpp
@@ -228,25 +228,17 @@ struct ExecuteTemplate
         break;
       }
 
-      progIncrement = static_cast<int64_t>(totalPoints / 50);
-      prog = 1;
-      progressInt = 0;
-      for(int64 voxelIndex = 0; voxelIndex < totalPoints; voxelIndex++)
+      // Sequential per-array transfer: process one array at a time so only one array's
+      // chunks compete for the OOC cache. The per-voxel-per-array ordering causes chunk
+      // thrashing when multiple arrays' chunks evict each other between voxel iterations.
+      for(const auto& [dataId, dataObject] : *attrMatrix)
       {
-        if(voxelIndex > prog)
+        auto& dataArray = dynamic_cast<IDataArray&>(*dataObject);
+        for(int64 voxelIndex = 0; voxelIndex < totalPoints; voxelIndex++)
         {
-          progressInt = static_cast<int64_t>(((float)voxelIndex / totalPoints) * 100.0f);
-          const std::string progressMessage = fmt::format("Transferring Loop({}) Progress: {}% Complete", count, progressInt);
-          messageHandler(IFilter::ProgressMessage{IFilter::Message::Type::Progress, progressMessage, static_cast<int32_t>(progressInt)});
-          prog = prog + progIncrement;
-        }
-
-        const int64 neighbor = bestNeighbor[voxelIndex];
-        if(neighbor != -1)
-        {
-          for(const auto& [dataId, dataObject] : *attrMatrix)
+          const int64 neighbor = bestNeighbor[voxelIndex];
+          if(neighbor != -1)
           {
-            auto& dataArray = dynamic_cast<IDataArray&>(*dataObject);
             dataArray.copyTuple(neighbor, voxelIndex);
           }
         }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.cpp
@@ -227,9 +227,10 @@ struct ExecuteTemplate
         break;
       }
 
-      // Sequential per-array transfer: process one array at a time so only one array's
-      // chunks compete for the OOC cache. The per-voxel-per-array ordering causes chunk
-      // thrashing when multiple arrays' chunks evict each other between voxel iterations.
+      // Sequential per-array transfer: process one array at a time across all voxels,
+      // so only one array's chunks compete for the OOC cache at a time. This avoids the
+      // chunk thrashing that occurs with per-voxel-per-array ordering. All cell-level
+      // arrays in the attribute matrix are updated (including the comparison array itself).
       for(const auto& [dataId, dataObject] : *attrMatrix)
       {
         auto* dataArrayPtr = dynamic_cast<IDataArray*>(dataObject.get());
@@ -271,7 +272,7 @@ ReplaceElementAttributesWithNeighborValues::ReplaceElementAttributesWithNeighbor
 ReplaceElementAttributesWithNeighborValues::~ReplaceElementAttributesWithNeighborValues() noexcept = default;
 
 // -----------------------------------------------------------------------------
-const std::atomic_bool& ReplaceElementAttributesWithNeighborValues::getCancel()
+const std::atomic_bool& ReplaceElementAttributesWithNeighborValues::getCancel() const
 {
   return m_ShouldCancel;
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.cpp
@@ -82,8 +82,7 @@ public:
 struct ExecuteTemplate
 {
   template <typename T>
-  void CompareValues(std::shared_ptr<IComparisonFunctor<T>>& comparator, T neighborValue, float thresholdValue, float32& best, std::vector<int64_t>& bestNeighbor, size_t i,
-                     int64 neighborPoint) const
+  void CompareValues(std::shared_ptr<IComparisonFunctor<T>>& comparator, T neighborValue, float thresholdValue, float32& best, std::vector<int64_t>& bestNeighbor, size_t i, int64 neighborPoint) const
   {
     if(comparator->compare1(neighborValue, thresholdValue) && comparator->compare2(neighborValue, best))
     {
@@ -192,12 +191,12 @@ struct ExecuteTemplate
               std::array<bool, 6> isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
 
               const std::array<usize, 6> neighborInSlice = {
-                  inSlice,                                          // -Z
+                  inSlice,                                         // -Z
                   static_cast<usize>((yIdx - 1) * dims[0] + xIdx), // -Y
                   static_cast<usize>(yIdx * dims[0] + (xIdx - 1)), // -X
                   static_cast<usize>(yIdx * dims[0] + (xIdx + 1)), // +X
                   static_cast<usize>((yIdx + 1) * dims[0] + xIdx), // +Y
-                  inSlice                                           // +Z
+                  inSlice                                          // +Z
               };
 
               for(const auto& faceIndex : faceNeighborInternalIdx)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.hpp
@@ -39,8 +39,19 @@ struct SIMPLNXCORE_EXPORT ReplaceElementAttributesWithNeighborValuesInputValues
 class SIMPLNXCORE_EXPORT ReplaceElementAttributesWithNeighborValues
 {
 public:
+  /**
+   * @brief Constructs the algorithm with all required references and parameters.
+   * @param dataStructure The DataStructure containing all input/output arrays
+   * @param mesgHandler Handler for sending progress messages to the UI
+   * @param shouldCancel Atomic flag checked between iterations to support cancellation
+   * @param inputValues User-supplied parameters controlling the algorithm behavior
+   */
   ReplaceElementAttributesWithNeighborValues(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel,
                                              ReplaceElementAttributesWithNeighborValuesInputValues* inputValues);
+
+  /**
+   * @brief Default destructor.
+   */
   ~ReplaceElementAttributesWithNeighborValues() noexcept;
 
   ReplaceElementAttributesWithNeighborValues(const ReplaceElementAttributesWithNeighborValues&) = delete;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.hpp
@@ -19,6 +19,10 @@ inline constexpr StringLiteral k_GreaterThan = "> [Greater Than]";
 inline const ChoicesParameter::Choices k_OperationChoices = {k_LessThan, k_GreaterThan};
 } // namespace detail
 
+/**
+ * @struct ReplaceElementAttributesWithNeighborValuesInputValues
+ * @brief Holds all user-supplied parameters for the ReplaceElementAttributesWithNeighborValues algorithm.
+ */
 struct SIMPLNXCORE_EXPORT ReplaceElementAttributesWithNeighborValuesInputValues
 {
   float32 MinConfidence;
@@ -29,7 +33,8 @@ struct SIMPLNXCORE_EXPORT ReplaceElementAttributesWithNeighborValuesInputValues
 };
 
 /**
- * @class
+ * @class ReplaceElementAttributesWithNeighborValues
+ * @brief Replaces voxel data with the best face-neighbor value based on a threshold comparison.
  */
 class SIMPLNXCORE_EXPORT ReplaceElementAttributesWithNeighborValues
 {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.hpp
@@ -59,9 +59,13 @@ public:
   ReplaceElementAttributesWithNeighborValues& operator=(const ReplaceElementAttributesWithNeighborValues&) = delete;
   ReplaceElementAttributesWithNeighborValues& operator=(ReplaceElementAttributesWithNeighborValues&&) noexcept = delete;
 
+  /**
+   * @brief Executes the replace element attributes with neighbor values algorithm.
+   * @return Result<> indicating success or any errors encountered during execution
+   */
   Result<> operator()();
 
-  const std::atomic_bool& getCancel();
+  const std::atomic_bool& getCancel() const;
 
 private:
   DataStructure& m_DataStructure;

--- a/src/Plugins/SimplnxCore/test/ErodeDilateBadDataTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ErodeDilateBadDataTest.cpp
@@ -8,7 +8,6 @@
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
 #include "simplnx/Parameters/MultiArraySelectionParameter.hpp"
-#include "simplnx/Utilities/AlgorithmDispatch.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include <filesystem>
@@ -34,8 +33,6 @@ const DataPath k_FeatureIdsDataPath = k_EbsdScanDataDataPath.createChildPath("Fe
 TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter(Erode)", "[SimplnxCore][ErodeDilateBadDataFilter]")
 {
   UnitTest::LoadPlugins();
-  bool forceOocAlgo = GENERATE(false);
-  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
@@ -84,8 +81,6 @@ TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter(Erode)", "[SimplnxCore][ErodeDi
 TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter(Dilate)", "[SimplnxCore][ErodeDilateBadDataFilter]")
 {
   UnitTest::LoadPlugins();
-  bool forceOocAlgo = GENERATE(false);
-  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
@@ -130,8 +125,6 @@ TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter(Dilate)", "[SimplnxCore][ErodeD
 TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter: Benchmark 200x200x200", "[SimplnxCore][ErodeDilateBadDataFilter][Benchmark]")
 {
   UnitTest::LoadPlugins();
-  bool forceOocAlgo = GENERATE(false);
-  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // 200x200x200, EulerAngles (float32, 3-comp) => 200*200*3*4 = 480,000 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 480000, true);
 

--- a/src/Plugins/SimplnxCore/test/ErodeDilateBadDataTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ErodeDilateBadDataTest.cpp
@@ -3,11 +3,12 @@
 #include "SimplnxCore/Filters/ErodeDilateBadDataFilter.hpp"
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
 
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
 #include "simplnx/Parameters/MultiArraySelectionParameter.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
-#include "simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp"
 
 #include <filesystem>
 
@@ -32,10 +33,10 @@ const DataPath k_FeatureIdsDataPath = k_EbsdScanDataDataPath.createChildPath("Fe
 TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter(Erode)", "[SimplnxCore][ErodeDilateBadDataFilter]")
 {
   UnitTest::LoadPlugins();
+  // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
+  const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
   const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_TestFilesDir, "6_6_erode_dilate_test.tar.gz", "6_6_erode_dilate_test");
-
-  UnitTest::LoadPlugins();
 
   // Read Exemplar DREAM3D File Filter
   auto exemplarFilePath = fs::path(fmt::format("{}/6_6_erode_dilate_test/6_6_erode_dilate_bad_data.dream3d", unit_test::k_TestFilesDir));
@@ -80,13 +81,13 @@ TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter(Erode)", "[SimplnxCore][ErodeDi
 TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter(Dilate)", "[SimplnxCore][ErodeDilateBadDataFilter]")
 {
   UnitTest::LoadPlugins();
+  // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
+  const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
   const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_TestFilesDir, "6_6_erode_dilate_test.tar.gz", "6_6_erode_dilate_test");
 
   const std::string k_ExemplarDataContainerName("Exemplar Bad Data Dilate");
   const DataPath k_DilateCellAttributeMatrixDataPath = DataPath({k_ExemplarDataContainerName, "EBSD Scan Data"});
-
-  UnitTest::LoadPlugins();
 
   // Read Exemplar DREAM3D File Filter
   auto exemplarFilePath = fs::path(fmt::format("{}/6_6_erode_dilate_test/6_6_erode_dilate_bad_data.dream3d", unit_test::k_TestFilesDir));
@@ -119,4 +120,90 @@ TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter(Dilate)", "[SimplnxCore][ErodeD
   UnitTest::CompareExemplarToGeneratedData(dataStructure, dataStructure, k_EbsdScanDataDataPath, k_ExemplarDataContainerName);
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter: Benchmark 200x200x200", "[SimplnxCore][ErodeDilateBadDataFilter][Benchmark]")
+{
+  UnitTest::LoadPlugins();
+  // 200x200x200, EulerAngles (float32, 3-comp) => 200*200*3*4 = 480,000 bytes/slice
+  const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 480000, true);
+
+  constexpr usize kDimX = 200;
+  constexpr usize kDimY = 200;
+  constexpr usize kDimZ = 200;
+  const ShapeType cellTupleShape = {kDimZ, kDimY, kDimX};
+  const auto benchmarkFile = fs::path(fmt::format("{}/erode_dilate_bad_data_benchmark.dream3d", unit_test::k_BinaryTestOutputDir));
+
+  // Stage 1: Build data programmatically and write to .dream3d
+  {
+    DataStructure buildDS;
+    auto* imageGeom = ImageGeom::Create(buildDS, "Input Data");
+    imageGeom->setDimensions({kDimX, kDimY, kDimZ});
+    imageGeom->setSpacing({1.0f, 1.0f, 1.0f});
+    imageGeom->setOrigin({0.0f, 0.0f, 0.0f});
+
+    auto* cellAM = AttributeMatrix::Create(buildDS, "EBSD Scan Data", cellTupleShape, imageGeom->getId());
+    imageGeom->setCellData(*cellAM);
+
+    auto* featureIdsArray = UnitTest::CreateTestDataArray<int32>(buildDS, "FeatureIds", cellTupleShape, {1}, cellAM->getId());
+    auto& featureIdsStore = featureIdsArray->getDataStoreRef();
+
+    auto* eulerArray = UnitTest::CreateTestDataArray<float32>(buildDS, "EulerAngles", cellTupleShape, {3}, cellAM->getId());
+    auto& eulerStore = eulerArray->getDataStoreRef();
+
+    auto* phasesArray = UnitTest::CreateTestDataArray<int32>(buildDS, "Phases", cellTupleShape, {1}, cellAM->getId());
+    auto& phasesStore = phasesArray->getDataStoreRef();
+
+    constexpr usize kBlockSize = 25;
+    constexpr usize kBlocksPerDim = kDimX / kBlockSize;
+    for(usize z = 0; z < kDimZ; z++)
+    {
+      for(usize y = 0; y < kDimY; y++)
+      {
+        for(usize x = 0; x < kDimX; x++)
+        {
+          const usize idx = z * kDimX * kDimY + y * kDimX + x;
+          phasesStore[idx] = 1;
+
+          usize bx = x / kBlockSize;
+          usize by = y / kBlockSize;
+          usize bz = z / kBlockSize;
+          int32 blockFeatureId = static_cast<int32>(bz * kBlocksPerDim * kBlocksPerDim + by * kBlocksPerDim + bx + 1);
+
+          bool isBad = ((x * 7 + y * 13 + z * 29) % 10 == 0);
+          featureIdsStore[idx] = isBad ? 0 : blockFeatureId;
+
+          const usize eIdx = idx * 3;
+          eulerStore[eIdx] = static_cast<float32>(x) / static_cast<float32>(kDimX);
+          eulerStore[eIdx + 1] = static_cast<float32>(y) / static_cast<float32>(kDimY);
+          eulerStore[eIdx + 2] = static_cast<float32>(z) / static_cast<float32>(kDimZ);
+        }
+      }
+    }
+
+    UnitTest::WriteTestDataStructure(buildDS, benchmarkFile);
+  }
+
+  DataStructure dataStructure = UnitTest::LoadDataStructure(benchmarkFile);
+
+  {
+    const ErodeDilateBadDataFilter filter;
+    Arguments args;
+
+    args.insertOrAssign(ErodeDilateBadDataFilter::k_Operation_Key, std::make_any<ChoicesParameter::ValueType>(k_Dilate));
+    args.insertOrAssign(ErodeDilateBadDataFilter::k_NumIterations_Key, std::make_any<int32>(2));
+    args.insertOrAssign(ErodeDilateBadDataFilter::k_XDirOn_Key, std::make_any<bool>(true));
+    args.insertOrAssign(ErodeDilateBadDataFilter::k_YDirOn_Key, std::make_any<bool>(true));
+    args.insertOrAssign(ErodeDilateBadDataFilter::k_ZDirOn_Key, std::make_any<bool>(true));
+    args.insertOrAssign(ErodeDilateBadDataFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(DataPath({"Input Data", "EBSD Scan Data", "FeatureIds"})));
+    args.insertOrAssign(ErodeDilateBadDataFilter::k_IgnoredDataArrayPaths_Key, std::make_any<MultiArraySelectionParameter::ValueType>(MultiArraySelectionParameter::ValueType{}));
+    args.insertOrAssign(ErodeDilateBadDataFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(DataPath({"Input Data"})));
+
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+    auto executeResult = filter.execute(dataStructure, args, nullptr, IFilter::MessageHandler{[](const IFilter::Message& message) { fmt::print("{}\n", message.message); }});
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+  }
+
+  fs::remove(benchmarkFile);
 }

--- a/src/Plugins/SimplnxCore/test/ErodeDilateBadDataTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ErodeDilateBadDataTest.cpp
@@ -8,6 +8,7 @@
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
 #include "simplnx/Parameters/MultiArraySelectionParameter.hpp"
+#include "simplnx/Utilities/AlgorithmDispatch.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include <filesystem>
@@ -33,6 +34,8 @@ const DataPath k_FeatureIdsDataPath = k_EbsdScanDataDataPath.createChildPath("Fe
 TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter(Erode)", "[SimplnxCore][ErodeDilateBadDataFilter]")
 {
   UnitTest::LoadPlugins();
+  bool forceOocAlgo = GENERATE(false);
+  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
@@ -81,6 +84,8 @@ TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter(Erode)", "[SimplnxCore][ErodeDi
 TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter(Dilate)", "[SimplnxCore][ErodeDilateBadDataFilter]")
 {
   UnitTest::LoadPlugins();
+  bool forceOocAlgo = GENERATE(false);
+  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
@@ -125,6 +130,8 @@ TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter(Dilate)", "[SimplnxCore][ErodeD
 TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter: Benchmark 200x200x200", "[SimplnxCore][ErodeDilateBadDataFilter][Benchmark]")
 {
   UnitTest::LoadPlugins();
+  bool forceOocAlgo = GENERATE(false);
+  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // 200x200x200, EulerAngles (float32, 3-comp) => 200*200*3*4 = 480,000 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 480000, true);
 

--- a/src/Plugins/SimplnxCore/test/ErodeDilateBadDataTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ErodeDilateBadDataTest.cpp
@@ -128,17 +128,17 @@ TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter: Benchmark 200x200x200", "[Simp
   // 200x200x200, EulerAngles (float32, 3-comp) => 200*200*3*4 = 480,000 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 480000, true);
 
-  constexpr usize kDimX = 200;
-  constexpr usize kDimY = 200;
-  constexpr usize kDimZ = 200;
-  const ShapeType cellTupleShape = {kDimZ, kDimY, kDimX};
+  constexpr usize k_DimX = 200;
+  constexpr usize k_DimY = 200;
+  constexpr usize k_DimZ = 200;
+  const ShapeType cellTupleShape = {k_DimZ, k_DimY, k_DimX};
   const auto benchmarkFile = fs::path(fmt::format("{}/erode_dilate_bad_data_benchmark.dream3d", unit_test::k_BinaryTestOutputDir));
 
   // Stage 1: Build data programmatically and write to .dream3d
   {
     DataStructure buildDS;
     auto* imageGeom = ImageGeom::Create(buildDS, "Input Data");
-    imageGeom->setDimensions({kDimX, kDimY, kDimZ});
+    imageGeom->setDimensions({k_DimX, k_DimY, k_DimZ});
     imageGeom->setSpacing({1.0f, 1.0f, 1.0f});
     imageGeom->setOrigin({0.0f, 0.0f, 0.0f});
 
@@ -154,29 +154,29 @@ TEST_CASE("SimplnxCore::ErodeDilateBadDataFilter: Benchmark 200x200x200", "[Simp
     auto* phasesArray = UnitTest::CreateTestDataArray<int32>(buildDS, "Phases", cellTupleShape, {1}, cellAM->getId());
     auto& phasesStore = phasesArray->getDataStoreRef();
 
-    constexpr usize kBlockSize = 25;
-    constexpr usize kBlocksPerDim = kDimX / kBlockSize;
-    for(usize z = 0; z < kDimZ; z++)
+    constexpr usize k_BlockSize = 25;
+    constexpr usize k_BlocksPerDim = k_DimX / k_BlockSize;
+    for(usize z = 0; z < k_DimZ; z++)
     {
-      for(usize y = 0; y < kDimY; y++)
+      for(usize y = 0; y < k_DimY; y++)
       {
-        for(usize x = 0; x < kDimX; x++)
+        for(usize x = 0; x < k_DimX; x++)
         {
-          const usize idx = z * kDimX * kDimY + y * kDimX + x;
+          const usize idx = z * k_DimX * k_DimY + y * k_DimX + x;
           phasesStore[idx] = 1;
 
-          usize bx = x / kBlockSize;
-          usize by = y / kBlockSize;
-          usize bz = z / kBlockSize;
-          int32 blockFeatureId = static_cast<int32>(bz * kBlocksPerDim * kBlocksPerDim + by * kBlocksPerDim + bx + 1);
+          usize bx = x / k_BlockSize;
+          usize by = y / k_BlockSize;
+          usize bz = z / k_BlockSize;
+          int32 blockFeatureId = static_cast<int32>(bz * k_BlocksPerDim * k_BlocksPerDim + by * k_BlocksPerDim + bx + 1);
 
           bool isBad = ((x * 7 + y * 13 + z * 29) % 10 == 0);
           featureIdsStore[idx] = isBad ? 0 : blockFeatureId;
 
           const usize eIdx = idx * 3;
-          eulerStore[eIdx] = static_cast<float32>(x) / static_cast<float32>(kDimX);
-          eulerStore[eIdx + 1] = static_cast<float32>(y) / static_cast<float32>(kDimY);
-          eulerStore[eIdx + 2] = static_cast<float32>(z) / static_cast<float32>(kDimZ);
+          eulerStore[eIdx] = static_cast<float32>(x) / static_cast<float32>(k_DimX);
+          eulerStore[eIdx + 1] = static_cast<float32>(y) / static_cast<float32>(k_DimY);
+          eulerStore[eIdx + 2] = static_cast<float32>(z) / static_cast<float32>(k_DimZ);
         }
       }
     }

--- a/src/Plugins/SimplnxCore/test/ErodeDilateCoordinationNumberTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ErodeDilateCoordinationNumberTest.cpp
@@ -3,6 +3,8 @@
 #include "SimplnxCore/Filters/ErodeDilateCoordinationNumberFilter.hpp"
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
 
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/MultiArraySelectionParameter.hpp"
@@ -30,6 +32,8 @@ const DataPath k_ErodeCellAttributeMatrixDataPath = DataPath({k_ExemplarDataCont
 TEST_CASE("SimplnxCore::ErodeDilateCoordinationNumberFilter", "[SimplnxCore][ErodeDilateCoordinationNumberFilter]")
 {
   UnitTest::LoadPlugins();
+  // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
+  const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
   const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_TestFilesDir, "6_6_erode_dilate_test.tar.gz", "6_6_erode_dilate_test");
 
@@ -61,4 +65,83 @@ TEST_CASE("SimplnxCore::ErodeDilateCoordinationNumberFilter", "[SimplnxCore][Ero
   UnitTest::CompareExemplarToGeneratedData(dataStructure, dataStructure, k_EbsdScanDataDataPath, k_ExemplarDataContainerName);
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ErodeDilateCoordinationNumberFilter: Benchmark 200x200x200", "[SimplnxCore][ErodeDilateCoordinationNumberFilter][Benchmark]")
+{
+  UnitTest::LoadPlugins();
+  // 200x200x200, EulerAngles (float32, 3-comp) => 200*200*3*4 = 480,000 bytes/slice
+  const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 480000, true);
+
+  constexpr usize kDimX = 200;
+  constexpr usize kDimY = 200;
+  constexpr usize kDimZ = 200;
+  const ShapeType cellTupleShape = {kDimZ, kDimY, kDimX};
+  const auto benchmarkFile = fs::path(fmt::format("{}/erode_dilate_coordination_number_benchmark.dream3d", unit_test::k_BinaryTestOutputDir));
+
+  // Stage 1: Build data programmatically and write to .dream3d
+  {
+    DataStructure buildDS;
+    auto* imageGeom = ImageGeom::Create(buildDS, "Input Data");
+    imageGeom->setDimensions({kDimX, kDimY, kDimZ});
+    imageGeom->setSpacing({1.0f, 1.0f, 1.0f});
+    imageGeom->setOrigin({0.0f, 0.0f, 0.0f});
+
+    auto* cellAM = AttributeMatrix::Create(buildDS, "EBSD Scan Data", cellTupleShape, imageGeom->getId());
+    imageGeom->setCellData(*cellAM);
+
+    auto* featureIdsArray = UnitTest::CreateTestDataArray<int32>(buildDS, "FeatureIds", cellTupleShape, {1}, cellAM->getId());
+    auto& featureIdsStore = featureIdsArray->getDataStoreRef();
+
+    auto* eulerArray = UnitTest::CreateTestDataArray<float32>(buildDS, "EulerAngles", cellTupleShape, {3}, cellAM->getId());
+    auto& eulerStore = eulerArray->getDataStoreRef();
+
+    constexpr usize kBlockSize = 25;
+    constexpr usize kBlocksPerDim = kDimX / kBlockSize;
+    for(usize z = 0; z < kDimZ; z++)
+    {
+      for(usize y = 0; y < kDimY; y++)
+      {
+        for(usize x = 0; x < kDimX; x++)
+        {
+          const usize idx = z * kDimX * kDimY + y * kDimX + x;
+
+          usize bx = x / kBlockSize;
+          usize by = y / kBlockSize;
+          usize bz = z / kBlockSize;
+          int32 blockFeatureId = static_cast<int32>(bz * kBlocksPerDim * kBlocksPerDim + by * kBlocksPerDim + bx + 1);
+
+          bool isBad = ((x * 7 + y * 13 + z * 29) % 7 == 0);
+          featureIdsStore[idx] = isBad ? 0 : blockFeatureId;
+
+          const usize eIdx = idx * 3;
+          eulerStore[eIdx] = static_cast<float32>(x) / static_cast<float32>(kDimX);
+          eulerStore[eIdx + 1] = static_cast<float32>(y) / static_cast<float32>(kDimY);
+          eulerStore[eIdx + 2] = static_cast<float32>(z) / static_cast<float32>(kDimZ);
+        }
+      }
+    }
+
+    UnitTest::WriteTestDataStructure(buildDS, benchmarkFile);
+  }
+
+  DataStructure dataStructure = UnitTest::LoadDataStructure(benchmarkFile);
+
+  {
+    const ErodeDilateCoordinationNumberFilter filter;
+    Arguments args;
+
+    args.insertOrAssign(ErodeDilateCoordinationNumberFilter::k_CoordinationNumber_Key, std::make_any<int32>(4));
+    args.insertOrAssign(ErodeDilateCoordinationNumberFilter::k_Loop_Key, std::make_any<bool>(false));
+    args.insertOrAssign(ErodeDilateCoordinationNumberFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(DataPath({"Input Data", "EBSD Scan Data", "FeatureIds"})));
+    args.insertOrAssign(ErodeDilateCoordinationNumberFilter::k_IgnoredDataArrayPaths_Key, std::make_any<MultiArraySelectionParameter::ValueType>(MultiArraySelectionParameter::ValueType{}));
+    args.insertOrAssign(ErodeDilateCoordinationNumberFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(DataPath({"Input Data"})));
+
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+    auto executeResult = filter.execute(dataStructure, args, nullptr, IFilter::MessageHandler{[](const IFilter::Message& message) { fmt::print("{}\n", message.message); }});
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+  }
+
+  fs::remove(benchmarkFile);
 }

--- a/src/Plugins/SimplnxCore/test/ErodeDilateCoordinationNumberTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ErodeDilateCoordinationNumberTest.cpp
@@ -8,7 +8,6 @@
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/MultiArraySelectionParameter.hpp"
-#include "simplnx/Utilities/AlgorithmDispatch.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include <filesystem>
@@ -33,8 +32,6 @@ const DataPath k_ErodeCellAttributeMatrixDataPath = DataPath({k_ExemplarDataCont
 TEST_CASE("SimplnxCore::ErodeDilateCoordinationNumberFilter", "[SimplnxCore][ErodeDilateCoordinationNumberFilter]")
 {
   UnitTest::LoadPlugins();
-  bool forceOocAlgo = GENERATE(false);
-  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
@@ -73,8 +70,6 @@ TEST_CASE("SimplnxCore::ErodeDilateCoordinationNumberFilter", "[SimplnxCore][Ero
 TEST_CASE("SimplnxCore::ErodeDilateCoordinationNumberFilter: Benchmark 200x200x200", "[SimplnxCore][ErodeDilateCoordinationNumberFilter][Benchmark]")
 {
   UnitTest::LoadPlugins();
-  bool forceOocAlgo = GENERATE(false);
-  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // 200x200x200, EulerAngles (float32, 3-comp) => 200*200*3*4 = 480,000 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 480000, true);
 

--- a/src/Plugins/SimplnxCore/test/ErodeDilateCoordinationNumberTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ErodeDilateCoordinationNumberTest.cpp
@@ -73,17 +73,17 @@ TEST_CASE("SimplnxCore::ErodeDilateCoordinationNumberFilter: Benchmark 200x200x2
   // 200x200x200, EulerAngles (float32, 3-comp) => 200*200*3*4 = 480,000 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 480000, true);
 
-  constexpr usize kDimX = 200;
-  constexpr usize kDimY = 200;
-  constexpr usize kDimZ = 200;
-  const ShapeType cellTupleShape = {kDimZ, kDimY, kDimX};
+  constexpr usize k_DimX = 200;
+  constexpr usize k_DimY = 200;
+  constexpr usize k_DimZ = 200;
+  const ShapeType cellTupleShape = {k_DimZ, k_DimY, k_DimX};
   const auto benchmarkFile = fs::path(fmt::format("{}/erode_dilate_coordination_number_benchmark.dream3d", unit_test::k_BinaryTestOutputDir));
 
   // Stage 1: Build data programmatically and write to .dream3d
   {
     DataStructure buildDS;
     auto* imageGeom = ImageGeom::Create(buildDS, "Input Data");
-    imageGeom->setDimensions({kDimX, kDimY, kDimZ});
+    imageGeom->setDimensions({k_DimX, k_DimY, k_DimZ});
     imageGeom->setSpacing({1.0f, 1.0f, 1.0f});
     imageGeom->setOrigin({0.0f, 0.0f, 0.0f});
 
@@ -96,28 +96,28 @@ TEST_CASE("SimplnxCore::ErodeDilateCoordinationNumberFilter: Benchmark 200x200x2
     auto* eulerArray = UnitTest::CreateTestDataArray<float32>(buildDS, "EulerAngles", cellTupleShape, {3}, cellAM->getId());
     auto& eulerStore = eulerArray->getDataStoreRef();
 
-    constexpr usize kBlockSize = 25;
-    constexpr usize kBlocksPerDim = kDimX / kBlockSize;
-    for(usize z = 0; z < kDimZ; z++)
+    constexpr usize k_BlockSize = 25;
+    constexpr usize k_BlocksPerDim = k_DimX / k_BlockSize;
+    for(usize z = 0; z < k_DimZ; z++)
     {
-      for(usize y = 0; y < kDimY; y++)
+      for(usize y = 0; y < k_DimY; y++)
       {
-        for(usize x = 0; x < kDimX; x++)
+        for(usize x = 0; x < k_DimX; x++)
         {
-          const usize idx = z * kDimX * kDimY + y * kDimX + x;
+          const usize idx = z * k_DimX * k_DimY + y * k_DimX + x;
 
-          usize bx = x / kBlockSize;
-          usize by = y / kBlockSize;
-          usize bz = z / kBlockSize;
-          int32 blockFeatureId = static_cast<int32>(bz * kBlocksPerDim * kBlocksPerDim + by * kBlocksPerDim + bx + 1);
+          usize bx = x / k_BlockSize;
+          usize by = y / k_BlockSize;
+          usize bz = z / k_BlockSize;
+          int32 blockFeatureId = static_cast<int32>(bz * k_BlocksPerDim * k_BlocksPerDim + by * k_BlocksPerDim + bx + 1);
 
           bool isBad = ((x * 7 + y * 13 + z * 29) % 7 == 0);
           featureIdsStore[idx] = isBad ? 0 : blockFeatureId;
 
           const usize eIdx = idx * 3;
-          eulerStore[eIdx] = static_cast<float32>(x) / static_cast<float32>(kDimX);
-          eulerStore[eIdx + 1] = static_cast<float32>(y) / static_cast<float32>(kDimY);
-          eulerStore[eIdx + 2] = static_cast<float32>(z) / static_cast<float32>(kDimZ);
+          eulerStore[eIdx] = static_cast<float32>(x) / static_cast<float32>(k_DimX);
+          eulerStore[eIdx + 1] = static_cast<float32>(y) / static_cast<float32>(k_DimY);
+          eulerStore[eIdx + 2] = static_cast<float32>(z) / static_cast<float32>(k_DimZ);
         }
       }
     }

--- a/src/Plugins/SimplnxCore/test/ErodeDilateCoordinationNumberTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ErodeDilateCoordinationNumberTest.cpp
@@ -8,6 +8,7 @@
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/MultiArraySelectionParameter.hpp"
+#include "simplnx/Utilities/AlgorithmDispatch.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include <filesystem>
@@ -32,6 +33,8 @@ const DataPath k_ErodeCellAttributeMatrixDataPath = DataPath({k_ExemplarDataCont
 TEST_CASE("SimplnxCore::ErodeDilateCoordinationNumberFilter", "[SimplnxCore][ErodeDilateCoordinationNumberFilter]")
 {
   UnitTest::LoadPlugins();
+  bool forceOocAlgo = GENERATE(false);
+  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
@@ -70,6 +73,8 @@ TEST_CASE("SimplnxCore::ErodeDilateCoordinationNumberFilter", "[SimplnxCore][Ero
 TEST_CASE("SimplnxCore::ErodeDilateCoordinationNumberFilter: Benchmark 200x200x200", "[SimplnxCore][ErodeDilateCoordinationNumberFilter][Benchmark]")
 {
   UnitTest::LoadPlugins();
+  bool forceOocAlgo = GENERATE(false);
+  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // 200x200x200, EulerAngles (float32, 3-comp) => 200*200*3*4 = 480,000 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 480000, true);
 

--- a/src/Plugins/SimplnxCore/test/ErodeDilateMaskTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ErodeDilateMaskTest.cpp
@@ -8,7 +8,6 @@
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
-#include "simplnx/Utilities/AlgorithmDispatch.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include <filesystem>
@@ -34,8 +33,6 @@ const DataPath k_MaskArrayDataPath = k_EbsdScanDataDataPath.createChildPath("Mas
 TEST_CASE("SimplnxCore::ErodeDilateMaskFilter(Dilate)", "[SimplnxCore][ErodeDilateMaskFilter]")
 {
   UnitTest::LoadPlugins();
-  bool forceOocAlgo = GENERATE(false);
-  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
@@ -79,8 +76,6 @@ TEST_CASE("SimplnxCore::ErodeDilateMaskFilter(Dilate)", "[SimplnxCore][ErodeDila
 TEST_CASE("SimplnxCore::ErodeDilateMaskFilter(Erode)", "[SimplnxCore][ErodeDilateMaskFilter]")
 {
   UnitTest::LoadPlugins();
-  bool forceOocAlgo = GENERATE(false);
-  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
@@ -124,8 +119,6 @@ TEST_CASE("SimplnxCore::ErodeDilateMaskFilter(Erode)", "[SimplnxCore][ErodeDilat
 TEST_CASE("SimplnxCore::ErodeDilateMaskFilter: Benchmark 200x200x200", "[SimplnxCore][ErodeDilateMaskFilter][Benchmark]")
 {
   UnitTest::LoadPlugins();
-  bool forceOocAlgo = GENERATE(false);
-  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // 200x200x200, Mask (bool, 1-comp) => 200*200*1 = 40,000 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 40000, true);
 

--- a/src/Plugins/SimplnxCore/test/ErodeDilateMaskTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ErodeDilateMaskTest.cpp
@@ -122,17 +122,17 @@ TEST_CASE("SimplnxCore::ErodeDilateMaskFilter: Benchmark 200x200x200", "[Simplnx
   // 200x200x200, Mask (bool, 1-comp) => 200*200*1 = 40,000 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 40000, true);
 
-  constexpr usize kDimX = 200;
-  constexpr usize kDimY = 200;
-  constexpr usize kDimZ = 200;
-  const ShapeType cellTupleShape = {kDimZ, kDimY, kDimX};
+  constexpr usize k_DimX = 200;
+  constexpr usize k_DimY = 200;
+  constexpr usize k_DimZ = 200;
+  const ShapeType cellTupleShape = {k_DimZ, k_DimY, k_DimX};
   const auto benchmarkFile = fs::path(fmt::format("{}/erode_dilate_mask_benchmark.dream3d", unit_test::k_BinaryTestOutputDir));
 
   // Stage 1: Build data programmatically and write to .dream3d
   {
     DataStructure buildDS;
     auto* imageGeom = ImageGeom::Create(buildDS, "Input Data");
-    imageGeom->setDimensions({kDimX, kDimY, kDimZ});
+    imageGeom->setDimensions({k_DimX, k_DimY, k_DimZ});
     imageGeom->setSpacing({1.0f, 1.0f, 1.0f});
     imageGeom->setOrigin({0.0f, 0.0f, 0.0f});
 
@@ -142,13 +142,13 @@ TEST_CASE("SimplnxCore::ErodeDilateMaskFilter: Benchmark 200x200x200", "[Simplnx
     auto* maskArray = UnitTest::CreateTestDataArray<bool>(buildDS, "Mask", cellTupleShape, {1}, cellAM->getId());
     auto& maskStore = maskArray->getDataStoreRef();
 
-    for(usize z = 0; z < kDimZ; z++)
+    for(usize z = 0; z < k_DimZ; z++)
     {
-      for(usize y = 0; y < kDimY; y++)
+      for(usize y = 0; y < k_DimY; y++)
       {
-        for(usize x = 0; x < kDimX; x++)
+        for(usize x = 0; x < k_DimX; x++)
         {
-          const usize idx = z * kDimX * kDimY + y * kDimX + x;
+          const usize idx = z * k_DimX * k_DimY + y * k_DimX + x;
           maskStore[idx] = ((x * 7 + y * 13 + z * 29) % 3 != 0);
         }
       }

--- a/src/Plugins/SimplnxCore/test/ErodeDilateMaskTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ErodeDilateMaskTest.cpp
@@ -3,6 +3,8 @@
 #include "SimplnxCore/Filters/ErodeDilateMaskFilter.hpp"
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
 
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
@@ -31,6 +33,8 @@ const DataPath k_MaskArrayDataPath = k_EbsdScanDataDataPath.createChildPath("Mas
 TEST_CASE("SimplnxCore::ErodeDilateMaskFilter(Dilate)", "[SimplnxCore][ErodeDilateMaskFilter]")
 {
   UnitTest::LoadPlugins();
+  // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
+  const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
   const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_TestFilesDir, "6_6_erode_dilate_test.tar.gz", "6_6_erode_dilate_test");
 
@@ -72,13 +76,13 @@ TEST_CASE("SimplnxCore::ErodeDilateMaskFilter(Dilate)", "[SimplnxCore][ErodeDila
 TEST_CASE("SimplnxCore::ErodeDilateMaskFilter(Erode)", "[SimplnxCore][ErodeDilateMaskFilter]")
 {
   UnitTest::LoadPlugins();
+  // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
+  const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
   const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_TestFilesDir, "6_6_erode_dilate_test.tar.gz", "6_6_erode_dilate_test");
 
   const std::string k_ExemplarDataContainerName("Exemplar Mask Erode");
   const DataPath k_ErodeCellAttributeMatrixDataPath = DataPath({k_ExemplarDataContainerName, "EBSD Scan Data"});
-
-  UnitTest::LoadPlugins();
 
   // Read Exemplar DREAM3D File Filter
   auto exemplarFilePath = fs::path(fmt::format("{}/6_6_erode_dilate_test/6_6_erode_dilate_mask.dream3d", unit_test::k_TestFilesDir));
@@ -110,4 +114,68 @@ TEST_CASE("SimplnxCore::ErodeDilateMaskFilter(Erode)", "[SimplnxCore][ErodeDilat
   UnitTest::CompareExemplarToGeneratedData(dataStructure, dataStructure, k_EbsdScanDataDataPath, k_ExemplarDataContainerName);
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ErodeDilateMaskFilter: Benchmark 200x200x200", "[SimplnxCore][ErodeDilateMaskFilter][Benchmark]")
+{
+  UnitTest::LoadPlugins();
+  // 200x200x200, Mask (bool, 1-comp) => 200*200*1 = 40,000 bytes/slice
+  const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 40000, true);
+
+  constexpr usize kDimX = 200;
+  constexpr usize kDimY = 200;
+  constexpr usize kDimZ = 200;
+  const ShapeType cellTupleShape = {kDimZ, kDimY, kDimX};
+  const auto benchmarkFile = fs::path(fmt::format("{}/erode_dilate_mask_benchmark.dream3d", unit_test::k_BinaryTestOutputDir));
+
+  // Stage 1: Build data programmatically and write to .dream3d
+  {
+    DataStructure buildDS;
+    auto* imageGeom = ImageGeom::Create(buildDS, "Input Data");
+    imageGeom->setDimensions({kDimX, kDimY, kDimZ});
+    imageGeom->setSpacing({1.0f, 1.0f, 1.0f});
+    imageGeom->setOrigin({0.0f, 0.0f, 0.0f});
+
+    auto* cellAM = AttributeMatrix::Create(buildDS, "EBSD Scan Data", cellTupleShape, imageGeom->getId());
+    imageGeom->setCellData(*cellAM);
+
+    auto* maskArray = UnitTest::CreateTestDataArray<bool>(buildDS, "Mask", cellTupleShape, {1}, cellAM->getId());
+    auto& maskStore = maskArray->getDataStoreRef();
+
+    for(usize z = 0; z < kDimZ; z++)
+    {
+      for(usize y = 0; y < kDimY; y++)
+      {
+        for(usize x = 0; x < kDimX; x++)
+        {
+          const usize idx = z * kDimX * kDimY + y * kDimX + x;
+          maskStore[idx] = ((x * 7 + y * 13 + z * 29) % 3 != 0);
+        }
+      }
+    }
+
+    UnitTest::WriteTestDataStructure(buildDS, benchmarkFile);
+  }
+
+  DataStructure dataStructure = UnitTest::LoadDataStructure(benchmarkFile);
+
+  {
+    const ErodeDilateMaskFilter filter;
+    Arguments args;
+
+    args.insertOrAssign(ErodeDilateMaskFilter::k_Operation_Key, std::make_any<ChoicesParameter::ValueType>(k_Dilate));
+    args.insertOrAssign(ErodeDilateMaskFilter::k_NumIterations_Key, std::make_any<int32>(2));
+    args.insertOrAssign(ErodeDilateMaskFilter::k_XDirOn_Key, std::make_any<bool>(true));
+    args.insertOrAssign(ErodeDilateMaskFilter::k_YDirOn_Key, std::make_any<bool>(true));
+    args.insertOrAssign(ErodeDilateMaskFilter::k_ZDirOn_Key, std::make_any<bool>(true));
+    args.insertOrAssign(ErodeDilateMaskFilter::k_MaskArrayPath_Key, std::make_any<DataPath>(DataPath({"Input Data", "EBSD Scan Data", "Mask"})));
+    args.insertOrAssign(ErodeDilateMaskFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(DataPath({"Input Data"})));
+
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+    auto executeResult = filter.execute(dataStructure, args, nullptr, IFilter::MessageHandler{[](const IFilter::Message& message) { fmt::print("{}\n", message.message); }});
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+  }
+
+  fs::remove(benchmarkFile);
 }

--- a/src/Plugins/SimplnxCore/test/ErodeDilateMaskTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ErodeDilateMaskTest.cpp
@@ -8,6 +8,7 @@
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
+#include "simplnx/Utilities/AlgorithmDispatch.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include <filesystem>
@@ -33,6 +34,8 @@ const DataPath k_MaskArrayDataPath = k_EbsdScanDataDataPath.createChildPath("Mas
 TEST_CASE("SimplnxCore::ErodeDilateMaskFilter(Dilate)", "[SimplnxCore][ErodeDilateMaskFilter]")
 {
   UnitTest::LoadPlugins();
+  bool forceOocAlgo = GENERATE(false);
+  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
@@ -76,6 +79,8 @@ TEST_CASE("SimplnxCore::ErodeDilateMaskFilter(Dilate)", "[SimplnxCore][ErodeDila
 TEST_CASE("SimplnxCore::ErodeDilateMaskFilter(Erode)", "[SimplnxCore][ErodeDilateMaskFilter]")
 {
   UnitTest::LoadPlugins();
+  bool forceOocAlgo = GENERATE(false);
+  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // Erode/Dilate test data: 20x201x189, EulerAngles (float32, 3-comp) => 201*189*3*4 = 455,868 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 455868, true);
 
@@ -119,6 +124,8 @@ TEST_CASE("SimplnxCore::ErodeDilateMaskFilter(Erode)", "[SimplnxCore][ErodeDilat
 TEST_CASE("SimplnxCore::ErodeDilateMaskFilter: Benchmark 200x200x200", "[SimplnxCore][ErodeDilateMaskFilter][Benchmark]")
 {
   UnitTest::LoadPlugins();
+  bool forceOocAlgo = GENERATE(false);
+  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // 200x200x200, Mask (bool, 1-comp) => 200*200*1 = 40,000 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 40000, true);
 

--- a/src/Plugins/SimplnxCore/test/ReplaceElementAttributesWithNeighborValuesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReplaceElementAttributesWithNeighborValuesTest.cpp
@@ -6,7 +6,6 @@
 #include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
-#include "simplnx/Utilities/AlgorithmDispatch.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include <filesystem>
@@ -25,8 +24,6 @@ const std::string k_ExemplarDataContainer2("DataContainer");
 TEST_CASE("SimplnxCore::ReplaceElementAttributesWithNeighborValuesFilter", "[SimplnxCore][ReplaceElementAttributesWithNeighborValuesFilter]")
 {
   UnitTest::LoadPlugins();
-  bool forceOocAlgo = GENERATE(false);
-  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // Replace Element test data: 1x201x189, EulerAngles (float32, 3-comp) = 455,868 total bytes
   // Z=1 so use smaller threshold to force chunking
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 50000, true);
@@ -75,8 +72,6 @@ TEST_CASE("SimplnxCore::ReplaceElementAttributesWithNeighborValuesFilter", "[Sim
 TEST_CASE("SimplnxCore::ReplaceElementAttributesWithNeighborValuesFilter: Benchmark 200x200x200", "[SimplnxCore][ReplaceElementAttributesWithNeighborValuesFilter][Benchmark]")
 {
   UnitTest::LoadPlugins();
-  bool forceOocAlgo = GENERATE(false);
-  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // 200x200x200, Confidence Index (float32, 1-comp) => 200*200*4 = 160,000 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 160000, true);
 

--- a/src/Plugins/SimplnxCore/test/ReplaceElementAttributesWithNeighborValuesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReplaceElementAttributesWithNeighborValuesTest.cpp
@@ -75,17 +75,17 @@ TEST_CASE("SimplnxCore::ReplaceElementAttributesWithNeighborValuesFilter: Benchm
   // 200x200x200, Confidence Index (float32, 1-comp) => 200*200*4 = 160,000 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 160000, true);
 
-  constexpr usize kDimX = 200;
-  constexpr usize kDimY = 200;
-  constexpr usize kDimZ = 200;
-  const ShapeType cellTupleShape = {kDimZ, kDimY, kDimX};
+  constexpr usize k_DimX = 200;
+  constexpr usize k_DimY = 200;
+  constexpr usize k_DimZ = 200;
+  const ShapeType cellTupleShape = {k_DimZ, k_DimY, k_DimX};
   const auto benchmarkFile = fs::path(fmt::format("{}/replace_element_attributes_benchmark.dream3d", unit_test::k_BinaryTestOutputDir));
 
   // Stage 1: Build data programmatically and write to .dream3d
   {
     DataStructure buildDS;
     auto* imageGeom = ImageGeom::Create(buildDS, "DataContainer");
-    imageGeom->setDimensions({kDimX, kDimY, kDimZ});
+    imageGeom->setDimensions({k_DimX, k_DimY, k_DimZ});
     imageGeom->setSpacing({1.0f, 1.0f, 1.0f});
     imageGeom->setOrigin({0.0f, 0.0f, 0.0f});
 
@@ -101,21 +101,21 @@ TEST_CASE("SimplnxCore::ReplaceElementAttributesWithNeighborValuesFilter: Benchm
     auto* phasesArray = UnitTest::CreateTestDataArray<int32>(buildDS, "Phases", cellTupleShape, {1}, cellAM->getId());
     auto& phasesStore = phasesArray->getDataStoreRef();
 
-    for(usize z = 0; z < kDimZ; z++)
+    for(usize z = 0; z < k_DimZ; z++)
     {
-      for(usize y = 0; y < kDimY; y++)
+      for(usize y = 0; y < k_DimY; y++)
       {
-        for(usize x = 0; x < kDimX; x++)
+        for(usize x = 0; x < k_DimX; x++)
         {
-          const usize idx = z * kDimX * kDimY + y * kDimX + x;
+          const usize idx = z * k_DimX * k_DimY + y * k_DimX + x;
           phasesStore[idx] = 1;
 
           confStore[idx] = static_cast<float32>((x * 3 + y * 7 + z * 11) % 100) / 100.0f;
 
           const usize eIdx = idx * 3;
-          eulerStore[eIdx] = static_cast<float32>(x) / static_cast<float32>(kDimX);
-          eulerStore[eIdx + 1] = static_cast<float32>(y) / static_cast<float32>(kDimY);
-          eulerStore[eIdx + 2] = static_cast<float32>(z) / static_cast<float32>(kDimZ);
+          eulerStore[eIdx] = static_cast<float32>(x) / static_cast<float32>(k_DimX);
+          eulerStore[eIdx + 1] = static_cast<float32>(y) / static_cast<float32>(k_DimY);
+          eulerStore[eIdx + 2] = static_cast<float32>(z) / static_cast<float32>(k_DimZ);
         }
       }
     }

--- a/src/Plugins/SimplnxCore/test/ReplaceElementAttributesWithNeighborValuesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReplaceElementAttributesWithNeighborValuesTest.cpp
@@ -6,6 +6,7 @@
 #include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
+#include "simplnx/Utilities/AlgorithmDispatch.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include <filesystem>
@@ -24,6 +25,8 @@ const std::string k_ExemplarDataContainer2("DataContainer");
 TEST_CASE("SimplnxCore::ReplaceElementAttributesWithNeighborValuesFilter", "[SimplnxCore][ReplaceElementAttributesWithNeighborValuesFilter]")
 {
   UnitTest::LoadPlugins();
+  bool forceOocAlgo = GENERATE(false);
+  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // Replace Element test data: 1x201x189, EulerAngles (float32, 3-comp) = 455,868 total bytes
   // Z=1 so use smaller threshold to force chunking
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 50000, true);
@@ -72,6 +75,8 @@ TEST_CASE("SimplnxCore::ReplaceElementAttributesWithNeighborValuesFilter", "[Sim
 TEST_CASE("SimplnxCore::ReplaceElementAttributesWithNeighborValuesFilter: Benchmark 200x200x200", "[SimplnxCore][ReplaceElementAttributesWithNeighborValuesFilter][Benchmark]")
 {
   UnitTest::LoadPlugins();
+  bool forceOocAlgo = GENERATE(false);
+  const nx::core::ForceOocAlgorithmGuard guard(forceOocAlgo);
   // 200x200x200, Confidence Index (float32, 1-comp) => 200*200*4 = 160,000 bytes/slice
   const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 160000, true);
 

--- a/src/Plugins/SimplnxCore/test/ReplaceElementAttributesWithNeighborValuesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReplaceElementAttributesWithNeighborValuesTest.cpp
@@ -3,6 +3,8 @@
 #include "SimplnxCore/Filters/ReplaceElementAttributesWithNeighborValuesFilter.hpp"
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
 
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
@@ -22,6 +24,9 @@ const std::string k_ExemplarDataContainer2("DataContainer");
 TEST_CASE("SimplnxCore::ReplaceElementAttributesWithNeighborValuesFilter", "[SimplnxCore][ReplaceElementAttributesWithNeighborValuesFilter]")
 {
   UnitTest::LoadPlugins();
+  // Replace Element test data: 1x201x189, EulerAngles (float32, 3-comp) = 455,868 total bytes
+  // Z=1 so use smaller threshold to force chunking
+  const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 50000, true);
 
   const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_TestFilesDir, "6_6_replace_element_attributes_with_neighbor.tar.gz",
                                                               "6_6_replace_element_attributes_with_neighbor");
@@ -62,4 +67,79 @@ TEST_CASE("SimplnxCore::ReplaceElementAttributesWithNeighborValuesFilter", "[Sim
 #endif
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ReplaceElementAttributesWithNeighborValuesFilter: Benchmark 200x200x200", "[SimplnxCore][ReplaceElementAttributesWithNeighborValuesFilter][Benchmark]")
+{
+  UnitTest::LoadPlugins();
+  // 200x200x200, Confidence Index (float32, 1-comp) => 200*200*4 = 160,000 bytes/slice
+  const UnitTest::PreferencesSentinel prefsSentinel("Zarr", 160000, true);
+
+  constexpr usize kDimX = 200;
+  constexpr usize kDimY = 200;
+  constexpr usize kDimZ = 200;
+  const ShapeType cellTupleShape = {kDimZ, kDimY, kDimX};
+  const auto benchmarkFile = fs::path(fmt::format("{}/replace_element_attributes_benchmark.dream3d", unit_test::k_BinaryTestOutputDir));
+
+  // Stage 1: Build data programmatically and write to .dream3d
+  {
+    DataStructure buildDS;
+    auto* imageGeom = ImageGeom::Create(buildDS, "DataContainer");
+    imageGeom->setDimensions({kDimX, kDimY, kDimZ});
+    imageGeom->setSpacing({1.0f, 1.0f, 1.0f});
+    imageGeom->setOrigin({0.0f, 0.0f, 0.0f});
+
+    auto* cellAM = AttributeMatrix::Create(buildDS, "CellData", cellTupleShape, imageGeom->getId());
+    imageGeom->setCellData(*cellAM);
+
+    auto* confArray = UnitTest::CreateTestDataArray<float32>(buildDS, "Confidence Index", cellTupleShape, {1}, cellAM->getId());
+    auto& confStore = confArray->getDataStoreRef();
+
+    auto* eulerArray = UnitTest::CreateTestDataArray<float32>(buildDS, "EulerAngles", cellTupleShape, {3}, cellAM->getId());
+    auto& eulerStore = eulerArray->getDataStoreRef();
+
+    auto* phasesArray = UnitTest::CreateTestDataArray<int32>(buildDS, "Phases", cellTupleShape, {1}, cellAM->getId());
+    auto& phasesStore = phasesArray->getDataStoreRef();
+
+    for(usize z = 0; z < kDimZ; z++)
+    {
+      for(usize y = 0; y < kDimY; y++)
+      {
+        for(usize x = 0; x < kDimX; x++)
+        {
+          const usize idx = z * kDimX * kDimY + y * kDimX + x;
+          phasesStore[idx] = 1;
+
+          confStore[idx] = static_cast<float32>((x * 3 + y * 7 + z * 11) % 100) / 100.0f;
+
+          const usize eIdx = idx * 3;
+          eulerStore[eIdx] = static_cast<float32>(x) / static_cast<float32>(kDimX);
+          eulerStore[eIdx + 1] = static_cast<float32>(y) / static_cast<float32>(kDimY);
+          eulerStore[eIdx + 2] = static_cast<float32>(z) / static_cast<float32>(kDimZ);
+        }
+      }
+    }
+
+    UnitTest::WriteTestDataStructure(buildDS, benchmarkFile);
+  }
+
+  DataStructure dataStructure = UnitTest::LoadDataStructure(benchmarkFile);
+
+  {
+    ReplaceElementAttributesWithNeighborValuesFilter filter;
+    Arguments args;
+
+    args.insertOrAssign(ReplaceElementAttributesWithNeighborValuesFilter::k_MinConfidence_Key, std::make_any<float32>(0.1F));
+    args.insertOrAssign(ReplaceElementAttributesWithNeighborValuesFilter::k_SelectedComparison_Key, std::make_any<ChoicesParameter::ValueType>(0));
+    args.insertOrAssign(ReplaceElementAttributesWithNeighborValuesFilter::k_Loop_Key, std::make_any<bool>(true));
+    args.insertOrAssign(ReplaceElementAttributesWithNeighborValuesFilter::k_ComparisonDataPath, std::make_any<DataPath>(DataPath({"DataContainer", "CellData", "Confidence Index"})));
+    args.insertOrAssign(ReplaceElementAttributesWithNeighborValuesFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(DataPath({"DataContainer"})));
+
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+    auto executeResult = filter.execute(dataStructure, args, nullptr, IFilter::MessageHandler{[](const IFilter::Message& message) { fmt::print("{}\n", message.message); }});
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+  }
+
+  fs::remove(benchmarkFile);
 }


### PR DESCRIPTION
## Summary

Optimizes all 5 Group C (Multi-Iteration Morphological / Neighbor Replacement) filters for out-of-core performance using Z-slice rolling buffers and sequential per-array data transfer.

### Algorithm: Z-Slice Rolling Buffer

A 3-slice rolling buffer holds the current and adjacent Z-slices in local `std::vector`s. All 6 face-neighbor reads come from RAM buffers instead of the OOC DataStore. Single shared codepath for both in-core and OOC — no DispatchAlgorithm needed. The buffers are lightweight enough (~2-64 MB depending on dataset) that they benefit or are neutral to in-core performance.

**Per-iteration sweep:**
1. Pre-read Z-slices 0 and 1 into buffer slots
2. For each Z from 0 to dimZ-1: read next slice, process all (y, x) from buffers, rotate slots
3. After the full Z-sweep, apply recorded changes to all cell data arrays

**Data transfer optimization:** Changed from `ParallelTaskAlgorithm` (multiple arrays processed concurrently, causing chunk evictions) to sequential per-array-per-voxel processing. Each array's chunks stay cached while all voxels are processed before moving to the next array.

### Per-Filter Changes

**NeighborOrientationCorrelation**
- Z-slice rolling buffer for quaternions (4-comp float32), phases (int32), and confidence index (float32)
- Removed dead `neighborDiffCount` computation (computed but never read)
- Pre-reads all neighbor quats/phases before pairwise comparison loop
- Store bestNeighbor as const reference in transfer functor (avoids 61 MB per-task copy)
- Clear bestNeighbor between cleanup levels to eliminate stale entries

**ErodeDilateBadData**
- Z-slice rolling buffer for FeatureIds
- Transfer changed from `ParallelTaskAlgorithm` to sequential per-array loop

**ErodeDilateCoordinationNumber**
- Z-slice rolling buffer for FeatureIds with in-place update
- Fixed `DataArrayCopyTupleFunctor` by-value DataArray copy to use reference
- Removed redundant second `computeValidFaceNeighbors` call

**ErodeDilateMask**
- Z-slice rolling buffer for both mask and maskCopy arrays
- Replaced `std::vector<bool>` (bit-packed) with `std::vector<uint8>` for direct byte access

**ReplaceElementAttributesWithNeighborValues**
- Z-slice rolling buffer for input comparison array
- Transfer reordered from per-voxel-per-array to per-array-per-voxel
- Added null-check guard for `dynamic_cast<IDataArray&>` on AttributeMatrix children

### Code Quality Fixes
- Removed Doxygen comments from `.cpp` files (documentation belongs in `.hpp` headers only)
- Fixed single-line Doxygen to multi-line format on destructor
- Fixed wrong `@class` tags in algorithm headers (ErodeDilateBadData, ErodeDilateCoordinationNumber, ErodeDilateMask)
- Fixed misleading "highest similarity count" comment to "positive similarity count"
- Renamed benchmark constants from `kDimX` to `k_DimX` convention (all 5 test files)

## Performance (200x200x200 benchmarks)

| Filter | IC Before | IC After | IC Speedup | OOC Before | OOC After | OOC Speedup |
|--------|-----------|----------|------------|------------|-----------|-------------|
| ErodeDilateBadData | 1.37s | 0.31s | **4.42x** | 25.09s | 15.57s | **1.61x** |
| ErodeDilateCoordinationNumber | 0.35s | 0.22s | **1.59x** | 12.43s | 3.13s | **3.97x** |
| ErodeDilateMask | 0.13s | 0.11s | 1.18x | 6.43s | 3.27s | **1.97x** |
| ReplaceElementAttributesWithNeighborValues | 0.35s | 0.24s | **1.46x** | 6.05s | 4.90s | **1.23x** |
| NeighborOrientationCorrelation | 2.19s | 1.57s | **1.39x** | 67.94s | 17.24s | **3.94x** |

### Why This Algorithm Was Chosen

1. **Single shared codepath**: Z-slice buffers are small enough that they don't hurt in-core performance. No need for separate in-core/OOC algorithm classes or DispatchAlgorithm.
2. **Eliminates neighbor chunk thrashing**: All 6-neighbor reads come from RAM buffers, regardless of chunk boundaries.
3. **Sequential transfer prevents cache eviction**: Processing one array at a time keeps that array's chunks in the 6-slot FIFO cache.
4. **Minimal memory overhead**: Buffers are O(3 Z-slices), well under 64 MB for even 1000x1000 datasets.

### Tradeoffs

| Aspect | Original | Optimized (Z-Slice Buffer) |
|--------|----------|---------------------------|
| **In-core speed** | Baseline | 1.18x-4.42x faster (buffer reads are cache-friendly + bug fixes) |
| **OOC speed** | 3x-110x slowdown | 1.23x-3.97x speedup over baseline OOC |
| **RAM usage** | O(1) per-voxel accesses | O(3 Z-slices) buffer |
| **Code complexity** | Simple neighbor reads | Buffer management + slot rotation |
| **Maintenance** | Single code path | Single code path (no dispatch) |

### Optimization Ceiling Analysis

The filter-level optimizations are at their ceiling. The remaining OOC overhead is dominated by per-element `operator[]` overhead in `ZarrStore`. Each `getValue()`/`setValue()` call acquires and releases a mutex lock (`std::lock_guard<std::mutex>`), plus performs a per-element Zarr chunk lookup (converting flat index to N-D chunk position, scanning the 6-slot FIFO cache, indexing into the chunk). Per-element overhead: ~55-75ns vs ~1ns for in-core `DataStore` (raw pointer access). This is intrinsic to the `ZarrStore` implementation and cannot be avoided by any filter-level algorithm change.

**Infrastructure-level changes that would improve further:**

1. **Bulk read/write API on `AbstractDataStore`**: Add `getValues(startIndex, count, T* dest)` and `setValues(startIndex, count, const T* src)` virtual methods. `DataStore` implements with `std::memcpy`. `ZarrStore` implements with a single mutex lock around a bulk loop — eliminating millions of redundant mutex lock/unlock cycles in the transfer phases.

2. **Chunk-level bulk transfer in FileCore**: A truly bulk Zarr API that reads/writes contiguous ranges directly from/to the chunk's internal buffer via `memcpy`, bypassing the per-element chunk lookup entirely. Estimated 3-5x additional improvement on transfer phases. Requires changes deep inside the FileCore library's `IArray`/`Block` classes.

3. **Larger or per-array FIFO cache**: The current 6-slot global FIFO means sequential per-array transfer is required to avoid cache thrashing. Per-array cache isolation or a larger cache would allow parallel array processing again.

These are infrastructure-level changes that would benefit all OOC-optimized filters, not just this group.

## Test Plan
- [x] In-core unit tests pass for all 5 filters (7/7 tests)
- [x] Out-of-core unit tests pass for all 5 filters (7/7 tests, verified via "chunk shape:" output)
- [x] Results match exemplar data identically on both configurations
- [x] 200x200x200 benchmark test cases added for all 5 filters
- [x] Post-review-fix benchmarks confirm no regressions (small improvements across the board)