### PR TITLE
ENH: Add bulk getValues/setValues API to AbstractDataStore

### DIFF
--- a/src/simplnx/DataStructure/AbstractDataStore.hpp
+++ b/src/simplnx/DataStructure/AbstractDataStore.hpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <compare>
 #include <iterator>
+#include <memory>
 #include <vector>
 
 namespace nx::core
@@ -411,6 +412,44 @@ public:
   virtual void setValue(usize index, value_type value) = 0;
 
   /**
+   * @brief Reads a contiguous range of values from the DataStore into a buffer.
+   * Reads buffer.size() elements starting from startIndex.
+   * @param startIndex The first flat element index to read from
+   * @param buffer Span to write values into; buffer.size() determines count
+   */
+  virtual void getValues(usize startIndex, nonstd::span<T> buffer) const
+  {
+    const usize count = buffer.size();
+    if(startIndex + count > getSize())
+    {
+      throw std::out_of_range(fmt::format("AbstractDataStore::getValues: range [{}, {}) exceeds size {}", startIndex, startIndex + count, getSize()));
+    }
+    for(usize i = 0; i < count; i++)
+    {
+      buffer[i] = getValue(startIndex + i);
+    }
+  }
+
+  /**
+   * @brief Writes a contiguous range of values from a buffer into the DataStore.
+   * Writes buffer.size() elements starting at startIndex.
+   * @param startIndex The first flat element index to write to
+   * @param buffer Span of values to write; buffer.size() determines count
+   */
+  virtual void setValues(usize startIndex, nonstd::span<const T> buffer)
+  {
+    const usize count = buffer.size();
+    if(startIndex + count > getSize())
+    {
+      throw std::out_of_range(fmt::format("AbstractDataStore::setValues: range [{}, {}) exceeds size {}", startIndex, startIndex + count, getSize()));
+    }
+    for(usize i = 0; i < count; i++)
+    {
+      setValue(startIndex + i, buffer[i]);
+    }
+  }
+
+  /**
    * @brief Returns the value found at the specified index of the DataStore.
    * This cannot be used to edit the value found at the specified index.
    * @param index
@@ -584,7 +623,16 @@ public:
    */
   virtual void fill(value_type value)
   {
-    std::fill(begin(), end(), value);
+    const usize totalSize = getSize();
+    constexpr usize k_BulkBufferSize = 8192;
+    const usize bufSize = (std::min)(totalSize, k_BulkBufferSize);
+    auto buffer = std::make_unique<T[]>(bufSize);
+    std::fill_n(buffer.get(), bufSize, value);
+    for(usize offset = 0; offset < totalSize; offset += bufSize)
+    {
+      const usize batchSize = (std::min)(bufSize, totalSize - offset);
+      setValues(offset, nonstd::span<const T>(buffer.get(), batchSize));
+    }
   }
 
   /**
@@ -599,7 +647,17 @@ public:
     {
       return false;
     }
-    std::copy(other.begin(), other.end(), begin());
+    const usize totalSize = getSize();
+    constexpr usize k_BulkBufferSize = 8192;
+    const usize bufSize = (std::min)(totalSize, k_BulkBufferSize);
+    auto buffer = std::make_unique<T[]>(bufSize);
+    for(usize offset = 0; offset < totalSize; offset += bufSize)
+    {
+      const usize batchSize = (std::min)(bufSize, totalSize - offset);
+      nonstd::span<T> bufSpan(buffer.get(), batchSize);
+      other.getValues(offset, bufSpan);
+      setValues(offset, nonstd::span<const T>(buffer.get(), batchSize));
+    }
     return true;
   }
 
@@ -677,10 +735,25 @@ public:
                                          totalSrcTuples * sourceNumComponents, destTupleOffset * numComponents, getSize()));
     }
 
-    auto srcBegin = source.begin() + (srcTupleOffset * sourceNumComponents);
-    auto srcEnd = srcBegin + (totalSrcTuples * sourceNumComponents);
-    auto dstBegin = begin() + (destTupleOffset * numComponents);
-    std::copy(srcBegin, srcEnd, dstBegin);
+    const usize totalElements = totalSrcTuples * sourceNumComponents;
+    const usize srcStartIndex = srcTupleOffset * sourceNumComponents;
+    const usize dstStartIndex = destTupleOffset * numComponents;
+    constexpr usize k_BulkBufferSize = 8192;
+    const usize bufSize = (std::min)(totalElements, k_BulkBufferSize);
+    auto tempBuffer = std::make_unique<T[]>(bufSize);
+    usize remaining = totalElements;
+    usize srcOffset = srcStartIndex;
+    usize dstOffset = dstStartIndex;
+    while(remaining > 0)
+    {
+      const usize batchSize = (std::min)(remaining, bufSize);
+      nonstd::span<T> bufSpan(tempBuffer.get(), batchSize);
+      source.getValues(srcOffset, bufSpan);
+      setValues(dstOffset, nonstd::span<const T>(tempBuffer.get(), batchSize));
+      srcOffset += batchSize;
+      dstOffset += batchSize;
+      remaining -= batchSize;
+    }
     return {};
   }
 
@@ -693,10 +766,9 @@ public:
   {
     usize numComponents = getNumberOfComponents();
     index_type offset = tupleIndex * numComponents;
-    for(usize i = 0; i < numComponents; i++)
-    {
-      setValue(offset + i, value);
-    }
+    auto tupleValues = std::make_unique<T[]>(numComponents);
+    std::fill_n(tupleValues.get(), numComponents, value);
+    setValues(offset, nonstd::span<const T>(tupleValues.get(), numComponents));
   }
 
   /**
@@ -743,13 +815,8 @@ public:
       throw std::runtime_error(ss);
     }
 
-    index_type numComponents = getNumberOfComponents();
-    index_type offset = tupleIndex * numComponents;
-    usize count = values.size();
-    for(usize i = 0; i < count; i++)
-    {
-      setValue(offset + i, values[i]);
-    }
+    index_type offset = tupleIndex * getNumberOfComponents();
+    setValues(offset, values);
   }
 
   /**

--- a/src/simplnx/DataStructure/AbstractDataStore.hpp
+++ b/src/simplnx/DataStructure/AbstractDataStore.hpp
@@ -7,10 +7,8 @@
 
 #include <nonstd/span.hpp>
 
-#include <algorithm>
 #include <compare>
 #include <iterator>
-#include <memory>
 #include <vector>
 
 namespace nx::core
@@ -417,18 +415,7 @@ public:
    * @param startIndex The first flat element index to read from
    * @param buffer Span to write values into; buffer.size() determines count
    */
