### PR TITLE
DOC: Add standardized ChoicesParameter descriptions to filter docs

### DIFF
--- a/src/Plugins/ITKImageProcessing/docs/ITKBinaryDilateImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKBinaryDilateImageFilter.md
@@ -25,6 +25,15 @@ for arbitrary size and shape". IEEE Transactions on Image Processing. Vol. 9. No
 
 ![](Images/ITKBinaryDilation.png)
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKBinaryDilateImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKBinaryDilateImageFilter.md
@@ -29,10 +29,10 @@ for arbitrary size and shape". IEEE Transactions on Image Processing. Vol. 9. No
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKBinaryErodeImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKBinaryErodeImageFilter.md
@@ -29,10 +29,10 @@ for arbitrary size and shape". IEEE Transactions on Image Processing. Vol. 9. No
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKBinaryErodeImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKBinaryErodeImageFilter.md
@@ -25,6 +25,15 @@ for arbitrary size and shape". IEEE Transactions on Image Processing. Vol. 9. No
 
 ![](Images/ITKBinaryErosion.png)
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKBinaryMorphologicalClosingImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKBinaryMorphologicalClosingImageFilter.md
@@ -28,10 +28,10 @@ This code was contributed in the Insight Journal paper: "Binary morphological cl
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKBinaryMorphologicalClosingImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKBinaryMorphologicalClosingImageFilter.md
@@ -24,6 +24,15 @@ This code was contributed in the Insight Journal paper: "Binary morphological cl
 
 ![](Images/ITKBinaryClosing.png)
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKBinaryMorphologicalOpeningImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKBinaryMorphologicalOpeningImageFilter.md
@@ -24,6 +24,15 @@ This code was contributed in the Insight Journal paper: "Binary morphological cl
 
 ![](Images/ITKBinaryOpening.png)
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKBinaryMorphologicalOpeningImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKBinaryMorphologicalOpeningImageFilter.md
@@ -28,10 +28,10 @@ This code was contributed in the Insight Journal paper: "Binary morphological cl
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKBinaryOpeningByReconstructionImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKBinaryOpeningByReconstructionImageFilter.md
@@ -26,10 +26,10 @@ This implementation was taken from the Insight Journal paper: <https://www.insig
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKBinaryOpeningByReconstructionImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKBinaryOpeningByReconstructionImageFilter.md
@@ -22,6 +22,15 @@ This implementation was taken from the Insight Journal paper: <https://www.insig
 
 ![](Images/ITKOpeningByReconstruction.png)
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKBlackTopHatImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKBlackTopHatImageFilter.md
@@ -21,6 +21,15 @@ Top-hats are described in Chapter 4.5 of Pierre Soille's book "Morphological Ima
 ![](Images/ITKBlackTopHat_1.png)
 ![](Images/ITKBlackTopHat_2.png)
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKBlackTopHatImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKBlackTopHatImageFilter.md
@@ -25,10 +25,10 @@ Top-hats are described in Chapter 4.5 of Pierre Soille's book "Morphological Ima
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKClosingByReconstructionImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKClosingByReconstructionImageFilter.md
@@ -25,6 +25,15 @@ Applications", Second Edition, Springer, 2003.
 
 - GrayscaleMorphologicalClosingImageFilter
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKClosingByReconstructionImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKClosingByReconstructionImageFilter.md
@@ -29,10 +29,10 @@ Applications", Second Edition, Springer, 2003.
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKDilateObjectMorphologyImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKDilateObjectMorphologyImageFilter.md
@@ -18,10 +18,10 @@ If a pixel's value is equal to the object value and the pixel is adjacent to a n
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKDilateObjectMorphologyImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKDilateObjectMorphologyImageFilter.md
@@ -14,6 +14,15 @@ If a pixel's value is equal to the object value and the pixel is adjacent to a n
 
 - BinaryDilateImageFilter
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKErodeObjectMorphologyImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKErodeObjectMorphologyImageFilter.md
@@ -18,10 +18,10 @@ If the pixel covered by the center of the kernel has the pixel value ObjectValue
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKErodeObjectMorphologyImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKErodeObjectMorphologyImageFilter.md
@@ -14,6 +14,15 @@ If the pixel covered by the center of the kernel has the pixel value ObjectValue
 
 - BinaryErodeImageFilter
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleDilateImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleDilateImageFilter.md
@@ -14,6 +14,15 @@ The structuring element is assumed to be composed of binary values (zero or one)
 
 ![](Images/ITKGrayscaleDilation.png)
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleDilateImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleDilateImageFilter.md
@@ -18,10 +18,10 @@ The structuring element is assumed to be composed of binary values (zero or one)
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleErodeImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleErodeImageFilter.md
@@ -18,10 +18,10 @@ The structuring element is assumed to be composed of binary values (zero or one)
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleErodeImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleErodeImageFilter.md
@@ -14,6 +14,15 @@ The structuring element is assumed to be composed of binary values (zero or one)
 
 ![](Images/ITKGrayscaleErosion.png)
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleMorphologicalClosingImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleMorphologicalClosingImageFilter.md
@@ -14,6 +14,15 @@ The structuring element is assumed to be composed of binary values (zero or one)
 
 ![](Images/ITKGrayscaleClosing.png)
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleMorphologicalClosingImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleMorphologicalClosingImageFilter.md
@@ -18,10 +18,10 @@ The structuring element is assumed to be composed of binary values (zero or one)
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleMorphologicalOpeningImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleMorphologicalOpeningImageFilter.md
@@ -18,10 +18,10 @@ The structuring element is assumed to be composed of binary values (zero or one)
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleMorphologicalOpeningImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKGrayscaleMorphologicalOpeningImageFilter.md
@@ -14,6 +14,15 @@ The structuring element is assumed to be composed of binary values (zero or one)
 
 ![](Images/ITKGrayscaleOpening.png)
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKImageReaderFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKImageReaderFilter.md
@@ -25,16 +25,24 @@ The user can optionally override the origin and spacing (length units per pixel)
 
 When setting a custom origin, the user can choose whether to place the origin at the corner of the geometry (default) or at the center of the geometry by enabling the "Put Input Origin at the Center of Geometry" option.
 
-The **Origin & Spacing Processing Order** parameter controls when origin and spacing overrides are applied:
-- **Preprocessed**: Origin and spacing are applied before any cropping operations
-- **Postprocessed**: Origin and spacing are applied after cropping operations
+### Origin & Spacing Processing
+
+The *Origin & Spacing Processing* parameter provides the following choices:
+
+- **Preprocessed [0]**: Origin and spacing overrides are applied before any cropping operations.
+- **Postprocessed [1]**: Origin and spacing overrides are applied after cropping operations.
+
+### Output Data Type
+
+The *Output Data Type* parameter provides the following choices:
+
+- **uint8 [0]**: Convert image data to 8-bit unsigned integer.
+- **uint16 [1]**: Convert image data to 16-bit unsigned integer.
+- **uint32 [2]**: Convert image data to 32-bit unsigned integer.
 
 ### Data Type Conversion
 
-The user can optionally convert the image data to a different data type by enabling the "Set Image Data Type" option. Supported output data types include:
-- uint8
-- uint16
-- uint32
+The user can optionally convert the image data to a different data type by enabling the "Set Image Data Type" option.
 
 ### Cropping Caveats
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKImageWriterFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKImageWriterFilter.md
@@ -11,6 +11,14 @@ This **Filter** will save images based on an array that represents grayscale, RG
 An example of a **Filter** that produces color data that can be used as input to this **Filter**
 is the {ref}`Generate IFP Colors <OrientationAnalysis/ComputeIPFColorsFilter:Description>` **Filter**, which will generate RGB values for each voxel in the volume.
 