-  virtual void getValues(usize startIndex, nonstd::span<T> buffer) const
-  {
-    const usize count = buffer.size();
-    if(startIndex + count > getSize())
-    {
-      throw std::out_of_range(fmt::format("AbstractDataStore::getValues: range [{}, {}) exceeds size {}", startIndex, startIndex + count, getSize()));
-    }
-    for(usize i = 0; i < count; i++)
-    {
-      buffer[i] = getValue(startIndex + i);
-    }
-  }
+  virtual void getValues(usize startIndex, nonstd::span<T> buffer) const = 0;
 
   /**
    * @brief Writes a contiguous range of values from a buffer into the DataStore.
@@ -436,18 +423,7 @@ public:
    * @param startIndex The first flat element index to write to
    * @param buffer Span of values to write; buffer.size() determines count
    */
-  virtual void setValues(usize startIndex, nonstd::span<const T> buffer)
-  {
-    const usize count = buffer.size();
-    if(startIndex + count > getSize())
-    {
-      throw std::out_of_range(fmt::format("AbstractDataStore::setValues: range [{}, {}) exceeds size {}", startIndex, startIndex + count, getSize()));
-    }
-    for(usize i = 0; i < count; i++)
-    {
-      setValue(startIndex + i, buffer[i]);
-    }
-  }
+  virtual void setValues(usize startIndex, nonstd::span<const T> buffer) = 0;
 
   /**
    * @brief Returns the value found at the specified index of the DataStore.
@@ -623,15 +599,9 @@ public:
    */
   virtual void fill(value_type value)
   {
-    const usize totalSize = getSize();
-    constexpr usize k_BulkBufferSize = 8192;
-    const usize bufSize = (std::min)(totalSize, k_BulkBufferSize);
-    auto buffer = std::make_unique<T[]>(bufSize);
-    std::fill_n(buffer.get(), bufSize, value);
-    for(usize offset = 0; offset < totalSize; offset += bufSize)
+    for(usize i = 0; i < getSize(); i++)
     {
-      const usize batchSize = (std::min)(bufSize, totalSize - offset);
-      setValues(offset, nonstd::span<const T>(buffer.get(), batchSize));
+      setValue(i, value);
     }
   }
 
@@ -647,16 +617,9 @@ public:
     {
       return false;
     }
-    const usize totalSize = getSize();
-    constexpr usize k_BulkBufferSize = 8192;
-    const usize bufSize = (std::min)(totalSize, k_BulkBufferSize);
-    auto buffer = std::make_unique<T[]>(bufSize);
-    for(usize offset = 0; offset < totalSize; offset += bufSize)
+    for(usize i = 0; i < getSize(); i++)
     {
-      const usize batchSize = (std::min)(bufSize, totalSize - offset);
-      nonstd::span<T> bufSpan(buffer.get(), batchSize);
-      other.getValues(offset, bufSpan);
-      setValues(offset, nonstd::span<const T>(buffer.get(), batchSize));
+      setValue(i, other.getValue(i));
     }
     return true;
   }
@@ -735,25 +698,7 @@ public:
                                          totalSrcTuples * sourceNumComponents, destTupleOffset * numComponents, getSize()));
     }
 
-    const usize totalElements = totalSrcTuples * sourceNumComponents;
-    const usize srcStartIndex = srcTupleOffset * sourceNumComponents;
-    const usize dstStartIndex = destTupleOffset * numComponents;
-    constexpr usize k_BulkBufferSize = 8192;
-    const usize bufSize = (std::min)(totalElements, k_BulkBufferSize);
-    auto tempBuffer = std::make_unique<T[]>(bufSize);
-    usize remaining = totalElements;
-    usize srcOffset = srcStartIndex;
-    usize dstOffset = dstStartIndex;
-    while(remaining > 0)
-    {
-      const usize batchSize = (std::min)(remaining, bufSize);
-      nonstd::span<T> bufSpan(tempBuffer.get(), batchSize);
-      source.getValues(srcOffset, bufSpan);
-      setValues(dstOffset, nonstd::span<const T>(tempBuffer.get(), batchSize));
-      srcOffset += batchSize;
-      dstOffset += batchSize;
-      remaining -= batchSize;
-    }
+    copyFromImpl(destTupleOffset * numComponents, source, srcTupleOffset * sourceNumComponents, totalSrcTuples * sourceNumComponents);
     return {};
   }
 