+### Plane
+
+The *Plane* parameter controls which orthogonal plane is used when writing a 3D volume as a series of 2D image slices:
+
+- **XY**: Write image slices along the XY plane (normal to Z axis).
+- **XZ**: Write image slices along the XZ plane (normal to Y axis).
+- **YZ**: Write image slices along the YZ plane (normal to X axis).
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKImageWriterFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKImageWriterFilter.md
@@ -15,9 +15,9 @@ is the {ref}`Generate IFP Colors <OrientationAnalysis/ComputeIPFColorsFilter:Des
 
 The *Plane* parameter controls which orthogonal plane is used when writing a 3D volume as a series of 2D image slices:
 
-- **XY**: Write image slices along the XY plane (normal to Z axis).
-- **XZ**: Write image slices along the XZ plane (normal to Y axis).
-- **YZ**: Write image slices along the YZ plane (normal to X axis).
+- **XY [0]**: Write image slices along the XY plane (normal to Z axis).
+- **XZ [1]**: Write image slices along the XZ plane (normal to Y axis).
+- **YZ [2]**: Write image slices along the YZ plane (normal to X axis).
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKImportFijiMontageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKImportFijiMontageFilter.md
@@ -65,6 +65,14 @@ The user can set the weightings to what ever values they would like.
     Unspecified = 100U
     Unknown = 101U
 
+### Output Data Type
+
+The *Output Data Type* parameter controls the numeric type used to store the imported image data:
+
+- **uint8**: Read image data as unsigned 8-bit integers (0–255).
+- **uint16**: Read image data as unsigned 16-bit integers (0–65535).
+- **uint32**: Read image data as unsigned 32-bit integers (0–4294967295).
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKImportFijiMontageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKImportFijiMontageFilter.md
@@ -69,9 +69,9 @@ The user can set the weightings to what ever values they would like.
 
 The *Output Data Type* parameter controls the numeric type used to store the imported image data:
 
-- **uint8**: Read image data as unsigned 8-bit integers (0–255).
-- **uint16**: Read image data as unsigned 16-bit integers (0–65535).
-- **uint32**: Read image data as unsigned 32-bit integers (0–4294967295).
+- **uint8 [0]**: Read image data as unsigned 8-bit integers (0–255).
+- **uint16 [1]**: Read image data as unsigned 16-bit integers (0–65535).
+- **uint32 [2]**: Read image data as unsigned 32-bit integers (0–4294967295).
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKImportImageStackFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKImportImageStackFilter.md
@@ -25,33 +25,46 @@ The filter will create a new Image Geometry. The user can optionally override th
 
 When setting a custom origin, the user can choose whether to place the origin at the corner of the geometry (default) or at the center of the geometry.
 
-The **Origin & Spacing Processing Order** parameter controls when origin and spacing overrides are applied relative to the Processing Order above:
+### Origin & Spacing Processing
 
-- **Preprocessed**: Origin and spacing are applied before the image cropping step, so the order becomes:
-  1. Read image
-  2. Set origin and spacing values
-  3. Crop image
-  4. Resample image
-  5. Convert to grayscale
-  6. Flip image in X or Y
-- **Postprocessed**: Origin and spacing are applied after the image flipping step, so the order becomes:
-  1. Read image
-  2. Crop image
-  3. Resample image
-  4. Convert to grayscale
-  5. Flip image in X or Y
-  6. Set origin and spacing values
+The *Origin & Spacing Processing* parameter provides the following choices:
+
+- **Preprocessed [0]**: Origin and spacing overrides are applied before the image cropping step.
+- **Postprocessed [1]**: Origin and spacing overrides are applied after the image flipping step.
+
+When **Preprocessed** is selected, the processing order becomes:
+
+1. Read image
+2. Set origin and spacing values
+3. Crop image
+4. Resample image
+5. Convert to grayscale
+6. Flip image in X or Y
+
+When **Postprocessed** is selected, the processing order becomes:
+
+1. Read image
+2. Crop image
+3. Resample image
+4. Convert to grayscale
+5. Flip image in X or Y
+6. Set origin and spacing values
 
 ### Resampling Caveats
 
 The user can decide to scale the images as they are being read in by turning on the Scale Images option, and setting a scale value. A scale value of 10.0 resamples the images in the stack to one-tenth the number of pixels, a scale value of 200.0 resamples the images in the stack to double the number of pixels. The default scale value is 100.0.
 
+### Output Data Type
+
+The *Output Data Type* parameter provides the following choices:
+
+- **uint8 [0]**: Convert image data to 8-bit unsigned integer.
+- **uint16 [1]**: Convert image data to 16-bit unsigned integer.
+- **uint32 [2]**: Convert image data to 32-bit unsigned integer.
+
 ### Data Type Conversion
 
-The user can optionally convert the image data to a different data type by enabling the "Set Image Data Type" option. Supported output data types include:
-- uint8
-- uint16
-- uint32
+The user can optionally convert the image data to a different data type by enabling the "Set Image Data Type" option.
 
 ### Cropping Caveats
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKMhaFileReaderFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKMhaFileReaderFilter.md
@@ -34,8 +34,8 @@ The key properties that make the transpose of a rotation matrix equivalent to it
 
 The *Interpolation Type* parameter controls the interpolation method used when resampling the image data:
 
-- **Nearest Neighbor**: Uses the value of the nearest voxel when resampling. Preserves original values but may produce blocky results.
-- **Linear Interpolation**: Computes a weighted average of surrounding voxels when resampling. Produces smoother results but may introduce new values.
+- **Nearest Neighbor [0]**: Uses the value of the nearest voxel when resampling. Preserves original values but may produce blocky results.
+- **Linear Interpolation [1]**: Computes a weighted average of surrounding voxels when resampling. Produces smoother results but may introduce new values.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKMhaFileReaderFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKMhaFileReaderFilter.md
@@ -30,6 +30,13 @@ The key properties that make the transpose of a rotation matrix equivalent to it
 - **Preservation of Dot Product**: The rotation does not change the dot product between vectors, preserving angles and lengths.
 - **Orthonormal Rows and Columns**: The rows (and columns) of a rotation matrix are orthonormal, meaning they have unit length and are perpendicular to each other. This property ensures that multiplying the matrix by its transpose results in the identity matrix, indicating that the transpose is indeed the inverse.
 
+### Interpolation Type
+
+The *Interpolation Type* parameter controls the interpolation method used when resampling the image data:
+
+- **Nearest Neighbor**: Uses the value of the nearest voxel when resampling. Preserves original values but may produce blocky results.
+- **Linear Interpolation**: Computes a weighted average of surrounding voxels when resampling. Produces smoother results but may introduce new values.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKMorphologicalGradientImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKMorphologicalGradientImageFilter.md
@@ -14,10 +14,10 @@ The structuring element is assumed to be composed of binary values (zero or one)
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKMorphologicalGradientImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKMorphologicalGradientImageFilter.md
@@ -10,6 +10,15 @@ ITKMathematicalMorphology (MathematicalMorphology)
 
 The structuring element is assumed to be composed of binary values (zero or one). Only elements of the structuring element having values > 0 are candidates for affecting the center pixel.* MorphologyImageFilter , GrayscaleFunctionDilateImageFilter , BinaryDilateImageFilter
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKOpeningByReconstructionImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKOpeningByReconstructionImageFilter.md
@@ -25,6 +25,15 @@ Applications", Second Edition, Springer, 2003.
 
 - GrayscaleMorphologicalOpeningImageFilter
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKOpeningByReconstructionImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKOpeningByReconstructionImageFilter.md
@@ -29,10 +29,10 @@ Applications", Second Edition, Springer, 2003.
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/ITKImageProcessing/docs/ITKWhiteTopHatImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKWhiteTopHatImageFilter.md
@@ -18,6 +18,15 @@ Top-hats are described in Chapter 4.5 of Pierre Soille's book "Morphological Ima
 
 ![](Images/ITKWhiteTopHat.png)
 
+### Kernel Type
+
+The *Kernel Type* parameter selects the structuring element used for the morphological operation:
+
+- **Annulus**: A ring-shaped structuring element.
+- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box**: A rectangular/cuboid structuring element.
+- **Cross**: A cross-shaped structuring element.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/ITKImageProcessing/docs/ITKWhiteTopHatImageFilter.md
+++ b/src/Plugins/ITKImageProcessing/docs/ITKWhiteTopHatImageFilter.md
@@ -22,10 +22,10 @@ Top-hats are described in Chapter 4.5 of Pierre Soille's book "Morphological Ima
 
 The *Kernel Type* parameter selects the structuring element used for the morphological operation:
 
-- **Annulus**: A ring-shaped structuring element.
-- **Ball**: A spherical structuring element (default). Most commonly used for general morphological operations.
-- **Box**: A rectangular/cuboid structuring element.
-- **Cross**: A cross-shaped structuring element.
+- **Annulus [0]**: A ring-shaped structuring element.
+- **Ball [1]**: A spherical structuring element (default). Most commonly used for general morphological operations.
+- **Box [2]**: A rectangular/cuboid structuring element.
+- **Cross [3]**: A cross-shaped structuring element.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/OrientationAnalysis/docs/CAxisSegmentFeaturesFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/CAxisSegmentFeaturesFilter.md
@@ -18,6 +18,13 @@ The user has the option to *Use Mask Array*, which allows the user to set a bool
 
 After all the **Features** have been identified, a **Feature Attribute Matrix** is created for the **Features** and each **Feature** is flagged as *Active* in a boolean array in the matrix.
 
+### Neighbor Scheme
+
+The *Neighbor Scheme* parameter provides the following choices:
+
+- **Face Neighbors [0]**: Only the 6 face-sharing neighbors of a voxel are considered during segmentation.
+- **All Connected Neighbors [1]**: All 26 neighbors connected by a face, edge, or vertex are considered during segmentation.
+
 ## Note on Neighbor Scheme
 
 Historically DREAM.3D version 6.x has used *only* the 6 face neighbors of a voxel. This release introduces the option

--- a/src/Plugins/OrientationAnalysis/docs/ComputeFeatureReferenceMisorientationsFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ComputeFeatureReferenceMisorientationsFilter.md
@@ -17,6 +17,13 @@ undergone plastic deformation and the amount of lattice rotation developed is of
 it may be more reasonable to use the orientation *near the center* of the **Feature** as it may 
 not have rotated and thus serve as a better *reference orientation*.
 
+### Reference Orientation
+
+The *Reference Orientation* parameter provides the following choices:
+
+- **Average Feature Orientation [0]**: Uses the average orientation of the **Feature** as the reference orientation for misorientation calculations.
+- **Orientation Farthest from Feature Boundary [1]**: Uses the orientation of the **Cell** that is furthest from the boundary of the **Feature** (nearest to its Euclidean center) as the reference orientation.
+
 ## IPF Colors <001> Direction
 
 This is the data set's IPF colors by the <001> direction which shows the reader the relative

--- a/src/Plugins/OrientationAnalysis/docs/ComputeGBCDMetricBasedFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ComputeGBCDMetricBasedFilter.md
@@ -42,6 +42,19 @@ Then, the directions are given as [ sin &theta; &times; cos &phi; , sin &theta; 
 ## Feedback
 
 In the case of any questions, suggestions, bugs, etc.,  please feel free to email the author of this **Filter** at kglowinski *at* ymail.com
+
+### Limiting Distances
+
+The *Limiting Distances* parameter selects the maximum angular deviations used when selecting boundary segments. The choices are pairs of (misorientation radius, plane-inclination radius):
+
+- **3 deg. Misorientations; 7 deg. Plane Inclinations**: Use a 3-degree misorientation radius and a 7-degree plane-inclination radius.
+- **5 deg. Misorientations; 5 deg. Plane Inclinations**: Use a 5-degree radius for both misorientations and plane inclinations.
+- **5 deg. Misorientations; 7 deg. Plane Inclinations**: Use a 5-degree misorientation radius and a 7-degree plane-inclination radius.
+- **5 deg. Misorientations; 8 deg. Plane Inclinations**: Use a 5-degree misorientation radius and an 8-degree plane-inclination radius.
+- **6 deg. Misorientations; 7 deg. Plane Inclinations**: Use a 6-degree misorientation radius and a 7-degree plane-inclination radius.
+- **7 deg. Misorientations; 7 deg. Plane Inclinations**: Use a 7-degree radius for both misorientations and plane inclinations.
+- **8 deg. Misorientations; 8 deg. Plane Inclinations**: Use an 8-degree radius for both misorientations and plane inclinations.
+
 % Auto generated parameter table will be inserted here
 
 ## References

--- a/src/Plugins/OrientationAnalysis/docs/ComputeGBCDMetricBasedFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ComputeGBCDMetricBasedFilter.md
@@ -47,13 +47,13 @@ In the case of any questions, suggestions, bugs, etc.,  please feel free to emai
 
 The *Limiting Distances* parameter selects the maximum angular deviations used when selecting boundary segments. The choices are pairs of (misorientation radius, plane-inclination radius):
 
-- **3 deg. Misorientations; 7 deg. Plane Inclinations**: Use a 3-degree misorientation radius and a 7-degree plane-inclination radius.
-- **5 deg. Misorientations; 5 deg. Plane Inclinations**: Use a 5-degree radius for both misorientations and plane inclinations.
-- **5 deg. Misorientations; 7 deg. Plane Inclinations**: Use a 5-degree misorientation radius and a 7-degree plane-inclination radius.
-- **5 deg. Misorientations; 8 deg. Plane Inclinations**: Use a 5-degree misorientation radius and an 8-degree plane-inclination radius.
-- **6 deg. Misorientations; 7 deg. Plane Inclinations**: Use a 6-degree misorientation radius and a 7-degree plane-inclination radius.
-- **7 deg. Misorientations; 7 deg. Plane Inclinations**: Use a 7-degree radius for both misorientations and plane inclinations.
-- **8 deg. Misorientations; 8 deg. Plane Inclinations**: Use an 8-degree radius for both misorientations and plane inclinations.
+- **3 deg. Misorientations; 7 deg. Plane Inclinations [0]**: Use a 3-degree misorientation radius and a 7-degree plane-inclination radius.
+- **5 deg. Misorientations; 5 deg. Plane Inclinations [1]**: Use a 5-degree radius for both misorientations and plane inclinations.
+- **5 deg. Misorientations; 7 deg. Plane Inclinations [2]**: Use a 5-degree misorientation radius and a 7-degree plane-inclination radius.
+- **5 deg. Misorientations; 8 deg. Plane Inclinations [3]**: Use a 5-degree misorientation radius and an 8-degree plane-inclination radius.
+- **6 deg. Misorientations; 7 deg. Plane Inclinations [4]**: Use a 6-degree misorientation radius and a 7-degree plane-inclination radius.
+- **7 deg. Misorientations; 7 deg. Plane Inclinations [5]**: Use a 7-degree radius for both misorientations and plane inclinations.
+- **8 deg. Misorientations; 8 deg. Plane Inclinations [6]**: Use an 8-degree radius for both misorientations and plane inclinations.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/OrientationAnalysis/docs/ComputeMisorientationsFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ComputeMisorientationsFilter.md
@@ -11,6 +11,13 @@ Euler Angles or an Euler Angle and a Reference Axis-Angle.
 
 Use the Orientation Utility to compute an input Axis-Angle if you only have another representation.
 
+### Computation Type
+
+The *Computation Type* parameter provides the following choices:
+
+- **Use Arrays [0]**: Computes the misorientation between corresponding Euler Angles in two input arrays, producing one misorientation value per tuple.
+- **Use Reference Axis Angle [1]**: Computes the misorientation between each Euler Angle in a single input array and a user-supplied reference axis-angle orientation.
+
 ## Compute by Arrays
 
 If 2 Euler Arrays are used then the output is an array with the same number of Tuples as the input

--- a/src/Plugins/OrientationAnalysis/docs/ComputeTwinBoundariesFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ComputeTwinBoundariesFilter.md
@@ -12,8 +12,8 @@ This **Filter** identifies all **Triangles** between neighboring **Features** th
 
 The *Output Type for Twin Boundaries Array* parameter controls the data type used to store the twin boundary identification result:
 
-- **boolean**: Stores the twin boundary flag as a boolean array (true if the **Triangle** is a twin boundary, false otherwise).
-- **uint8**: Stores the twin boundary flag as an unsigned 8-bit integer array (1 if the **Triangle** is a twin boundary, 0 otherwise).
+- **boolean [0]**: Stores the twin boundary flag as a boolean array (true if the **Triangle** is a twin boundary, false otherwise).
+- **uint8 [1]**: Stores the twin boundary flag as an unsigned 8-bit integer array (1 if the **Triangle** is a twin boundary, 0 otherwise).
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/OrientationAnalysis/docs/ComputeTwinBoundariesFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ComputeTwinBoundariesFilter.md
@@ -8,6 +8,13 @@ Statistics (Crystallography)
 
 This **Filter** identifies all **Triangles** between neighboring **Features** that have a &sigma; = 3 twin relationship.  The **Filter** uses the average orientation of the **Features** on either side of the **Triangle** to determine the *misorientation* between the **Features**.  If the *axis-angle* that describes the *misorientation* is within both the axis and angle user-defined tolerance, then the **Triangle** is flagged as being a twin.  After the **Triangle** is flagged as a twin, the crystal direction parallel to the **Face** normal is determined and compared with the *misorientation axis* if *Compute Coherence* is selected.  The misalignment of these two crystal directions is stored as the incoherence value for the **Triangle** (in degrees). Note that this **Filter** will only extract twin boundaries if the twin **Feature** is the same phase as the parent **Feature**.
 
+### Output Type for Twin Boundaries Array
+
+The *Output Type for Twin Boundaries Array* parameter controls the data type used to store the twin boundary identification result:
+
+- **boolean**: Stores the twin boundary flag as a boolean array (true if the **Triangle** is a twin boundary, false otherwise).
+- **uint8**: Stores the twin boundary flag as an unsigned 8-bit integer array (1 if the **Triangle** is a twin boundary, 0 otherwise).
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/OrientationAnalysis/docs/ConvertOrientationsFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ConvertOrientationsFilter.md
@@ -12,6 +12,32 @@ The following table lists the various orientation representations that are suppo
 is capable of converting between any representation with some caveats. The Input and
 Output Orientation Type are represented as a zero based index into the combo box widget.
 
+### Input Orientation Type
+
+The *Input Orientation Type* parameter provides the following choices:
+
+- **Euler Angles [0]**: Three-component Euler angle representation (phi1, Phi, phi2).
+- **Orientation Matrix [1]**: Nine-component 3x3 orientation matrix in row major format.
+- **Quaternion [2]**: Four-component quaternion representation ([x, y, z], w).
+- **Axis Angle [3]**: Four-component axis-angle representation ([x, y, z], Angle in degrees).
+- **Rodrigues Vector [4]**: Four-component Rodrigues vector ([x, y, z], w).
+- **Homochoric [5]**: Three-component homochoric vector ([x, y, z]).
+- **Cubochoric [6]**: Three-component cubochoric vector ([x, y, z]).
+- **Stereographic Projection [7]**: Three-component stereographic projection vector ([x, y, z]).
+
+### Output Orientation Type
+
+The *Output Orientation Type* parameter provides the following choices:
+
+- **Euler Angles [0]**: Three-component Euler angle representation (phi1, Phi, phi2).
+- **Orientation Matrix [1]**: Nine-component 3x3 orientation matrix in row major format.
+- **Quaternion [2]**: Four-component quaternion representation ([x, y, z], w).
+- **Axis Angle [3]**: Four-component axis-angle representation ([x, y, z], Angle in degrees).
+- **Rodrigues Vector [4]**: Four-component Rodrigues vector ([x, y, z], w).
+- **Homochoric [5]**: Three-component homochoric vector ([x, y, z]).
+- **Cubochoric [6]**: Three-component cubochoric vector ([x, y, z]).
+- **Stereographic Projection [7]**: Three-component stereographic projection vector ([x, y, z]).
+
 ### Orientation Representation Enumeration Index
 
 | Enumeration Index | Orientation Representation |

--- a/src/Plugins/OrientationAnalysis/docs/ConvertOrientationsToVertexGeometryFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ConvertOrientationsToVertexGeometryFilter.md
@@ -18,6 +18,19 @@ This is the same data, but with the option to convert the data to the Fundamenta
 
 Note the coloring used in the previous images is via an IPF-Z <001> Coloring.
 
+### Input Orientation Type
+
+The *Input Orientation Type* parameter specifies the orientation representation of the input array:
+
+- **Euler Angles**: Three-component (phi1, Phi, phi2) Bunge Euler angle representation.
+- **Orientation Matrix**: Nine-component (3x3) rotation matrix in row-major format.
+- **Quaternions**: Four-component quaternion in vector-scalar ordering ([x, y, z], w).
+- **Axis Angle**: Four-component axis-angle representation ([x, y, z], Angle).
+- **Rodrigues Vectors**: Four-component Rodrigues vector ([x, y, z], w) where the vector is normalized and the length is stored as the last component.
+- **Homochoric**: Three-component homochoric vector [x, y, z].
+- **Cubochoric**: Three-component cubochoric vector [x, y, z].
+- **Stereographic**: Three-component stereographic projection vector [x, y, z].
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/OrientationAnalysis/docs/ConvertOrientationsToVertexGeometryFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ConvertOrientationsToVertexGeometryFilter.md
@@ -22,14 +22,14 @@ Note the coloring used in the previous images is via an IPF-Z <001> Coloring.
 
 The *Input Orientation Type* parameter specifies the orientation representation of the input array:
 
-- **Euler Angles**: Three-component (phi1, Phi, phi2) Bunge Euler angle representation.
-- **Orientation Matrix**: Nine-component (3x3) rotation matrix in row-major format.
-- **Quaternions**: Four-component quaternion in vector-scalar ordering ([x, y, z], w).
-- **Axis Angle**: Four-component axis-angle representation ([x, y, z], Angle).
-- **Rodrigues Vectors**: Four-component Rodrigues vector ([x, y, z], w) where the vector is normalized and the length is stored as the last component.
-- **Homochoric**: Three-component homochoric vector [x, y, z].
-- **Cubochoric**: Three-component cubochoric vector [x, y, z].
-- **Stereographic**: Three-component stereographic projection vector [x, y, z].
+- **Euler Angles [0]**: Three-component (phi1, Phi, phi2) Bunge Euler angle representation.
+- **Orientation Matrix [1]**: Nine-component (3x3) rotation matrix in row-major format.
+- **Quaternions [2]**: Four-component quaternion in vector-scalar ordering ([x, y, z], w).
+- **Axis Angle [3]**: Four-component axis-angle representation ([x, y, z], Angle).
+- **Rodrigues Vectors [4]**: Four-component Rodrigues vector ([x, y, z], w) where the vector is normalized and the length is stored as the last component.
+- **Homochoric [5]**: Three-component homochoric vector [x, y, z].
+- **Cubochoric [6]**: Three-component cubochoric vector [x, y, z].
+- **Stereographic [7]**: Three-component stereographic projection vector [x, y, z].
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/OrientationAnalysis/docs/ConvertQuaternionFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ConvertQuaternionFilter.md
@@ -10,6 +10,13 @@ Internally DREAM3D-NX assumes that a quaternion is laid out in the order such th
 
 For Example if the user has imported quaternion data in the form of Scalar-Vector then they would run this filter using a conversion type of **ToVectorScalar** and using the generated quaternions in subsequent filters. If the user wanted to then write out the Quaternions in the Scalar-Vector form then could add this filter again to the end of the pipeline (but before writing out data) to convert the Vector-Scalar quaternions array (assuming something modified the array).
 
+### Conversion Type
+
+The *Conversion Type* parameter selects the target quaternion component ordering:
+
+- **To Scalar Vector ( w, [x, y, z] )**: Converts quaternions to scalar-vector ordering where the scalar component (w) comes first, followed by the vector components (x, y, z).
+- **To Vector Scalar ( [x, y, z], w )**: Converts quaternions to vector-scalar ordering where the vector components (x, y, z) come first, followed by the scalar component (w). This is the internal ordering expected by DREAM3D-NX.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/OrientationAnalysis/docs/ConvertQuaternionFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ConvertQuaternionFilter.md
@@ -14,8 +14,8 @@ For Example if the user has imported quaternion data in the form of Scalar-Vecto
 
 The *Conversion Type* parameter selects the target quaternion component ordering:
 
-- **To Scalar Vector ( w, [x, y, z] )**: Converts quaternions to scalar-vector ordering where the scalar component (w) comes first, followed by the vector components (x, y, z).
-- **To Vector Scalar ( [x, y, z], w )**: Converts quaternions to vector-scalar ordering where the vector components (x, y, z) come first, followed by the scalar component (w). This is the internal ordering expected by DREAM3D-NX.
+- **To Scalar Vector ( w, [x, y, z] ) [0]**: Converts quaternions to scalar-vector ordering where the scalar component (w) comes first, followed by the vector components (x, y, z).
+- **To Vector Scalar ( [x, y, z], w ) [1]**: Converts quaternions to vector-scalar ordering where the vector components (x, y, z) come first, followed by the scalar component (w). This is the internal ordering expected by DREAM3D-NX.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/OrientationAnalysis/docs/EBSDSegmentFeaturesFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/EBSDSegmentFeaturesFilter.md
@@ -20,6 +20,13 @@ After all the **Features** have been identified, a **Feature Attribute Matrix** 
 
 If the data is specified as **Periodic**, the segmentation will check if features wrap around geometry bounds in a tileable fashion. If any such features are detected, the filter will throw a warning that centroid data may be incorrect.
 
+### Neighbor Scheme
+
+The *Neighbor Scheme* parameter provides the following choices:
+
+- **Face Neighbors [0]**: Only the 6 face-sharing neighbors of a voxel are considered during segmentation.
+- **All Connected Neighbors [1]**: All 26 neighbors connected by a face, edge, or vertex are considered during segmentation.
+
 ## Note on Neighbor Scheme
 
 Historically DREAM.3D version 6.x has used *only* the 6 face neighbors of a voxel. This release introduces the option

--- a/src/Plugins/OrientationAnalysis/docs/EbsdToH5EbsdFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/EbsdToH5EbsdFilter.md
@@ -16,8 +16,10 @@ In order to work with orientation data, DREAM3D-NX needs to read the data from a
 
 Due to different experimental setups, the definition of the _bottom_ slice or the **Z=0** slice can be different. The user should verify that the proper button box is checked for their data set.
 
-+ **Low to High** This means that the file with the lowest index, closest to zero (0), will be considered the Z=0 slice.
-+ **High to Low** This means that the file with the highest index, farthest from zero (0), will be considered the Z=0 slice.
+The *Stacking Order* parameter provides the following choices:
+
+- **Low to High [0]**: The file with the lowest index, closest to zero (0), will be considered the Z=0 slice.
+- **High To Low [1]**: The file with the highest index, farthest from zero (0), will be considered the Z=0 slice.
 
 ### Z Resolution
 
@@ -40,6 +42,15 @@ The user needs to click the _Set Reference Frame_ button to set the proper refer
 | No Sample Transform | Edax/HKL Sample Transform |
 |--|--|
 |  ![No Transform or Unknown Manufacturer or HEDM Data](Images/EbsdToH5Ebsd_NoUnknown_HEDM_RefFrame.png) | ![TSL or HKL Transform](Images/EbsdToH5Ebsd_EDAX_HKL_RefFrame.png)  |
+
+### Reference Frame Options
+
+The *Reference Frame Options* parameter provides the following choices:
+
+- **Edax - TSL [0]**: Apply the sample and Euler reference frame transformations for EDAX/TSL systems (180 @ <010>, 90 @ <001>).
+- **Oxford - CTF [1]**: Apply the sample and Euler reference frame transformations for Oxford/HKL systems (180 @ <010>, 0 @ <001>).
+- **No/Unknown Transformation [2]**: Apply no reference frame transformation (0 @ <001>, 0 @ <001>).
+- **HEDM - IceNine [3]**: Apply the reference frame transformations for HEDM IceNine data (0 @ <001>, 0 @ <001>).
 
 ### Preset Transformations
 

--- a/src/Plugins/OrientationAnalysis/docs/WritePoleFigureFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/WritePoleFigureFilter.md
@@ -58,16 +58,16 @@ The *Image Layout* parameter controls how the pole figures are arranged in the o
 
 The available layout choices are:
 
-- **Horizontal**: Pole figures are arranged in a single horizontal row.
-- **Vertical**: Pole figures are arranged in a single vertical column.
-- **Square**: Pole figures are arranged in a square grid.
+- **Horizontal [0]**: Pole figures are arranged in a single horizontal row.
+- **Vertical [1]**: Pole figures are arranged in a single vertical column.
+- **Square [2]**: Pole figures are arranged in a square grid.
 
 ### Pole Figure Type
 
 The *Pole Figure Type* parameter selects the rendering method for the pole figure:
 
-- **Color Intensity**: Generates a continuous color intensity map using a modified Lambert square interpolation onto the unit circle.
-- **Discrete**: Generates a discrete point-based pole figure by marking each pixel that received at least one orientation count.
+- **Color Intensity [0]**: Generates a continuous color intensity map using a modified Lambert square interpolation onto the unit circle.
+- **Discrete [1]**: Generates a discrete point-based pole figure by marking each pixel that received at least one orientation count.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/OrientationAnalysis/docs/WritePoleFigureFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/WritePoleFigureFilter.md
@@ -50,11 +50,24 @@ data that went into the creation: Number of points, which hemisphere, Phase Name
 
 ### Image Layout
 
-The 3 pole figures can be laid out in a Square, Horizontal row or vertical column. Supporting information (including the color bar legend for color pole figures) will also be printed on the image.
+The *Image Layout* parameter controls how the pole figures are arranged in the output image. Supporting information (including the color bar legend for color pole figures) will also be printed on the image.
 
 | Colorized Intensity | Discrete |
 |--------------------|----------|
 | ![Example Pole Figure Using Square Layout](Images/PoleFigure_Example.png) | ![Example Pole Figure Using Square Layout](Images/Pole_Figure_Discrete_Example.png) |
+
+The available layout choices are:
+
+- **Horizontal**: Pole figures are arranged in a single horizontal row.
+- **Vertical**: Pole figures are arranged in a single vertical column.
+- **Square**: Pole figures are arranged in a square grid.
+
+### Pole Figure Type
+
+The *Pole Figure Type* parameter selects the rendering method for the pole figure:
+
+- **Color Intensity**: Generates a continuous color intensity map using a modified Lambert square interpolation onto the unit circle.
+- **Discrete**: Generates a discrete point-based pole figure by marking each pixel that received at least one orientation count.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/OrientationAnalysis/docs/WriteStatsGenOdfAngleFileFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/WriteStatsGenOdfAngleFileFilter.md
@@ -54,13 +54,13 @@ There are 5 columns of data which are the 3 Euler Angles, the Weight Value and t
 
 ### Delimiter
 
-Choice of delimiter is as follows:
+The *Delimiter* parameter provides the following choices:
 
-    0 = , (comma)
-    1 = ; (semicolon)
-    2 = (space)   <==== DEFAULT VALUE
-    3 = : (colon)
-    4 = \t (tab)
+- **, (comma) [0]**: Uses a comma as the column separator.
+- **; (semicolon) [1]**: Uses a semicolon as the column separator.
+- **(space) [2]**: Uses a space as the column separator. This is the default value.
+- **: (colon) [3]**: Uses a colon as the column separator.
+- **\t (tab) [4]**: Uses a tab character as the column separator.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/AlignGeometriesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/AlignGeometriesFilter.md
@@ -17,8 +17,8 @@ The input geometries can be of any type. The *Moving* geometry is translated in 
 
 The *Alignment Type* parameter controls how the two geometries are aligned:
 
-- **Origin**: Aligns geometries by translating the moving geometry so that its minimum coordinate point (origin) matches the minimum coordinate point of the target geometry.
-- **Centroid**: Aligns geometries by translating the moving geometry so that its centroid (center of mass) matches the centroid of the target geometry.
+- **Origin [0]**: Aligns geometries by translating the moving geometry so that its minimum coordinate point (origin) matches the minimum coordinate point of the target geometry.
+- **Centroid [1]**: Aligns geometries by translating the moving geometry so that its centroid (center of mass) matches the centroid of the target geometry.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/AlignGeometriesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/AlignGeometriesFilter.md
@@ -13,6 +13,13 @@ This **Filter** will align 2 Geometry objects using 1 of the following alignment
 
 The input geometries can be of any type. The *Moving* geometry is translated in space to match the *Target* geometry. When using *Origin* alignment, the moving geometry is translated so that its minimum coordinate point matches the target geometry's minimum coordinate point. When using *Centroid* alignment, the moving geometry is translated so that its centroid matches the target geometry's centroid.
 
+### Alignment Type
+
+The *Alignment Type* parameter controls how the two geometries are aligned:
+
+- **Origin**: Aligns geometries by translating the moving geometry so that its minimum coordinate point (origin) matches the minimum coordinate point of the target geometry.
+- **Centroid**: Aligns geometries by translating the moving geometry so that its centroid (center of mass) matches the centroid of the target geometry.
+
 % Auto generated parameter table will be inserted here
 
 ## License & Copyright

--- a/src/Plugins/SimplnxCore/docs/AlignSectionsListFilter.md
+++ b/src/Plugins/SimplnxCore/docs/AlignSectionsListFilter.md
@@ -8,6 +8,13 @@ Reconstruction (Alignment)
 
 This **Filter** will apply the precalculated cell shifts to each section of an Image Geometry. It allows for both *relative* or *cumulative* cell shifts. The difference between the two being the former is dependent on the previous slice's position. Under the covers, relative is translated to cumulative before applying shifts to the cells themselves. Previously, the only accepted input was utilizing relative shifts, so use those for backwards compatibility. See the **Handling User Created Shifts File** and **Example Pipelines** sections of this documentation for further hints.
 
+### Input Array Type
+
+The *Input Array Type* parameter controls how the shift values in the input arrays are interpreted:
+
+- **Relative**: Each shift value is a relative offset between adjacent sections. The shift for section N describes how far section N has moved compared to section N-1. These values are internally converted to cumulative shifts before being applied.
+- **Cumulative**: Each shift value is an absolute (cumulative) offset measured from a fixed reference point. The shift for section N describes how far section N has moved from that reference.
+
 ## Handling User Created Shifts File
 
 In this section we will be covering how to get a user defined shift file into the algorithm. This has been included in the documentation for posterity, as the capability was removed in order to offer a less rigid file structuring and to centralize the I/O paradigm.

--- a/src/Plugins/SimplnxCore/docs/AlignSectionsListFilter.md
+++ b/src/Plugins/SimplnxCore/docs/AlignSectionsListFilter.md
@@ -12,8 +12,8 @@ This **Filter** will apply the precalculated cell shifts to each section of an I
 
 The *Input Array Type* parameter controls how the shift values in the input arrays are interpreted:
 
-- **Relative**: Each shift value is a relative offset between adjacent sections. The shift for section N describes how far section N has moved compared to section N-1. These values are internally converted to cumulative shifts before being applied.
-- **Cumulative**: Each shift value is an absolute (cumulative) offset measured from a fixed reference point. The shift for section N describes how far section N has moved from that reference.
+- **Relative [0]**: Each shift value is a relative offset between adjacent sections. The shift for section N describes how far section N has moved compared to section N-1. These values are internally converted to cumulative shifts before being applied.
+- **Cumulative [1]**: Each shift value is an absolute (cumulative) offset measured from a fixed reference point. The shift for section N describes how far section N has moved from that reference.
 
 ## Handling User Created Shifts File
 

--- a/src/Plugins/SimplnxCore/docs/AppendImageGeometryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/AppendImageGeometryFilter.md
@@ -15,9 +15,9 @@ This filter also has an option to mirror the resulting geometry in the chosen di
 
 The *Direction* parameter selects the axis along which the input geometries are appended onto the destination geometry:
 
-- **X**: Appends geometries along the X axis. The input and destination geometries must have matching Y and Z dimensions.
-- **Y**: Appends geometries along the Y axis. The input and destination geometries must have matching X and Z dimensions.
-- **Z**: Appends geometries along the Z axis. The input and destination geometries must have matching X and Y dimensions.
+- **X [0]**: Appends geometries along the X axis. The input and destination geometries must have matching Y and Z dimensions.
+- **Y [1]**: Appends geometries along the Y axis. The input and destination geometries must have matching X and Z dimensions.
+- **Z [2]**: Appends geometries along the Z axis. The input and destination geometries must have matching X and Y dimensions.
 
 ### X Direction Examples
 

--- a/src/Plugins/SimplnxCore/docs/AppendImageGeometryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/AppendImageGeometryFilter.md
@@ -11,6 +11,14 @@ destination **ImageGeometry** objects must have the same dimensions in the direc
 
 This filter also has an option to mirror the resulting geometry in the chosen direction.  If the X direction is chosen, it will mirror the positions of the YZ planes.  If the Y direction is chosen, it will mirror the positions of the XZ planes.  If the Z direction is chosen, it will mirror the positions of the XY planes.
 
+### Direction
+
+The *Direction* parameter selects the axis along which the input geometries are appended onto the destination geometry:
+
+- **X**: Appends geometries along the X axis. The input and destination geometries must have matching Y and Z dimensions.
+- **Y**: Appends geometries along the Y axis. The input and destination geometries must have matching X and Z dimensions.
+- **Z**: Appends geometries along the Z axis. The input and destination geometries must have matching X and Y dimensions.
+
 ### X Direction Examples
 
 #### Example 1 (X)

--- a/src/Plugins/SimplnxCore/docs/ApplyTransformationToGeometryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ApplyTransformationToGeometryFilter.md
@@ -91,6 +91,17 @@ This caveat is ONLY for image geometries.  Multiple transformations can be appli
 
 ## Transformation Information
 
+### Transformation Type
+
+The *Transformation Type* parameter provides the following choices:
+
+- **No Transform [0]**: Applies an identity transformation; the geometry is unchanged.
+- **Pre-Computed Transformation Matrix (4x4) [1]**: Uses a 4x4 transformation matrix supplied as an Attribute Array in row major order.
+- **Manual Transformation Matrix [2]**: Uses a manually entered 4x4 transformation matrix.
+- **Rotation [3]**: Rotates about a supplied axis-angle <x,y,z> with the angle specified in degrees.
+- **Translation [4]**: Translates the geometry by the supplied (x, y, z) values.
+- **Scale [5]**: Scales the geometry by the supplied (x, y, z) values.
+
 The user may select from a variety of options for the type of transformation to apply:
 
 | Enum Value | Transformation Type                | Representation                                                                       |

--- a/src/Plugins/SimplnxCore/docs/ApplyTransformationToGeometryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ApplyTransformationToGeometryFilter.md
@@ -108,9 +108,9 @@ The **Translate Geometry To Global Origin Before Transformation** option must be
 
 When transforming an **Image Geometry**, the *Resampling or Interpolation* parameter controls how cell data values are assigned in the newly created grid:
 
-- **Nearest Neighbor Resampling**: Each output cell takes the value of the nearest input cell. This is fast and preserves sharp boundaries, but may produce a blocky appearance.
-- **Linear Interpolation**: Each output cell value is computed using trilinear interpolation from the surrounding input cells. This produces smoother results but may blur sharp features.
-- **No Interpolation**: The transformation is applied without any resampling of cell data. Use this option when the transformation does not change the grid topology (e.g., integer translations that align exactly with the existing grid).
+- **Nearest Neighbor Resampling [0]**: Each output cell takes the value of the nearest input cell. This is fast and preserves sharp boundaries, but may produce a blocky appearance.
+- **Linear Interpolation [1]**: Each output cell value is computed using trilinear interpolation from the surrounding input cells. This produces smoother results but may blur sharp features.
+- **No Interpolation [2]**: The transformation is applied without any resampling of cell data. Use this option when the transformation does not change the grid topology (e.g., integer translations that align exactly with the existing grid).
 
 ## Saving the final transformation Matrix.
 

--- a/src/Plugins/SimplnxCore/docs/ApplyTransformationToGeometryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ApplyTransformationToGeometryFilter.md
@@ -104,6 +104,14 @@ The user may select from a variety of options for the type of transformation to 
 
 The **Translate Geometry To Global Origin Before Transformation** option must be selected if the user wants to translate their volume to (0, 0, 0), apply the transform, and then translate the volume back to its original location.
 
+### Resampling or Interpolation (Image Geometry Only)
+
+When transforming an **Image Geometry**, the *Resampling or Interpolation* parameter controls how cell data values are assigned in the newly created grid:
+
+- **Nearest Neighbor Resampling**: Each output cell takes the value of the nearest input cell. This is fast and preserves sharp boundaries, but may produce a blocky appearance.
+- **Linear Interpolation**: Each output cell value is computed using trilinear interpolation from the surrounding input cells. This produces smoother results but may blur sharp features.
+- **No Interpolation**: The transformation is applied without any resampling of cell data. Use this option when the transformation does not change the grid topology (e.g., integer translations that align exactly with the existing grid).
+
 ## Saving the final transformation Matrix.
 
 There is an option to save the final transformation matrix into its own array. The format of the output DataArray is a

--- a/src/Plugins/SimplnxCore/docs/ChangeAngleRepresentationFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ChangeAngleRepresentationFilter.md
@@ -8,6 +8,13 @@ Orientation Analysis (Conversion)
 
 This **Filter** will multiply the values of every **Element** by a factor to convert *degrees to radians* or *radians to degrees*.  The user needs to know the units of their data in order to use this **Filter** properly.
 
+### Conversion Type
+
+The *Conversion Type* parameter selects the direction of the angle conversion:
+
+- **Degrees to Radians**: Multiplies each value by π/180, converting angles expressed in degrees to their equivalent in radians.
+- **Radians to Degrees**: Multiplies each value by 180/π, converting angles expressed in radians to their equivalent in degrees.
+
 ### Example Usage
 
 2D data files that are in *HKL*'s .ctf format use degrees. 3D data files in *HKL*'s .ctf format use radians. All files in *TSL*'s .ang format use radians. If other file types are used, determine the units before running this **Filter**.

--- a/src/Plugins/SimplnxCore/docs/ChangeAngleRepresentationFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ChangeAngleRepresentationFilter.md
@@ -12,8 +12,8 @@ This **Filter** will multiply the values of every **Element** by a factor to con
 
 The *Conversion Type* parameter selects the direction of the angle conversion:
 
-- **Degrees to Radians**: Multiplies each value by π/180, converting angles expressed in degrees to their equivalent in radians.
-- **Radians to Degrees**: Multiplies each value by 180/π, converting angles expressed in radians to their equivalent in degrees.
+- **Degrees to Radians [0]**: Multiplies each value by π/180, converting angles expressed in degrees to their equivalent in radians.
+- **Radians to Degrees [1]**: Multiplies each value by 180/π, converting angles expressed in radians to their equivalent in degrees.
 
 ### Example Usage
 

--- a/src/Plugins/SimplnxCore/docs/ComputeArrayStatisticsFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeArrayStatisticsFilter.md
@@ -39,6 +39,16 @@ The user is creating the destination Attribute Matrix inside the `DataContainer`
 ![Images/Compute_Array_Statistics_2.png](Images/Compute_Array_Statistics_2.png)
 The user is creating the destination Attribute Matrix inside the `Statistics` group which was created by filter #2 in the pipeline.
 
+### Feature Range Type
+
+The *Feature Range Type* parameter provides the following choices:
+
+- **None [0]**: No feature-based range is applied; statistics are computed over the entire array without range constraints.
+- **Ignore Feature 0 [1]**: Excludes Feature Id 0 (the invalid/background feature) from statistics calculations.
+- **Shrink To Fit [2]**: Automatically determines the minimum and maximum Feature Ids present and uses that as the range, removing empty entries.
+- **Padded Custom Range [3]**: Uses a user-specified range and pads with generated/filled values for Feature Ids below the minimum and above the maximum actually present in the data.
+- **Minimum Size in Custom Range [4]**: Uses a user-specified range but clamps to the actual min/max Feature Ids if the specified bounds exceed them, avoiding padding.
+
 ## Ranges Breakdown
 
 The ranges feature was added to primarily offer the following functionality:

--- a/src/Plugins/SimplnxCore/docs/ComputeCoordinateThresholdFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeCoordinateThresholdFilter.md
@@ -12,8 +12,8 @@ This filter produces a mask that marks cells that fall inside or outside a given
 
 The *Coordinate Container Shape* parameter selects the shape used to define the threshold region:
 
-- **Rectangle**: Uses an axis-aligned rectangular box (bounding box) defined by minimum and maximum coordinate values along each axis. Cells are flagged based on whether their coordinates fall within this box.
-- **Sphere**: Uses a spherical region defined by a center point and a radius. Cells are flagged based on whether their coordinates satisfy the sphere equation (see the **Sphere Bounding Type** section below for details).
+- **Rectangle [0]**: Uses an axis-aligned rectangular box (bounding box) defined by minimum and maximum coordinate values along each axis. Cells are flagged based on whether their coordinates fall within this box.
+- **Sphere [1]**: Uses a spherical region defined by a center point and a radius. Cells are flagged based on whether their coordinates satisfy the sphere equation (see the **Sphere Bounding Type** section below for details).
 
 This filter has a check at runtime (during the execute phase, before individual mask value determination begins) that will return a warning (not error) if the bounds don't intersect any cells in the geometry. The intention of this is to alert the user that the mask will contain the same value throughout to allow the user to adapt the pipeline/parameters accordingly. When this check causes early bailout and warning, the mask will still be filled with outside bounds flag at every value. `ImageGeom` is the exception to this as it has checks done at preflight to prevent this from occurring.
 

--- a/src/Plugins/SimplnxCore/docs/ComputeCoordinateThresholdFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeCoordinateThresholdFilter.md
@@ -8,6 +8,13 @@ Geometry
 
 This filter produces a mask that marks cells that fall inside or outside a given bounding shape within a supplied geometry. The filter outputs a mask to provide the greatest flexibility, while leveraging existing algorithms. This filter doesn't modify the input geometry in any way if you wish to modify the data within the bounding box, consider using one of the cleanup filters on the marked values. See *Remove Flagged Vertices/Edges/Triangles* for an example of a potential followup filter.
 
+### Coordinate Container Shape
+
+The *Coordinate Container Shape* parameter selects the shape used to define the threshold region:
+
+- **Rectangle**: Uses an axis-aligned rectangular box (bounding box) defined by minimum and maximum coordinate values along each axis. Cells are flagged based on whether their coordinates fall within this box.
+- **Sphere**: Uses a spherical region defined by a center point and a radius. Cells are flagged based on whether their coordinates satisfy the sphere equation (see the **Sphere Bounding Type** section below for details).
+
 This filter has a check at runtime (during the execute phase, before individual mask value determination begins) that will return a warning (not error) if the bounds don't intersect any cells in the geometry. The intention of this is to alert the user that the mask will contain the same value throughout to allow the user to adapt the pipeline/parameters accordingly. When this check causes early bailout and warning, the mask will still be filled with outside bounds flag at every value. `ImageGeom` is the exception to this as it has checks done at preflight to prevent this from occurring.
 
 There are several issues to be aware of with this filter, detailed thoroughly in the following sections.

--- a/src/Plugins/SimplnxCore/docs/ComputeCoordinatesImageGeomFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeCoordinatesImageGeomFilter.md
@@ -12,9 +12,9 @@ This **Filter** produces one or two arrays that stores implicit image informatio
 
 The *Output Array(s) Type* parameter controls which arrays are produced by the filter:
 
-- **Physical Coordinates**: Outputs a single 3-component array containing the physical (spatial) XYZ coordinates of the center of each cell, computed from the geometry's origin and spacing.
-- **Indices**: Outputs a single 3-component array containing the integer ijk grid indices of each cell.
-- **Both**: Outputs both the physical coordinates array and the indices array.
+- **Physical Coordinates [0]**: Outputs a single 3-component array containing the physical (spatial) XYZ coordinates of the center of each cell, computed from the geometry's origin and spacing.
+- **Indices [1]**: Outputs a single 3-component array containing the integer ijk grid indices of each cell.
+- **Both [2]**: Outputs both the physical coordinates array and the indices array.
 
 The arrays follow the following cell parsing scheme: `0,0,0 -> 1,0,0 -> 2,0,0 -> ... n,0,0 -> 0,1,0 -> 1,1,0 -> 2,1,0 -> ... n,n,0 -> 0,0,1 -> 1,0,1 -> 2,0,1 -> ... n,n,n`.
 

--- a/src/Plugins/SimplnxCore/docs/ComputeCoordinatesImageGeomFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeCoordinatesImageGeomFilter.md
@@ -8,6 +8,14 @@ Statistics
 
 This **Filter** produces one or two arrays that stores implicit image information (indices and physical coordinates of each point) as explicit cell level data. The produced arrays are in XYZ component format and stored as X by Y by Z, starting from the origin. The intention behind this filter is primarily for output compatibility and readability.
 
+### Output Array(s) Type
+
+The *Output Array(s) Type* parameter controls which arrays are produced by the filter:
+
+- **Physical Coordinates**: Outputs a single 3-component array containing the physical (spatial) XYZ coordinates of the center of each cell, computed from the geometry's origin and spacing.
+- **Indices**: Outputs a single 3-component array containing the integer ijk grid indices of each cell.
+- **Both**: Outputs both the physical coordinates array and the indices array.
+
 The arrays follow the following cell parsing scheme: `0,0,0 -> 1,0,0 -> 2,0,0 -> ... n,0,0 -> 0,1,0 -> 1,1,0 -> 2,1,0 -> ... n,n,0 -> 0,0,1 -> 1,0,1 -> 2,0,1 -> ... n,n,n`.
 
 The printed output will look something like this:

--- a/src/Plugins/SimplnxCore/docs/ComputeFeatureBoundsFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeFeatureBoundsFilter.md
@@ -10,6 +10,13 @@ Geometry
 
 This filter calculates the bounding boxes for each feature given Feature Ids and Geometry (refer to table below for supported geometry types and their corresponding feature id sizing). _**This filter does output `NaN`s for empty features**_, cases where a point can not be associated to a feature. The bounding boxes are defined and stored as two points in space, a lower and upper point. The optimal storage solution is use case defined, and as such there are two options provided `split` and `unified`.
 
+### Output Array(s) Type
+
+The *Output Array(s) Type* parameter controls how the bounding box data is stored in the output:
+
+- **Split**: Produces two separate 3-component `float32` arrays — one for the minimum (lower) bound and one for the maximum (upper) bound of each feature's bounding box. Best for visualization and cases where min and max bounds need to be handled independently.
+- **Unified**: Produces a single 6-component `float32` array containing all bounds data in the format min-x, min-y, min-z, max-x, max-y, max-z. Best for passing bounding box data to other simplnx filters and internal calculations.
+
 | Geometry Type | Expected Feature ID Length|
 |---------------|---------------------------|
 | Image | Equal to Image Dimesions; typically equivalent to the `Cell Data` Attribute Matrix |

--- a/src/Plugins/SimplnxCore/docs/ComputeFeatureBoundsFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeFeatureBoundsFilter.md
@@ -14,8 +14,8 @@ This filter calculates the bounding boxes for each feature given Feature Ids and
 
 The *Output Array(s) Type* parameter controls how the bounding box data is stored in the output:
 
-- **Split**: Produces two separate 3-component `float32` arrays — one for the minimum (lower) bound and one for the maximum (upper) bound of each feature's bounding box. Best for visualization and cases where min and max bounds need to be handled independently.
-- **Unified**: Produces a single 6-component `float32` array containing all bounds data in the format min-x, min-y, min-z, max-x, max-y, max-z. Best for passing bounding box data to other simplnx filters and internal calculations.
+- **Split [0]**: Produces two separate 3-component `float32` arrays — one for the minimum (lower) bound and one for the maximum (upper) bound of each feature's bounding box. Best for visualization and cases where min and max bounds need to be handled independently.
+- **Unified [1]**: Produces a single 6-component `float32` array containing all bounds data in the format min-x, min-y, min-z, max-x, max-y, max-z. Best for passing bounding box data to other simplnx filters and internal calculations.
 
 | Geometry Type | Expected Feature ID Length|
 |---------------|---------------------------|

--- a/src/Plugins/SimplnxCore/docs/ComputeKMeansFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeKMeansFilter.md
@@ -10,6 +10,17 @@ DREAM3D Review (Clustering)
 
 This **Filter** applies the k means algorithm to an **Attribute Array**.  K means is a *clustering algorithm* that assigns to each point of the **Attribute Array** a *cluster Id*.  The user must specify the number of clusters in which to partition the array.  Specifically, a k means partitioning is a *Voronoi tesselation*; an optimal solution to the k means problem is such that each point in the data set is associated with the cluster that has the closest mean.  This partitioning is the one that minimizes the within cluster variance (i.e., minimizes the within cluster sum of squares differences).  The user may select from several distance metrics: *Euclidean*, *Squared Euclidean*, *Manhattan*, *Cosine*, *Pearson*, and *Squared Pearson*.
 
+### Distance Metric
+
+The *Distance Metric* parameter determines how distances between data points are measured when assigning points to clusters:
+
+- **Euclidean**: Standard straight-line distance between two points in the data space.
+- **Squared Euclidean**: The square of the Euclidean distance. Avoids a square root computation and gives extra weight to larger differences.
+- **Manhattan**: Sum of the absolute differences along each dimension (also known as L1 or city-block distance).
+- **Cosine**: One minus the cosine similarity between two points. Measures the angle between vectors, making it invariant to magnitude.
+- **Pearson**: One minus the Pearson correlation coefficient. Measures the linear correlation between two points, normalized by their standard deviations.
+- **Squared Pearson**: The square of the Pearson distance metric.
+
 Optimal solutions to the k means partitioning problem are computationally difficult; this **Filter** used *Lloyd's algorithm* to approximate the solution.  Lloyd's algorithm is an iterative algorithm that proceeds as follows:
 
 1. Choose k points at random to serve as the initial cluster "means"

--- a/src/Plugins/SimplnxCore/docs/ComputeKMeansFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeKMeansFilter.md
@@ -14,12 +14,12 @@ This **Filter** applies the k means algorithm to an **Attribute Array**.  K mean
 
 The *Distance Metric* parameter determines how distances between data points are measured when assigning points to clusters:
 
-- **Euclidean**: Standard straight-line distance between two points in the data space.
-- **Squared Euclidean**: The square of the Euclidean distance. Avoids a square root computation and gives extra weight to larger differences.
-- **Manhattan**: Sum of the absolute differences along each dimension (also known as L1 or city-block distance).
-- **Cosine**: One minus the cosine similarity between two points. Measures the angle between vectors, making it invariant to magnitude.
-- **Pearson**: One minus the Pearson correlation coefficient. Measures the linear correlation between two points, normalized by their standard deviations.
-- **Squared Pearson**: The square of the Pearson distance metric.
+- **Euclidean [0]**: Standard straight-line distance between two points in the data space.
+- **Squared Euclidean [1]**: The square of the Euclidean distance. Avoids a square root computation and gives extra weight to larger differences.
+- **Manhattan [2]**: Sum of the absolute differences along each dimension (also known as L1 or city-block distance).
+- **Cosine [3]**: One minus the cosine similarity between two points. Measures the angle between vectors, making it invariant to magnitude.
+- **Pearson [4]**: One minus the Pearson correlation coefficient. Measures the linear correlation between two points, normalized by their standard deviations.
+- **Squared Pearson [5]**: The square of the Pearson distance metric.
 
 Optimal solutions to the k means partitioning problem are computationally difficult; this **Filter** used *Lloyd's algorithm* to approximate the solution.  Lloyd's algorithm is an iterative algorithm that proceeds as follows:
 

--- a/src/Plugins/SimplnxCore/docs/ComputeKMedoidsFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeKMedoidsFilter.md
@@ -14,12 +14,12 @@ This **Filter** applies the k medoids algorithm to an **Attribute Array**.  K me
 
 The *Distance Metric* parameter determines how distances between data points are measured when assigning points to clusters and selecting medoids:
 
-- **Euclidean**: Standard straight-line distance between two points in the data space.
-- **Squared Euclidean**: The square of the Euclidean distance. Avoids a square root computation and gives extra weight to larger differences.
-- **Manhattan**: Sum of the absolute differences along each dimension (also known as L1 or city-block distance).
-- **Cosine**: One minus the cosine similarity between two points. Measures the angle between vectors, making it invariant to magnitude.
-- **Pearson**: One minus the Pearson correlation coefficient. Measures the linear correlation between two points, normalized by their standard deviations.
-- **Squared Pearson**: The square of the Pearson distance metric.
+- **Euclidean [0]**: Standard straight-line distance between two points in the data space.
+- **Squared Euclidean [1]**: The square of the Euclidean distance. Avoids a square root computation and gives extra weight to larger differences.
+- **Manhattan [2]**: Sum of the absolute differences along each dimension (also known as L1 or city-block distance).
+- **Cosine [3]**: One minus the cosine similarity between two points. Measures the angle between vectors, making it invariant to magnitude.
+- **Pearson [4]**: One minus the Pearson correlation coefficient. Measures the linear correlation between two points, normalized by their standard deviations.
+- **Squared Pearson [5]**: The square of the Pearson distance metric.
 
 This **Filter** uses the *Voronoi iteration* algorithm to produce the clustering.  The algorithm is iterative and proceeds as follows:
 

--- a/src/Plugins/SimplnxCore/docs/ComputeKMedoidsFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeKMedoidsFilter.md
@@ -10,6 +10,17 @@ DREAM3D Review (Clustering)
 
 This **Filter** applies the k medoids algorithm to an **Attribute Array**.  K medoids is a *clustering algorithm* that assigns to each point of the **Attribute Array** a *cluster Id*.  The user must specify the number of clusters in which to partition the array.  Specifically, a k medoids partitioning is such that each point in the data set is associated with the cluster that minimizes the sum of the pair-wise distances between the data points and their associated cluster centers (medoids).  This approach is analogous to k means, but uses actual data points (the medoids) as the cluster exemplars instead of the means.  Medoids in this context refer to the data point in each cluster that is most like all other data points, i.e., that data point whose average distance to all other data points in the cluster is smallest.  Unlike k means, since pair-wise distances are minimized instead of variance, any arbirtary concept of "distance" may be used; this **Filter** allows for the selection of a variety of distance metrics.
 
+### Distance Metric
+
+The *Distance Metric* parameter determines how distances between data points are measured when assigning points to clusters and selecting medoids:
+
+- **Euclidean**: Standard straight-line distance between two points in the data space.
+- **Squared Euclidean**: The square of the Euclidean distance. Avoids a square root computation and gives extra weight to larger differences.
+- **Manhattan**: Sum of the absolute differences along each dimension (also known as L1 or city-block distance).
+- **Cosine**: One minus the cosine similarity between two points. Measures the angle between vectors, making it invariant to magnitude.
+- **Pearson**: One minus the Pearson correlation coefficient. Measures the linear correlation between two points, normalized by their standard deviations.
+- **Squared Pearson**: The square of the Pearson distance metric.
+
 This **Filter** uses the *Voronoi iteration* algorithm to produce the clustering.  The algorithm is iterative and proceeds as follows:
 
 1. Choose k points at random to serve as the initial cluster medoids

--- a/src/Plugins/SimplnxCore/docs/ComputeLargestCrossSectionsFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeLargestCrossSectionsFilter.md
@@ -8,6 +8,14 @@ Statistics (Morphological)
 
 This **Filter** calculates the largest cross-sectional area on a user-defined plane for all **Features**.  The **Filter** simply iterates through all **Cells** (on each section) asking for **Feature** that owns them.  On each section, the count of **Cells** for each **Feature** is then converted to an area and stored as the *LargestCrossSection* if the area for the current section is larger than the existing *LargestCrossSection* for that **Feature**.
 
+### Plane of Interest
+
+The *Plane of Interest* parameter selects the plane along which cross-sections are computed. The filter iterates through all slices perpendicular to the remaining axis:
+
+- **XY**: Cross-sections are taken on planes perpendicular to the Z axis. Each Z slice is one cross-section.
+- **XZ**: Cross-sections are taken on planes perpendicular to the Y axis. Each Y slice is one cross-section.
+- **YZ**: Cross-sections are taken on planes perpendicular to the X axis. Each X slice is one cross-section.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/SimplnxCore/docs/ComputeLargestCrossSectionsFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeLargestCrossSectionsFilter.md
@@ -12,9 +12,9 @@ This **Filter** calculates the largest cross-sectional area on a user-defined pl
 
 The *Plane of Interest* parameter selects the plane along which cross-sections are computed. The filter iterates through all slices perpendicular to the remaining axis:
 
-- **XY**: Cross-sections are taken on planes perpendicular to the Z axis. Each Z slice is one cross-section.
-- **XZ**: Cross-sections are taken on planes perpendicular to the Y axis. Each Y slice is one cross-section.
-- **YZ**: Cross-sections are taken on planes perpendicular to the X axis. Each X slice is one cross-section.
+- **XY [0]**: Cross-sections are taken on planes perpendicular to the Z axis. Each Z slice is one cross-section.
+- **XZ [1]**: Cross-sections are taken on planes perpendicular to the Y axis. Each Y slice is one cross-section.
+- **YZ [2]**: Cross-sections are taken on planes perpendicular to the X axis. Each X slice is one cross-section.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/ConvertColorToGrayScaleFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ConvertColorToGrayScaleFilter.md
@@ -8,10 +8,14 @@ Processing (Image)
 
 This **Filter** allows the user to select a *flattening* method for turning an array of RGB or RGBa values into grayscale values.
 
-+ Luminosity: The **luminosity** method is a more sophisticated version of the average method. It also averages the values, but it forms a weighted average to account for human perception. We   re more sensitive to green than other colors, so green is weighted most heavily. The default formula for luminosity is BT709 Greyscale: Red: 0.2125 Green: 0.7154 Blue: 0.0721. The user can set the weightings to what ever values they would like.
-+ Average  (R + G + B) / 3
-+ Lightness (max(R, G, B) + min(R, G, B)) / 2
-+ Color Channel: The user selects a specific R|G|B channel to use as the GrayScale values.
+### Conversion Algorithm
+
+The *Conversion Algorithm* parameter provides the following choices:
+
+- **Luminosity [0]**: A weighted average of RGB channels that accounts for human perception (more sensitive to green). Uses the BT709 formula by default: Red: 0.2125, Green: 0.7154, Blue: 0.0721. The user can set custom weightings.
+- **Average [1]**: Computes a simple arithmetic average of R, G, and B channel values: (R + G + B) / 3.
+- **Lightness [2]**: Averages the maximum and minimum channel values: (max(R, G, B) + min(R, G, B)) / 2.
+- **SingleChannel [3]**: The user selects a specific R, G, or B channel to use directly as the grayscale values.
 
 The user can select 1 or more image data arrays which are assumed to be multi-component arrays of unsigned 8 bit values. The user can create a new AttributeMatrix if they want to store all the newly created arrays in a separate AttributeMatrix.
 

--- a/src/Plugins/SimplnxCore/docs/ConvertDataFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ConvertDataFilter.md
@@ -12,17 +12,17 @@ This **Filter** converts attribute data from one primitive type to another by us
 
 The *Scalar Type* parameter selects the target primitive data type for the converted array:
 
-- **int8**: Signed 8-bit integer (-128 to 127)
-- **uint8**: Unsigned 8-bit integer (0 to 255)
-- **int16**: Signed 16-bit integer (-32,768 to 32,767)
-- **uint16**: Unsigned 16-bit integer (0 to 65,535)
-- **int32**: Signed 32-bit integer (-2,147,483,648 to 2,147,483,647)
-- **uint32**: Unsigned 32-bit integer (0 to 4,294,967,295)
-- **int64**: Signed 64-bit integer
-- **uint64**: Unsigned 64-bit integer
-- **float32**: 32-bit floating point
-- **float64**: 64-bit floating point (double precision)
-- **boolean**: Boolean (0 = false, any non-zero value = true)
+- **int8 [0]**: Signed 8-bit integer (-128 to 127)
+- **uint8 [1]**: Unsigned 8-bit integer (0 to 255)
+- **int16 [2]**: Signed 16-bit integer (-32,768 to 32,767)
+- **uint16 [3]**: Unsigned 16-bit integer (0 to 65,535)
+- **int32 [4]**: Signed 32-bit integer (-2,147,483,648 to 2,147,483,647)
+- **uint32 [5]**: Unsigned 32-bit integer (0 to 4,294,967,295)
+- **int64 [6]**: Signed 64-bit integer
+- **uint64 [7]**: Unsigned 64-bit integer
+- **float32 [8]**: 32-bit floating point
+- **float64 [9]**: 64-bit floating point (double precision)
+- **boolean [10]**: Boolean (0 = false, any non-zero value = true)
 
 **This Filter is here for convenience and should be used with great care and understanding of the input and output data. This Filter should rarely be required, and if the user thinks that they require this Filter then a detailed examination of all the data involved should be undertaken to avoid possible undefined behaviors.**
 

--- a/src/Plugins/SimplnxCore/docs/ConvertDataFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ConvertDataFilter.md
@@ -8,6 +8,22 @@ Core (Misc)
 
 This **Filter** converts attribute data from one primitive type to another by using the built in translation of the compiler. This **Filter** can be used if the user needs to convert an array into a type that is accepted by another **Filter**. For example, a **Filter** may need an input array to be of type _int32_t_ but the array that the user would like to use is _uint16_t_. The user may use this **Filter** to create a new array that has the proper target type (_int32_t_).
 
+### Scalar Type
+
+The *Scalar Type* parameter selects the target primitive data type for the converted array:
+
+- **int8**: Signed 8-bit integer (-128 to 127)
+- **uint8**: Unsigned 8-bit integer (0 to 255)
+- **int16**: Signed 16-bit integer (-32,768 to 32,767)
+- **uint16**: Unsigned 16-bit integer (0 to 65,535)
+- **int32**: Signed 32-bit integer (-2,147,483,648 to 2,147,483,647)
+- **uint32**: Unsigned 32-bit integer (0 to 4,294,967,295)
+- **int64**: Signed 64-bit integer
+- **uint64**: Unsigned 64-bit integer
+- **float32**: 32-bit floating point
+- **float64**: 64-bit floating point (double precision)
+- **boolean**: Boolean (0 = false, any non-zero value = true)
+
 **This Filter is here for convenience and should be used with great care and understanding of the input and output data. This Filter should rarely be required, and if the user thinks that they require this Filter then a detailed examination of all the data involved should be undertaken to avoid possible undefined behaviors.**
 
 ### Important Notes

--- a/src/Plugins/SimplnxCore/docs/CreateDataArrayAdvancedFilter.md
+++ b/src/Plugins/SimplnxCore/docs/CreateDataArrayAdvancedFilter.md
@@ -8,6 +8,22 @@ Core (Generation)
 
 This **Filter** creates a **Data Array** of any primitive type with any set of component dimensions.  The array is initialized to a user defined value or with random values within a specified range.
 
+### Initialization Type
+
+The *Initialization Type* parameter selects how the array values are populated:
+
+- **Fill Value**: Every element in the array is set to the same user-supplied value (or per-component values when using the semicolon-separated notation).
+- **Incremental**: Values are filled in sequence starting from a user-supplied starting value, stepping by a fixed amount using the chosen *Step Operation*.
+- **Random**: Each element is assigned a uniformly random value over the full range of the selected data type. An optional seed can be supplied for reproducibility.
+- **Random With Range**: Each element is assigned a uniformly random value within a user-specified minimum and maximum range. An optional seed can be supplied for reproducibility.
+
+### Step Operation
+
+The *Step Operation* parameter is active when *Initialization Type* is set to **Incremental**. It controls whether each successive value increases or decreases:
+
+- **Addition**: Each successive element value is the previous value plus the step amount (ascending sequence).
+- **Subtraction**: Each successive element value is the previous value minus the step amount (descending sequence).
+
 When initializing a multicomponent array square bracket notation can be used to specify different initialization values for each component. For example say that I want to intialize a 2 component array where the first component is 0 and the second component is 1 we would use the following input string for the *Initialization Value*
 
     0;1

--- a/src/Plugins/SimplnxCore/docs/CreateDataArrayAdvancedFilter.md
+++ b/src/Plugins/SimplnxCore/docs/CreateDataArrayAdvancedFilter.md
@@ -12,17 +12,17 @@ This **Filter** creates a **Data Array** of any primitive type with any set of c
 
 The *Initialization Type* parameter selects how the array values are populated:
 
-- **Fill Value**: Every element in the array is set to the same user-supplied value (or per-component values when using the semicolon-separated notation).
-- **Incremental**: Values are filled in sequence starting from a user-supplied starting value, stepping by a fixed amount using the chosen *Step Operation*.
-- **Random**: Each element is assigned a uniformly random value over the full range of the selected data type. An optional seed can be supplied for reproducibility.
-- **Random With Range**: Each element is assigned a uniformly random value within a user-specified minimum and maximum range. An optional seed can be supplied for reproducibility.
+- **Fill Value [0]**: Every element in the array is set to the same user-supplied value (or per-component values when using the semicolon-separated notation).
+- **Incremental [1]**: Values are filled in sequence starting from a user-supplied starting value, stepping by a fixed amount using the chosen *Step Operation*.
+- **Random [2]**: Each element is assigned a uniformly random value over the full range of the selected data type. An optional seed can be supplied for reproducibility.
+- **Random With Range [3]**: Each element is assigned a uniformly random value within a user-specified minimum and maximum range. An optional seed can be supplied for reproducibility.
 
 ### Step Operation
 
 The *Step Operation* parameter is active when *Initialization Type* is set to **Incremental**. It controls whether each successive value increases or decreases:
 
-- **Addition**: Each successive element value is the previous value plus the step amount (ascending sequence).
-- **Subtraction**: Each successive element value is the previous value minus the step amount (descending sequence).
+- **Addition [0]**: Each successive element value is the previous value plus the step amount (ascending sequence).
+- **Subtraction [1]**: Each successive element value is the previous value minus the step amount (descending sequence).
 
 When initializing a multicomponent array square bracket notation can be used to specify different initialization values for each component. For example say that I want to intialize a 2 component array where the first component is 0 and the second component is 1 we would use the following input string for the *Initialization Value*
 

--- a/src/Plugins/SimplnxCore/docs/CreateGeometryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/CreateGeometryFilter.md
@@ -111,8 +111,8 @@ A **Hexahedral Geometry** is a *mesh-like* **Geometry**, consisting of a collect
 
 The *Array Handling* parameter controls how the input **Attribute Arrays** (vertex list, element connectivity, etc.) are transferred to the new **Geometry**:
 
-- **Copy Attribute Arrays**: The input arrays are copied into the new **Geometry**. The original arrays remain in the **Data Structure** and are unaffected by any subsequent geometric operations.
-- **Move Attribute Arrays**: The input arrays are moved into the new **Geometry**. The original array paths are removed from the **Data Structure**, reducing memory usage when the originals are no longer needed.
+- **Copy Attribute Arrays [0]**: The input arrays are copied into the new **Geometry**. The original arrays remain in the **Data Structure** and are unaffected by any subsequent geometric operations.
+- **Move Attribute Arrays [1]**: The input arrays are moved into the new **Geometry**. The original array paths are removed from the **Data Structure**, reducing memory usage when the originals are no longer needed.
 
 This **Filter** will validate that the arrays selected to define a **Geometry** "make sense", given the above information for how **Geometries** are stored in **DREAM3D-NX** (for example, no dimension for an **Image** may be less than or equal to zero, no bounds arrays for a **Rectilinear Grid** may have less than two values, and no **Vertex** Ids stored in a shared **Element** list may be larger than the total number of **Vertices** in the shared **Vertex** list).  The checks that require accessing the actual array values (as opposed to just descriptive information) will be performed at run time.  By default, these checks will only produce warnings, allowing the **Pipeline** to continue; the user may opt to change these warnings to errors by selecting the *Treat Geometry Warnings as Errors* option.
 

--- a/src/Plugins/SimplnxCore/docs/CreateGeometryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/CreateGeometryFilter.md
@@ -107,6 +107,13 @@ A **Hexahedral Geometry** is a *mesh-like* **Geometry**, consisting of a collect
 
  For **Geometries** that require the selection of **Attribute Arrays** (all **Geometries** except **Image**), the arrays will be *copied* to create the new **Geometry**.  Therefore, any operations on the original array will not affect the topology of the **Geometry**, and any geometric operations will not affect the original array. This behavior can be adjusted in the filter by using the *Array Handling* boolean.
 
+### Array Handling
+
+The *Array Handling* parameter controls how the input **Attribute Arrays** (vertex list, element connectivity, etc.) are transferred to the new **Geometry**:
+
+- **Copy Attribute Arrays**: The input arrays are copied into the new **Geometry**. The original arrays remain in the **Data Structure** and are unaffected by any subsequent geometric operations.
+- **Move Attribute Arrays**: The input arrays are moved into the new **Geometry**. The original array paths are removed from the **Data Structure**, reducing memory usage when the originals are no longer needed.
+
 This **Filter** will validate that the arrays selected to define a **Geometry** "make sense", given the above information for how **Geometries** are stored in **DREAM3D-NX** (for example, no dimension for an **Image** may be less than or equal to zero, no bounds arrays for a **Rectilinear Grid** may have less than two values, and no **Vertex** Ids stored in a shared **Element** list may be larger than the total number of **Vertices** in the shared **Vertex** list).  The checks that require accessing the actual array values (as opposed to just descriptive information) will be performed at run time.  By default, these checks will only produce warnings, allowing the **Pipeline** to continue; the user may opt to change these warnings to errors by selecting the *Treat Geometry Warnings as Errors* option.
 
 Generally, arrays used by this **Filter** to create **Geometries** must be supplied by the user.  One method to import geometric information into **DREAM3D-NX** is to read the information in from a text file using the Import ASCII Data **Filter**.  For example, imagine having an external simulation code that creates a tetrahedral volume mesh with two associated field values, one stored on the mesh vertices and one stored on the mesh tetrahedra.  It is possible to import this mesh and corresponding information into **DREAM3D-NX** for further analysis.  The user must supply at least two files: one that contains the vertex information and one that contains the tetrahedra information.  The vertex file would contain, on each line, the three coordinates of the vertex and the value of the field array on that vertex.  It may, for example, look like this:

--- a/src/Plugins/SimplnxCore/docs/CropEdgeGeometryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/CropEdgeGeometryFilter.md
@@ -8,11 +8,11 @@ Users can selectively crop specific dimensions of the **Edge Geometry** by toggl
 
 ### Boundary Intersection Behavior
 
-The filter provides options to handle edges that intersect the defined cropping bounds:
+The *Boundary Intersection Behavior* parameter provides the following choices:
 
-- **Filter Error**: Throws an error if any edge intersects the cropping boundary, ensuring strict adherence to the ROI.
-- **Interpolate Outside Vertex**: Interpolates the position of vertices that lie outside the ROI, allowing partial edges to be included based on interpolation.
-- **Ignore Edge**: Excludes edges that intersect the cropping boundary without throwing an error or interpolating vertices.
+- **Interpolate Outside Vertex [0]**: Interpolates the position of vertices that lie outside the ROI, allowing partial edges to be included based on interpolation.
+- **Ignore Edge [1]**: Excludes edges that intersect the cropping boundary without throwing an error or interpolating vertices.
+- **Filter Error [2]**: Throws an error if any edge intersects the cropping boundary, ensuring strict adherence to the ROI.
 
 **NOTE:** When the **Interpolate Outside Vertex** boundary intersection behavior is chosen, this filter DOES NOT interpolate any vertex data, only the vertex position!
 

--- a/src/Plugins/SimplnxCore/docs/DBSCANFilter.md
+++ b/src/Plugins/SimplnxCore/docs/DBSCANFilter.md
@@ -149,6 +149,25 @@ This can obviously be caused by large datasets, but it can be mitigated with som
 **If your algorithm spends more time in "cluster expansion pass:" than "Identifying Qualifying Independent Clusters".** See output window.
 There are many datasets that this is normal in such as `No Structure` from **Examples**. This typically happens when `Minimum Points` is too high. This results in too few Core grids being identified. Since few clusters are able to be formed, most of the time is spent in iterative loops expanding the clusters rather than just preforming the early merges in the Core grid step.
 
+### Parse Order
+
+The *Parse Order* parameter provides the following choices:
+
+- **Low Density First [0]**: Processes lower-density grid voxels first; deterministic and typically the fastest option.
+- **Random [1]**: Processes grid voxels in a non-deterministic random order using a time-based seed.
+- **Seeded Random [2]**: Processes grid voxels in a deterministic random order using a user-supplied seed for reproducibility.
+
+### Distance Metric
+
+The *Distance Metric* parameter provides the following choices:
+
+- **Euclidean [0]**: Uses the standard straight-line (L2) distance between points.
+- **Squared Euclidean [1]**: Uses the squared L2 distance, avoiding the square-root computation for faster calculations.
+- **Manhattan [2]**: Uses the L1 (taxicab) distance, summing absolute differences per component.
+- **Cosine [3]**: Uses the cosine distance, measuring the angular dissimilarity between points.
+- **Pearson [4]**: Uses the Pearson correlation distance, measuring linear correlation dissimilarity.
+- **Squared Pearson [5]**: Uses the squared Pearson correlation distance.
+
 ## Note on Randomness
 
 The inclusion of randomness in this algorithm is solely to attempt to reduce bias from starting cluster. Three parse order options are available: *Low Density First* (deterministic, no seed needed), *Random* (non-deterministic, uses a time-based seed), and *Seeded Random* (deterministic, uses a user-supplied seed value for reproducibility). Low Density First produced identical results faster in our test cases, but the random initialization is truest to the well known DBSCAN algorithm.

--- a/src/Plugins/SimplnxCore/docs/ErodeDilateBadDataFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ErodeDilateBadDataFilter.md
@@ -47,6 +47,12 @@ would remove the single **Cells** and reduce the pores by one **Cell**. If this 
 operation, then the pores would grow by one **Cell** and return to near their original size, while the single **Cells**
 would remain removed and not "grow back".
 
+### Operation
+
+The *Operation* parameter selects which morphological operation to apply:
+
+- **Dilate**: Grows bad data regions by one **Cell** per iteration. Any **Cell** neighboring a bad **Cell** has its *Feature Id* changed to 0.
+- **Erode**: Shrinks bad data regions by one **Cell** per iteration. Each bad **Cell** is assigned the *Feature Id* of the majority of its neighbors.
 
 ## WARNING: Feature Data Will Become Invalid
 

--- a/src/Plugins/SimplnxCore/docs/ErodeDilateBadDataFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ErodeDilateBadDataFilter.md
@@ -51,8 +51,8 @@ would remain removed and not "grow back".
 
 The *Operation* parameter selects which morphological operation to apply:
 
-- **Dilate**: Grows bad data regions by one **Cell** per iteration. Any **Cell** neighboring a bad **Cell** has its *Feature Id* changed to 0.
-- **Erode**: Shrinks bad data regions by one **Cell** per iteration. Each bad **Cell** is assigned the *Feature Id* of the majority of its neighbors.
+- **Dilate [0]**: Grows bad data regions by one **Cell** per iteration. Any **Cell** neighboring a bad **Cell** has its *Feature Id* changed to 0.
+- **Erode [1]**: Shrinks bad data regions by one **Cell** per iteration. Each bad **Cell** is assigned the *Feature Id* of the majority of its neighbors.
 
 ## WARNING: Feature Data Will Become Invalid
 

--- a/src/Plugins/SimplnxCore/docs/ErodeDilateMaskFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ErodeDilateMaskFilter.md
@@ -29,8 +29,8 @@ The example images below were generated **AFTER** the execution of the filter an
 
 The *Operation* parameter selects which morphological operation to apply to the mask:
 
-- **Dilate**: Expands the masked (true) regions by one **Cell** per iteration. Any **Cell** neighboring a false **Cell** is changed to true.
-- **Erode**: Shrinks the masked (true) regions by one **Cell** per iteration. True **Cells** that have at least one false neighbor are changed to false.
+- **Dilate [0]**: Expands the masked (true) regions by one **Cell** per iteration. Any **Cell** neighboring a false **Cell** is changed to true.
+- **Erode [1]**: Shrinks the masked (true) regions by one **Cell** per iteration. True **Cells** that have at least one false neighbor are changed to false.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/ErodeDilateMaskFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ErodeDilateMaskFilter.md
@@ -25,6 +25,13 @@ The example images below were generated **AFTER** the execution of the filter an
 |--------------------------------------|--------------------------------------|
 | ![](Images/ErodeDilateMask_Before.png) | ![](Images/ErodeDilateMask_Erode.png) |
 
+### Operation
+
+The *Operation* parameter selects which morphological operation to apply to the mask:
+
+- **Dilate**: Expands the masked (true) regions by one **Cell** per iteration. Any **Cell** neighboring a false **Cell** is changed to true.
+- **Erode**: Shrinks the masked (true) regions by one **Cell** per iteration. True **Cells** that have at least one false neighbor are changed to false.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/SimplnxCore/docs/ExtractFeatureBoundaries2DFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ExtractFeatureBoundaries2DFilter.md
@@ -15,13 +15,13 @@ The algorithm scans the Feature IDs array and identifies boundaries where adjace
 - **Shared Vertex List**: 3D coordinates of all unique vertices at feature boundaries
 - **Shared Edge List**: Connectivity pairs defining line segments between vertices
 
-### Z Value Caveats
+### Z Value Source
 
-The filter provides three options for setting the Z coordinate of the generated vertices:
+The *Z Value Source* parameter provides the following choices:
 
-1. **Use min z value from Image geometry**: Uses the origin Z value of the input Image Geometry
-2. **Use max z value from Image geometry**: Uses the origin Z plus the spacing times the Z dimension
-3. **Use Custom z Offset**: Allows specifying a custom Z value for all vertices
+- **Use min z value from Image geometry [0]**: Uses the origin Z value of the input Image Geometry as the Z coordinate for all generated vertices.
+- **Use max z value from Image geometry [1]**: Uses the origin Z plus the spacing times the Z dimension as the Z coordinate for all generated vertices.
+- **Use Custom z Offset [2]**: Allows the user to specify an arbitrary Z coordinate value for all generated vertices.
 
 ### Algorithm Details
 

--- a/src/Plugins/SimplnxCore/docs/ExtractVertexGeometryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ExtractVertexGeometryFilter.md
@@ -13,6 +13,13 @@ creating a vertex if the mask value = TRUE.
 
 ![Example showing the use of a Mask array to only generate specific points.](Images/ExtractVertexGeometry_1.png)
 
+### Array Handling
+
+The *Array Handling* parameter controls how the selected cell arrays are transferred to the new **Vertex Geometry**:
+
+- **Copy Attribute Arrays**: Creates copies of the selected arrays in the new vertex geometry, leaving the originals intact in the source geometry.
+- **Move Attribute Arrays**: Moves the selected arrays to the new vertex geometry, removing them from their original location.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/SimplnxCore/docs/ExtractVertexGeometryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ExtractVertexGeometryFilter.md
@@ -17,8 +17,8 @@ creating a vertex if the mask value = TRUE.
 
 The *Array Handling* parameter controls how the selected cell arrays are transferred to the new **Vertex Geometry**:
 
-- **Copy Attribute Arrays**: Creates copies of the selected arrays in the new vertex geometry, leaving the originals intact in the source geometry.
-- **Move Attribute Arrays**: Moves the selected arrays to the new vertex geometry, removing them from their original location.
+- **Copy Attribute Arrays [0]**: Creates copies of the selected arrays in the new vertex geometry, leaving the originals intact in the source geometry.
+- **Move Attribute Arrays [1]**: Moves the selected arrays to the new vertex geometry, removing them from their original location.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/IdentifySampleFilter.md
+++ b/src/Plugins/SimplnxCore/docs/IdentifySampleFilter.md
@@ -38,6 +38,14 @@ filling the surrounding overscan area.
 | ![Small IN100 IPF Map](Images/Small_IN100.png) | Good dataset to use this filter                                              |
 | ![APTR IPF Colors](Images/aptr12_001_0.png)    | NOT** a good data set to use because there is **no** overscan of the sample. |
 
+### Slice-By-Slice Plane
+
+When *Process Data Slice-By-Slice* is enabled, the *Slice-By-Slice Plane* parameter selects the plane along which the volume is scanned one slice at a time:
+
+- **XY**: Processes the volume slice by slice along the Z axis, scanning each XY plane independently.
+- **XZ**: Processes the volume slice by slice along the Y axis, scanning each XZ plane independently.
+- **YZ**: Processes the volume slice by slice along the X axis, scanning each YZ plane independently.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/SimplnxCore/docs/IdentifySampleFilter.md
+++ b/src/Plugins/SimplnxCore/docs/IdentifySampleFilter.md
@@ -42,9 +42,9 @@ filling the surrounding overscan area.
 
 When *Process Data Slice-By-Slice* is enabled, the *Slice-By-Slice Plane* parameter selects the plane along which the volume is scanned one slice at a time:
 
-- **XY**: Processes the volume slice by slice along the Z axis, scanning each XY plane independently.
-- **XZ**: Processes the volume slice by slice along the Y axis, scanning each XZ plane independently.
-- **YZ**: Processes the volume slice by slice along the X axis, scanning each YZ plane independently.
+- **XY [0]**: Processes the volume slice by slice along the Z axis, scanning each XY plane independently.
+- **XZ [1]**: Processes the volume slice by slice along the Y axis, scanning each XZ plane independently.
+- **YZ [2]**: Processes the volume slice by slice along the X axis, scanning each YZ plane independently.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/InitializeDataFilter.md
+++ b/src/Plugins/SimplnxCore/docs/InitializeDataFilter.md
@@ -8,6 +8,22 @@ Processing (Cleanup)
 
 This **Filter** allows the user to define the data set in a _DataArray_.
 
+### Initialization Type
+
+The *Initialization Type* parameter provides the following choices:
+
+- **Fill Value [0]**: Copies a user-supplied constant value (or per-component values) into every tuple in the array.
+- **Incremental [1]**: Fills the array starting from a user-supplied value and applying a fixed step (increment or decrement) to each successive tuple.
+- **Random [2]**: Generates random values across the full scalar type range. An optional fixed seed can be supplied for reproducibility.
+- **Random With Range [3]**: Generates random values within a user-specified minimum/maximum range per component.
+
+### Step Operation
+
+The *Step Operation* parameter (used with **Incremental** initialization) provides the following choices:
+
+- **Addition [0]**: Adds the step value to the previous tuple's value at each successive tuple.
+- **Subtraction [1]**: Subtracts the step value from the previous tuple's value at each successive tuple.
+
 This **Filter** provides several ways to do this:
 
 - Fill Value:

--- a/src/Plugins/SimplnxCore/docs/InitializeImageGeomCellDataFilter.md
+++ b/src/Plugins/SimplnxCore/docs/InitializeImageGeomCellDataFilter.md
@@ -8,6 +8,14 @@ Processing (Cleanup)
 
 This **Filter** allows the user to define a subvolume of the data set in which the **Filter** will reset all data for every **Cell** within the subvolume. The user can choose from three initialization modes: *Manual* (initialize to a user-specified value), *Random* (initialize with random values across the full range of the data type), or *Random With Range* (initialize with random values within a user-specified range).
 
+### Initialization Type
+
+The *Initialization Type* parameter provides the following choices:
+
+- **Manual [0]**: Initializes every cell in the subvolume to a user-specified constant value.
+- **Random [1]**: Initializes every cell in the subvolume with random values drawn from the full range of the data type.
+- **Random With Range [2]**: Initializes every cell in the subvolume with random values drawn from a user-specified minimum/maximum range.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/SimplnxCore/docs/InterpolatePointCloudToRegularGridFilter.md
+++ b/src/Plugins/SimplnxCore/docs/InterpolatePointCloudToRegularGridFilter.md
@@ -8,14 +8,16 @@ Sampling (Interpolation)
 
 This **Filter** interpolates the values of arrays stored in a **Vertex Geometry** (point cloud) onto a user-selected **Image Geometry** (regular grid). For each point in the cloud, the filter applies a kernel centered on the point's voxel and accumulates weighted contributions into every voxel the kernel overlaps. The result is a single interpolated value per voxel per array, computed as a weighted average of all contributions.
 
+### Interpolation Technique
+
+The *Interpolation Technique* parameter provides the following choices:
+
+- **Uniform [0]**: Every voxel within the kernel radius receives equal weight (1.0).
+- **Gaussian [1]**: Voxel weights fall off with distance from the kernel center according to a Gaussian function, controlled by user-specified sigma values in each dimension.
+
 ### Kernel
 
-The user defines the (x, y, z) radii of a kernel in *real space units*. The kernel can be initialized to one of two modes:
-
-- **Uniform** – Every voxel within the kernel radius receives equal weight (1.0).
-- **Gaussian** - Voxel weights fall off with distance from the center according to a Gaussian function controlled by user-specified *sigmas* in each dimension.
-
-The kernel radii are converted to voxel units based on the spacing of the **Image Geometry**. If the kernel radius in a given dimension is smaller than the voxel spacing, the kernel has a zero extent in that dimension (i.e., each point only affects its own voxel along that axis).
+The user defines the (x, y, z) radii of a kernel in *real space units*. The kernel radii are converted to voxel units based on the spacing of the **Image Geometry**. If the kernel radius in a given dimension is smaller than the voxel spacing, the kernel has a zero extent in that dimension (i.e., each point only affects its own voxel along that axis).
 
 ### Algorithm
 

--- a/src/Plugins/SimplnxCore/docs/MapPointCloudToRegularGridFilter.md
+++ b/src/Plugins/SimplnxCore/docs/MapPointCloudToRegularGridFilter.md
@@ -14,16 +14,16 @@ Additionally, the user may opt to use a mask; points for which the mask are fals
 
 The *Sampling Grid Type* parameter controls how the target grid is defined:
 
-- **Manual**: The user specifies the grid dimensions directly. The filter creates a new **Image Geometry** with those dimensions to use as the sampling grid.
-- **Use Existing Image Geometry**: The user selects a pre-existing **Image Geometry** from the data structure to use as the sampling grid.
+- **Manual [0]**: The user specifies the grid dimensions directly. The filter creates a new **Image Geometry** with those dimensions to use as the sampling grid.
+- **Use Existing Image Geometry [1]**: The user selects a pre-existing **Image Geometry** from the data structure to use as the sampling grid.
 
 ### Out of Bounds Handling
 
 The *Out of Bounds Handling* parameter provides the following choices:
 
-- **Silent**: Silently uses the user-supplied out-of-bounds value. This is the default.
-- **Warning with Count**: Emits a filter warning after execution containing the number of out-of-bounds values encountered.
-- **Error at First Instance**: Emits a filter error at the first out-of-bounds value encountered.
+- **Silent [0]**: Silently uses the user-supplied out-of-bounds value. This is the default.
+- **Warning with Count [1]**: Emits a filter warning after execution containing the number of out-of-bounds values encountered.
+- **Error at First Instance [2]**: Emits a filter error at the first out-of-bounds value encountered.
 
 The default selection is `Silent`, but it is mostly provided as a way to preserve existing functionality. What follows are a few use cases we had in mind when adding this functionality, organized by handling type:
 

--- a/src/Plugins/SimplnxCore/docs/MapPointCloudToRegularGridFilter.md
+++ b/src/Plugins/SimplnxCore/docs/MapPointCloudToRegularGridFilter.md
@@ -6,15 +6,24 @@ Sampling (Mapping)
 
 ## Description
 
-This **Filter** determines, for a user-defined grid, in which voxel each point in a **Vertex Geometry** lies.  The user can either construct a sampling grid by specifying the dimensions, or select a pre-existing **Image Geometry** to use as the sampling grid.  The voxel indices that each point lies in are stored on the vertices.  
+This **Filter** determines, for a user-defined grid, in which voxel each point in a **Vertex Geometry** lies.  The user can either construct a sampling grid by specifying the dimensions, or select a pre-existing **Image Geometry** to use as the sampling grid.  The voxel indices that each point lies in are stored on the vertices.
 
 Additionally, the user may opt to use a mask; points for which the mask are false are ignored when computing voxel indices (instead, they are initialized to voxel 0).
 
-One of the features provided to the user is control over the value used when a point is Out-of-Bounds. The three options are:
+### Sampling Grid Type
 
-- `Silent`: (default) Will silently use the user supplied value
-- `Warning with Count`: Will emit a filer warning that contains the number of out-of-bounds values were encountered.
-- `Error at First Instance`: Will emit a filter error at the out-of-bounds value that is encountered.
+The *Sampling Grid Type* parameter controls how the target grid is defined:
+
+- **Manual**: The user specifies the grid dimensions directly. The filter creates a new **Image Geometry** with those dimensions to use as the sampling grid.
+- **Use Existing Image Geometry**: The user selects a pre-existing **Image Geometry** from the data structure to use as the sampling grid.
+
+### Out of Bounds Handling
+
+The *Out of Bounds Handling* parameter provides the following choices:
+
+- **Silent**: Silently uses the user-supplied out-of-bounds value. This is the default.
+- **Warning with Count**: Emits a filter warning after execution containing the number of out-of-bounds values encountered.
+- **Error at First Instance**: Emits a filter error at the first out-of-bounds value encountered.
 
 The default selection is `Silent`, but it is mostly provided as a way to preserve existing functionality. What follows are a few use cases we had in mind when adding this functionality, organized by handling type:
 

--- a/src/Plugins/SimplnxCore/docs/PartitionGeometryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/PartitionGeometryFilter.md
@@ -10,6 +10,15 @@ This **Filter** generates a partition grid and assigns partition IDs for every v
 
 If the **Filter** determines that any voxel/node of the original geometry is out-of-bounds compared to the generated partition grid, the **Out-Of-Bounds Cell ID** will be used as the partition ID in the output partition IDs array.
 
+### Partitioning Mode
+
+The *Partitioning Mode* parameter provides the following choices:
+
+- **Basic (0) [0]**: Creates a partition grid exactly the same size as the input geometry, divided into a specified number of cells per axis.
+- **Advanced (1) [1]**: Creates a custom-sized partition grid that the input geometry may or may not fit within, using an explicit origin and cell length.
+- **Bounding Box (2) [2]**: Creates a custom-sized partition grid defined by minimum and maximum grid coordinates.
+- **Existing Partition Grid (3) [3]**: Uses a partition grid from a previous run of the Partition Geometry filter.
+
 ## Partitioning Modes
 
 There are four available partitioning modes to choose from: **1. Basic**, **2. Advanced**, **3. Bounding Box**, and **4. Existing Partition Grid**

--- a/src/Plugins/SimplnxCore/docs/ReadBinaryCTNorthstarFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReadBinaryCTNorthstarFilter.md
@@ -12,6 +12,12 @@ The user should note that when using the subvolume feature that the ending voxel
 
 The .nsihdr file will be read during preflight and the .nsidat file(s) will be extracted from there. The expectation is that the .nsidat files are in the same directory as the .nsihdr files.
 
+### Length Unit
+
+The *Length Unit* parameter sets the physical units associated with the **Image Geometry** spacing. This is for descriptive purposes only and does not affect the numerical values. The available choices are:
+
+Yoctometer, Zeptometer, Attometer, Femtometer, Picometer, Nanometer, Micrometer, Millimeter, Centimeter, Decimeter, Meter, Decameter, Hectometer, Kilometer, Megameter, Gigameter, Terameter, Petameter, Exameter, Zettameter, Yottameter, Angstrom, Mil, Inch, Foot, Mile, Fathom, Unspecified, Unknown.
+
 % Auto generated parameter table will be inserted here
 
 ## License & Copyright

--- a/src/Plugins/SimplnxCore/docs/ReadRawBinaryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReadRawBinaryFilter.md
@@ -46,6 +46,11 @@ This parameter tells the program which byte is *most significant* for multibyte 
 
 This setting is *crucial* to the correct interpretation of the binary data, so the user must be aware of how their binary data was encoded.
 
+The *Endian* parameter provides the following choices:
+
+- **Little**: Little endian byte order (least significant byte first). Used by Intel/AMD x86 and x86-64 architectures.
+- **Big**: Big endian byte order (most significant byte first). Used by network protocols, older RISC architectures, and some scientific instruments.
+
 ### Skip Header Bytes
 
 If the raw binary file you are reading has a *header* before the actual data begins, the user can instruct the **Filter** to skip this header portion of the file. The user needs to know how lond the header is in bytes. Another way to use this value is if the user wants to read data out of the interior of a file by skipping a defined number of bytes.

--- a/src/Plugins/SimplnxCore/docs/ReadRawBinaryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReadRawBinaryFilter.md
@@ -48,8 +48,8 @@ This setting is *crucial* to the correct interpretation of the binary data, so t
 
 The *Endian* parameter provides the following choices:
 
-- **Little**: Little endian byte order (least significant byte first). Used by Intel/AMD x86 and x86-64 architectures.
-- **Big**: Big endian byte order (most significant byte first). Used by network protocols, older RISC architectures, and some scientific instruments.
+- **Little [0]**: Little endian byte order (least significant byte first). Used by Intel/AMD x86 and x86-64 architectures.
+- **Big [1]**: Big endian byte order (most significant byte first). Used by network protocols, older RISC architectures, and some scientific instruments.
 
 ### Skip Header Bytes
 

--- a/src/Plugins/SimplnxCore/docs/ReadStringDataArrayFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReadStringDataArrayFilter.md
@@ -48,12 +48,12 @@ If the input file has a single string per line then the delimiter does not matte
 
 The *Delimiter* parameter provides the following choices:
 
-- **, (comma)**: Values are separated by a comma character.
-- **; (semicolon)**: Values are separated by a semicolon character.
-- **  (space)**: Values are separated by a space character.
-- **: (colon)**: Values are separated by a colon character.
-- **\t (Tab)**: Values are separated by a tab character.
-- **New Line**: Each value occupies its own line; the newline character acts as the delimiter.
+- **, (comma) [0]**: Values are separated by a comma character.
+- **; (semicolon) [1]**: Values are separated by a semicolon character.
+- **  (space) [2]**: Values are separated by a space character.
+- **: (colon) [3]**: Values are separated by a colon character.
+- **\t (Tab) [4]**: Values are separated by a tab character.
+- **New Line [5]**: Each value occupies its own line; the newline character acts as the delimiter.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/ReadStringDataArrayFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReadStringDataArrayFilter.md
@@ -6,15 +6,7 @@ Core (IO/Read)
 
 ## Description
 
-This **Filter** allows the user to import a plain text file containing the contents of a single Attribute Array. The delimeters can be one of the following:
-
-    + comma
-    + semicolon
-    + space
-    + colon
-    + tab
-
-The filter does not care about how many values per line but only about reading the proper number of values from the file.
+This **Filter** allows the user to import a plain text file containing the contents of a single Attribute Array. The filter does not care about how many values per line but only about reading the proper number of values from the file.
 
 ## Use Cases
 
@@ -52,15 +44,16 @@ The example data below has 10 Tuples. The AttributeMatrix would need to have dim
 
 If the input file has a single string per line then the delimiter does not matter.
 
-### Delimeter Types
+### Delimiter
 
-| Value | Type |
-|--|------|
-| 0 | comma |
-| 1 | semicolon |
-| 2 | space |
-| 3 | colon |
-| 4 | tab |
+The *Delimiter* parameter provides the following choices:
+
+- **, (comma)**: Values are separated by a comma character.
+- **; (semicolon)**: Values are separated by a semicolon character.
+- **  (space)**: Values are separated by a space character.
+- **: (colon)**: Values are separated by a colon character.
+- **\t (Tab)**: Values are separated by a tab character.
+- **New Line**: Each value occupies its own line; the newline character acts as the delimiter.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/ReadTextDataArrayFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReadTextDataArrayFilter.md
@@ -70,11 +70,11 @@ as the filter is reading data directly into an array.
 
 The *Delimiter* parameter provides the following choices:
 
-- **, (comma)**: Values are separated by a comma character.
-- **; (semicolon)**: Values are separated by a semicolon character.
-- **  (space)**: Values are separated by a space character.
-- **: (colon)**: Values are separated by a colon character.
-- **\t (Tab)**: Values are separated by a tab character.
+- **, (comma) [0]**: Values are separated by a comma character.
+- **; (semicolon) [1]**: Values are separated by a semicolon character.
+- **  (space) [2]**: Values are separated by a space character.
+- **: (colon) [3]**: Values are separated by a colon character.
+- **\t (Tab) [4]**: Values are separated by a tab character.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/ReadTextDataArrayFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReadTextDataArrayFilter.md
@@ -6,15 +6,7 @@ Core (IO/Read)
 
 ## Description
 
-This **Filter** allows the user to import a plain text file containing the contents of a single Attribute Array. The delimeters can be one of the following:
-
-    + comma
-    + semicolon
-    + space
-    + colon
-    + tab
-
-The filter does not care about how many values per line but only about reading the proper number of values from 
+This **Filter** allows the user to import a plain text file containing the contents of a single Attribute Array. The filter does not care about how many values per line but only about reading the proper number of values from 
 the file.
 
 ## Use Cases
@@ -74,15 +66,15 @@ as the filter is reading data directly into an array.
 | 8 |        Float 32 bit |
 | 9 |       Double 64 bit |
 
-### Delimeter Types
+### Delimiter
 
-| Value | Type |
-|--|------|
-| 0 | comma |
-| 1 | semicolon |
-| 2 | space |
-| 3 | colon |
-| 4 | tab |
+The *Delimiter* parameter provides the following choices:
+
+- **, (comma)**: Values are separated by a comma character.
+- **; (semicolon)**: Values are separated by a semicolon character.
+- **  (space)**: Values are separated by a space character.
+- **: (colon)**: Values are separated by a colon character.
+- **\t (Tab)**: Values are separated by a tab character.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/RegularGridSampleSurfaceMeshFilter.md
+++ b/src/Plugins/SimplnxCore/docs/RegularGridSampleSurfaceMeshFilter.md
@@ -12,8 +12,8 @@ This **Filter** "samples" a triangulated surface mesh onto a regular grid (Image
 
 The *Use existing geometry* parameter controls how the target **Image Geometry** is provided:
 
-- **Create geometry**: Creates a new **Image Geometry** with user-specified dimensions, spacing, and origin for sampling the surface mesh.
-- **Use existing geometry**: Uses a pre-existing **Image Geometry** from the data structure as the sampling grid.
+- **Create geometry [0]**: Creates a new **Image Geometry** with user-specified dimensions, spacing, and origin for sampling the surface mesh.
+- **Use existing geometry [1]**: Uses a pre-existing **Image Geometry** from the data structure as the sampling grid.
 
 ### Algorithm
 

--- a/src/Plugins/SimplnxCore/docs/RegularGridSampleSurfaceMeshFilter.md
+++ b/src/Plugins/SimplnxCore/docs/RegularGridSampleSurfaceMeshFilter.md
@@ -8,6 +8,13 @@ Sampling (Resolution)
 
 This **Filter** "samples" a triangulated surface mesh onto a regular grid (Image Geometry) using scanline rasterization. The user can either create a new Image Geometry by specifying dimensions, spacing, and origin, or use an existing Image Geometry. The filter assigns a **Feature Id** (or part number) to each voxel based on which region of the surface mesh the voxel falls within.
 
+### Use existing geometry
+
+The *Use existing geometry* parameter controls how the target **Image Geometry** is provided:
+
+- **Create geometry**: Creates a new **Image Geometry** with user-specified dimensions, spacing, and origin for sampling the surface mesh.
+- **Use existing geometry**: Uses a pre-existing **Image Geometry** from the data structure as the sampling grid.
+
 ### Algorithm
 
 The sampling is performed using the following scanline rasterization approach:

--- a/src/Plugins/SimplnxCore/docs/RemoveFlaggedEdgesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/RemoveFlaggedEdgesFilter.md
@@ -16,15 +16,15 @@ For each of the vertex and edge data attribute matrices, the user can select to 
 
 The *Vertex Data Handling* parameter controls which vertex data arrays are transferred to the reduced geometry:
 
-- **Copy Selected Vertex Data**: Copies only the vertex arrays selected by the user into the new geometry.
-- **Copy All Vertex Data**: Copies all arrays from the vertex attribute matrix into the new geometry.
+- **Copy Selected Vertex Data [0]**: Copies only the vertex arrays selected by the user into the new geometry.
+- **Copy All Vertex Data [1]**: Copies all arrays from the vertex attribute matrix into the new geometry.
 
 ### Edge Data Handling
 
 The *Edge Data Handling* parameter controls which edge data arrays are transferred to the reduced geometry:
 
-- **Copy Selected Edge Data**: Copies only the edge arrays selected by the user into the new geometry.
-- **Copy All Edge Data**: Copies all arrays from the edge attribute matrix into the new geometry.
+- **Copy Selected Edge Data [0]**: Copies only the edge arrays selected by the user into the new geometry.
+- **Copy All Edge Data [1]**: Copies all arrays from the edge attribute matrix into the new geometry.
 
 *Note:* Since it cannot be known before run time how many **Edges** will be removed, the new **Edge Geometry** and all associated **Edge** data to be copied will be initialized to have size 0.
 

--- a/src/Plugins/SimplnxCore/docs/RemoveFlaggedEdgesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/RemoveFlaggedEdgesFilter.md
@@ -10,7 +10,21 @@ This **Filter** removes **Edges** from the supplied **Edges Geometry** that are 
 
 ## Data Handling
 
-For each of the vertex and edge data attribute matrices, the user can select to copy none, some or all of the associated data arrays into the newly created geometry. If the user wishes to not copy any of the data, just leave the choice to "Copy Selected XXX Data" [0] but do not populate the list with any selections.
+For each of the vertex and edge data attribute matrices, the user can select to copy none, some or all of the associated data arrays into the newly created geometry. If the user wishes to not copy any of the data, just leave the choice to "Copy Selected XXX Data" but do not populate the list with any selections.
+
+### Vertex Data Handling
+
+The *Vertex Data Handling* parameter controls which vertex data arrays are transferred to the reduced geometry:
+
+- **Copy Selected Vertex Data**: Copies only the vertex arrays selected by the user into the new geometry.
+- **Copy All Vertex Data**: Copies all arrays from the vertex attribute matrix into the new geometry.
+
+### Edge Data Handling
+
+The *Edge Data Handling* parameter controls which edge data arrays are transferred to the reduced geometry:
+
+- **Copy Selected Edge Data**: Copies only the edge arrays selected by the user into the new geometry.
+- **Copy All Edge Data**: Copies all arrays from the edge attribute matrix into the new geometry.
 
 *Note:* Since it cannot be known before run time how many **Edges** will be removed, the new **Edge Geometry** and all associated **Edge** data to be copied will be initialized to have size 0.
 

--- a/src/Plugins/SimplnxCore/docs/RemoveFlaggedFeaturesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/RemoveFlaggedFeaturesFilter.md
@@ -8,11 +8,13 @@ Processing (Cleanup)
 
 This **Filter** will remove **Features** that have been flagged by another **Filter** from the structure.  The **Filter** requires that the user point to a boolean array at the **Feature** level that tells the **Filter** whether the **Feature** should remain in the structure.  If the boolean array is *false* for a **Feature**, then all **Cells** that belong to that **Feature** are temporarily *unassigned*. Optionally, after all *undesired* **Features** are removed, the remaining **Features** are isotropically coarsened to fill in the gaps left by the removed **Features**.
 
-| Operation | Meaning |
-|-----------|---------|
-| 0 | Remove features. |
-| 1 | Extract features into new geometry. |
-| 2 | Extract features and then remove them. |
+### Selected Operation
+
+The *Selected Operation* parameter provides the following choices:
+
+- **Remove**: Removes the flagged **Features** from the geometry and coarsens remaining features to fill the gaps.
+- **Extract**: Extracts the flagged **Features** into a new separate geometry without removing them from the original.
+- **Extract then Remove**: Extracts the flagged **Features** into a new geometry and then removes them from the original geometry.
 
 ## WARNING: NeighborList Removal
 

--- a/src/Plugins/SimplnxCore/docs/RemoveFlaggedFeaturesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/RemoveFlaggedFeaturesFilter.md
@@ -12,9 +12,9 @@ This **Filter** will remove **Features** that have been flagged by another **Fil
 
 The *Selected Operation* parameter provides the following choices:
 
-- **Remove**: Removes the flagged **Features** from the geometry and coarsens remaining features to fill the gaps.
-- **Extract**: Extracts the flagged **Features** into a new separate geometry without removing them from the original.
-- **Extract then Remove**: Extracts the flagged **Features** into a new geometry and then removes them from the original geometry.
+- **Remove [0]**: Removes the flagged **Features** from the geometry and coarsens remaining features to fill the gaps.
+- **Extract [1]**: Extracts the flagged **Features** into a new separate geometry without removing them from the original.
+- **Extract then Remove [2]**: Extracts the flagged **Features** into a new geometry and then removes them from the original geometry.
 
 ## WARNING: NeighborList Removal
 

--- a/src/Plugins/SimplnxCore/docs/RemoveFlaggedTrianglesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/RemoveFlaggedTrianglesFilter.md
@@ -10,7 +10,21 @@ This **Filter** removes **Triangles** from the supplied **Triangle Geometry** th
 
 ## Data Handling
 
-For each of the vertex and triangle (face) data attribute matrices, the user can select to copy none, some or all of the associated data arrays into the newly created geometry. If the user wishes to not copy any of the data, just leave the choice to "Copy Selected XXX Data" [0] but do not populate the list with any selections.
+For each of the vertex and triangle (face) data attribute matrices, the user can select to copy none, some or all of the associated data arrays into the newly created geometry. If the user wishes to not copy any of the data, just leave the choice to "Copy Selected XXX Data" but do not populate the list with any selections.
+
+### Vertex Data Handling
+
+The *Vertex Data Handling* parameter controls which vertex data arrays are transferred to the reduced geometry:
+
+- **Copy Selected Vertex Data**: Copies only the vertex arrays selected by the user into the new geometry.
+- **Copy All Vertex Data**: Copies all arrays from the vertex attribute matrix into the new geometry.
+
+### Triangle Data Handling
+
+The *Triangle Data Handling* parameter controls which triangle (face) data arrays are transferred to the reduced geometry:
+
+- **Copy Selected Triangle Data**: Copies only the triangle arrays selected by the user into the new geometry.
+- **Copy All Triangle Data**: Copies all arrays from the triangle attribute matrix into the new geometry.
 
 *Note:* Since it cannot be known before run time how many **Vertices** will be removed, the new **Triangle Geometry** and all associated **Triangle** data to be copied will be initialized to have size 0.
 

--- a/src/Plugins/SimplnxCore/docs/RemoveFlaggedTrianglesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/RemoveFlaggedTrianglesFilter.md
@@ -16,15 +16,15 @@ For each of the vertex and triangle (face) data attribute matrices, the user can
 
 The *Vertex Data Handling* parameter controls which vertex data arrays are transferred to the reduced geometry:
 
-- **Copy Selected Vertex Data**: Copies only the vertex arrays selected by the user into the new geometry.
-- **Copy All Vertex Data**: Copies all arrays from the vertex attribute matrix into the new geometry.
+- **Copy Selected Vertex Data [0]**: Copies only the vertex arrays selected by the user into the new geometry.
+- **Copy All Vertex Data [1]**: Copies all arrays from the vertex attribute matrix into the new geometry.
 
 ### Triangle Data Handling
 
 The *Triangle Data Handling* parameter controls which triangle (face) data arrays are transferred to the reduced geometry:
 
-- **Copy Selected Triangle Data**: Copies only the triangle arrays selected by the user into the new geometry.
-- **Copy All Triangle Data**: Copies all arrays from the triangle attribute matrix into the new geometry.
+- **Copy Selected Triangle Data [0]**: Copies only the triangle arrays selected by the user into the new geometry.
+- **Copy All Triangle Data [1]**: Copies all arrays from the triangle attribute matrix into the new geometry.
 
 *Note:* Since it cannot be known before run time how many **Vertices** will be removed, the new **Triangle Geometry** and all associated **Triangle** data to be copied will be initialized to have size 0.
 

--- a/src/Plugins/SimplnxCore/docs/ReplaceElementAttributesWithNeighborValuesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReplaceElementAttributesWithNeighborValuesFilter.md
@@ -11,6 +11,13 @@ user. Then, for each of those **Cells**, their neighboring **Cells** are checked
 maximum or minimum value. The attributes of the neighbor with the maximum/minimum value are then reassigned to the
 reference **Cell**.
 
+### Comparison Operator
+
+The *Comparison Operator* parameter selects how each cell value is compared to the threshold:
+
+- **< [Less Than]**: Targets **Cells** whose value is less than the threshold. The replacement neighbor is the one with the highest value among neighbors that exceed the threshold.
+- **> [Greater Than]**: Targets **Cells** whose value is greater than the threshold. The replacement neighbor is the one with the lowest value among neighbors that fall below the threshold.
+
 *Note:* By default, the **Filter** will run only one iteration of the cleanup. If the user selects the *Loop Until Gone*
 option, then the **Filter** will run iteratively until no **Cells** exist that meet the users criteria. So, if a **Cell**
 meets the threshold and so are all of its neighbors, then that **Cell** will not be changed during that iteration and

--- a/src/Plugins/SimplnxCore/docs/ReplaceElementAttributesWithNeighborValuesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReplaceElementAttributesWithNeighborValuesFilter.md
@@ -15,8 +15,8 @@ reference **Cell**.
 
 The *Comparison Operator* parameter selects how each cell value is compared to the threshold:
 
-- **< [Less Than]**: Targets **Cells** whose value is less than the threshold. The replacement neighbor is the one with the highest value among neighbors that exceed the threshold.
-- **> [Greater Than]**: Targets **Cells** whose value is greater than the threshold. The replacement neighbor is the one with the lowest value among neighbors that fall below the threshold.
+- **< [Less Than] [0]**: Targets **Cells** whose value is less than the threshold. The replacement neighbor is the one with the highest value among neighbors that exceed the threshold.
+- **> [Greater Than] [1]**: Targets **Cells** whose value is greater than the threshold. The replacement neighbor is the one with the lowest value among neighbors that fall below the threshold.
 
 *Note:* By default, the **Filter** will run only one iteration of the cleanup. If the user selects the *Loop Until Gone*
 option, then the **Filter** will run iteratively until no **Cells** exist that meet the users criteria. So, if a **Cell**

--- a/src/Plugins/SimplnxCore/docs/ResampleImageGeomFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ResampleImageGeomFilter.md
@@ -8,6 +8,14 @@ Sampling (Resample)
 
 This **Filter** changes the **Cell** spacing/resolution based on inputs from the user. There are several resampling modes:
 
+### Resampling Mode
+
+The *Resampling Mode* parameter provides the following choices:
+
+- **Spacing (0) [0]**: The entered values are the desired new spacings (not multiples of the current resolution). The number of cells in the volume will change accordingly.
+- **Scaling (1) [1]**: The entered values are the desired scaling factor for each dimension, expressed as percentages.
+- **Exact Dimensions (2) [2]**: The entered values are the desired cell dimensions of the resampled geometry.
+
 ## WARNING: NeighborList Removal
 
 If the option to "Renumber Features" is turn ON and the Cell Feature AttributeMatrix contains any *NeighborList* data arrays, those arrays will be **REMOVED** because those lists are now invalid. Re-run the *Find Neighbors* filter to re-create the lists.

--- a/src/Plugins/SimplnxCore/docs/RotateSampleRefFrameFilter.md
+++ b/src/Plugins/SimplnxCore/docs/RotateSampleRefFrameFilter.md
@@ -10,6 +10,13 @@ Sampling (Rotating/Transforming)
 
 This **Filter** will rotate the *spatial reference frame* around a user defined axis, by a user defined angle.  The **Filter** will modify the (X, Y, Z) positions of each **Cell** to correctly represent where the **Cell** sits in the newly defined reference frame. For example, if a user selected a *rotation angle* of 90<sup>o</sup> and a *rotation axis* of (001), then a **Cell** sitting at (10, 0, 0) would be transformed to (0, -10, 0), since the new *reference frame* would have x'=y and y'=-x.
 
+### Rotation Representation
+
+The *Rotation Representation* parameter selects how the rotation is specified:
+
+- **Axis Angle**: The rotation is defined by a unit axis vector (x, y, z) and an angle in degrees. This is the most common representation for single-axis rotations.
+- **Rotation Matrix**: The rotation is defined as a 3x3 rotation matrix entered directly by the user.
+
 The equivalent rotation matrix for the above rotation would be the following:
 
 |   |   |   |

--- a/src/Plugins/SimplnxCore/docs/RotateSampleRefFrameFilter.md
+++ b/src/Plugins/SimplnxCore/docs/RotateSampleRefFrameFilter.md
@@ -14,8 +14,8 @@ This **Filter** will rotate the *spatial reference frame* around a user defined 
 
 The *Rotation Representation* parameter selects how the rotation is specified:
 
-- **Axis Angle**: The rotation is defined by a unit axis vector (x, y, z) and an angle in degrees. This is the most common representation for single-axis rotations.
-- **Rotation Matrix**: The rotation is defined as a 3x3 rotation matrix entered directly by the user.
+- **Axis Angle [0]**: The rotation is defined by a unit axis vector (x, y, z) and an angle in degrees. This is the most common representation for single-axis rotations.
+- **Rotation Matrix [1]**: The rotation is defined as a 3x3 rotation matrix entered directly by the user.
 
 The equivalent rotation matrix for the above rotation would be the following:
 

--- a/src/Plugins/SimplnxCore/docs/ScalarSegmentFeaturesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ScalarSegmentFeaturesFilter.md
@@ -20,6 +20,13 @@ After all the **Features** have been identified, an **Attribute Matrix** is crea
 
 If the data is specified as **Periodic**, the segmentation will check if features wrap around geometry bounds in a tileable fashion. If any such features are detected, the filter will throw a warning that centroid data may be incorrect.
 
+### Neighbor Scheme
+
+The *Neighbor Scheme* parameter provides the following choices:
+
+- **Face Neighbors [0]**: Only the 6 face-sharing neighbors of a voxel are considered during segmentation.
+- **All Connected Neighbors [1]**: All 26 neighbors connected by a face, edge, or vertex are considered during segmentation.
+
 ## Note on Neighbor Scheme
 
 Historically DREAM.3D version 6.x has used *only* the 6 face neighbors of a voxel. This release introduces the option

--- a/src/Plugins/SimplnxCore/docs/SilhouetteFilter.md
+++ b/src/Plugins/SimplnxCore/docs/SilhouetteFilter.md
@@ -18,12 +18,12 @@ The silhouette can be used to determine how well a particular clustering has per
 
 The *Distance Metric* parameter controls how the distance between two points is calculated when computing silhouette values:
 
-- **Euclidean**: Standard straight-line distance between two points.
-- **Squared Euclidean**: Square of the Euclidean distance, avoiding the square root computation.
-- **Manhattan**: Sum of the absolute differences of coordinates (L1 / city-block distance).
-- **Cosine**: Measures the cosine of the angle between two vectors.
-- **Pearson**: Correlation-based distance derived from the Pearson correlation coefficient.
-- **Squared Pearson**: Square of the Pearson distance.
+- **Euclidean [0]**: Standard straight-line distance between two points.
+- **Squared Euclidean [1]**: Square of the Euclidean distance, avoiding the square root computation.
+- **Manhattan [2]**: Sum of the absolute differences of coordinates (L1 / city-block distance).
+- **Cosine [3]**: Measures the cosine of the angle between two vectors.
+- **Pearson [4]**: Correlation-based distance derived from the Pearson correlation coefficient.
+- **Squared Pearson [5]**: Square of the Pearson distance.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/SilhouetteFilter.md
+++ b/src/Plugins/SimplnxCore/docs/SilhouetteFilter.md
@@ -14,6 +14,17 @@ where \f$ a \f$ is the average distance between point \f$ i \f$ and all other po
 
 The silhouette can be used to determine how well a particular clustering has performed, such as k means or k medoids.
 
+### Distance Metric
+
+The *Distance Metric* parameter controls how the distance between two points is calculated when computing silhouette values:
+
+- **Euclidean**: Standard straight-line distance between two points.
+- **Squared Euclidean**: Square of the Euclidean distance, avoiding the square root computation.
+- **Manhattan**: Sum of the absolute differences of coordinates (L1 / city-block distance).
+- **Cosine**: Measures the cosine of the angle between two vectors.
+- **Pearson**: Correlation-based distance derived from the Pearson correlation coefficient.
+- **Squared Pearson**: Square of the Pearson distance.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/SimplnxCore/docs/SliceTriangleGeometryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/SliceTriangleGeometryFilter.md
@@ -25,8 +25,8 @@ Example Surface Mesh being sliced with a 2.0 slice spacing.
 
 The *Slice Range* parameter controls which portion of the geometry is sliced:
 
-- **Full Range**: Slices across the entire extent of the geometry along the slicing direction.
-- **User Defined Range**: Allows specifying custom start and end values for the slicing range, restricting slices to a subregion of the geometry.
+- **Full Range [0]**: Slices across the entire extent of the geometry along the slicing direction.
+- **User Defined Range [1]**: Allows specifying custom start and end values for the slicing range, restricting slices to a subregion of the geometry.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/SliceTriangleGeometryFilter.md
+++ b/src/Plugins/SimplnxCore/docs/SliceTriangleGeometryFilter.md
@@ -21,6 +21,13 @@ Example Surface Mesh being sliced with a 2.0 slice spacing.
 
 ![](Images/SliceTriangleGeometry_2.png)
 
+### Slice Range
+
+The *Slice Range* parameter controls which portion of the geometry is sliced:
+
+- **Full Range**: Slices across the entire extent of the geometry along the slicing direction.
+- **User Defined Range**: Allows specifying custom start and end values for the slicing range, restricting slices to a subregion of the geometry.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/SimplnxCore/docs/SplitDataArrayByTupleFilter.md
+++ b/src/Plugins/SimplnxCore/docs/SplitDataArrayByTupleFilter.md
@@ -35,7 +35,16 @@ with tuples for the output arrays set to 2 & 1 and split dimension set to 1 prod
 ```
 
 