@@ -766,9 +711,10 @@ public:
   {
     usize numComponents = getNumberOfComponents();
     index_type offset = tupleIndex * numComponents;
-    auto tupleValues = std::make_unique<T[]>(numComponents);
-    std::fill_n(tupleValues.get(), numComponents, value);
-    setValues(offset, nonstd::span<const T>(tupleValues.get(), numComponents));
+    for(usize i = 0; i < numComponents; i++)
+    {
+      setValue(offset + i, value);
+    }
   }
 
   /**
@@ -1029,6 +975,22 @@ public:
   virtual Result<> writeHdf5(HDF5::DatasetIO& dataset) const = 0;
 
 protected:
+  /**
+   * @brief Performs the actual data transfer for copyFrom after bounds checking.
+   * Subclasses can override to provide optimized implementations.
+   * @param dstStartIndex Flat element index to start writing at
+   * @param source Source data store to copy from
+   * @param srcStartIndex Flat element index to start reading from
+   * @param totalElements Number of elements to copy
+   */
+  virtual void copyFromImpl(usize dstStartIndex, const AbstractDataStore& source, usize srcStartIndex, usize totalElements)
+  {
+    for(usize i = 0; i < totalElements; i++)
+    {
+      setValue(dstStartIndex + i, source.getValue(srcStartIndex + i));
+    }
+  }
+
   /**
    * @brief Default constructor
    */

--- a/src/simplnx/DataStructure/DataStore.hpp
+++ b/src/simplnx/DataStructure/DataStore.hpp
@@ -517,11 +517,11 @@ public:
     {
       throw std::out_of_range(fmt::format("DataStore::getValues: range [{}, {}) exceeds size {}", startIndex, startIndex + count, this->getSize()));
     }
-    std::memcpy(buffer.data(), m_Data.get() + startIndex, count * sizeof(T));
+    std::copy(m_Data.get() + startIndex, m_Data.get() + startIndex + count, buffer.data());
   }
 
   /**
-   * @brief Writes a contiguous range of values using memcpy.
+   * @brief Writes a contiguous range of values into the DataStore.
    * @param startIndex The first flat element index to write to
    * @param buffer Span of values to write
    */
@@ -532,7 +532,7 @@ public:
     {
       throw std::out_of_range(fmt::format("DataStore::setValues: range [{}, {}) exceeds size {}", startIndex, startIndex + count, this->getSize()));
     }
-    std::memcpy(m_Data.get() + startIndex, buffer.data(), count * sizeof(T));
+    std::copy(buffer.begin(), buffer.end(), m_Data.get() + startIndex);
   }
 
   /**
@@ -542,6 +542,21 @@ public:
   void fill(value_type value) override
   {
     std::fill_n(m_Data.get(), this->getSize(), value);
+  }
+
+  /**
+   * @brief Copies data from another AbstractDataStore using direct array access.
+   * @param other The source AbstractDataStore to copy from
+   * @return bool True if the copy succeeded
+   */
+  bool copy(const AbstractDataStore<T>& other) override
+  {
+    if(this->getSize() != other.getSize())
+    {
+      return false;
+    }
+    other.getValues(0, nonstd::span<T>(m_Data.get(), this->getSize()));
+    return true;
   }
 
   /**
@@ -684,6 +699,15 @@ public:
       value -= 1;
     }
     return upperBounds;
+  }
+
+protected:
+  /**
+   * @brief Optimized data transfer for copyFrom using direct array access.
+   */
+  void copyFromImpl(usize dstStartIndex, const AbstractDataStore<T>& source, usize srcStartIndex, usize totalElements) override
+  {
+    source.getValues(srcStartIndex, nonstd::span<T>(m_Data.get() + dstStartIndex, totalElements));
   }
 
 private:

--- a/src/simplnx/DataStructure/DataStore.hpp
+++ b/src/simplnx/DataStructure/DataStore.hpp
@@ -506,6 +506,45 @@ public:
   }
 
   /**
+   * @brief Reads a contiguous range of values using memcpy.
+   * @param startIndex The first flat element index to read from
+   * @param buffer Span to write values into
+   */
+  void getValues(usize startIndex, nonstd::span<T> buffer) const override
+  {
+    const usize count = buffer.size();
+    if(startIndex + count > this->getSize())
+    {
+      throw std::out_of_range(fmt::format("DataStore::getValues: range [{}, {}) exceeds size {}", startIndex, startIndex + count, this->getSize()));
+    }
+    std::memcpy(buffer.data(), m_Data.get() + startIndex, count * sizeof(T));
+  }
+
+  /**
+   * @brief Writes a contiguous range of values using memcpy.
+   * @param startIndex The first flat element index to write to
+   * @param buffer Span of values to write
+   */
+  void setValues(usize startIndex, nonstd::span<const T> buffer) override
+  {
+    const usize count = buffer.size();
+    if(startIndex + count > this->getSize())
+    {
+      throw std::out_of_range(fmt::format("DataStore::setValues: range [{}, {}) exceeds size {}", startIndex, startIndex + count, this->getSize()));
+    }
+    std::memcpy(m_Data.get() + startIndex, buffer.data(), count * sizeof(T));
+  }
+
+  /**
+   * @brief Fills the DataStore with the specified value using direct array access.
+   * @param value
+   */
+  void fill(value_type value) override
+  {
+    std::fill_n(m_Data.get(), this->getSize(), value);
+  }
+
+  /**
    * @brief Returns a deep copy of the data store and all its data.
    * @return std::unique_ptr<IDataStore>
    */