-If you choose *Existing Data Group or Existing Attribute Matrix* the split arrays are placed into a pre‑existing container.  Otherwise the filter can create a *new* Data Group or *new* Attribute Matrix to hold the results.  An optional flag allows you to delete the original input array after splitting.
+### Output Container
+
+The *Output Container* parameter controls where the resulting split arrays are placed:
+
+- **New Data Group**: Creates a new **DataGroup** to hold the split arrays.
+- **Existing Data Group**: Places the split arrays into an existing **DataGroup** selected by the user.
+- **New Attribute Matrix**: Creates a new **Attribute Matrix** to hold the split arrays.
+- **Existing Attribute Matrix**: Places the split arrays into an existing **Attribute Matrix** selected by the user.
+
+An optional flag allows you to delete the original input array after splitting.
 
 **Looking to split by _components_ instead?**  
 

--- a/src/Plugins/SimplnxCore/docs/SplitDataArrayByTupleFilter.md
+++ b/src/Plugins/SimplnxCore/docs/SplitDataArrayByTupleFilter.md
@@ -39,10 +39,10 @@ with tuples for the output arrays set to 2 & 1 and split dimension set to 1 prod
 
 The *Output Container* parameter controls where the resulting split arrays are placed:
 
-- **New Data Group**: Creates a new **DataGroup** to hold the split arrays.
-- **Existing Data Group**: Places the split arrays into an existing **DataGroup** selected by the user.
-- **New Attribute Matrix**: Creates a new **Attribute Matrix** to hold the split arrays.
-- **Existing Attribute Matrix**: Places the split arrays into an existing **Attribute Matrix** selected by the user.
+- **New Data Group [0]**: Creates a new **DataGroup** to hold the split arrays.
+- **Existing Data Group [1]**: Places the split arrays into an existing **DataGroup** selected by the user.
+- **New Attribute Matrix [2]**: Creates a new **Attribute Matrix** to hold the split arrays.
+- **Existing Attribute Matrix [3]**: Places the split arrays into an existing **Attribute Matrix** selected by the user.
 
 An optional flag allows you to delete the original input array after splitting.
 

--- a/src/Plugins/SimplnxCore/docs/WriteASCIIDataFilter.md
+++ b/src/Plugins/SimplnxCore/docs/WriteASCIIDataFilter.md
@@ -33,20 +33,20 @@ Euler_0,Euler_1,Euler_2
 
 The *Delimiter* parameter selects the character used to separate values within each row:
 
-- **Space**: Values are separated by a single space character.
-- **Semicolon**: Values are separated by a semicolon (`;`).
-- **Comma**: Values are separated by a comma (`,`). This is the standard CSV delimiter.
-- **Colon**: Values are separated by a colon (`:`).
-- **Tab**: Values are separated by a tab character.
+- **Space [0]**: Values are separated by a single space character.
+- **Semicolon [1]**: Values are separated by a semicolon (`;`).
+- **Comma [2]**: Values are separated by a comma (`,`). This is the standard CSV delimiter.
+- **Colon [3]**: Values are separated by a colon (`:`).
+- **Tab [4]**: Values are separated by a tab character.
 
 ### Header and Index Options
 
 The *Header and Index Options* parameter controls whether column headers and/or a row index are written to the output file:
 
-- **Neither**: No headers or index columns are written; only data values are output.
-- **Headers**: Column headers (array names) are written as the first row of the file.
-- **Index**: A zero-based row index column is prepended to each data row.
-- **Both**: Both column headers (first row) and a row index column are included.
+- **Neither [0]**: No headers or index columns are written; only data values are output.
+- **Headers [1]**: Column headers (array names) are written as the first row of the file.
+- **Index [2]**: A zero-based row index column is prepended to each data row.
+- **Both [3]**: Both column headers (first row) and a row index column are included.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/WriteASCIIDataFilter.md
+++ b/src/Plugins/SimplnxCore/docs/WriteASCIIDataFilter.md
@@ -29,6 +29,25 @@ Euler_0,Euler_1,Euler_2
 
 ![Example of single output file](Images/Write_Asci_2.png)
 