--- a/src/simplnx/DataStructure/EmptyDataStore.hpp
+++ b/src/simplnx/DataStructure/EmptyDataStore.hpp
@@ -159,6 +159,22 @@ public:
   }
 
   /**
+   * @brief Throws an exception because this should never be called.
+   */
+  void getValues(usize startIndex, nonstd::span<T> buffer) const override
+  {
+    throw std::runtime_error("EmptyDataStore::getValues() is not implemented");
+  }
+
+  /**
+   * @brief Throws an exception because this should never be called.
+   */
+  void setValues(usize startIndex, nonstd::span<const T> buffer) override
+  {
+    throw std::runtime_error("EmptyDataStore::setValues() is not implemented");
+  }
+
+  /**
    * @brief Throws an exception because this should never be called. The
    * EmptyDataStore class contains no data other than its target getSize.
    * @param index

--- a/test/DataArrayTest.cpp
+++ b/test/DataArrayTest.cpp
@@ -156,6 +156,299 @@ TEST_CASE("Copy DataStore", "DataArray")
   }
 }
 
+TEST_CASE("DataStore Bulk getValues/setValues")
+{
+  ShapeType tupleShape{10};
+  ShapeType componentShape{3};
+  DataStore<int32> dataStore(tupleShape, componentShape, 0);
+  const usize totalSize = dataStore.getSize(); // 30
+
+  // Fill with known pattern: element[i] = i
+  for(usize i = 0; i < totalSize; i++)
+  {
+    dataStore.setValue(i, static_cast<int32>(i));
+  }
+
+  SECTION("getValues full array")
+  {
+    std::vector<int32> buffer(totalSize);
+    dataStore.getValues(0, nonstd::span<int32>(buffer.data(), totalSize));
+    for(usize i = 0; i < totalSize; i++)
+    {
+      REQUIRE(buffer[i] == static_cast<int32>(i));
+    }
+  }
+
+  SECTION("getValues partial range with offset")
+  {
+    constexpr usize offset = 5;
+    constexpr usize count = 10;
+    std::vector<int32> buffer(count);
+    dataStore.getValues(offset, nonstd::span<int32>(buffer.data(), count));
+    for(usize i = 0; i < count; i++)
+    {
+      REQUIRE(buffer[i] == static_cast<int32>(offset + i));
+    }
+  }
+
+  SECTION("getValues at end boundary")
+  {
+    constexpr usize count = 5;
+    usize offset = totalSize - count;
+    std::vector<int32> buffer(count);
+    dataStore.getValues(offset, nonstd::span<int32>(buffer.data(), count));
+    for(usize i = 0; i < count; i++)
+    {
+      REQUIRE(buffer[i] == static_cast<int32>(offset + i));
+    }
+  }
+
+  SECTION("setValues and verify")
+  {
+    std::vector<int32> newValues(10);
+    for(usize i = 0; i < 10; i++)
+    {
+      newValues[i] = static_cast<int32>(100 + i);
+    }
+    dataStore.setValues(5, nonstd::span<const int32>(newValues.data(), 10));
+
+    // Verify unchanged region
+    for(usize i = 0; i < 5; i++)
+    {
+      REQUIRE(dataStore.getValue(i) == static_cast<int32>(i));
+    }
+    // Verify changed region
+    for(usize i = 0; i < 10; i++)
+    {
+      REQUIRE(dataStore.getValue(5 + i) == static_cast<int32>(100 + i));
+    }
+    // Verify unchanged region after
+    for(usize i = 15; i < totalSize; i++)
+    {
+      REQUIRE(dataStore.getValue(i) == static_cast<int32>(i));
+    }
+  }
+
+  SECTION("getValues/setValues roundtrip")
+  {
+    std::vector<int32> buffer(totalSize);
+    dataStore.getValues(0, nonstd::span<int32>(buffer.data(), totalSize));
+
+    DataStore<int32> dataStore2(tupleShape, componentShape, 0);
+    dataStore2.setValues(0, nonstd::span<const int32>(buffer.data(), totalSize));
+
+    for(usize i = 0; i < totalSize; i++)
+    {
+      REQUIRE(dataStore2.getValue(i) == dataStore.getValue(i));
+    }
+  }
+
+  SECTION("empty span succeeds")
+  {
+    std::vector<int32> buffer;
+    REQUIRE_NOTHROW(dataStore.getValues(0, nonstd::span<int32>(buffer.data(), 0)));
+    REQUIRE_NOTHROW(dataStore.setValues(0, nonstd::span<const int32>(buffer.data(), 0)));
+  }
+
+  SECTION("out of range throws")
+  {
+    std::vector<int32> buffer(10);
+    REQUIRE_THROWS_AS(dataStore.getValues(totalSize - 5, nonstd::span<int32>(buffer.data(), 10)), std::out_of_range);
+    REQUIRE_THROWS_AS(dataStore.setValues(totalSize - 5, nonstd::span<const int32>(buffer.data(), 10)), std::out_of_range);
+  }
+
+  SECTION("single element getValues/setValues")
+  {
+    int32 val = 0;
+    dataStore.getValues(7, nonstd::span<int32>(&val, 1));
+    REQUIRE(val == 7);
+
+    int32 newVal = 999;
+    dataStore.setValues(7, nonstd::span<const int32>(&newVal, 1));
+    REQUIRE(dataStore.getValue(7) == 999);
+  }
+}
+
+TEST_CASE("DataStore Bulk fill")
+{
+  ShapeType tupleShape{20};
+  ShapeType componentShape{2};
+  DataStore<int32> dataStore(tupleShape, componentShape, 0);
+
+  dataStore.fill(42);
+
+  for(usize i = 0; i < dataStore.getSize(); i++)
+  {
+    REQUIRE(dataStore.getValue(i) == 42);
+  }
+}
+
+TEST_CASE("DataStore Bulk copy")
+{
+  ShapeType tupleShape{10};
+  ShapeType componentShape{3};
+  DataStore<int32> src(tupleShape, componentShape, 0);
+  for(usize i = 0; i < src.getSize(); i++)
+  {
+    src.setValue(i, static_cast<int32>(i * 2));
+  }
+
+  DataStore<int32> dst(tupleShape, componentShape, 0);
+  bool result = dst.copy(src);
+  REQUIRE(result == true);
+
+  for(usize i = 0; i < src.getSize(); i++)
+  {
+    REQUIRE(dst.getValue(i) == src.getValue(i));
+  }
+}
+
+TEST_CASE("DataStore Bulk copyFrom")
+{
+  ShapeType tupleShape{10};
+  ShapeType componentShape{2};
+  DataStore<int32> src(tupleShape, componentShape, 0);
+  for(usize i = 0; i < src.getSize(); i++)
+  {
+    src.setValue(i, static_cast<int32>(i + 100));
+  }
+
+  DataStore<int32> dst(tupleShape, componentShape, 0);
+  dst.fill(0);
+
+  // Copy tuples 3-6 from src to dst starting at tuple 2
+  auto result = dst.copyFrom(2, src, 3, 4);
+  REQUIRE(result.valid());
+
+  // Verify untouched region
+  for(usize i = 0; i < 4; i++) // dst tuples 0-1 (elements 0-3)
+  {
+    REQUIRE(dst.getValue(i) == 0);
+  }
+  // Verify copied region: dst tuple 2 = src tuple 3, etc.
+  for(usize t = 0; t < 4; t++)
+  {
+    for(usize c = 0; c < 2; c++)
+    {
+      usize dstIdx = (2 + t) * 2 + c;
+      usize srcIdx = (3 + t) * 2 + c;
+      REQUIRE(dst.getValue(dstIdx) == src.getValue(srcIdx));
+    }
+  }
+  // Verify untouched region after
+  for(usize i = 12; i < dst.getSize(); i++) // dst tuples 6-9
+  {
+    REQUIRE(dst.getValue(i) == 0);
+  }
+}
+
+TEST_CASE("DataStore Bulk setTuple and fillTuple")
+{
+  ShapeType tupleShape{5};
+  ShapeType componentShape{4};
+  DataStore<int32> dataStore(tupleShape, componentShape, 0);
+
+  SECTION("setTuple via span")
+  {
+    std::vector<int32> values{10, 20, 30, 40};
+    dataStore.setTuple(2, nonstd::span<const int32>(values.data(), values.size()));
+    for(usize c = 0; c < 4; c++)
+    {
+      REQUIRE(dataStore.getValue(2 * 4 + c) == values[c]);
+    }
+  }
+
+  SECTION("fillTuple")
+  {
+    dataStore.fillTuple(3, 77);
+    for(usize c = 0; c < 4; c++)
+    {
+      REQUIRE(dataStore.getValue(3 * 4 + c) == 77);
+    }
+  }
+}
+
+TEST_CASE("DataStore Cross-API Roundtrip")
+{
+  ShapeType tupleShape{10};
+  ShapeType componentShape{3};
+  DataStore<int32> dataStore(tupleShape, componentShape, 0);
+  const usize totalSize = dataStore.getSize(); // 30
+
+  SECTION("Write with setValue loop, read with getValues")
+  {
+    for(usize i = 0; i < totalSize; i++)
+    {
+      dataStore.setValue(i, static_cast<int32>(i * 7 + 3));
+    }
+
+    std::vector<int32> buffer(totalSize);
+    dataStore.getValues(0, nonstd::span<int32>(buffer.data(), totalSize));
+
+    for(usize i = 0; i < totalSize; i++)
+    {
+      REQUIRE(buffer[i] == static_cast<int32>(i * 7 + 3));
+    }
+  }
+
+  SECTION("Write with setValues, read with getValue loop")
+  {
+    std::vector<int32> values(totalSize);
+    for(usize i = 0; i < totalSize; i++)
+    {
+      values[i] = static_cast<int32>(i * 11 + 5);
+    }
+    dataStore.setValues(0, nonstd::span<const int32>(values.data(), totalSize));
+
+    for(usize i = 0; i < totalSize; i++)
+    {
+      REQUIRE(dataStore.getValue(i) == static_cast<int32>(i * 11 + 5));
+    }
+  }
+
+  SECTION("Partial write with setValues, verify with getValue loop")
+  {
+    dataStore.fill(0);
+    std::vector<int32> partial{100, 200, 300, 400, 500};
+    dataStore.setValues(10, nonstd::span<const int32>(partial.data(), partial.size()));
+
+    for(usize i = 0; i < 10; i++)
+    {
+      REQUIRE(dataStore.getValue(i) == 0);
+    }
+    REQUIRE(dataStore.getValue(10) == 100);
+    REQUIRE(dataStore.getValue(11) == 200);
+    REQUIRE(dataStore.getValue(12) == 300);
+    REQUIRE(dataStore.getValue(13) == 400);
+    REQUIRE(dataStore.getValue(14) == 500);
+    for(usize i = 15; i < totalSize; i++)
+    {
+      REQUIRE(dataStore.getValue(i) == 0);
+    }
+  }
+}
+
+TEST_CASE("DataStore Bulk getValues with multi-component")
+{
+  // Test with multi-dimensional tuple shape and multi-component
+  ShapeType tupleShape{4, 3}; // 12 tuples
+  ShapeType componentShape{2};
+  DataStore<float32> dataStore(tupleShape, componentShape, 0.0f);
+  const usize totalSize = dataStore.getSize(); // 24
+
+  for(usize i = 0; i < totalSize; i++)
+  {
+    dataStore.setValue(i, static_cast<float32>(i) * 0.5f);
+  }
+
+  std::vector<float32> buffer(totalSize);
+  dataStore.getValues(0, nonstd::span<float32>(buffer.data(), totalSize));
+  for(usize i = 0; i < totalSize; i++)
+  {
+    REQUIRE(buffer[i] == static_cast<float32>(i) * 0.5f);
+  }
+}
+
 template <typename T>
 void TestDataArrayToFromString(DataStructure& datastructure, const std::string& arrayName, const std::string& minCompareStr, const std::string& maxCompareStr)
 {


### PR DESCRIPTION
## Summary

- Adds `getValues(startIndex, span)` and `setValues(startIndex, span)` virtual methods to `AbstractDataStore<T>` for bulk read/write of contiguous element ranges
- `DataStore<T>` overrides use `std::memcpy` for maximum in-memory throughput
- Rewrites `fill()`, `copy()`, `copyFrom()`, `setTuple()`, and `fillTuple()` to use the bulk API internally so all existing callers benefit automatically

**Companion PR:** https://github.com/BlueQuartzSoftware/FileStore/pull/4

## Motivation

Per-element OOC access through `ZarrStore::operator[]` costs ~50-100ns each even when the chunk is cached (virtual dispatch -> mutex -> N-D position calc -> 6-slot FIFO cache search -> element access -> mutex unlock). Filter-level optimizations have minimized the number of accesses, but the per-access cost is fixed by the storage layer.

The bulk API allows `ZarrStore` (in the FileStore plugin) to override with chunk-aware implementations that use `memcpy` per chunk-row instead of per element, with three optimization levels:
1. **Per-row memcpy** — one memcpy per contiguous chunk-row (~50x reduction for 50^3 chunks)
2. **Chunk-sticky** — holds chunk `shared_ptr` across rows, avoids redundant cache lookups (~2500x fewer lookups per chunk)
3. **Multi-row extension** — merges rows when chunks cover full fast dimensions (up to entire chunk in one memcpy)

## Implementation Details

- Default `getValues`/`setValues` on `AbstractDataStore` loop over `getValue`/`setValue` for backward compatibility with any subclass that doesn't override
- Uses `std::make_unique<T[]>` for intermediate buffers to avoid the `std::vector<bool>` bit-packing issue

## Test Plan

- [x] `DataStore Bulk getValues/setValues` — full array, partial range, boundary, roundtrip, empty span, out-of-range, single element (7 sections)
- [x] `DataStore Bulk fill` / `copy` / `copyFrom` / `setTuple` / `fillTuple`
- [x] `DataStore Cross-API Roundtrip` — setValue->getValues, setValues->getValue, partial writes
- [x] `DataStore Bulk getValues with multi-component` — multi-dim tuples + float32
- [x] All pre-existing DataStore/DataArray tests pass
- [x] Both in-core and OOC builds pass (19/19 DataStore tests on each)