+### Delimiter
+
+The *Delimiter* parameter selects the character used to separate values within each row:
+
+- **Space**: Values are separated by a single space character.
+- **Semicolon**: Values are separated by a semicolon (`;`).
+- **Comma**: Values are separated by a comma (`,`). This is the standard CSV delimiter.
+- **Colon**: Values are separated by a colon (`:`).
+- **Tab**: Values are separated by a tab character.
+
+### Header and Index Options
+
+The *Header and Index Options* parameter controls whether column headers and/or a row index are written to the output file:
+
+- **Neither**: No headers or index columns are written; only data values are output.
+- **Headers**: Column headers (array names) are written as the first row of the file.
+- **Index**: A zero-based row index column is prepended to each data row.
+- **Both**: Both column headers (first row) and a row index column are included.
+
 % Auto generated parameter table will be inserted here
 
 ## License & Copyright

--- a/src/Plugins/SimplnxCore/docs/WriteBinaryDataFilter.md
+++ b/src/Plugins/SimplnxCore/docs/WriteBinaryDataFilter.md
@@ -8,6 +8,13 @@ IO (Output) (Write) (Export) (Binary)
 
 This **Filter** accepts DataArray(s) as input, extracts the data, and writes each array to a separate binary file in the specified output directory
 
+### Endianess
+
+The *Endianess* parameter controls the byte order used when writing numeric values to the binary file:
+
+- **Little Endian**: The least significant byte is stored first. This is the native byte order for x86 and ARM processors and is the most common choice for files consumed on modern desktop systems.
+- **Big Endian**: The most significant byte is stored first. This byte order is used by some network protocols and legacy systems.
+
 % Auto generated parameter table will be inserted here
 
 ## License & Copyright

--- a/src/Plugins/SimplnxCore/docs/WriteBinaryDataFilter.md
+++ b/src/Plugins/SimplnxCore/docs/WriteBinaryDataFilter.md
@@ -12,8 +12,8 @@ This **Filter** accepts DataArray(s) as input, extracts the data, and writes eac
 
 The *Endianess* parameter controls the byte order used when writing numeric values to the binary file:
 
-- **Little Endian**: The least significant byte is stored first. This is the native byte order for x86 and ARM processors and is the most common choice for files consumed on modern desktop systems.
-- **Big Endian**: The most significant byte is stored first. This byte order is used by some network protocols and legacy systems.
+- **Little Endian [0]**: The least significant byte is stored first. This is the native byte order for x86 and ARM processors and is the most common choice for files consumed on modern desktop systems.
+- **Big Endian [1]**: The most significant byte is stored first. This byte order is used by some network protocols and legacy systems.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/WriteFeatureDataCSVFilter.md
+++ b/src/Plugins/SimplnxCore/docs/WriteFeatureDataCSVFilter.md
@@ -39,6 +39,16 @@ The *CSV* file with Write Neighbor Data checked:
     4,1,886
     5,26,61,224,278,454,786,923,1119,1137,1478,1517,1525,1651,1812,1814,2227,2233,2731,2750,2907,2930,3175,3548,3619,4492,4791,5010
 
+### Delimiter
+
+The *Delimiter* parameter selects the character used to separate values within each row of the output CSV file:
+
+- **Space**: Values are separated by a single space character.
+- **Semicolon**: Values are separated by a semicolon (`;`).
+- **Comma**: Values are separated by a comma (`,`). This is the standard CSV delimiter.
+- **Colon**: Values are separated by a colon (`:`).
+- **Tab**: Values are separated by a tab character.
+
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines

--- a/src/Plugins/SimplnxCore/docs/WriteFeatureDataCSVFilter.md
+++ b/src/Plugins/SimplnxCore/docs/WriteFeatureDataCSVFilter.md
@@ -43,11 +43,11 @@ The *CSV* file with Write Neighbor Data checked:
 
 The *Delimiter* parameter selects the character used to separate values within each row of the output CSV file:
 
-- **Space**: Values are separated by a single space character.
-- **Semicolon**: Values are separated by a semicolon (`;`).
-- **Comma**: Values are separated by a comma (`,`). This is the standard CSV delimiter.
-- **Colon**: Values are separated by a colon (`:`).
-- **Tab**: Values are separated by a tab character.
+- **Space [0]**: Values are separated by a single space character.
+- **Semicolon [1]**: Values are separated by a semicolon (`;`).
+- **Comma [2]**: Values are separated by a comma (`,`). This is the standard CSV delimiter.
+- **Colon [3]**: Values are separated by a colon (`:`).
+- **Tab [4]**: Values are separated by a tab character.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/SimplnxCore/docs/WriteStlFileFilter.md
+++ b/src/Plugins/SimplnxCore/docs/WriteStlFileFilter.md
@@ -8,19 +8,16 @@ IO (Output)
 
 ***WARNING:*** The filter now provides implict overflow capabilities for very large datasets, but **this will lead to many duplicated vertices being produced**. Be sure to run a cleaning algorithm when importing these files into DREAM3DNX or other software. For more info see below.
 
-This **Filter** can generate a single or multiple binary STL (StereoLithography) 
-files for a given Triangle Geometry. This is controlled by the "File Grouping Type"
-parameter which is a combo box parameter type with the following choices:
+This **Filter** can generate a single or multiple binary STL (StereoLithography) files for a given Triangle Geometry.
 
-- Features: The user must supply a 2 component Int32 array where the values are the 2 features that the triangle belongs to.
-- Phases and Features: The user must the same kind of array as in the "Features" but also
- must supply a single component array that represents another higher order of grouping, such
- as a phase (in the case of microstructure data) or a part number in the base of importing
- a large multipart geometry.
-- Single File: The entire Triangle Geometry is saved as a single STL File
-- Part Index: The user must supply a single component Int32 array at the triangle
- level that represents which part the triangle belongs to. This is handy when the Triangle Geometry
- has distinct, non-overlapping "parts", such as an AM build with.
+### File Grouping Type
+
+The *File Grouping Type* parameter provides the following choices:
+
+- **Features [0]**: The user must supply a 2-component Int32 array where the values are the 2 features that each triangle belongs to. One STL file is written per feature.
+- **Phases and Features [1]**: The same 2-component array as Features, plus a single-component array representing a higher-order grouping such as a phase or part number.
+- **Single File [2]**: The entire Triangle Geometry is saved as a single STL file.
+- **Part Index [3]**: The user must supply a single-component Int32 array at the triangle level that indicates which part each triangle belongs to.
 
 This filter supports overflow capabilities for all of the "File Grouping Type"(s) (including single file). This means if you have over the maximum number of triangles for a single STL file (2,147,483,647), the remaining triangles will be written to "overflow files" which will follow the following syntax `{filename}_overflow_{count}`. *Warnings will be emitted during preflight if it is known or a possibility this will occur.* Due to the nature of STL files containing all the vertices relative to the triangles in the file, **duplicate vertices will be written between the files**. For single file overflow, the files will be written in parallel with the number of additional tasks being equivalent to `({number of triangles in Geometry} / 2,147,483,647) + 1`. For multiple files, the existing tasks handling the grouping write out are also responsible for creating/writing any overflow files.
 


### PR DESCRIPTION
## Summary

- Added standardized choice descriptions to 59 filter documentation files across SimplnxCore, OrientationAnalysis, and ITKImageProcessing plugins
- Each ChoicesParameter now has a `### Parameter Label` subsection with bold-bulleted choices and brief descriptions, using the exact human label from the filter's C++ source
- Filters that already adequately described their choices were left unchanged

## Test plan

- [x] Verify documentation renders correctly in DREAM3D-NX help viewer
- [x] Spot-check a few filters to confirm choice descriptions match the actual parameter options