### PR TITLE
ENH: Add throttled progress messaging to all filter algorithms

### DIFF
--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/AlignSectionsMutualInformation.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/AlignSectionsMutualInformation.cpp
@@ -6,6 +6,7 @@
 #include "simplnx/DataStructure/Geometry/IGridGeometry.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include <EbsdLib/LaueOps/LaueOps.h>
@@ -35,6 +36,10 @@ Result<> AlignSectionsMutualInformation::operator()()
   {
     return {};
   }
+
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Aligning Sections by Mutual Information...");
+
   const auto& gridGeom = m_DataStructure.getDataRefAs<IGridGeometry>(m_InputValues->ImageGeometryPath);
 
   return execute(gridGeom.getDimensions(), m_InputValues->ImageGeometryPath);
@@ -84,6 +89,12 @@ Result<> AlignSectionsMutualInformation::findShifts(std::vector<int64>& xShifts,
     misorientations[i].assign(dims[1], 0.0f);
   }
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(dims[2] - 1);
+  progressHelper.setProgressMessageTemplate("Align Sections Mutual Information: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   if(m_InputValues->StoreAlignmentShifts)
   {
     auto& slicesStore = m_DataStructure.getDataAs<UInt32Array>(m_InputValues->SlicesArrayPath)->getDataStoreRef();
@@ -95,7 +106,6 @@ Result<> AlignSectionsMutualInformation::findShifts(std::vector<int64>& xShifts,
       {
         return {};
       }
-      m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Determining Shifts: Slice {}/{} complete", iter, dims[2]));
 
       float32 minDisorientation = std::numeric_limits<float32>::max();
       int64 slice = (dims[2] - 1) - iter;
@@ -211,13 +221,13 @@ Result<> AlignSectionsMutualInformation::findShifts(std::vector<int64>& xShifts,
       relativeShiftsStore[yIndex] = newYShift;
       cumulativeShiftsStore[xIndex] = xShifts[iter];
       cumulativeShiftsStore[yIndex] = yShifts[iter];
+      progressMessenger.sendProgressMessage(1);
     }
   }
   else
   {
     for(int64 iter = 1; iter < dims[2]; iter++)
     {
-      m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Determining Shifts: Slice {}/{} complete", iter, dims[2]));
 
       float32 minDisorientation = std::numeric_limits<float32>::max();
       int64 slice = (dims[2] - 1) - iter;
@@ -324,6 +334,7 @@ Result<> AlignSectionsMutualInformation::findShifts(std::vector<int64>& xShifts,
       }
       xShifts[iter] = xShifts[iter - 1] + newXShift;
       yShifts[iter] = yShifts[iter - 1] + newYShift;
+      progressMessenger.sendProgressMessage(1);
     }
   }
 
@@ -357,9 +368,14 @@ void AlignSectionsMutualInformation::formFeaturesSections(std::vector<int32>& mi
   std::vector<int64_t> voxelList(initialVoxelsListSize, -1);
   int64_t neighborPoints[4] = {-dims[0], -1, 1, dims[0]};
 
+  MessageHelper formFeatMessageHelper(m_MessageHandler);
+  auto formFeatProgressHelper = formFeatMessageHelper.createProgressMessageHelper();
+  formFeatProgressHelper.setMaxProgresss(dims[2]);
+  formFeatProgressHelper.setProgressMessageTemplate("Identifying Features: {:.1f}% Complete");
+  auto formFeatProgressMessenger = formFeatProgressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(int64_t slice = 0; slice < dims[2]; slice++)
   {
-    m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Identifying Features: Slice {}/{} complete", slice, dims[2]));
 
     int64 startPoint = slice * dims[0] * dims[1];
     int64 endPoint = (slice + 1) * dims[0] * dims[1];
@@ -458,5 +474,6 @@ void AlignSectionsMutualInformation::formFeaturesSections(std::vector<int32>& mi
       }
     }
     featureCounts[slice] = featureCount;
+    formFeatProgressMessenger.sendProgressMessage(1);
   }
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CAxisSegmentFeatures.cpp
@@ -6,6 +6,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/ClusteringUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/Orientation/OrientationFwd.hpp>
 #include <EbsdLib/Orientation/OrientationMatrix.hpp>
@@ -29,6 +30,8 @@ CAxisSegmentFeatures::~CAxisSegmentFeatures() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> CAxisSegmentFeatures::operator()()
 {
+  m_MessageHelper.sendMessage("Segmenting Features by C-Axis Misorientation...");
+
   this->m_NeighborScheme = m_InputValues->NeighborScheme;
   auto* imageGeometry = m_DataStructure.getDataAs<ImageGeom>(m_InputValues->ImageGeometryPath);
   m_QuatsArray = m_DataStructure.getDataAs<Float32Array>(m_InputValues->QuatsArrayPath);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeAvgCAxes.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeAvgCAxes.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/ImageRotationUtilities.hpp"
 #include "simplnx/Utilities/Math/GeometryMath.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/Core/Orientation.hpp>
 #include <EbsdLib/Orientation/OrientationFwd.hpp>
@@ -75,6 +76,12 @@ Result<> ComputeAvgCAxes::operator()()
 
   std::vector<int32> counter(totalFeatures, 0);
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalPoints);
+  progressHelper.setProgressMessageTemplate("Compute Avg C-Axes: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   // Loop over each cell
   for(usize i = 0; i < totalPoints; i++)
   {
@@ -135,6 +142,7 @@ Result<> ComputeAvgCAxes::operator()()
       value = avgCAxes[cAxesIndex + 2] + c1[2];
       avgCAxes[cAxesIndex + 2] = value;
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   for(size_t i = 1; i < totalFeatures; i++)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeAvgCAxes.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeAvgCAxes.cpp
@@ -85,6 +85,11 @@ Result<> ComputeAvgCAxes::operator()()
   // Loop over each cell
   for(usize i = 0; i < totalPoints; i++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     int32 currentFeatureId = featureIds[i];
     // If the featureId for a given cell is valid ( > 0) then analyze that value
     if(currentFeatureId > 0)
@@ -147,6 +152,11 @@ Result<> ComputeAvgCAxes::operator()()
 
   for(size_t i = 1; i < totalFeatures; i++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     const usize tupleIndex = i * 3;
     float32 avgCAxesValue = avgCAxes[tupleIndex];
     if(std::isnan(avgCAxesValue))

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeAvgOrientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeAvgOrientations.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/LaueOps/LaueOps.h>
 
@@ -88,6 +89,12 @@ Result<> ComputeAvgOrientations::operator()()
   // Get the Identity Quaternion
   static const ebsdlib::QuatF identityQuat(0.0f, 0.0f, 0.0f, 1.0f);
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalPoints);
+  progressHelper.setProgressMessageTemplate("Compute Avg Orientations: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(size_t i = 0; i < totalPoints; i++)
   {
     if(m_ShouldCancel)
@@ -115,6 +122,7 @@ Result<> ComputeAvgOrientations::operator()()
 
       UpdateQuaternionArray(avgQuats, curAvgQuat, currentFeatureId);
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   for(size_t featureId = 1; featureId < totalFeatures; featureId++)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeBoundaryStrengths.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeBoundaryStrengths.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Common/Array.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/LaueOps/LaueOps.h>
 #include <EbsdLib/Orientation/Quaternion.hpp>
@@ -52,6 +53,12 @@ Result<> ComputeBoundaryStrengths::operator()()
   LD = LD.normalize();
 
   bool emitLaueClassWarning = false;
+
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(numTriangles);
+  progressHelper.setProgressMessageTemplate("Compute Boundary Strengths: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
   for(usize i = 0; i < numTriangles; i++)
   {
@@ -112,6 +119,7 @@ Result<> ComputeBoundaryStrengths::operator()()
     f1sPts[2 * i + 1] = F1spt_2;
     f7s[2 * i] = F7_1;
     f7s[2 * i + 1] = F7_2;
+    progressMessenger.sendProgressMessage(1);
   }
 
   if(emitLaueClassWarning)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeBoundaryStrengths.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeBoundaryStrengths.cpp
@@ -62,6 +62,11 @@ Result<> ComputeBoundaryStrengths::operator()()
 
   for(usize i = 0; i < numTriangles; i++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     gName1 = surfaceMeshFaceLabels[i * 2];
     gName2 = surfaceMeshFaceLabels[i * 2 + 1];
     if(gName1 > 0 && gName2 > 0)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeCAxisLocations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeCAxisLocations.cpp
@@ -77,6 +77,11 @@ Result<> ComputeCAxisLocations::operator()()
   usize index = 0;
   for(size_t i = 0; i < totalPoints; i++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     index = 3 * i;
     const auto crystalStructureType = crystalStructures[cellPhases[i]];
     if(crystalStructureType == ebsdlib::CrystalStructure::Hexagonal_High || crystalStructureType == ebsdlib::CrystalStructure::Hexagonal_Low)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeCAxisLocations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeCAxisLocations.cpp
@@ -3,6 +3,7 @@
 #include "OrientationAnalysis/utilities/OrientationUtilities.hpp"
 
 #include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/LaueOps/LaueOps.h>
 #include <EbsdLib/Orientation/OrientationFwd.hpp>
@@ -67,6 +68,12 @@ Result<> ComputeCAxisLocations::operator()()
   const Eigen::Vector3f cAxis{0.0f, 0.0f, 1.0f};
   Eigen::Vector3f c1{0.0f, 0.0f, 0.0f};
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalPoints);
+  progressHelper.setProgressMessageTemplate("Compute C-Axis Locations: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   usize index = 0;
   for(size_t i = 0; i < totalPoints; i++)
   {
@@ -96,6 +103,7 @@ Result<> ComputeCAxisLocations::operator()()
       cAxisLocation[index + 1] = NAN;
       cAxisLocation[index + 2] = NAN;
     }
+    progressMessenger.sendProgressMessage(1);
   }
   return result;
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFZQuaternions.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFZQuaternions.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 #include "EbsdLib/Core/EbsdLibConstants.h"
@@ -118,6 +119,8 @@ ComputeFZQuaternions::~ComputeFZQuaternions() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ComputeFZQuaternions::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Fundamental Zone Quaternions...");
 
   Int32Array& phaseArray = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->CellPhasesArrayPath);
   Float32Array& quatArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->InputQuatsArrayPath);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFaceIPFColoring.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFaceIPFColoring.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Common/RgbColor.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 #include <EbsdLib/Core/EbsdLibConstants.h>
@@ -165,6 +166,9 @@ const std::atomic_bool& ComputeFaceIPFColoring::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ComputeFaceIPFColoring::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Face IPF Colors...");
+
   auto& faceLabels = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->SurfaceMeshFaceLabelsArrayPath);
   auto& faceNormals = m_DataStructure.getDataRefAs<Float64Array>(m_InputValues->SurfaceMeshFaceNormalsArrayPath);
   auto& eulerAngles = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->FeatureEulerAnglesArrayPath);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureFaceMisorientation.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureFaceMisorientation.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Common/Constants.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 #include <EbsdLib/Core/EbsdLibConstants.h>
@@ -124,6 +125,9 @@ const std::atomic_bool& ComputeFeatureFaceMisorientation::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ComputeFeatureFaceMisorientation::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Feature Face Misorientations...");
+
   auto& faceLabels = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->SurfaceMeshFaceLabelsArrayPath);
   auto& avgQuats = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->AvgQuatsArrayPath);
   auto& phases = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->FeaturePhasesArrayPath);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureNeighborCAxisMisalignments.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureNeighborCAxisMisalignments.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/NeighborList.hpp"
 #include "simplnx/Utilities/ImageRotationUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/Core/Orientation.hpp>
 #include <EbsdLib/Orientation/OrientationFwd.hpp>
@@ -77,6 +78,12 @@ Result<> ComputeFeatureNeighborCAxisMisalignments::operator()()
   usize hexNeighborListSize = 0;
   uint32 xtalPhase1 = 0;
   uint32 xtalPhase2 = 0;
+
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalFeatures - 1);
+  progressHelper.setProgressMessageTemplate("Compute Feature Neighbor C-Axis Misalignments: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
   // Loop over every feature
   for(usize featureIdx = 1; featureIdx < totalFeatures; featureIdx++)
@@ -165,6 +172,7 @@ Result<> ComputeFeatureNeighborCAxisMisalignments::operator()()
     }
 
     cAxisMisalignmentList.setList(featureIdx, {currentMisalignmentList.begin(), currentMisalignmentList.end()});
+    progressMessenger.sendProgressMessage(1);
   }
 
   return result;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureNeighborCAxisMisalignments.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureNeighborCAxisMisalignments.cpp
@@ -88,6 +88,11 @@ Result<> ComputeFeatureNeighborCAxisMisalignments::operator()()
   // Loop over every feature
   for(usize featureIdx = 1; featureIdx < totalFeatures; featureIdx++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     // Get the crystal structure of phase 1
     xtalPhase1 = crystalStructures[featurePhases[featureIdx]];
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureNeighborMisorientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureNeighborMisorientations.cpp
@@ -59,6 +59,11 @@ Result<> ComputeFeatureNeighborMisorientations::operator()()
   usize quatIndex = 0;
   for(size_t i = 1; i < totalFeatures; i++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     quatIndex = i * 4;
 
     ebsdlib::QuatD q1(inAvgQuats[quatIndex], inAvgQuats[quatIndex + 1], inAvgQuats[quatIndex + 2], inAvgQuats[quatIndex + 3]);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureNeighborMisorientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureNeighborMisorientations.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/NeighborList.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/LaueOps/LaueOps.h>
 
@@ -49,6 +50,12 @@ Result<> ComputeFeatureNeighborMisorientations::operator()()
   size_t totalFeatures = inFeaturePhases.getNumberOfTuples();
 
   std::vector<std::vector<float>> tempMisorientationLists(totalFeatures);
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalFeatures - 1);
+  progressHelper.setProgressMessageTemplate("Compute Feature Neighbor Misorientations: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   usize quatIndex = 0;
   for(size_t i = 1; i < totalFeatures; i++)
   {
@@ -99,6 +106,7 @@ Result<> ComputeFeatureNeighborMisorientations::operator()()
       }
       tempMisoList = 0;
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   // Output Variables

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureReferenceCAxisMisorientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureReferenceCAxisMisorientations.cpp
@@ -109,6 +109,11 @@ Result<> ComputeFeatureReferenceCAxisMisorientations::operator()()
    */
   for(int64 plane = 0; plane < zPoints; plane++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     for(int64 row = 0; row < yPoints; row++)
     {
       for(int64 col = 0; col < xPoints; col++)
@@ -165,6 +170,11 @@ Result<> ComputeFeatureReferenceCAxisMisorientations::operator()()
   // average C Axis Misorientation for each feature
   for(usize featureId = 1; featureId < totalFeatures; featureId++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     // Compute the average value of the misorientations between each feature's cell
     // and the average C-Axis for that feature
     featAvgCAxisMis[featureId] = avgMisorientations[featureId] / static_cast<float32>(counts[featureId]);
@@ -175,6 +185,11 @@ Result<> ComputeFeatureReferenceCAxisMisorientations::operator()()
   std::vector<double> stdevs(totalFeatures, 0.0);
   for(usize cellIdx = 0; cellIdx < totalPoints; cellIdx++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     const int32 featureId = featureIds[cellIdx];
     double diff = cellRefCAxisMis.getValue(cellIdx) - featAvgCAxisMis.getValue(featureId);
     stdevs[featureId] += (diff * diff);
@@ -183,6 +198,11 @@ Result<> ComputeFeatureReferenceCAxisMisorientations::operator()()
   // Finish computing the standard deviation in this loop
   for(usize featureId = 1; featureId < totalFeatures; featureId++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     featStdevCAxisMis[featureId] = std::sqrt(stdevs[featureId] / static_cast<double>(counts[featureId]));
   }
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureReferenceCAxisMisorientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureReferenceCAxisMisorientations.cpp
@@ -6,6 +6,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/ImageRotationUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/Core/EbsdDataArray.hpp>
 #include <EbsdLib/Core/Orientation.hpp>
@@ -97,6 +98,12 @@ Result<> ComputeFeatureReferenceCAxisMisorientations::operator()()
 
   const Eigen::Vector3d cAxis{0.0, 0.0, 1.0};
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(zPoints);
+  progressHelper.setProgressMessageTemplate("Compute Feature Reference C-Axis Misorientations: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   /* **************************************************************************
    * Loop over all cells in the ImageGeometry
    */
@@ -151,16 +158,13 @@ Result<> ComputeFeatureReferenceCAxisMisorientations::operator()()
         }
       }
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   // Loop over all the features from the feature attribute matrix and compute the
   // average C Axis Misorientation for each feature
   for(usize featureId = 1; featureId < totalFeatures; featureId++)
   {
-    if(featureId % 1000 == 0)
-    {
-      m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Working On Feature {} of {}", featureId, totalFeatures));
-    }
     // Compute the average value of the misorientations between each feature's cell
     // and the average C-Axis for that feature
     featAvgCAxisMis[featureId] = avgMisorientations[featureId] / static_cast<float32>(counts[featureId]);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureReferenceMisorientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureReferenceMisorientations.cpp
@@ -6,6 +6,7 @@
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/LaueOps/LaueOps.h>
 
@@ -110,6 +111,12 @@ Result<> ComputeFeatureReferenceMisorientations::operator()()
   std::vector<float> avgMisorientationSums(totalFeatures, 0.0F);
   std::vector<float> avgMisorientationCounts(totalFeatures, 0.0F);
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalVoxels);
+  progressHelper.setProgressMessageTemplate("Compute Feature Reference Misorientations: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   featureReferenceMisorientations.fill(0.0f); // Fill all values with Zeros.
   for(int64_t voxelIdx = 0; voxelIdx < totalVoxels; voxelIdx++)
   {
@@ -141,6 +148,7 @@ Result<> ComputeFeatureReferenceMisorientations::operator()()
       avgMisorientationCounts[idx]++;
       avgMisorientationSums[idx] = avgMisorientationSums[idx] + featureReferenceMisorientations[voxelIdx];
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   // Update the avgReferenceMisorientation output array

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureReferenceMisorientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeFeatureReferenceMisorientations.cpp
@@ -89,6 +89,11 @@ Result<> ComputeFeatureReferenceMisorientations::operator()()
     const auto& m_GBEuclideanDistances = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->GBEuclideanDistancesArrayPath);
     for(size_t voxelIdx = 0; voxelIdx < totalVoxels; voxelIdx++)
     {
+      if(m_ShouldCancel)
+      {
+        return {};
+      }
+
       int32_t featureId = featureIds[voxelIdx];
       float32 distance = m_GBEuclideanDistances[voxelIdx];
       if(distance >= m_CenterDistances[featureId])
@@ -120,6 +125,11 @@ Result<> ComputeFeatureReferenceMisorientations::operator()()
   featureReferenceMisorientations.fill(0.0f); // Fill all values with Zeros.
   for(int64_t voxelIdx = 0; voxelIdx < totalVoxels; voxelIdx++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     if(featureIds[voxelIdx] > 0 && cellPhases[voxelIdx] > 0)
     {
       // Get the orientation of the current voxel
@@ -155,6 +165,11 @@ Result<> ComputeFeatureReferenceMisorientations::operator()()
   avgReferenceMisorientation[0] = 0.0f;
   for(size_t featureIdx = 1; featureIdx < totalFeatures; featureIdx++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     if(avgMisorientationCounts[featureIdx] == 0.0f)
     {
       avgReferenceMisorientation[featureIdx] = 0.0f;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeGBCDMetricBased.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeGBCDMetricBased.cpp
@@ -6,6 +6,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
@@ -415,7 +416,8 @@ Result<> ComputeGBCDMetricBased::operator()()
   }
 
   // ------------------------------ generation of sampling points ----------------------------------
-  m_MessageHandler(IFilter::Message::Type::Info, "Generating sampling points");
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("GBCD Metric Based: Generating sampling points...");
 
   // generate "Golden Section Spiral", see http://www.softimageblog.com/archives/115
   const int32 numSamplePtsWholeSphere = 2 * m_InputValues->NumSamplPts; // here we generate points on the whole sphere
@@ -484,8 +486,8 @@ Result<> ComputeGBCDMetricBased::operator()()
     {
       return {};
     }
-    m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Step 1/2: Selecting Triangles with the Specified Misorientation ({}% completed)",
-                                                               static_cast<int32>(100.0 * static_cast<float64>(i) / static_cast<float64>(numMeshTriangles))));
+    messageHelper.sendMessage(
+        fmt::format("Step 1/2: Selecting Triangles with the Specified Misorientation ({}% completed)", static_cast<int32>(100.0 * static_cast<float64>(i) / static_cast<float64>(numMeshTriangles))));
     if(i + triChunkSize >= numMeshTriangles)
     {
       triChunkSize = numMeshTriangles - i;
@@ -545,8 +547,8 @@ Result<> ComputeGBCDMetricBased::operator()()
     {
       return {};
     }
-    m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Step 2/2: Computing Distribution Values at the Section of Interest ({}% completed)",
-                                                               static_cast<int32>(100.0 * static_cast<float64>(i) / static_cast<float64>(samplePtsX.size()))));
+    messageHelper.sendMessage(fmt::format("Step 2/2: Computing Distribution Values at the Section of Interest ({}% completed)",
+                                          static_cast<int32>(100.0 * static_cast<float64>(i) / static_cast<float64>(samplePtsX.size()))));
     if(i + pointsChunkSize >= samplePtsX.size())
     {
       pointsChunkSize = samplePtsX.size() - i;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeGBCDMetricBased.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeGBCDMetricBased.cpp
@@ -506,6 +506,11 @@ Result<> ComputeGBCDMetricBased::operator()()
 
   for(usize featureFaceIdx = 0; featureFaceIdx < numFaceFeatures; featureFaceIdx++)
   {
+    if(getCancel())
+    {
+      return {};
+    }
+
     const int32 feature1 = featureFaceLabels[2 * featureFaceIdx];
     const int32 feature2 = featureFaceLabels[2 * featureFaceIdx + 1];
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeGBCDPoleFigure.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeGBCDPoleFigure.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Common/Array.hpp"
 #include "simplnx/Common/Constants.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelData2DAlgorithm.hpp"
 
 #include <EbsdLib/Core/Orientation.hpp>
@@ -318,7 +319,8 @@ Result<> ComputeGBCDPoleFigure::operator()()
   float32 yRes = 2.0f / static_cast<float32>(yPoints);
   float32 zRes = (xRes + yRes) / 2.0F;
 
-  m_MessageHandler({IFilter::Message::Type::Info, fmt::format("Generating Intensity Plot for phase {}", m_InputValues->PhaseOfInterest)});
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage(fmt::format("Generating Intensity Plot for phase {}", m_InputValues->PhaseOfInterest));
 
   typename IParallelAlgorithm::AlgorithmArrays algArrays;
   algArrays.push_back(&poleFigure);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeGBPDMetricBased.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeGBPDMetricBased.cpp
@@ -602,6 +602,11 @@ Result<> ComputeGBPDMetricBased::operator()()
 
   for(usize featureFaceIdx = 0; featureFaceIdx < numFaceFeatures; featureFaceIdx++)
   {
+    if(getCancel())
+    {
+      return {};
+    }
+
     const int32 feature1 = featureFaceLabels[2 * featureFaceIdx];
     const int32 feature2 = featureFaceLabels[2 * featureFaceIdx + 1];
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeGBPDMetricBased.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeGBPDMetricBased.cpp
@@ -6,6 +6,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
@@ -372,7 +373,8 @@ Result<> ComputeGBPDMetricBased::operator()()
   auto ballVolume = static_cast<float64>(nSym) * 2.0 * (1.0 - std::cos(limitDist));
 
   // ------------------------------ generation of sampling points ----------------------------------
-  m_MessageHandler(IFilter::Message::Type::Info, "Generating sampling points");
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("GBPD Metric Based: Generating sampling points...");
 
   // generate "Golden Section Spiral", see http://www.softimageblog.com/archives/115
   const int numSamplePtsWholeSphere = 2 * m_InputValues->NumSamplPts; // here we generate points on the whole sphere
@@ -582,7 +584,7 @@ Result<> ComputeGBPDMetricBased::operator()()
     {
       return {};
     }
-    m_MessageHandler(IFilter::Message::Type::Info, "Selecting triangles corresponding to Phase Of Interest");
+    messageHelper.sendMessage("Selecting triangles corresponding to Phase Of Interest...");
     if(i + triChunkSize >= numMeshTriangles)
     {
       triChunkSize = numMeshTriangles - i;
@@ -641,7 +643,7 @@ Result<> ComputeGBPDMetricBased::operator()()
     {
       return {};
     }
-    m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Determining GBPD values ({}%)", static_cast<int32>(100.0 * static_cast<float64>(i) / static_cast<float64>(samplePtsX.size()))));
+    messageHelper.sendMessage(fmt::format("Determining GBPD values ({}%)", static_cast<int32>(100.0 * static_cast<float64>(i) / static_cast<float64>(samplePtsX.size()))));
     if(i + pointsChunkSize >= samplePtsX.size())
     {
       pointsChunkSize = samplePtsX.size() - i;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeIPFColors.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeIPFColors.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/Common/RgbColor.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataStore.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 #include <EbsdLib/LaueOps/LaueOps.h>
@@ -141,6 +142,8 @@ ComputeIPFColors::~ComputeIPFColors() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ComputeIPFColors::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing IPF Colors...");
 
   std::vector<ebsdlib::LaueOps::Pointer> orientationOps = ebsdlib::LaueOps::GetAllOrientationOps();
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeMisorientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeMisorientations.cpp
@@ -1,6 +1,7 @@
 #include "ComputeMisorientations.hpp"
 
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include "simplnx/Common/Constants.hpp"
 #include <EbsdLib/LaueOps/LaueOps.h>
@@ -127,6 +128,9 @@ ComputeMisorientations::~ComputeMisorientations() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ComputeMisorientations::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Misorientations...");
+
   Result<> result;
 
   if(m_InputValues->ComputationType == compute_misorientations_constants::k_UseArraysIndex)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeQuaternionConjugate.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeQuaternionConjugate.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -67,6 +68,9 @@ const std::atomic_bool& ComputeQuaternionConjugate::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ComputeQuaternionConjugate::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Quaternion Conjugates...");
+
   const auto& input = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->QuaternionDataArrayPath);
   auto& output = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->OutputDataArrayPath);
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeSchmids.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeSchmids.cpp
@@ -3,6 +3,7 @@
 #include "OrientationAnalysis/utilities/OrientationUtilities.hpp"
 
 #include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/LaueOps/LaueOps.h>
 
@@ -72,6 +73,12 @@ Result<> ComputeSchmids::operator()()
     direction.normalize();
   }
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalFeatures - 1);
+  progressHelper.setProgressMessageTemplate("Compute Schmids: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(size_t i = 1; i < totalFeatures; i++)
   {
     uint32_t laueClass = crystalStructures[featurePhases[i]];
@@ -102,6 +109,7 @@ Result<> ComputeSchmids::operator()()
     poleArrays[3 * i + 1] = static_cast<int32>(crystalLoading[1] * 100.0);
     poleArrays[3 * i + 2] = static_cast<int32>(crystalLoading[2] * 100.0);
     slipSystems[i] = slipSystem;
+    progressMessenger.sendProgressMessage(1);
   }
 
   return {};

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeSchmids.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeSchmids.cpp
@@ -81,6 +81,11 @@ Result<> ComputeSchmids::operator()()
 
   for(size_t i = 1; i < totalFeatures; i++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     uint32_t laueClass = crystalStructures[featurePhases[i]];
     if(laueClass >= ebsdlib::CrystalStructure::LaueGroupEnd)
     {

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeShapes.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeShapes.cpp
@@ -207,6 +207,11 @@ void ComputeShapes::findMoments()
   size_t zStride = 0, yStride = 0;
   for(size_t i = 0; i < zPoints; i++)
   {
+    if(m_ShouldCancel)
+    {
+      return;
+    }
+
     zStride = i * xPoints * yPoints;
     for(size_t j = 0; j < yPoints; j++)
     {
@@ -286,6 +291,11 @@ void ComputeShapes::findMoments()
   double o3 = 0.0, vol5 = 0.0, omega3 = 0.0;
   for(size_t featureId = 1; featureId < numfeatures; featureId++)
   {
+    if(m_ShouldCancel)
+    {
+      return;
+    }
+
     // calculating the modified volume for the omega3 value
     vol5 = volumes[featureId] * konst3;
     volumes[featureId] = volumes[featureId] * konst2;
@@ -405,6 +415,11 @@ void ComputeShapes::findMoments2D()
   size_t yStride = 0;
   for(size_t yPoint = 0; yPoint < yPoints; yPoint++)
   {
+    if(m_ShouldCancel)
+    {
+      return;
+    }
+
     yStride = yPoint * xPoints;
     for(size_t xPoint = 0; xPoint < xPoints; xPoint++)
     {
@@ -436,6 +451,11 @@ void ComputeShapes::findMoments2D()
   double konst2 = static_cast<double>(spacing[0] * spacing[1]);
   for(size_t featureId = 1; featureId < numfeatures; featureId++)
   {
+    if(m_ShouldCancel)
+    {
+      return;
+    }
+
     // Eq. 12 Moment matrix. Omega 2
     // Eq. 11 Omega 2
     // E1. 13 Omega 1
@@ -459,6 +479,11 @@ void ComputeShapes::findAxes()
   constexpr double multiplier = 1.0 / (4.0 * std::numbers::pi);
   for(size_t featureId = 1; featureId < numfeatures; featureId++)
   {
+    if(m_ShouldCancel)
+    {
+      return;
+    }
+
     double r1 = m_FeatureEigenVals[3 * featureId];
     double r2 = m_FeatureEigenVals[3 * featureId + 1];
     double r3 = m_FeatureEigenVals[3 * featureId + 2];
@@ -525,6 +550,11 @@ void ComputeShapes::findAxes2D()
 
   for(size_t i = 1; i < numfeatures; i++)
   {
+    if(m_ShouldCancel)
+    {
+      return;
+    }
+
     Ixx = m_FeatureMoments[i * 6 + 0];
     Iyy = m_FeatureMoments[i * 6 + 1];
     Ixy = m_FeatureMoments[i * 6 + 2];
@@ -573,6 +603,11 @@ void ComputeShapes::findAxisEulers()
   size_t numfeatures = centroids.getNumberOfTuples();
   for(size_t featureId = 1; featureId < numfeatures; featureId++)
   {
+    if(m_ShouldCancel)
+    {
+      return;
+    }
+
     // insert principal unit vectors into rotation matrix representing Feature reference frame within the sample reference frame
     // (Note that the 3 directions are actually the long axis and the 1 direction is actually the short axis)
     /* clang-format off */
@@ -609,6 +644,11 @@ void ComputeShapes::findAxisEulers2D()
 
   for(size_t featureId = 1; featureId < numfeatures; featureId++)
   {
+    if(m_ShouldCancel)
+    {
+      return;
+    }
+
     double Ixx = m_FeatureMoments[featureId * 6 + 0];
     double Iyy = m_FeatureMoments[featureId * 6 + 1];
     double Ixy = m_FeatureMoments[featureId * 6 + 2];

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeShapes.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeShapes.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/Orientation/Euler.hpp>
 #include <EbsdLib/Orientation/OrientationFwd.hpp>
@@ -117,6 +118,9 @@ const std::atomic_bool& ComputeShapes::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ComputeShapes::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Shapes...");
+
   const auto& featureIds = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->FeatureIdsArrayPath);
   auto validateNumFeatResult = ValidateFeatureIdsToFeatureAttributeMatrixIndexing(m_DataStructure, m_InputValues->FeatureAttributeMatrixPath, featureIds, false, m_MessageHandler);
   if(validateNumFeatResult.invalid())

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeShapesTriangleGeom.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeShapesTriangleGeom.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/GeometryHelpers.hpp"
 #include "simplnx/Utilities/IntersectionUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 #include <EbsdLib/Core/Orientation.hpp>
@@ -492,6 +493,9 @@ void ComputeShapesTriangleGeom::updateResults(const std::vector<ShapeResultValue
 // -----------------------------------------------------------------------------
 Result<> ComputeShapesTriangleGeom::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Shapes (Triangle Geometry)...");
+
   const auto& triangleGeom = m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues->TriangleGeometryPath);
   const auto& faceLabels = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->FaceLabelsArrayPath).getDataStoreRef();
   const auto& centroids = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->CentroidsArrayPath).getDataStoreRef();

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeSlipTransmissionMetrics.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeSlipTransmissionMetrics.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/NeighborList.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/EbsdLibVersion.h>
 #include <EbsdLib/LaueOps/LaueOps.h>
@@ -53,6 +54,12 @@ Result<> ComputeSlipTransmissionMetrics::operator()()
 
   bool emitLaueClassWarning = false;
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalFeatures - 1);
+  progressHelper.setProgressMessageTemplate("Compute Slip Transmission Metrics: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(usize i = 1; i < totalFeatures; i++)
   {
     usize listLength = neighborList[i].size();
@@ -93,6 +100,7 @@ Result<> ComputeSlipTransmissionMetrics::operator()()
       F1sPtLists[i][j] = F1sPt;
       F7Lists[i][j] = F7;
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   auto& F1L = m_DataStructure.getDataRefAs<Float32NeighborList>(m_InputValues->F1ListArrayName);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeSlipTransmissionMetrics.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeSlipTransmissionMetrics.cpp
@@ -62,6 +62,11 @@ Result<> ComputeSlipTransmissionMetrics::operator()()
 
   for(usize i = 1; i < totalFeatures; i++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     usize listLength = neighborList[i].size();
     F1Lists[i].assign(listLength, 0.0f);
     F1sPtLists[i].assign(listLength, 0.0f);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeTwinBoundaries.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeTwinBoundaries.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
 #include "simplnx/Utilities/Math/GeometryMath.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 #include <EbsdLib/LaueOps/LaueOps.h>
@@ -332,6 +333,9 @@ const std::atomic_bool& ComputeTwinBoundaries::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ComputeTwinBoundaries::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Twin Boundaries...");
+
   const auto& crystalStructures = m_DataStructure.getDataAs<UInt32Array>(m_InputValues->CrystalStructuresArrayPath)->getDataStoreRef();
 
   bool allPhasesCubic = true;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertHexGridToSquareGrid.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertHexGridToSquareGrid.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
 #include "simplnx/Utilities/FilePathGenerator.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include <EbsdLib/IO/TSL/AngConstants.h>
@@ -391,12 +392,16 @@ Result<> ConvertHexGridToSquareGrid::operator()()
   int32 progress;
   int64 z = m_InputValues->InputFileListInfo.startIndex;
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(fileList.size());
+  progressHelper.setProgressMessageTemplate("Convert Hex Grid To Square Grid: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   auto result = Result<>{};
   ::Converter converter(getCancel(), m_InputValues->OutputPath, m_InputValues->OutputFilePrefix, m_InputValues->XYSpacing);
   for(const auto& filepath : fileList)
   {
-    m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Now Processing: {}", filepath));
-
     result = MergeResults(converter(filepath), result);
     if(result.invalid())
     {
@@ -405,10 +410,7 @@ Result<> ConvertHexGridToSquareGrid::operator()()
 
     {
       z++;
-      progress = static_cast<int32>(z - m_InputValues->InputFileListInfo.startIndex - 1);
-      progress = static_cast<int32>(100.0f * static_cast<float32>(progress) / total);
-      std::string msg = "Converted File: " + filepath;
-      m_MessageHandler(IFilter::Message::Type::Progress, msg, progress);
+      progressMessenger.sendProgressMessage(1);
     }
 
     if(getCancel())

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertOrientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertOrientations.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 #include <EbsdLib/Core/Orientation.hpp>
@@ -209,6 +210,9 @@ ConvertOrientations::~ConvertOrientations() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ConvertOrientations::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Converting Orientations...");
+
   using ValidateInputDataFunctionType = std::function<void(float32*)>;
 
   DataPath outputDataPath = m_InputValues->InputOrientationArrayPath.replaceName(m_InputValues->OutputOrientationArrayName);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertOrientationsToVertexGeometry.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertOrientationsToVertexGeometry.cpp
@@ -7,6 +7,7 @@
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/DataStructure/IDataArray.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <iostream>
 
@@ -29,6 +30,9 @@ Result<> ConvertOrientationsToVertexGeometry::operator()()
   {
     return {};
   }
+
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Converting Orientations to Vertex Geometry...");
 
   DataStructure tmpDs;
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertQuaternion.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertQuaternion.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 #include <EbsdLib/Utilities/EbsdStringUtils.hpp>
@@ -94,6 +95,9 @@ const std::atomic_bool& ConvertQuaternion::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ConvertQuaternion::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Converting Quaternions...");
+
   const auto& iDataArray = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->QuaternionDataArrayPath);
 
   ParallelDataAlgorithm dataAlg;

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CreateEnsembleInfo.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/CreateEnsembleInfo.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/Core/EbsdLibConstants.h>
 
@@ -59,6 +60,9 @@ const std::atomic_bool& CreateEnsembleInfo::getCancel()
 // -----------------------------------------------------------------------------
 Result<> CreateEnsembleInfo::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Creating Ensemble Info...");
+
   AttributeMatrix& cellEnsembleAttributeMatrix = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->CellEnsembleAttributeMatrixName);
   UInt32Array& crystalStructures = m_DataStructure.getDataRefAs<UInt32Array>(m_InputValues->CellEnsembleAttributeMatrixName.createChildPath(m_InputValues->CrystalStructuresArrayName));
   UInt32Array& phaseTypes = m_DataStructure.getDataRefAs<UInt32Array>(m_InputValues->CellEnsembleAttributeMatrixName.createChildPath(m_InputValues->PhaseTypesArrayName));

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EBSDSegmentFeatures.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataStore.hpp"
 #include "simplnx/DataStructure/Geometry/IGridGeometry.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -20,6 +21,8 @@ EBSDSegmentFeatures::~EBSDSegmentFeatures() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> EBSDSegmentFeatures::operator()()
 {
+  m_MessageHelper.sendMessage("Segmenting Features by EBSD Misorientation...");
+
   this->m_NeighborScheme = m_InputValues->NeighborScheme;
   auto* gridGeom = m_DataStructure.getDataAs<IGridGeometry>(m_InputValues->ImageGeometryPath);
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EbsdToH5Ebsd.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/EbsdToH5Ebsd.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/Core/EbsdLibConstants.h>
 #include <EbsdLib/IO/HKL/CtfFields.h>
@@ -234,9 +235,14 @@ Result<> EbsdToH5Ebsd::operator()()
     int64_t biggestXDim = 0;
     int64_t biggestYDim = 0;
     int32_t totalSlicesImported = 0;
+    MessageHelper messageHelper(m_MessageHandler);
+    auto progressHelper = messageHelper.createProgressMessageHelper();
+    progressHelper.setMaxProgresss(fileList.size());
+    progressHelper.setProgressMessageTemplate("EBSD to H5EBSD: {:.1f}% Complete");
+    auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
     for(const auto& ebsdFName : fileList)
     {
-      m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Converting File: '{}'", ebsdFName));
 
       err = fileImporter->importFile(fileId, z, ebsdFName);
       if(err < 0)
@@ -258,6 +264,7 @@ Result<> EbsdToH5Ebsd::operator()()
 
       indices.push_back(static_cast<int32_t>(z));
       ++z;
+      progressMessenger.sendProgressMessage(1);
       if(getCancel())
       {
         return {};

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/MergeTwins.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/MergeTwins.cpp
@@ -119,6 +119,11 @@ void MergeTwins::groupFeaturesExecute()
 
   while(featureSeed >= 0)
   {
+    if(m_ShouldCancel)
+    {
+      return;
+    }
+
     bool m_PatchGrouping = false;
     parentCount++;
     featureSeed = getSeed(parentCount);
@@ -221,6 +226,11 @@ Result<> MergeTwins::operator()()
   usize totalPoints = featureIds.getNumberOfTuples();
   for(usize k = 0; k < totalPoints; k++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
     int32 featureName = featureIds[k];
     cellParentIds[k] = featureParentIds[featureName];
     if(featureParentIds[featureName] > numParents)

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/MergeTwins.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/MergeTwins.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/ClusteringUtilities.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/Core/EbsdLibConstants.h>
 #include <EbsdLib/Orientation/Quaternion.hpp>
@@ -169,6 +170,9 @@ void MergeTwins::groupFeaturesExecute()
 // -----------------------------------------------------------------------------
 Result<> MergeTwins::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Merging Twins...");
+
   Result result = {};
 
   m_Generator = std::mt19937_64(std::mt19937::default_seed);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadAngData.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadAngData.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include <EbsdLib/Core/Orientation.hpp>
@@ -27,6 +28,9 @@ ReadAngData::~ReadAngData() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ReadAngData::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading ANG data...");
+
   ebsdlib::AngReader reader;
   reader.setFileName(m_InputValues->InputFile.string());
   const int32_t err = reader.readFile();

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadChannel5Data.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadChannel5Data.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include <EbsdLib/Core/Orientation.hpp>
@@ -46,6 +47,9 @@ ReadChannel5Data::~ReadChannel5Data() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ReadChannel5Data::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading Channel 5 data...");
+
   ebsdlib::CprReader reader;
   reader.setFileName(m_InputValues->InputFile.string());
   const int32_t err = reader.readFile();

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadCtfData.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadCtfData.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/IO/HKL/CtfConstants.h>
 #include <EbsdLib/Math/EbsdLibMath.h>
@@ -32,6 +33,9 @@ const std::atomic_bool& ReadCtfData::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ReadCtfData::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading CTF data...");
+
   ebsdlib::CtfReader reader;
   reader.setFileName(m_InputValues->InputFile.string());
   const int32_t err = reader.readFile();

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadEnsembleInfo.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadEnsembleInfo.cpp
@@ -5,6 +5,7 @@
 
 #include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include <EbsdLib/Core/EbsdLibConstants.h>
@@ -70,6 +71,9 @@ const std::atomic_bool& ReadEnsembleInfo::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ReadEnsembleInfo::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading Ensemble Info...");
+
   return readFile();
 }
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadGrainMapper3D.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadGrainMapper3D.cpp
@@ -8,6 +8,7 @@
 #include "simplnx/DataStructure/NeighborList.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
 #include "simplnx/Filter/IFilter.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/H5DataStore.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/H5Support.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/DatasetIO.hpp"
@@ -292,6 +293,9 @@ Result<> ReadGrainMapper3D::copyAbsorptionData(GrainMapperReader& reader, hid_t 
 // -----------------------------------------------------------------------------
 Result<> ReadGrainMapper3D::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading GrainMapper3D data...");
+
   GrainMapperReader reader(m_InputValues->InputFile.string(), m_InputValues->ReadDctData, m_InputValues->ReadAbsorptionData);
 
   hid_t fileId = H5Support::H5Utilities::openFile(m_InputValues->InputFile.string(), true);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadH5Ebsd.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadH5Ebsd.cpp
@@ -11,6 +11,7 @@
 #include "simplnx/Filter/IFilter.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
 #include "simplnx/Parameters/VectorParameter.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/Core/EbsdLibConstants.h>
 #include <EbsdLib/Core/EbsdMacros.h>
@@ -266,6 +267,9 @@ ReadH5Ebsd::~ReadH5Ebsd() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ReadH5Ebsd::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading H5EBSD data...");
+
   // Get the Size and Spacing of the Volume
   ebsdlib::H5EbsdVolumeInfo::Pointer volumeInfoReader = ebsdlib::H5EbsdVolumeInfo::New();
   volumeInfoReader->setFileName(m_InputValues->inputFilePath);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadH5EspritData.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadH5EspritData.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Common/Constants.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -20,6 +21,9 @@ ReadH5EspritData::~ReadH5EspritData() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ReadH5EspritData::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading H5 Esprit data...");
+
   return execute();
 }
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadH5OimData.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadH5OimData.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -17,6 +18,9 @@ ReadH5OimData::~ReadH5OimData() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ReadH5OimData::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading H5 OIM data...");
+
   return execute();
 }
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadH5OinaData.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadH5OinaData.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -59,6 +60,9 @@ ReadH5OinaData::~ReadH5OinaData() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ReadH5OinaData::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading H5 OINA data...");
+
   return execute();
 }
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/RodriguesConvertor.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/RodriguesConvertor.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -72,6 +73,9 @@ const std::atomic_bool& RodriguesConvertor::getCancel()
 // -----------------------------------------------------------------------------
 Result<> RodriguesConvertor::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Converting Rodrigues Vectors...");
+
   const auto& input = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->RodriguesDataArrayPath);
   auto& output = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->OutputDataArrayPath);
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteGBCDGMTFile.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteGBCDGMTFile.cpp
@@ -9,6 +9,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <cmath>
 #include <filesystem>
@@ -67,6 +68,9 @@ const std::atomic_bool& WriteGBCDGMTFile::getCancel()
 // -----------------------------------------------------------------------------
 Result<> WriteGBCDGMTFile::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing GBCD GMT File...");
+
   auto gbcd = m_DataStructure.getDataRefAs<Float64Array>(m_InputValues->GBCDArrayPath);
   auto crystalStructures = m_DataStructure.getDataRefAs<UInt32Array>(m_InputValues->CrystalStructuresArrayPath);
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteGBCDTriangleData.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteGBCDTriangleData.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -27,6 +28,9 @@ const std::atomic_bool& WriteGBCDTriangleData::getCancel()
 // -----------------------------------------------------------------------------
 Result<> WriteGBCDTriangleData::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing GBCD Triangle Data...");
+
   auto& faceLabels = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->SurfaceMeshFaceLabelsArrayPath);
   auto& faceNormals = m_DataStructure.getDataRefAs<Float64Array>(m_InputValues->SurfaceMeshFaceNormalsArrayPath);
   auto& faceAreas = m_DataStructure.getDataRefAs<Float64Array>(m_InputValues->SurfaceMeshFaceAreasArrayPath);

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteINLFile.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteINLFile.cpp
@@ -6,6 +6,7 @@
 #include "simplnx/DataStructure/StringArray.hpp"
 #include "simplnx/SIMPLNXVersion.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <EbsdLib/Core/EbsdLibConstants.h>
 #include <EbsdLib/IO/TSL/AngConstants.h>
@@ -73,6 +74,9 @@ const std::atomic_bool& WriteINLFile::getCancel()
 // -----------------------------------------------------------------------------
 Result<> WriteINLFile::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing INL File...");
+
   // Make sure any directory path is also available as the user may have just typed
   // in a path without actually creating the full path
   Result<> createDirectoriesResult = nx::core::CreateOutputDirectories(m_InputValues->OutputFile.parent_path());

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WritePoleFigure.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WritePoleFigure.cpp
@@ -17,6 +17,7 @@
 #include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 #include "simplnx/Utilities/IntersectionUtilities.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 #include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
 #include "simplnx/Utilities/RTree.hpp"
@@ -658,6 +659,9 @@ const std::atomic_bool& WritePoleFigure::getCancel()
 // -----------------------------------------------------------------------------
 Result<> WritePoleFigure::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing Pole Figures...");
+
   // Make sure any directory path is also available as the user may have just typed
   // in a path without actually creating the full path
   // Ensure the complete path to the output file exists or can be created

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteStatsGenOdfAngleFile.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/WriteStatsGenOdfAngleFile.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Common/Constants.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 class QFile;
@@ -36,6 +37,9 @@ const std::atomic_bool& WriteStatsGenOdfAngleFile::getCancel()
 // -----------------------------------------------------------------------------
 Result<> WriteStatsGenOdfAngleFile::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing StatsGen ODF Angle File...");
+
   Result<> results;
 
   // Make sure any directory path is also available as the user may have just typed

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/AddBadData.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/AddBadData.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <random>
 
@@ -42,6 +43,9 @@ const std::atomic_bool& AddBadData::getCancel()
 // -----------------------------------------------------------------------------
 Result<> AddBadData::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+
   std::mt19937 generator(m_InputValues->SeedValue); // Standard mersenne_twister_engine seeded
   std::uniform_real_distribution<float32> distribution(0.0F, 1.0F);
 
@@ -53,6 +57,11 @@ Result<> AddBadData::operator()()
 
   float32 random = 0.0f;
   const size_t totalPoints = GBEuclideanDistances.getSize();
+
+  progressHelper.setMaxProgresss(totalPoints);
+  progressHelper.setProgressMessageTemplate("AddBadData: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(size_t i = 0; i < totalPoints; ++i)
   {
     if(m_InputValues->BoundaryNoise && GBEuclideanDistances[i] < 1)
@@ -77,6 +86,7 @@ Result<> AddBadData::operator()()
         }
       }
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/AlignGeometries.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/AlignGeometries.cpp
@@ -8,6 +8,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/Geometry/RectGridGeom.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -375,6 +376,8 @@ AlignGeometries::~AlignGeometries() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> AlignGeometries::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("AlignGeometries: Aligning geometries...");
 
   auto movingGeometryPath = m_InputValues->InputMovingGeometryPath;
   auto targetGeometryPath = m_InputValues->InputTargetGeometryPath;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/AlignGeometries.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/AlignGeometries.cpp
@@ -389,7 +389,15 @@ Result<> AlignGeometries::operator()()
   if(alignmentType == 0)
   {
     FloatVec3 movingOrigin = extractOrigin(moving);
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
     FloatVec3 targetOrigin = extractOrigin(target);
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
 
     float translation[3] = {targetOrigin[0] - movingOrigin[0], targetOrigin[1] - movingOrigin[1], targetOrigin[2] - movingOrigin[2]};
     translateGeometry(moving, translation);
@@ -397,7 +405,15 @@ Result<> AlignGeometries::operator()()
   else if(alignmentType == 1)
   {
     FloatVec3 movingCentroid = extractCentroid(moving);
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
     FloatVec3 targetCentroid = extractCentroid(target);
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
 
     float translation[3] = {targetCentroid[0] - movingCentroid[0], targetCentroid[0] - movingCentroid[0], targetCentroid[0] - movingCentroid[0]};
     translateGeometry(moving, translation);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/AlignSectionsList.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/AlignSectionsList.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -27,6 +28,10 @@ Result<> AlignSectionsList::operator()()
   {
     return {};
   }
+
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("AlignSectionsList: Aligning sections from list...");
+
   const auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ImageGeometryPath);
 
   return execute(imageGeom.getDimensions(), m_InputValues->ImageGeometryPath);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/AppendImageGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/AppendImageGeometry.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/IArray.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
 using namespace nx::core;
@@ -29,6 +30,9 @@ const std::atomic_bool& AppendImageGeometry::getCancel()
 // -----------------------------------------------------------------------------
 Result<> AppendImageGeometry::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("AppendImageGeometry: Beginning geometry append...");
+
   Result<> results = {};
 
   auto& destGeometry = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->DestinationGeometryPath);
@@ -62,6 +66,12 @@ Result<> AppendImageGeometry::operator()()
   DataStructure tmpDataStructure;
 
   ParallelTaskAlgorithm taskRunner;
+  usize totalArrays = newCellData->getSize();
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalArrays);
+  progressHelper.setProgressMessageTemplate("AppendImageGeometry: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(const auto& [dataId, dataObject] : *newCellData)
   {
     if(getCancel())
@@ -165,6 +175,7 @@ Result<> AppendImageGeometry::operator()()
       CopyFromArray::RunParallelAppend(*destDataArray, taskRunner, inputDataArrays, inputTupleShapes, originalDestGeomDimsVec, newDestGeomDimsVec, m_InputValues->Direction,
                                        m_InputValues->MirrorGeometry);
     }
+    progressMessenger.sendProgressMessage(1);
   }
   taskRunner.wait(); // This will spill over if the number of DataArrays to process does not divide evenly by the number of threads.
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ApplyTransformationToGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ApplyTransformationToGeometry.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/INodeGeometry0D.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
@@ -146,6 +147,9 @@ Result<> ApplyTransformationToGeometry::applyNodeGeometryTransformation()
 // -----------------------------------------------------------------------------
 Result<> ApplyTransformationToGeometry::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("ApplyTransformationToGeometry: Beginning transformation...");
+
   if(!m_InputValues->RemoveOriginalGeometry)
   {
     return MakeErrorResult(-84500, fmt::format("Keeping the original geometry is not supported."));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ApproximatePointCloudHull.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ApproximatePointCloudHull.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -109,9 +110,11 @@ Result<> ApproximatePointCloudHull::operator()()
   int64 multiplier[3] = {1, static_cast<int64>(samplingGrid->getNumXCells()), static_cast<int64>(samplingGrid->getNumXCells() * samplingGrid->getNumYCells())};
   std::vector<std::vector<int64>> vertsInVoxels(samplingGrid->getNumberOfCells());
 
-  int64 progIncrement = numVerts / 100;
-  int64 prog = 1;
-  int64 progressInt = 0;
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(numVerts);
+  progressHelper.setProgressMessageTemplate("Mapping Vertices to Voxels: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
   for(int64 v = 0; v < numVerts; v++)
   {
@@ -120,24 +123,18 @@ Result<> ApproximatePointCloudHull::operator()()
     auto k = static_cast<int64>(std::floor((*verts)[3 * v + 2] * inverseResolution[2]) - static_cast<float>(bboxMin[2]));
     int64 index = i * multiplier[0] + j * multiplier[1] + k * multiplier[2];
     vertsInVoxels[index].push_back(v);
-
-    if(v > prog)
-    {
-      progressInt = static_cast<int64>((static_cast<float>(v) / numVerts) * 100.0f);
-      std::string ss = fmt::format("Mapping Vertices to Voxels || {}% Complete", progressInt);
-      // notifyStatusMessage(ss);
-      prog = prog + progIncrement;
-    }
+    progressMessenger.sendProgressMessage(1);
   }
 
   std::vector<float> tmpVerts;
   int64 neighborhood[78] = {1,  0, 0,  -1, 0, 0, 0, 1, 0,  0, -1, 0, 0, 0,  1,  0, 0, -1, 1, 1, 0,  -1, 1,  0, 1, -1, 0,  -1, -1, 0, 1,  0, 1,  1,  0,  -1, -1, 0,  1,
                             -1, 0, -1, 0,  1, 1, 0, 1, -1, 0, -1, 1, 0, -1, -1, 1, 1, 1,  1, 1, -1, 1,  -1, 1, 1, -1, -1, -1, 1,  1, -1, 1, -1, -1, -1, 1,  -1, -1, -1};
 
-  progIncrement = (dims[0] * dims[1] * dims[2]) / 100;
-  prog = 1;
-  progressInt = 0;
-  int64 counter = 0;
+  progressHelper.resetProgress();
+  progressHelper.setMaxProgresss(dims[2]);
+  progressHelper.setProgressMessageTemplate("Trimming Interior Voxels: {:.1f}% Complete");
+  auto trimProgressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   int64 vertCounter = 0;
   float xAvg = 0.0f;
   float yAvg = 0.0f;
@@ -145,6 +142,10 @@ Result<> ApproximatePointCloudHull::operator()()
 
   for(int64 z = 0; z < dims[2]; z++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
     for(int64 y = 0; y < dims[1]; y++)
     {
       for(int64 x = 0; x < dims[0]; x++)
@@ -152,7 +153,6 @@ Result<> ApproximatePointCloudHull::operator()()
         usize index = (z * dims[1] * dims[0]) + (y * dims[0]) + x;
         if(vertsInVoxels[index].empty())
         {
-          counter++;
           continue;
         }
 
@@ -190,17 +190,9 @@ Result<> ApproximatePointCloudHull::operator()()
           yAvg = 0.0f;
           zAvg = 0.0f;
         }
-
-        if(counter > prog)
-        {
-          progressInt = static_cast<int64>((static_cast<float>(counter) / (dims[0] * dims[1] * dims[2])) * 100.0f);
-          std::string ss = fmt::format("Trimming Interior Voxels || {}% Complete", progressInt);
-          // notifyStatusMessage(ss);
-          prog = prog + progIncrement;
-        }
-        counter++;
       }
     }
+    trimProgressMessenger.sendProgressMessage(1);
   }
 
   auto* hull = m_DataStructure.getDataAs<VertexGeom>(m_InputValues->OutputVertexGeometryPath);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ArrayCalculator.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ArrayCalculator.cpp
@@ -33,6 +33,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include <regex>
@@ -209,9 +210,17 @@ Result<> ArrayCalculator::operator()()
   }
 
   // Execute the RPN expression
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+
   DataPath temporaryCalculatedArrayPath = DataPath({m_InputValues->CalculatedArray.getTargetName() + "_TEMPORARY"});
   std::stack<ICalculatorArray::Pointer> executionStack;
   int totalItems = rpn.size();
+
+  progressHelper.setMaxProgresss(totalItems);
+  progressHelper.setProgressMessageTemplate("ArrayCalculator: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(int rpnCount = 0; rpnCount < totalItems; rpnCount++)
   {
     m_MessageHandler({IFilter::Message::Type::Info, "Computing Operator " + StringUtilities::number(rpnCount + 1) + "/" + StringUtilities::number(totalItems)});
@@ -230,6 +239,8 @@ Result<> ArrayCalculator::operator()()
 
       rpnOperator->calculate(parser.m_TemporaryDataStructure, m_InputValues->Units, temporaryCalculatedArrayPath, executionStack);
     }
+
+    progressMessenger.sendProgressMessage(1);
 
     if(getCancel())
     {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ChangeAngleRepresentation.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ChangeAngleRepresentation.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/Common/Numbers.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -59,6 +60,9 @@ ChangeAngleRepresentation::~ChangeAngleRepresentation() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ChangeAngleRepresentation::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("ChangeAngleRepresentation: Converting angle representation...");
+
   auto& angles = m_DataStructure.getDataAs<Float32Array>(m_InputValues->AnglesArrayPath)->getDataStoreRef();
 
   float conversionFactor = 1.0f;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CombineAttributeArrays.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CombineAttributeArrays.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -151,6 +152,10 @@ Result<> CombineAttributeArrays::operator()()
   {
     return {};
   }
+
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("CombineAttributeArrays: Combining attribute arrays...");
+
   std::vector<DataObject*> inputArrays;
   for(const auto& dataPath : m_InputValues->SelectedDataArrayPaths)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CombineNodeBasedGeometries.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CombineNodeBasedGeometries.cpp
@@ -8,6 +8,7 @@
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/SIMPLNXVersion.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include "SimplnxCore/Filters/Algorithms/ConcatenateDataArrays.hpp"
@@ -383,6 +384,9 @@ void CombineNodeBasedGeometries::sendMessage(const std::string& message)
 // -----------------------------------------------------------------------------
 Result<> CombineNodeBasedGeometries::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("CombineNodeBasedGeometries: Beginning geometry combination...");
+
   CombineVertexElements(m_DataStructure, m_InputValues->OutputGeometryPath, m_InputValues->InputGeometryPaths, m_MessageHandler, m_ShouldCancel);
   CombineEdgeElements(m_DataStructure, m_InputValues->OutputGeometryPath, m_InputValues->InputGeometryPaths, m_MessageHandler, m_ShouldCancel);
   CombineFaceElements(m_DataStructure, m_InputValues->OutputGeometryPath, m_InputValues->InputGeometryPaths, m_MessageHandler, m_ShouldCancel);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CombineStlFiles.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CombineStlFiles.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
@@ -81,6 +82,8 @@ const std::atomic_bool& CombineStlFiles::getCancel()
 // -----------------------------------------------------------------------------
 Result<> CombineStlFiles::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+
   DataStructure tempDataStructure;
   std::vector<fs::path> paths;
   const std::string ext(".stl");
@@ -106,6 +109,11 @@ Result<> CombineStlFiles::operator()()
   activeArray[0] = 0;
   auto fileListStrArray = m_DataStructure.getDataRefAs<StringArray>(fileListPath);
 
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(paths.size());
+  progressHelper.setProgressMessageTemplate("CombineStlFiles Reading: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   int32 currentIndex = 1;
   for(const auto& filePath : paths)
   {
@@ -129,6 +137,7 @@ Result<> CombineStlFiles::operator()()
     {
       return executeResult.result;
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   usize totalTriangles = 0;
@@ -172,6 +181,11 @@ Result<> CombineStlFiles::operator()()
   usize vertexLabelOffset = 0;
 
   m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Moving final triangle geometry data..."));
+
+  progressHelper.resetProgress();
+  progressHelper.setMaxProgresss(stlGeometries.size());
+  progressHelper.setProgressMessageTemplate("CombineStlFiles Merging: {:.1f}% Complete");
+  auto mergeProgressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
   // Loop over each temp geometry and copy the data into the destination geometry
   for(auto* currentGeometry : stlGeometries)
@@ -221,6 +235,7 @@ Result<> CombineStlFiles::operator()()
     vertexOffset += currentGeomNumVertices * 3;
     faceNormalsOffset += curFaceNormals.getSize();
     fileIndex++;
+    mergeProgressMessenger.sendProgressMessage(1);
   }
   taskRunner.wait(); // This will spill over if the number of geometries to processes does not divide evenly by the number of threads.
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CombineTransformationMatrices.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CombineTransformationMatrices.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/ImageRotationUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <Eigen/Dense>
 
@@ -82,6 +83,9 @@ const std::atomic_bool& CombineTransformationMatrices::getCancel()
 // -----------------------------------------------------------------------------
 Result<> CombineTransformationMatrices::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("CombineTransformationMatrices: Combining transformation matrices...");
+
   auto& outputArray = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->OutputPath);
   auto pathsIter = m_InputValues->SelectedPaths.begin();
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeArrayHistogram.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeArrayHistogram.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/Utilities/HistogramUtilities.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
@@ -44,6 +45,12 @@ Result<> ComputeArrayHistogram::operator()()
   const int32 numBins = m_InputValues->NumberOfBins;
   const std::vector<DataPath> selectedArrayPaths = m_InputValues->SelectedArrayPaths;
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(selectedArrayPaths.size());
+  progressHelper.setProgressMessageTemplate("Computing Array Histogram: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   ParallelTaskAlgorithm taskRunner;
 
   std::atomic<usize> overflow = 0;
@@ -82,6 +89,7 @@ Result<> ComputeArrayHistogram::operator()()
       const std::string arrayName = inputData->getName();
       ComputeArrayHistogram::updateProgress(fmt::format("{} values not categorized into bin for array {}", overflow.load(), arrayName));
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   taskRunner.wait();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBiasedFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBiasedFeatures.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -45,6 +46,9 @@ Result<> ComputeBiasedFeatures::operator()()
 // -----------------------------------------------------------------------------
 Result<> ComputeBiasedFeatures::findBoundingBoxFeatures()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+
   const ImageGeom imageGeometry = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ImageGeometryPath);
   const auto& centroidsStore = m_DataStructure.getDataAs<Float32Array>(m_InputValues->CentroidsArrayPath)->getDataStoreRef();
   AbstractDataStore<int32>* phasesStorePtr = nullptr;
@@ -77,6 +81,10 @@ Result<> ComputeBiasedFeatures::findBoundingBoxFeatures()
   {
     numPhases = *std::max_element(phasesStorePtr->begin(), phasesStorePtr->end());
   }
+  progressHelper.setMaxProgresss(numPhases);
+  progressHelper.setProgressMessageTemplate("Computing Biased Features: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(int32 iter = 1; iter <= numPhases; iter++)
   {
     if(m_InputValues->CalcByPhase)
@@ -177,6 +185,8 @@ Result<> ComputeBiasedFeatures::findBoundingBoxFeatures()
       }
     }
 
+    progressMessenger.sendProgressMessage(1);
+
     if(getCancel())
     {
       return {};
@@ -208,7 +218,14 @@ Result<> ComputeBiasedFeatures::findBoundingBoxFeatures2D()
     return MakeErrorResult(-54900, message);
   }
 
+  MessageHelper messageHelper2D(m_MessageHandler);
+  auto progressHelper2D = messageHelper2D.createProgressMessageHelper();
+
   const usize size = centroidsStore.getNumberOfTuples();
+
+  progressHelper2D.setMaxProgresss(size);
+  progressHelper2D.setProgressMessageTemplate("Computing Biased Features 2D: {:.1f}% Complete");
+  auto progressMessenger2D = progressHelper2D.createProgressMessenger(std::chrono::milliseconds(1000));
 
   std::vector<float32> coords = {0.0f, 0.0f, 0.0f, 0.0f};
 
@@ -301,6 +318,8 @@ Result<> ComputeBiasedFeatures::findBoundingBoxFeatures2D()
         boundBox[sideToMove] = coords[sideToMove];
       }
     }
+
+    progressMessenger2D.sendProgressMessage(1);
 
     if(getCancel())
     {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBiasedFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBiasedFeatures.cpp
@@ -105,6 +105,10 @@ Result<> ComputeBiasedFeatures::findBoundingBoxFeatures()
 
     for(usize i = 1; i < size; i++)
     {
+      if(m_ShouldCancel)
+      {
+        return {};
+      }
       if(surfaceFeatures->isTrue(i) && (!m_InputValues->CalcByPhase || (*phasesStorePtr)[i] == iter))
       {
         int32 sideToMove = 0;
@@ -156,6 +160,10 @@ Result<> ComputeBiasedFeatures::findBoundingBoxFeatures()
     }
     for(usize j = 1; j < size; j++)
     {
+      if(m_ShouldCancel)
+      {
+        return {};
+      }
       if(!m_InputValues->CalcByPhase || (*phasesStorePtr)[j] == iter)
       {
         if(centroidsStore[3 * j] <= boundBox[0])

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBoundaryCells.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBoundaryCells.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/NeighborUtilities.hpp"
 
 using namespace nx::core;
@@ -51,11 +52,18 @@ Result<> ComputeBoundaryCells::operator()()
     ignoreFeatureZeroVal = -1;
   }
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(dims[2]);
+  progressHelper.setProgressMessageTemplate("Computing Boundary Cells: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   int64 kStride = 0;
   int64 jStride = 0;
 
   for(int64 zIdx = 0; zIdx < dims[2]; zIdx++)
   {
+    progressMessenger.sendProgressMessage(1);
     kStride = dims[0] * dims[1] * zIdx;
     for(int64 yIdx = 0; yIdx < dims[1]; yIdx++)
     {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBoundaryCells.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBoundaryCells.cpp
@@ -63,6 +63,10 @@ Result<> ComputeBoundaryCells::operator()()
 
   for(int64 zIdx = 0; zIdx < dims[2]; zIdx++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
     progressMessenger.sendProgressMessage(1);
     kStride = dims[0] * dims[1] * zIdx;
     for(int64 yIdx = 0; yIdx < dims[1]; yIdx++)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBoundaryElementFractions.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBoundaryElementFractions.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -29,6 +30,12 @@ Result<> ComputeBoundaryElementFractions::operator()()
   usize totalPoints = featureIds.getNumberOfTuples();
   usize numFeatures = boundaryCellFractions.getNumberOfTuples();
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalPoints);
+  progressHelper.setProgressMessageTemplate("Computing Boundary Element Fractions: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   std::vector<float32> surfVoxCounts(numFeatures, 0);
   std::vector<float32> voxCounts(numFeatures, 0);
 
@@ -40,6 +47,7 @@ Result<> ComputeBoundaryElementFractions::operator()()
     {
       surfVoxCounts[gnum]++;
     }
+    progressMessenger.sendProgressMessage(1);
   }
   for(usize i = 1; i < numFeatures; i++)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBoundaryElementFractions.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBoundaryElementFractions.cpp
@@ -41,6 +41,10 @@ Result<> ComputeBoundaryElementFractions::operator()()
 
   for(usize j = 0; j < totalPoints; j++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
     int32 gnum = featureIds[j];
     voxCounts[gnum]++;
     if(boundaryCells[j] > 0)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBoundingBoxStats.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeBoundingBoxStats.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/NeighborList.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
@@ -730,6 +731,9 @@ ComputeBoundingBoxStats::~ComputeBoundingBoxStats() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ComputeBoundingBoxStats::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Bounding Box Stats...");
+
   const auto& geom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->GeometryPath);
   auto& unifiedArray = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->UnifiedPath).getDataStoreRef();
   auto& inputArray = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->InputPath);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeCoordinateThreshold.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeCoordinateThreshold.cpp
@@ -12,6 +12,7 @@
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/Utilities/IntersectionUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -275,6 +276,9 @@ ComputeCoordinateThreshold::~ComputeCoordinateThreshold() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ComputeCoordinateThreshold::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Coordinate Threshold...");
+
   std::function<uint8(float32, float32, float32)> f_IsInBounds;
   switch(static_cast<BoundsType>(m_InputValues->ShapeType))
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeCoordinatesImageGeom.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeCoordinatesImageGeom.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -119,6 +120,9 @@ ComputeCoordinatesImageGeom::~ComputeCoordinatesImageGeom() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ComputeCoordinatesImageGeom::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Coordinates for Image Geometry...");
+
   auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ImageGeomPath);
 
   usize zPoints = imageGeom.getNumZCells();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeDifferencesMap.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeDifferencesMap.cpp
@@ -58,6 +58,11 @@ Result<> ComputeDifferencesMap::operator()()
   auto* secondInputArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->SecondInputArrayPath);
   auto* differenceMapArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->DifferenceMapArrayPath);
 
+  if(m_ShouldCancel)
+  {
+    return {};
+  }
+
   ExecuteDataFunction(ExecuteFindDifferenceMapFunctor{}, firstInputArray->getDataType(), firstInputArray, secondInputArray, differenceMapArray);
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeDifferencesMap.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeDifferencesMap.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 namespace
@@ -50,6 +51,8 @@ ComputeDifferencesMap::~ComputeDifferencesMap() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ComputeDifferencesMap::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Differences Map...");
 
   auto* firstInputArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->FirstInputArrayPath);
   auto* secondInputArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->SecondInputArrayPath);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeEuclideanDistMap.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeEuclideanDistMap.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/NeighborUtilities.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
@@ -459,6 +460,9 @@ const std::atomic_bool& ComputeEuclideanDistMap::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ComputeEuclideanDistMap::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Euclidean Distance Map...");
+
   if(m_InputValues->CalcManhattanDist)
   {
     findDistanceMap<int32>(m_DataStructure, m_InputValues);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureBounds.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureBounds.cpp
@@ -222,6 +222,11 @@ Result<> ComputeFeatureBounds::operator()()
 
   const auto& geom = m_DataStructure.getDataRefAs<IGeometry>(m_InputValues->GeometryPath);
 
+  if(m_ShouldCancel)
+  {
+    return {};
+  }
+
   std::vector<float32> bounds = ExecuteComputeBounds(geom, featureIds, numFeatures);
   if(bounds.empty())
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureBounds.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureBounds.cpp
@@ -12,6 +12,7 @@
 #include "simplnx/DataStructure/Geometry/QuadGeom.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -206,6 +207,9 @@ ComputeFeatureBounds::~ComputeFeatureBounds() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ComputeFeatureBounds::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Feature Bounds...");
+
   const auto& featureIds = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->FeatureIdsArrayPath).getDataStoreRef();
   const auto& featureAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->FeatureAMPath);
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureCentroids.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureCentroids.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/GeometryHelpers.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 #include <algorithm>
@@ -127,6 +128,9 @@ const std::atomic_bool& ComputeFeatureCentroids::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ComputeFeatureCentroids::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Feature Centroids...");
+
   // Input Cell Data
 
   const auto* featureIdsPtr = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsArrayPath);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureClustering.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureClustering.cpp
@@ -199,6 +199,10 @@ Result<> ComputeFeatureClustering::operator()()
 
   for(usize i = 1; i < totalFeatures; i++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
     if(featurePhasesStore[i] == m_InputValues->PhaseNumber)
     {
 
@@ -226,6 +230,10 @@ Result<> ComputeFeatureClustering::operator()()
 
   for(usize i = 1; i < totalFeatures; i++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
     if(featurePhasesStore[i] == m_InputValues->PhaseNumber)
     {
       for(auto value : clusters[i])
@@ -251,6 +259,10 @@ Result<> ComputeFeatureClustering::operator()()
   {
     for(usize i = 1; i < totalFeatures; i++)
     {
+      if(m_ShouldCancel)
+      {
+        return {};
+      }
       if(featurePhasesStore[i] == m_InputValues->PhaseNumber)
       {
         if(maskCompare->isTrue(i))
@@ -275,6 +287,10 @@ Result<> ComputeFeatureClustering::operator()()
   {
     for(usize i = 1; i < totalFeatures; i++)
     {
+      if(m_ShouldCancel)
+      {
+        return {};
+      }
       if(featurePhasesStore[i] == m_InputValues->PhaseNumber)
       {
         for(usize j = 0; j < clusters[i].size(); j++)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureClustering.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureClustering.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/NeighborList.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <random>
 
@@ -130,6 +131,9 @@ const std::atomic_bool& ComputeFeatureClustering::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ComputeFeatureClustering::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+
   const auto& imageGeometry = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ImageGeometryPath);
   const auto& featurePhasesStore = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeaturePhasesArrayPath)->getDataStoreRef();
   const auto& centroidsStore = m_DataStructure.getDataAs<Float32Array>(m_InputValues->CentroidsArrayPath)->getDataStoreRef();
@@ -189,14 +193,14 @@ Result<> ComputeFeatureClustering::operator()()
 
   clusters.resize(totalFeatures);
 
+  progressHelper.setMaxProgresss(totalFeatures);
+  progressHelper.setProgressMessageTemplate("Computing Feature Clustering: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(usize i = 1; i < totalFeatures; i++)
   {
     if(featurePhasesStore[i] == m_InputValues->PhaseNumber)
     {
-      if(i % 1000 == 0)
-      {
-        m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Working on Feature {} of {}", i, totalPptFeatures));
-      }
 
       x = centroidsStore[3 * i];
       y = centroidsStore[3 * i + 1];
@@ -217,6 +221,7 @@ Result<> ComputeFeatureClustering::operator()()
         }
       }
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   for(usize i = 1; i < totalFeatures; i++)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeaturePhases.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeaturePhases.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <map>
 #include <set>
@@ -42,6 +43,12 @@ Result<> ComputeFeaturePhases::operator()()
   std::map<int32, int32> featureMap;
   std::set<int32> warnFeatures;
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalPoints);
+  progressHelper.setProgressMessageTemplate("Computing Feature Phases: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(usize i = 0; i < totalPoints; i++)
   {
     if(m_ShouldCancel)
@@ -58,6 +65,7 @@ Result<> ComputeFeaturePhases::operator()()
       warnFeatures.insert(gnum);
     }
     featurePhases[gnum] = cellPhases[i];
+    progressMessenger.sendProgressMessage(1);
   }
 
   Result<> result;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeaturePhasesBinary.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeaturePhasesBinary.cpp
@@ -47,6 +47,10 @@ Result<> ComputeFeaturePhasesBinary::operator()()
 
   for(usize i = 0; i < totalPoints; i++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
     featurePhasesStoreRef[featureIdsStoreRef[i]] = goodVoxelsMask->isTrue(i);
     progressMessenger.sendProgressMessage(1);
   }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeaturePhasesBinary.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeaturePhasesBinary.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -38,9 +39,16 @@ Result<> ComputeFeaturePhasesBinary::operator()()
 
   usize totalPoints = featureIdsStoreRef.getNumberOfTuples();
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalPoints);
+  progressHelper.setProgressMessageTemplate("Computing Feature Phases Binary: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(usize i = 0; i < totalPoints; i++)
   {
     featurePhasesStoreRef[featureIdsStoreRef[i]] = goodVoxelsMask->isTrue(i);
+    progressMessenger.sendProgressMessage(1);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureRect.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureRect.cpp
@@ -1,6 +1,7 @@
 #include "ComputeFeatureRect.hpp"
 
 #include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -61,6 +62,12 @@ Result<> ComputeFeatureRect::operator()()
   const usize yDim = imageDims[1];
   const usize zDim = imageDims[2];
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(zDim);
+  progressHelper.setProgressMessageTemplate("Computing Feature Rect: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   usize index = 0;
   // Store the coordinates in the corners array
   for(uint32 z = 0; z < zDim; z++)
@@ -104,6 +111,7 @@ Result<> ComputeFeatureRect::operator()()
         }
       }
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeKMeans.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeKMeans.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/Utilities/ClusteringUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <random>
 
@@ -207,6 +208,9 @@ const std::atomic_bool& ComputeKMeans::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ComputeKMeans::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing K-Means Clustering...");
+
   auto* clusteringArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->ClusteringArrayPath);
 
   std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeKMedoids.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeKMedoids.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/Utilities/ClusteringUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <random>
 
@@ -208,6 +209,9 @@ const std::atomic_bool& ComputeKMedoids::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ComputeKMedoids::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing K-Medoids Clustering...");
+
   auto* clusteringArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->ClusteringArrayPath);
   std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;
   try

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeLargestCrossSections.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeLargestCrossSections.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -83,7 +84,11 @@ Result<> ComputeLargestCrossSections::operator()()
     stride3 = inPlane1 * inPlane2;
   }
 
-  m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Computing Cross Section for {} planes", outPlane));
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(outPlane);
+  progressHelper.setProgressMessageTemplate("Computing Largest Cross Sections: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
   for(size_t i = 0; i < outPlane; i++)
   {
@@ -109,6 +114,7 @@ Result<> ComputeLargestCrossSections::operator()()
         largestCrossSectStore[g] = area;
       }
     }
+    progressMessenger.sendProgressMessage(1);
   }
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeLargestCrossSections.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeLargestCrossSections.cpp
@@ -92,6 +92,10 @@ Result<> ComputeLargestCrossSections::operator()()
 
   for(size_t i = 0; i < outPlane; i++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
     std::fill(featureCounts.begin(), featureCounts.end(), 0.0f);
 
     iStride = i * stride1;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeMomentInvariants2D.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeMomentInvariants2D.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Common/Numbers.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -363,6 +364,9 @@ const std::atomic_bool& ComputeMomentInvariants2D::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ComputeMomentInvariants2D::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing 2D Moment Invariants...");
+
   const auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ImageGeometryPath);
   const SizeVec3 volDims = imageGeom.getDimensions();
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeSurfaceAreaToVolume.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeSurfaceAreaToVolume.cpp
@@ -80,6 +80,10 @@ Result<> ComputeSurfaceAreaToVolume::operator()()
   // Start looping over the regular grid data (This could be either an Image Geometry or a Rectilinear Grid geometry (in theory)
   for(int64 zIdx = 0; zIdx < zPoints; zIdx++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
 
     int64 zStride = zIdx * xPoints * yPoints;
     for(int64 yIdx = 0; yIdx < yPoints; yIdx++)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeSurfaceAreaToVolume.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeSurfaceAreaToVolume.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -70,10 +71,15 @@ Result<> ComputeSurfaceAreaToVolume::operator()()
   neighborOffset[4] = xPoints;            // +Y
   neighborOffset[5] = xPoints * yPoints;  // +Z
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(zPoints);
+  progressHelper.setProgressMessageTemplate("Computing Surface Area to Volume: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   // Start looping over the regular grid data (This could be either an Image Geometry or a Rectilinear Grid geometry (in theory)
   for(int64 zIdx = 0; zIdx < zPoints; zIdx++)
   {
-    m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Computing Z Slice: '{}'", zIdx));
 
     int64 zStride = zIdx * xPoints * yPoints;
     for(int64 yIdx = 0; yIdx < yPoints; yIdx++)
@@ -139,6 +145,7 @@ Result<> ComputeSurfaceAreaToVolume::operator()()
         featureSurfaceArea[featureId] = featureSurfaceArea[featureId] + onSurface;
       }
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   const float32 thirdRootPi = std::pow(nx::core::Constants::k_PiF, 0.333333f);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeSurfaceFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeSurfaceFeatures.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -196,6 +197,8 @@ ComputeSurfaceFeatures::~ComputeSurfaceFeatures() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ComputeSurfaceFeatures::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Surface Features...");
 
   const auto pMarkFeature0NeighborsValue = m_InputValues->MarkFeature0Neighbors;
   const auto pFeatureGeometryPathValue = m_InputValues->InputImageGeometryPath;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeTriangleGeomCentroids.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeTriangleGeomCentroids.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/Geometry/IGeometry.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/GeometryHelpers.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -54,7 +55,11 @@ Result<> ComputeTriangleGeomCentroids::operator()()
   auto& centroids = m_DataStructure.getDataAs<Float32Array>(m_InputValues->CentroidsArrayPath)->getDataStoreRef();
   std::vector<std::set<MeshIndexType>> vertexSets(numFeatures);
 
-  m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Gathering unique vertices for {} triangles", numTriangles));
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(numTriangles);
+  progressHelper.setProgressMessageTemplate("Gathering Triangle Vertices: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
   for(MeshIndexType i = 0; i < numTriangles; i++)
   {
@@ -72,9 +77,13 @@ Result<> ComputeTriangleGeomCentroids::operator()()
       vertexSets[faceLabel1].insert(triangles[3 * i + 1]);
       vertexSets[faceLabel1].insert(triangles[3 * i + 2]);
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
-  m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Computing centroids for {} features", numFeatures));
+  progressHelper.resetProgress();
+  progressHelper.setMaxProgresss(numFeatures);
+  progressHelper.setProgressMessageTemplate("Computing Triangle Geom Centroids: {:.1f}% Complete");
+  auto progressMessenger2 = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
   for(MeshIndexType i = 0; i < numFeatures; i++)
   {
@@ -103,6 +112,7 @@ Result<> ComputeTriangleGeomCentroids::operator()()
       }
     }
     vertexSets[i].clear();
+    progressMessenger2.sendProgressMessage(1);
   }
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeTriangleGeomVolumes.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeTriangleGeomVolumes.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/Meshing/TriangleUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -30,6 +31,9 @@ const std::atomic_bool& ComputeTriangleGeomVolumes::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ComputeTriangleGeomVolumes::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Triangle Geometry Volumes...");
+
   using MeshIndexType = IGeometry::MeshIndexType;
   using SharedVertexListType = AbstractDataStore<IGeometry::SharedVertexList::value_type>;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeVectorColors.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeVectorColors.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <Eigen/Dense>
 
@@ -52,6 +53,12 @@ Result<> ComputeVectorColors::operator()()
   auto& cellVectorColors = m_DataStructure.getDataAs<UInt8Array>(m_InputValues->CellVectorColorsArrayPath)->getDataStoreRef();
 
   usize totalPoints = vectors.getNumberOfTuples();
+
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalPoints);
+  progressHelper.setProgressMessageTemplate("Computing Vector Colors: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
   usize index;
   // Write the Vector Coloring Cell Data
@@ -129,6 +136,7 @@ Result<> ComputeVectorColors::operator()()
       cellVectorColors[index + 1] = RgbColor::dGreen(argb);
       cellVectorColors[index + 2] = RgbColor::dBlue(argb);
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ConcatenateDataArrays.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ConcatenateDataArrays.cpp
@@ -1,6 +1,7 @@
 #include "ConcatenateDataArrays.hpp"
 
 #include "simplnx/DataStructure/IArray.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -26,6 +27,9 @@ const std::atomic_bool& ConcatenateDataArrays::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ConcatenateDataArrays::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Starting ConcatenateDataArrays...");
+
   const auto& outputDataArray = m_DataStructure.getDataRefAs<IArray>(m_InputValues->OutputArrayPath);
   std::string arrayTypeName = outputDataArray.getTypeName();
   switch(outputDataArray.getArrayType())

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ConditionalSetValue.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ConditionalSetValue.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 
 using namespace nx::core;
@@ -47,6 +48,9 @@ ConditionalSetValue::~ConditionalSetValue() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ConditionalSetValue::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Starting ConditionalSetValue...");
+
   if(m_InputValues->UseConditional)
   {
     DataObject& inputDataObject = m_DataStructure.getDataRef(m_InputValues->SelectedArrayPath);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ConditionalSetValue.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ConditionalSetValue.cpp
@@ -51,6 +51,11 @@ Result<> ConditionalSetValue::operator()()
   MessageHelper messageHelper(m_MessageHandler);
   messageHelper.sendMessage("Starting ConditionalSetValue...");
 
+  if(m_ShouldCancel)
+  {
+    return {};
+  }
+
   if(m_InputValues->UseConditional)
   {
     DataObject& inputDataObject = m_DataStructure.getDataRef(m_InputValues->SelectedArrayPath);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ConvertColorToGrayScale.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ConvertColorToGrayScale.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/Core/Preferences.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -187,6 +188,11 @@ const std::atomic_bool& ConvertColorToGrayScale::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ConvertColorToGrayScale::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(m_InputValues->InputDataArrayPaths.size());
+  progressHelper.setProgressMessageTemplate("ConvertColorToGrayScale: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
   auto outputPathIter = m_InputValues->OutputDataArrayPaths.begin();
   for(const auto& arrayPath : m_InputValues->InputDataArrayPaths)
@@ -249,6 +255,7 @@ Result<> ConvertColorToGrayScale::operator()()
       }
       break;
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ConvertData.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ConvertData.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -155,6 +156,9 @@ const std::atomic_bool& ConvertData::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ConvertData::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Starting ConvertData...");
+
   DataType inputArrayType = m_DataStructure.getDataAs<IDataArray>(m_InputValues->SelectedArrayPath)->getDataType();
   switch(inputArrayType)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CopyFeatureArrayToElementArray.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CopyFeatureArrayToElementArray.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
@@ -66,6 +67,12 @@ CopyFeatureArrayToElementArray::~CopyFeatureArrayToElementArray() noexcept = def
 // -----------------------------------------------------------------------------
 Result<> CopyFeatureArrayToElementArray::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(m_InputValues->SelectedFeatureArrayPaths.size());
+  progressHelper.setProgressMessageTemplate("CopyFeatureArrayToElementArray: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   const auto& featureIds = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->FeatureIdsPath);
 
   for(const auto& selectedFeatureArrayPath : m_InputValues->SelectedFeatureArrayPaths)
@@ -84,6 +91,7 @@ Result<> CopyFeatureArrayToElementArray::operator()()
     dataAlg.setRange(0, featureIds.getNumberOfTuples());
     ExecuteParallelFunction<::CopyFeatureArrayToElementArrayImpl>(selectedFeatureArray->getDataType(), dataAlg, selectedFeatureArray, featureIds.getDataStoreRef(),
                                                                   m_DataStructure.getDataAs<IDataArray>(createdArrayPath), m_ShouldCancel);
+    progressMessenger.sendProgressMessage(1);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CreateAMScanPaths.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CreateAMScanPaths.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/EdgeGeom.hpp"
 #include "simplnx/Utilities/ImageRotationUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <Eigen/Dense>
 
@@ -380,6 +381,12 @@ Result<> CreateAMScanPaths::operator()()
 
   using LineSegmentsType = std::vector<LineSegment>;
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(numCADRegions);
+  progressHelper.setProgressMessageTemplate("CreateAMScanPaths: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   // Loop on every Region
   // Parallelize over the regions?
   for(int32 regionId = 0; regionId < numCADRegions; regionId++)
@@ -447,6 +454,7 @@ Result<> CreateAMScanPaths::operator()()
       }
       currentSliceId++;
     }
+    progressMessenger.sendProgressMessage(1);
   }
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CreateColorMap.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CreateColorMap.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/Utilities/ColorTableUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -231,6 +232,9 @@ const std::atomic_bool& CreateColorMap::getCancel()
 // -----------------------------------------------------------------------------
 Result<> CreateColorMap::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Starting CreateColorMap...");
+
   const IDataArray& selectedIDataArray = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->SelectedDataArrayPath);
 
   auto controlPointsResult = ColorTableUtilities::ExtractControlPoints(m_InputValues->PresetName);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CreateFeatureArrayFromElementArray.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CreateFeatureArrayFromElementArray.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataStore.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -77,6 +78,9 @@ CreateFeatureArrayFromElementArray::~CreateFeatureArrayFromElementArray() noexce
 // -----------------------------------------------------------------------------
 Result<> CreateFeatureArrayFromElementArray::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Starting CreateFeatureArrayFromElementArray...");
+
   const DataPath createdArrayPath = m_InputValues->CellFeatureAttributeMatrixPath.createChildPath(m_InputValues->CreatedArrayName);
   const auto* selectedCellArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->SelectedCellArrayPath);
   const auto& featureIdsRef = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsPath)->getDataStoreRef();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CreateGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CreateGeometry.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/IGeometry.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <fmt/format.h>
 
@@ -77,6 +78,9 @@ CreateGeometry::~CreateGeometry() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> CreateGeometry::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Starting CreateGeometry...");
+
   auto geometryPath = m_InputValues->OutputGeometryPath;
   auto geometryType = m_InputValues->GeometryTypeIndex;
   auto treatWarningsAsErrors = m_InputValues->WarningsAsErrors;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CreatePythonSkeleton.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CreatePythonSkeleton.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Common/RgbColor.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -27,6 +28,9 @@ const std::atomic_bool& CreatePythonSkeleton::getCancel()
 // -----------------------------------------------------------------------------
 Result<> CreatePythonSkeleton::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Starting CreatePythonSkeleton...");
+
   if(m_InputValues->useExistingPlugin)
   {
     return nx::core::WritePythonFiltersToPlugin(m_InputValues->pluginInputDir, m_InputValues->filterNames);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CropEdgeGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CropEdgeGeometry.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/Geometry/EdgeGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
@@ -182,6 +183,9 @@ const std::atomic_bool& CropEdgeGeometry::getCancel()
 // -----------------------------------------------------------------------------
 Result<> CropEdgeGeometry::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+
   DataPath destEdgeGeomPath = m_InputValues->destEdgeGeomPath;
   if(m_InputValues->removeOriginalGeometry)
   {
@@ -225,6 +229,10 @@ Result<> CropEdgeGeometry::operator()()
   std::vector<bool> edgesMask(numEdges, false);
   std::vector<bool> vertexReferenced(numVertices, false);
   std::unordered_map<uint64, std::tuple<float32, float32, float32>> interpolatedValuesMap;
+
+  progressHelper.setMaxProgresss(numEdges);
+  progressHelper.setProgressMessageTemplate("CropEdgeGeometry: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
   for(usize i = 0; i < numEdges; ++i)
   {
@@ -302,6 +310,7 @@ Result<> CropEdgeGeometry::operator()()
       vertexReferenced[v1] = true;
       edgesMask[i] = true;
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   // Tally up the number of vertices referenced and edges kept

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CropImageGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CropImageGeometry.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 #include "simplnx/Utilities/SamplingUtils.hpp"
@@ -98,6 +99,9 @@ CropImageGeometry::~CropImageGeometry() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> CropImageGeometry::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Starting CropImageGeometry...");
+
   auto srcImagePath = m_InputValues->InputImageGeometryPath;
   auto destImagePath = m_InputValues->OutputImageGeometryPath;
   const auto featureIdsArrayPath = m_InputValues->FeatureIdsPath;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CropVertexGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CropVertexGeometry.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -63,6 +64,12 @@ Result<> CropVertexGeometry::operator()()
   std::vector<int64> croppedPoints;
   croppedPoints.reserve(numVerts);
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(numVerts);
+  progressHelper.setProgressMessageTemplate("CropVertexGeometry: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(int64 i = 0; i < numVerts; i++)
   {
     if(m_ShouldCancel)
@@ -73,6 +80,7 @@ Result<> CropVertexGeometry::operator()()
     {
       croppedPoints.push_back(i);
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   croppedPoints.shrink_to_fit();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateCoordinationNumber.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/NeighborUtilities.hpp"
 
 using namespace nx::core;
@@ -81,6 +82,11 @@ Result<> ErodeDilateCoordinationNumber::operator()()
   bool keepGoing = true;
   int32 counter = 1;
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(dims[2]);
+  progressHelper.setProgressMessageTemplate("ErodeDilateCoordinationNumber: {:.1f}% Complete");
+
   while(counter > 0 && keepGoing)
   {
     counter = 0;
@@ -88,6 +94,9 @@ Result<> ErodeDilateCoordinationNumber::operator()()
     {
       keepGoing = false;
     }
+
+    progressHelper.resetProgress();
+    auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
     for(int64 zIdx = 0; zIdx < dims[2]; zIdx++)
     {
@@ -158,6 +167,7 @@ Result<> ErodeDilateCoordinationNumber::operator()()
           }
         }
       }
+      progressMessenger.sendProgressMessage(1);
     }
     for(int64 zIndex = 0; zIndex < dims[2]; zIndex++)
     {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/NeighborUtilities.hpp"
 
 using namespace nx::core;
@@ -47,9 +48,17 @@ Result<> ErodeDilateMask::operator()()
   std::array<int64, 6> neighborVoxelIndexOffsets = initializeFaceNeighborOffsets(dims);
   std::array<FaceNeighborType, 6> faceNeighborInternalIdx = initializeFaceNeighborInternalIdx();
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(dims[2]);
+  progressHelper.setProgressMessageTemplate("ErodeDilateMask: {:.1f}% Complete");
+
   for(int32_t iteration = 0; iteration < m_InputValues->NumIterations; iteration++)
   {
     m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Iteration {}", iteration));
+
+    progressHelper.resetProgress();
+    auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
     for(size_t j = 0; j < totalPoints; j++)
     {
@@ -90,6 +99,7 @@ Result<> ErodeDilateMask::operator()()
           }
         }
       }
+      progressMessenger.sendProgressMessage(1);
     }
     for(size_t j = 0; j < totalPoints; j++)
     {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExecuteProcess.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExecuteProcess.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include <reproc++/drain.hpp>
@@ -36,6 +37,9 @@ const std::atomic_bool& ExecuteProcess::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ExecuteProcess::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Starting ExecuteProcess...");
+
   auto absPath = m_InputValues->LogFile;
   if(!absPath.is_absolute())
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExtractComponentAsArray.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExtractComponentAsArray.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 namespace
@@ -84,6 +85,9 @@ const std::atomic_bool& ExtractComponentAsArray::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ExtractComponentAsArray::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Starting ExtractComponentAsArray...");
+
   /* baseArrayRef CANNOT be const because it can either be the original array [can be const] OR the resized array [can't be const]*/
   /* tempArrayRef CANNOT be const because the functor has to be capable of handling both cases of remove components*/
   const bool moveComponentsToNewArrayBool = m_InputValues->MoveComponentsToNewArray;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExtractFeatureBoundaries2D.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExtractFeatureBoundaries2D.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/GeometryUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 #include <atomic>
@@ -496,6 +497,8 @@ const std::atomic_bool& ExtractFeatureBoundaries2D::getCancel() const
 // -----------------------------------------------------------------------------
 Result<> ExtractFeatureBoundaries2D::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+
   // Get references to the input/output geometries and feature IDs array
   const auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->InputImageGeometryPath);
   auto& edgeGeom = m_DataStructure.getDataRefAs<EdgeGeom>(m_InputValues->OutputEdgeGeometryPath);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -152,6 +152,10 @@ Result<> ExtractInternalSurfacesFromTriangleGeometry::operator()()
   // Transfer the data from the old SharedVertexList to the new VertexList
   for(MeshIndexType vertIndex = 0; vertIndex < numVerts; vertIndex++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
     MeshIndexType mappedIndex = vertNewIndex[vertIndex];
     if(mappedIndex != notSeen)
     {
@@ -169,6 +173,10 @@ Result<> ExtractInternalSurfacesFromTriangleGeometry::operator()()
   // Transfer the data from the old SharedTriangleList to the new TriangleList
   for(MeshIndexType triIndex = 0; triIndex < numTris; triIndex++)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
     MeshIndexType mappedIndex = triNewIndex[triIndex];
     if(mappedIndex != notSeen)
     {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExtractInternalSurfacesFromTriangleGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExtractInternalSurfacesFromTriangleGeometry.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <limits>
 #include <unordered_map>
@@ -94,6 +95,12 @@ Result<> ExtractInternalSurfacesFromTriangleGeometry::operator()()
   MeshIndexType currentNewTriIndex = 0;
   MeshIndexType currentNewVertIndex = 0;
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(numTris);
+  progressHelper.setProgressMessageTemplate("ExtractInternalSurfaces: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   // Loop over all the triangles mapping the triangle and the vertices to the new array locations
   for(MeshIndexType triIndex = 0; triIndex < numTris; triIndex++)
   {
@@ -124,6 +131,8 @@ Result<> ExtractInternalSurfacesFromTriangleGeometry::operator()()
         currentNewVertIndex++;
       }
     }
+
+    progressMessenger.sendProgressMessage(1);
 
     if(m_ShouldCancel)
     {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExtractPipelineToFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExtractPipelineToFile.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/Common/AtomicFile.hpp"
 #include "simplnx/Pipeline/Pipeline.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
 
 #include <nlohmann/json.hpp>
@@ -28,6 +29,9 @@ ExtractPipelineToFile::~ExtractPipelineToFile() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ExtractPipelineToFile::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Starting ExtractPipelineToFile...");
+
   const auto importFile = m_InputValues->InputFilePath;
   auto outputFile = m_InputValues->OutputFilePath;
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExtractVertexGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ExtractVertexGeometry.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -129,6 +130,12 @@ Result<> ExtractVertexGeometry::operator()()
   // of each cell and then set that into the new VertexGeometry
   m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Generating vertex geometry"));
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalCells);
+  progressHelper.setProgressMessageTemplate("ExtractVertexGeometry: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   IGeometry::SharedVertexList& vertices = vertexGeometry.getVerticesRef();
   auto& verticesDataStore = vertices.getDataStoreRef();
   usize vertIdx = 0;
@@ -148,6 +155,7 @@ Result<> ExtractVertexGeometry::operator()()
       const Point3D<float32> coords = inputGeometry.getCoordsf(idx);
       verticesDataStore.setTuple(idx, coords.toArray());
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Copying cell data to vertex geometry"));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/FindNRingNeighbors.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/FindNRingNeighbors.cpp
@@ -60,6 +60,10 @@ Result<> FindNRingNeighbors::operator()(const IFilter::MessageHandler& mesgHandl
 
   for(int64_t ring = 0; ring < m_InputValues->Ring; ++ring)
   {
+    if(shouldCancel)
+    {
+      return {};
+    }
     throttledMessenger.sendThrottledMessage([&]() { return fmt::format("Find N-Ring Neighbors: Processing ring {} of {}", ring + 1, m_InputValues->Ring); });
 
     // Make a copy of the 1 Ring Triangles that we just found so that we can use those triangles as the

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/FindNRingNeighbors.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/FindNRingNeighbors.cpp
@@ -1,6 +1,7 @@
 #include "FindNRingNeighbors.hpp"
 
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <sstream>
 
@@ -54,8 +55,13 @@ Result<> FindNRingNeighbors::operator()(const IFilter::MessageHandler& mesgHandl
   // Add our seed triangle
   m_NRingTriangles.insert(triangleId);
 
+  MessageHelper messageHelper(mesgHandler);
+  auto throttledMessenger = messageHelper.createThrottledMessenger(std::chrono::milliseconds(1000));
+
   for(int64_t ring = 0; ring < m_InputValues->Ring; ++ring)
   {
+    throttledMessenger.sendThrottledMessage([&]() { return fmt::format("Find N-Ring Neighbors: Processing ring {} of {}", ring + 1, m_InputValues->Ring); });
+
     // Make a copy of the 1 Ring Triangles that we just found so that we can use those triangles as the
     // seed triangles for the 2 Ring triangles
     UniqueFaceIds_t lcvTriangles(m_NRingTriangles);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/FlyingEdges3D.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/FlyingEdges3D.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/FlyingEdges.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -47,6 +48,9 @@ const std::atomic_bool& FlyingEdges3D::getCancel()
 // -----------------------------------------------------------------------------
 Result<> FlyingEdges3D::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Flying Edges 3D: Starting isosurface extraction...");
+
   const auto& image = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->imageGeomPath);
   float64 isoVal = m_InputValues->isoVal;
   const auto* iDataArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->contouringArrayPath);
@@ -59,6 +63,8 @@ Result<> FlyingEdges3D::operator()()
   auto& normAM = m_DataStructure.getDataRefAs<AttributeMatrix>(normAMPath);
 
   ExecuteNeighborFunction(ExecuteFlyingEdgesFunctor{}, iDataArray->getDataType(), image, iDataArray, isoVal, triangleGeom, normalsStore, normAM);
+
+  messageHelper.sendMessage("Flying Edges 3D: Isosurface extraction complete.");
 
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/IdentifyDuplicateVertices.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/IdentifyDuplicateVertices.cpp
@@ -7,6 +7,7 @@
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/Meshing/VertexUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -60,6 +61,14 @@ Result<> IdentifyDuplicateVertices::operator()()
 
   auto& duplicatesMask = m_DataStructure.getDataAs<UInt8Array>(m_InputValues->DuplicatesMaskPath)->getDataStoreRef();
   duplicatesMask.fill(0);
+
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  usize totalVertices = sortedVerticesList.ordering.size();
+  progressHelper.setMaxProgresss(totalVertices);
+  progressHelper.setProgressMessageTemplate("Identify Duplicate Vertices: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   using VertT = INodeGeometry0D::SharedVertexList::value_type;
   for(usize i = 1; i < sortedVerticesList.ordering.size(); i++)
   {
@@ -68,21 +77,25 @@ Result<> IdentifyDuplicateVertices::operator()()
     if(std::numeric_limits<VertT>::epsilon() < std::fabs(verts[prevIndex + offset[0]] - verts[currentIndex + offset[0]]))
     {
       // value on first axis is different; proceed to next iteration
+      progressMessenger.sendProgressMessage(1);
       continue;
     }
     if(std::numeric_limits<VertT>::epsilon() < std::fabs(verts[prevIndex + offset[1]] - verts[currentIndex + offset[1]]))
     {
       // value on second axis is different; proceed to next iteration
+      progressMessenger.sendProgressMessage(1);
       continue;
     }
     if(std::numeric_limits<VertT>::epsilon() < std::fabs(verts[prevIndex + offset[2]] - verts[currentIndex + offset[2]]))
     {
       // value on third axis is different; proceed to next iteration
+      progressMessenger.sendProgressMessage(1);
       continue;
     }
 
     // Duplicate found flag true
     duplicatesMask[sortedVerticesList.ordering[i]] = 1;
+    progressMessenger.sendProgressMessage(1);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/IdentifySample.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/IdentifySample.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/NeighborUtilities.hpp"
 
 using namespace nx::core;
@@ -36,24 +37,19 @@ struct IdentifySampleFunctor
     std::vector<bool> sample(totalPoints, false);
     int64 biggestBlock = 0;
 
+    MessageHelper messageHelper(messageHandler);
+    auto progressHelper = messageHelper.createProgressMessageHelper();
+    progressHelper.setMaxProgresss(static_cast<usize>(totalPoints));
+    progressHelper.setProgressMessageTemplate("Identify Sample: Finding Largest Region: {:.1f}% Complete");
+    auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
     // In this loop over the data we are finding the biggest contiguous set of GoodVoxels and calling that the 'sample'  All GoodVoxels that do not touch the 'sample'
     // are flipped to be called 'bad' voxels or 'not sample'
-    float threshold = 0.0f;
     for(int64 voxelIndex = 0; voxelIndex < totalPoints; voxelIndex++)
     {
       if(shouldCancel)
       {
         return;
-      }
-      const float percentIncrement = static_cast<float>(voxelIndex) / static_cast<float>(totalPoints) * 100.0f;
-      if(percentIncrement > threshold)
-      {
-        messageHandler(IFilter::Message::Type::Info, fmt::format("Completed: {}", percentIncrement));
-        threshold = threshold + 5.0f;
-        if(threshold < percentIncrement)
-        {
-          threshold = percentIncrement;
-        }
       }
 
       if(!checked[voxelIndex] && goodVoxels.getValue(voxelIndex))
@@ -94,6 +90,7 @@ struct IdentifySampleFunctor
         }
         currentVList.clear();
       }
+      progressMessenger.sendProgressMessage(1);
     }
     for(int64 i = 0; i < totalPoints; i++)
     {
@@ -107,10 +104,12 @@ struct IdentifySampleFunctor
 
     // In this loop we are going to 'close' all the 'holes' inside the region already identified as the 'sample' if the user chose to do so.
     // This is done by flipping all 'bad' voxel features that do not touch the outside of the sample (i.e. they are fully contained inside the 'sample').
-    threshold = 0.0F;
     if(fillHoles)
     {
-      messageHandler(IFilter::Message::Type::Info, fmt::format("Filling holes in sample..."));
+      progressHelper.resetProgress();
+      progressHelper.setMaxProgresss(static_cast<usize>(totalPoints));
+      progressHelper.setProgressMessageTemplate("Identify Sample: Filling Holes: {:.1f}% Complete");
+      auto fillProgressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
       bool touchesBoundary = false;
       for(int64 voxelIndex = 0; voxelIndex < totalPoints; voxelIndex++)
@@ -118,15 +117,6 @@ struct IdentifySampleFunctor
         if(shouldCancel)
         {
           return;
-        }
-        const float percentIncrement = static_cast<float>(voxelIndex) / static_cast<float>(totalPoints) * 100.0f;
-        if(percentIncrement > threshold)
-        {
-          threshold = threshold + 5.0f;
-          if(threshold < percentIncrement)
-          {
-            threshold = percentIncrement;
-          }
         }
 
         if(!checked[voxelIndex] && !goodVoxels.getValue(voxelIndex))
@@ -171,6 +161,7 @@ struct IdentifySampleFunctor
           }
           currentVList.clear();
         }
+        fillProgressMessenger.sendProgressMessage(1);
       }
     }
     checked.clear();
@@ -229,13 +220,18 @@ struct IdentifySampleSliceBySliceFunctor
       break;
     }
 
+    MessageHelper messageHelper(messageHandler);
+    auto progressHelper = messageHelper.createProgressMessageHelper();
+    progressHelper.setMaxProgresss(static_cast<usize>(fixedDim));
+    progressHelper.setProgressMessageTemplate("Identify Sample (Slice-by-Slice): {:.1f}% Complete");
+    auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
     for(int64 fixedIdx = 0; fixedIdx < fixedDim; ++fixedIdx) // Process each slice
     {
       if(shouldCancel)
       {
         return;
       }
-      messageHandler(IFilter::Message::Type::Info, fmt::format("Slice {}", fixedIdx));
 
       std::vector<bool> checked(planeDim1 * planeDim2, false);
       std::vector<bool> sample(planeDim1 * planeDim2, false);
@@ -384,6 +380,7 @@ struct IdentifySampleSliceBySliceFunctor
           }
         }
       }
+      progressMessenger.sendProgressMessage(1);
     }
   }
 };

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InitializeData.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InitializeData.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/AbstractDataStore.hpp"
 #include "simplnx/DataStructure/IDataArray.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 
 #include <chrono>
@@ -525,10 +526,14 @@ const std::atomic_bool& InitializeData::getCancel()
 // -----------------------------------------------------------------------------
 Result<> InitializeData::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Initialize Data: Filling array values...");
 
   auto& iDataArray = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->InputArrayPath);
 
   ExecuteDataFunction(::FillArrayFunctor{}, iDataArray.getDataType(), iDataArray, *m_InputValues);
+
+  messageHelper.sendMessage("Initialize Data: Complete.");
 
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InitializeImageGeomCellData.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InitializeImageGeomCellData.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <chrono>
 #include <limits>
@@ -157,6 +158,12 @@ Result<> InitializeImageGeomCellData::operator()()
 
   std::array<usize, 3> dims = imageGeom.getDimensions().toArray();
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(cellArrayPaths.size());
+  progressHelper.setProgressMessageTemplate("Initialize Image Geom Cell Data: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(const DataPath& path : cellArrayPaths)
   {
     auto& iDataArray = m_DataStructure.getDataRefAs<IDataArray>(path);
@@ -165,6 +172,7 @@ Result<> InitializeImageGeomCellData::operator()()
 
     // Avoid the exact same seeding for each array
     seed++;
+    progressMessenger.sendProgressMessage(1);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InitializeImageGeomCellData.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InitializeImageGeomCellData.cpp
@@ -166,6 +166,10 @@ Result<> InitializeImageGeomCellData::operator()()
 
   for(const DataPath& path : cellArrayPaths)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
     auto& iDataArray = m_DataStructure.getDataRefAs<IDataArray>(path);
 
     ExecuteNeighborFunction(InitializeArrayFunctor{}, iDataArray.getDataType(), iDataArray, dims, xMin, xMax, yMin, yMax, zMin, zMax, initType, initValue, initRange, seed); // NO BOOL

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/InterpolatePointCloudToRegularGrid.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <cmath>
 #include <limits>
@@ -196,8 +197,11 @@ Result<> InterpolatePointCloudToRegularGrid::operator()()
   std::vector<std::vector<float64>> copyWeightSum(numCopyArrays, std::vector<float64>(numVoxels, 0.0));
 
   // Main vertex loop
-  usize progIncrement = numVerts / 100;
-  usize prog = 1;
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(numVerts);
+  progressHelper.setProgressMessageTemplate("Interpolate Point Cloud: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
   for(usize i = 0; i < numVerts; i++)
   {
@@ -284,16 +288,11 @@ Result<> InterpolatePointCloudToRegularGrid::operator()()
       }
     }
 
-    if(i > prog)
-    {
-      usize progressInt = static_cast<usize>((static_cast<float64>(i) / static_cast<float64>(numVerts)) * 100.0);
-      m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Interpolating Point Cloud || {}% Completed", progressInt));
-      prog += progIncrement;
-    }
+    progressMessenger.sendProgressMessage(1);
   }
 
   // Finalization pass - write outputs
-  m_MessageHandler(IFilter::Message::Type::Info, "Writing interpolated results...");
+  messageHelper.sendMessage("Interpolate Point Cloud: Writing interpolated results...");
 
   for(usize a = 0; a < numInterpArrays; a++)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/IterativeClosestPoint.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/IterativeClosestPoint.cpp
@@ -4,6 +4,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <Eigen/Geometry>
 
@@ -126,7 +127,8 @@ Result<> IterativeClosestPoint::operator()()
   using Adaptor = VertexGeomAdaptor<VertexGeom*>;
   const Adaptor adaptor(targetVertexGeom);
 
-  m_MessageHandler("Building kd-tree index...");
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Iterative Closest Point: Building kd-tree index...");
 
   using KDtree = nanoflann::KDTreeSingleIndexAdaptor<nanoflann::L2_Adaptor<float32, Adaptor>, Adaptor, 3>;
   KDtree index(3, adaptor, nanoflann::KDTreeSingleIndexAdaptorParams(30));
@@ -140,7 +142,11 @@ Result<> IterativeClosestPoint::operator()()
   UmeyamaTransform globalTransform;
   globalTransform << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1;
 
-  auto start = std::chrono::steady_clock::now();
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(m_InputValues->NumIterations);
+  progressHelper.setProgressMessageTemplate("Iterative Closest Point: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(usize i = 0; i < m_InputValues->NumIterations; i++)
   {
     if(m_ShouldCancel)
@@ -174,12 +180,7 @@ Result<> IterativeClosestPoint::operator()()
     // Update the global transform
     globalTransform = transform * globalTransform;
 
-    auto now = std::chrono::steady_clock::now();
-    if(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count() > 1000)
-    {
-      m_MessageHandler(fmt::format("Performing Registration Iterations || {}% Completed", static_cast<int64>((static_cast<float>(i) / m_InputValues->NumIterations) * 100.0f)));
-      start = now;
-    }
+    progressMessenger.sendProgressMessage(1);
   }
 
   auto& transformStore = m_DataStructure.getDataAs<Float32Array>(m_InputValues->TransformArrayPath)->getDataStoreRef();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LabelTriangleGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LabelTriangleGeometry.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -32,6 +33,8 @@ Result<> LabelTriangleGeometry::operator()()
   std::vector<uint32> triangleCounts = {0, 0};
   auto& triangle = m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues->TriangleGeomPath);
 
+  MessageHelper messageHelper(m_MessageHandler);
+
   {
     usize numTris = triangle.getNumberOfFaces();
 
@@ -44,6 +47,11 @@ Result<> LabelTriangleGeometry::operator()()
     const TriangleGeom::ElementDynamicList* triangleNeighborsPtr = triangle.getElementNeighbors();
 
     auto& regionIdsStore = m_DataStructure.getDataAs<Int32Array>(m_InputValues->RegionIdsPath)->getDataStoreRef();
+
+    auto progressHelper = messageHelper.createProgressMessageHelper();
+    progressHelper.setMaxProgresss(numTris);
+    progressHelper.setProgressMessageTemplate("Label Triangle Geometry: {:.1f}% Complete");
+    auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
     usize chunkSize = 1000;
     std::vector<int32> triList(chunkSize, -1);
@@ -89,6 +97,7 @@ Result<> LabelTriangleGeometry::operator()()
         regionCount++;
         triangleCounts.push_back(0);
       }
+      progressMessenger.sendProgressMessage(1);
     }
 
     // Resize the Triangle Region AttributeMatrix

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LaplacianSmoothing.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/LaplacianSmoothing.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/INodeGeometry2D.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -72,13 +73,18 @@ Result<> LaplacianSmoothing::edgeBasedSmoothing()
   std::vector<double> deltaArray(numberOfVertices * 3);
   double dlta = 0.0;
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(static_cast<usize>(m_InputValues->pIterationSteps));
+  progressHelper.setProgressMessageTemplate("Laplacian Smoothing: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(int32_t q = 0; q < m_InputValues->pIterationSteps; q++)
   {
     if(m_ShouldCancel)
     {
       return {};
     }
-    m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Iteration {} of {}", q, m_InputValues->pIterationSteps));
     // Compute the Deltas for each point
     for(IGeometry::MeshIndexType i = 0; i < numEdges; i++)
     {
@@ -124,7 +130,6 @@ Result<> LaplacianSmoothing::edgeBasedSmoothing()
       {
         return {};
       }
-      m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Iteration {} of {}", q, m_InputValues->pIterationSteps));
       // Compute the Delta's
       for(IGeometry::MeshIndexType i = 0; i < numEdges; i++)
       {
@@ -160,6 +165,7 @@ Result<> LaplacianSmoothing::edgeBasedSmoothing()
         numConnections[i] = 0; // reset for next iteration
       }
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MapPointCloudToRegularGrid.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MapPointCloudToRegularGrid.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -45,13 +46,20 @@ Result<> ProcessVertices(const IFilter::MessageHandler& messageHandler, const Ve
 
   // Execution
   usize numVerts = vertices.getNumberOfVertices();
-  auto start = std::chrono::steady_clock::now();
+
+  MessageHelper messageHelper(messageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(numVerts);
+  progressHelper.setProgressMessageTemplate("Map Point Cloud To Regular Grid: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(int64 i = 0; i < numVerts; i++)
   {
     if constexpr(UseMask)
     {
       if(!maskCompare->isTrue(i))
       {
+        progressMessenger.sendProgressMessage(1);
         continue;
       }
     }
@@ -80,12 +88,7 @@ Result<> ProcessVertices(const IFilter::MessageHandler& messageHandler, const Ve
       count++;
     }
 
-    auto now = std::chrono::steady_clock::now();
-    if(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count() > 1000)
-    {
-      messageHandler(fmt::format("Computing Point Cloud Voxel Indices || {}% Completed", static_cast<int64>((static_cast<float32>(i) / numVerts) * 100.0f)));
-      start = now;
-    }
+    progressMessenger.sendProgressMessage(1);
   }
 
   if constexpr(OutOfBoundsType::UsingWarning)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
@@ -260,6 +260,10 @@ Result<> MultiThresholdObjects::operator()()
 
   for(const std::shared_ptr<IArrayThreshold>& threshold : thresholdSet)
   {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
     const IArrayThreshold* thresholdPtr = threshold.get();
     if(const auto* comparisonSet = dynamic_cast<const ArrayThresholdSet*>(thresholdPtr); comparisonSet != nullptr)
     {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/ArrayThreshold.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <algorithm>
 
@@ -250,6 +251,13 @@ Result<> MultiThresholdObjects::operator()()
   DataPath maskArrayPath = (*thresholdsObject.getRequiredPaths().begin()).replaceName(maskArrayName);
   int32_t err = 0;
   ArrayThresholdSet::CollectionType thresholdSet = thresholdsObject.getArrayThresholds();
+
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(thresholdSet.size());
+  progressHelper.setProgressMessageTemplate("Multi Threshold Objects: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(const std::shared_ptr<IArrayThreshold>& threshold : thresholdSet)
   {
     const IArrayThreshold* thresholdPtr = threshold.get();
@@ -265,6 +273,7 @@ Result<> MultiThresholdObjects::operator()()
                           thresholdsObject.isInverted(), trueValue, falseValue);
       firstValueFound = true;
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/NearestPointFuseRegularGrids.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/NearestPointFuseRegularGrids.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/StringArray.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
@@ -156,6 +157,8 @@ const std::atomic_bool& NearestPointFuseRegularGrids::getCancel()
 // -----------------------------------------------------------------------------
 Result<> NearestPointFuseRegularGrids::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+
   auto& refImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ReferenceGeometryPath);
   auto& sampleImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->SamplingGeometryPath);
   auto& sampleAM = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->SamplingCellAttributeMatrixPath);
@@ -171,6 +174,7 @@ Result<> NearestPointFuseRegularGrids::operator()()
   }
 
   // Copy according to  calculated values
+  messageHelper.sendMessage("Fusing regular grids by nearest point...");
   ParallelTaskAlgorithm taskRunner;
   auto sampleVoxelArrays = sampleAM.findAllChildrenOfType<IArray>();
   for(const auto& array : sampleVoxelArrays)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/PadImageGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/PadImageGeometry.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
@@ -98,6 +99,7 @@ const std::atomic_bool& PadImageGeometry::getCancel()
 // -----------------------------------------------------------------------------
 Result<> PadImageGeometry::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
 
   auto& srcImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->SelectedImageGeometryPath);
 
@@ -152,7 +154,7 @@ Result<> PadImageGeometry::operator()()
 
     auto& newDataArray = dynamic_cast<IDataArray&>(destCellDataAM.at(srcName));
 
-    m_MessageHandler(fmt::format("Padding Volume || Copying Data Array {}", srcName));
+    messageHelper.sendMessage(fmt::format("Padding Volume || Copying Data Array {}", srcName));
     ExecuteParallelFunction<PadImageGeomDataArray>(oldDataArray.getDataType(), taskRunner, oldDataArray, newDataArray, srcImageGeom, m_InputValues, m_ShouldCancel);
   }
   taskRunner.wait(); // This will spill over if the number of DataArrays to process does not divide evenly by the number of threads.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/PartitionGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/PartitionGeometry.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/Common/Range.hpp"
 #include "simplnx/DataStructure/Geometry/RectGridGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelData3DAlgorithm.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
@@ -152,6 +153,9 @@ const std::atomic_bool& PartitionGeometry::getCancel()
 // -----------------------------------------------------------------------------
 Result<> PartitionGeometry::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Partitioning geometry...");
+
   auto partitioningMode = static_cast<PartitionGeometryFilter::PartitioningMode>(m_InputValues->PartitioningMode);
 
   DataPath partitionGridGeomPath;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/PointSampleEdgeGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/PointSampleEdgeGeometry.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/Geometry/EdgeGeom.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
@@ -144,6 +145,8 @@ PointSampleEdgeGeometry::~PointSampleEdgeGeometry() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> PointSampleEdgeGeometry::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+
   auto& edgeGeom = m_DataStructure.getDataRefAs<EdgeGeom>(m_InputValues->ScanVectorGeometryPath);
   auto numEdges = edgeGeom.getNumberOfEdges();
 
@@ -162,7 +165,7 @@ Result<> PointSampleEdgeGeometry::operator()()
   }
 
   // --- Step 1: Count how many total sample points to generate ---
-  m_MessageHandler(IFilter::Message::Type::Info, "Computing total sampling points...");
+  messageHelper.sendMessage("Computing total sampling points...");
   usize numVertices = 0;
 
   auto& edgeVertices = edgeGeom.getVerticesRef();
@@ -182,7 +185,7 @@ Result<> PointSampleEdgeGeometry::operator()()
     numVertices += result.value();
   }
 
-  m_MessageHandler(IFilter::Message::Type::Info, fmt::format("Total sampling points: {}", numVertices));
+  messageHelper.sendMessage(fmt::format("Total sampling points: {}", numVertices));
 
   // Resize the vertex geometry and the vertex attribute matrix
   auto& vertices = vertexGeom.getVerticesRef();
@@ -191,7 +194,11 @@ Result<> PointSampleEdgeGeometry::operator()()
   vertexAttrMatrix.resizeTuples({numVertices});
 
   // --- Step 2: Generate and write each sampled point ---
-  m_MessageHandler(IFilter::Message::Type::Info, "Generating sampled points along edge geometry...");
+  messageHelper.sendMessage("Generating sampled points along edge geometry...");
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(static_cast<usize>(numEdges));
+  progressHelper.setProgressMessageTemplate("Sampling Edges: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
   int64 vertCount = 0;
   for(int64 i = 0; i < numEdges; i++)
   {
@@ -200,11 +207,12 @@ Result<> PointSampleEdgeGeometry::operator()()
       return {};
     }
     sampleEdge(i, edgeVertices, edges, m_InputValues->ScanVectorSamplingRes, vertices, vertexEdgeIdsDataArrayPtr, cumulativeSampleDistArrayPtr, vertCount);
+    progressMessenger.sendProgressMessage(1);
   }
 
   usize maxEdgeId = *std::max_element(vertexEdgeIdsDataStore.begin(), vertexEdgeIdsDataStore.end());
 
-  m_MessageHandler(IFilter::Message::Type::Info, "Copying Edge Data to Vertex Geometry...");
+  messageHelper.sendMessage("Copying Edge Data to Vertex Geometry...");
   const DataPath vertexAttrMatPath = vertexGeom.getVertexAttributeMatrixDataPath();
   for(const auto& selectedArrayPath : m_InputValues->pSelectedDataArrayPaths)
   {
@@ -218,7 +226,7 @@ Result<> PointSampleEdgeGeometry::operator()()
                                                  vertexEdgeIdsDataPath.toString(), maxEdgeId, selectedEdgeArray->getNumberOfTuples(), selectedArrayPath.toString()));
     }
 
-    m_MessageHandler(IFilter::ProgressMessage{IFilter::ProgressMessage::Type::Info, fmt::format("Copying data into vertex array '{}'...", createdArrayPath.toString())});
+    messageHelper.sendMessage(fmt::format("Copying data into vertex array '{}'...", createdArrayPath.toString()));
     ParallelDataAlgorithm dataAlg;
     dataAlg.setRange(0, createdVertexArray->getNumberOfTuples());
     ExecuteParallelFunction<::CopyEdgeDataToVertexData>(selectedEdgeArray->getDataType(), dataAlg, selectedEdgeArray, createdVertexArray, vertexEdgeIdsDataStore, m_ShouldCancel);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/PointSampleTriangleGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/PointSampleTriangleGeometry.cpp
@@ -37,6 +37,7 @@
 
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -55,6 +56,8 @@ PointSampleTriangleGeometry::~PointSampleTriangleGeometry() noexcept = default;
 
 Result<> PointSampleTriangleGeometry::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+
   DataPath triangleGeometryDataPath = m_Inputs->pTriangleGeometry;
   auto& triangle = m_DataStructure.getDataRefAs<TriangleGeom>(triangleGeometryDataPath);
   auto numTris = static_cast<int64_t>(triangle.getNumberOfFaces());
@@ -74,10 +77,10 @@ Result<> PointSampleTriangleGeometry::operator()()
   // really is a massively idiotic oversight; hack the equivalent using the unary_op constructor
   std::discrete_distribution<size_t> triangle_distribution(numTris, -0.5, -0.5 + static_cast<double>(numTris), [&faceAreasStore](double index) { return faceAreasStore[static_cast<size_t>(index)]; });
 
-  int64_t progIncrement = m_Inputs->pNumberOfSamples / 100;
-  int64_t prog = 1;
-  int64_t progressInt = 0;
-  int64_t counter = 0;
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(static_cast<usize>(m_Inputs->pNumberOfSamples));
+  progressHelper.setProgressMessageTemplate("Sampling Triangles: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
   std::vector<Point3Df> faceVerts = {{0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 0.0F}};
 
@@ -161,14 +164,7 @@ Result<> PointSampleTriangleGeometry::operator()()
       tupleTransferFunctions[dataVectorIndex]->pointSampleTransfer(randomTri, curVertex);
     }
 
-    if(counter > prog)
-    {
-      progressInt = static_cast<int64_t>((static_cast<float>(counter) / static_cast<float>(m_Inputs->pNumberOfSamples)) * 100.0f);
-      std::string ss = fmt::format("Sampling Triangles || {}% Completed", progressInt);
-      m_MessageHandler(IFilter::Message::Type::Info, ss);
-      prog = prog + progIncrement;
-    }
-    counter++;
+    progressMessenger.sendProgressMessage(1);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/QuickSurfaceMesh.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/QuickSurfaceMesh.cpp
@@ -7,6 +7,7 @@
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/Meshing/TriangleUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelData3DAlgorithm.hpp"
 
 #include <array>
@@ -329,6 +330,8 @@ QuickSurfaceMesh::~QuickSurfaceMesh() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> QuickSurfaceMesh::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+
   // Get the ImageGeometry
   auto& grid = m_DataStructure.getDataRefAs<IGridGeometry>(m_InputValues->GridGeomDataPath);
 
@@ -351,6 +354,7 @@ Result<> QuickSurfaceMesh::operator()()
 
   if(m_InputValues->FixProblemVoxels)
   {
+    messageHelper.sendMessage("Correcting problem voxels...");
     correctProblemVoxels();
   }
   if(m_ShouldCancel)
@@ -358,6 +362,7 @@ Result<> QuickSurfaceMesh::operator()()
     return {};
   }
 
+  messageHelper.sendMessage("Determining active nodes...");
   determineActiveNodes(nodeIds, nodeCount, triangleCount);
   if(m_ShouldCancel)
   {
@@ -377,6 +382,7 @@ Result<> QuickSurfaceMesh::operator()()
     Result<> result = nx::core::ResizeAndReplaceDataArray(m_DataStructure, dataPath, tupleShape, nx::core::IDataAction::Mode::Execute);
   }
 
+  messageHelper.sendMessage("Creating nodes and triangles...");
   createNodesAndTriangles(nodeIds, nodeCount, triangleCount);
   if(m_ShouldCancel)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadBinaryCTNorthstar.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadBinaryCTNorthstar.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Common/ScopeGuard.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -138,6 +139,9 @@ const std::atomic_bool& ReadBinaryCTNorthstar::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ReadBinaryCTNorthstar::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading binary CT data files...");
+
   Result<> result = ReadBinaryCTFiles(m_DataStructure, m_MessageHandler, m_ShouldCancel, m_InputValues);
   if(result.invalid())
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadCSVFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadCSVFile.cpp
@@ -1,6 +1,7 @@
 #include "ReadCSVFile.hpp"
 
 #include "simplnx/Utilities/FileUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -42,6 +43,9 @@ Result<> ReadCSVFile::readFile(DataStructure& dataStructure, const std::string& 
                                const std::vector<CSVType>& columnDataTypes, const std::vector<bool>& columnsSkipped, const DataPath& groupPath, const ShapeType& tupleDims,
                                const std::vector<char>& delimiters, bool consecutiveDelimiters, const std::atomic_bool& shouldCancel, const IFilter::MessageHandler& msgHandler)
 {
+  MessageHelper messageHelper(msgHandler);
+  messageHelper.sendMessage(fmt::format("Reading CSV file: {}", inputFilePath));
+
   auto headers = columnHeaders;
   headers = FileUtilities::CSV::RemoveIllegalCharacters(headers);
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadDeformKeyFileV12.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadDeformKeyFileV12.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/DataStructure/Geometry/IGeometry.hpp"
 #include "simplnx/DataStructure/Geometry/QuadGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include <fstream>
@@ -827,6 +828,9 @@ Result<> ReadDeformKeyFileV12::operator()(bool allocate)
    * have been passed in within inputValues are not valid as they have
    * not been created.
    */
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage(fmt::format("Reading DEFORM key file: {}", m_InputValues->InputFilePath.string()));
+
   std::ifstream inStream(m_InputValues->InputFilePath, std::ios_base::binary);
   if(!inStream.is_open())
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadHDF5Dataset.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadHDF5Dataset.cpp
@@ -1,6 +1,7 @@
 #include "ReadHDF5Dataset.hpp"
 
 #include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/H5.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/H5DataStore.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/H5Support.hpp"
@@ -27,6 +28,9 @@ ReadHDF5Dataset::~ReadHDF5Dataset() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ReadHDF5Dataset::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading HDF5 dataset...");
+
   auto pSelectedAttributeMatrixValue = m_InputValues->ImportHdf5Object.parent;
   auto inputFile = m_InputValues->ImportHdf5Object.inputFile;
   fs::path inputFilePath(inputFile);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadRawBinary.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadRawBinary.cpp
@@ -41,6 +41,7 @@
 #include "simplnx/Common/Types.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 namespace fs = std::filesystem;
 using namespace nx::core;
@@ -116,6 +117,9 @@ Result<> ReadRawBinary::operator()()
 // -----------------------------------------------------------------------------
 Result<> ReadRawBinary::execute()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading raw binary data...");
+
   if(m_ShouldCancel)
   {
     return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadStringDataArray.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadStringDataArray.cpp
@@ -6,6 +6,7 @@
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/GeometryUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/Parsing/Text/CsvParser.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
@@ -59,6 +60,9 @@ ReadStringDataArray::~ReadStringDataArray() noexcept = default;
 
 Result<> ReadStringDataArray::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading string data array...");
+
   auto& data = m_DataStructure.getDataRefAs<StringArray>(m_InputValues->outputArrayPath);
   char delimiter = nx::core::CsvParser::IndexToDelimiter(m_InputValues->delimiterIndex);
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadTextDataArray.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadTextDataArray.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/IDataArray.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/Parsing/Text/CsvParser.hpp"
 
 #include <filesystem>
@@ -38,6 +39,9 @@ ReadTextDataArray::~ReadTextDataArray() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ReadTextDataArray::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading text data array...");
+
   const auto& inputFilePath = m_InputValues->InputFile;
   auto skipLines = m_InputValues->SkipLineCount;
   auto choiceIndex = m_InputValues->DelimiterIndex;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadVolumeGraphicsFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadVolumeGraphicsFile.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 namespace fs = std::filesystem;
@@ -46,6 +47,7 @@ Result<> ReadVolumeGraphicsFile::operator()()
     return MakeErrorResult(k_VolBinaryAllocateMismatch, fmt::format("Binary file size ({}) is smaller than the number of allocated bytes ({}).", filesize, allocatedBytes));
   }
 
-  m_MessageHandler(IFilter::Message::Type::Info, "Reading Data from .vol File.....");
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading Data from .vol File...");
   return ImportFromBinaryFile(m_InputValues->VGDataFile, *densityArray);
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadVtkStructuredPoints.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadVtkStructuredPoints.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Filter/Actions/CreateArrayAction.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/Parsing/Text/CsvParser.hpp"
 #include "simplnx/Utilities/StringInterpretationUtilities.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
@@ -419,6 +420,8 @@ const std::atomic_bool& ReadVtkStructuredPoints::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ReadVtkStructuredPoints::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading VTK structured points file...");
   return readFile();
 }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadZeissTxmFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadZeissTxmFile.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/NeighborList.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/Math/GeometryMath.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include "oless/oless.h"
 #include "oless/pole.h"
@@ -241,6 +242,8 @@ const std::atomic_bool& ReadZeissTxmFile::getCancel() const
 // -----------------------------------------------------------------------------
 Result<> ReadZeissTxmFile::operator()() const
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reading Zeiss TXM file...");
 
   Result<ZeissTxmHeaderMetadata> metadataResult = ReadHeaderMetaData(m_InputValues->TxmDataFile.string());
   if(metadataResult.invalid())

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RegularGridSampleSurfaceMesh.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RegularGridSampleSurfaceMesh.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
 #include <algorithm>
@@ -363,6 +364,9 @@ RegularGridSampleSurfaceMesh::~RegularGridSampleSurfaceMesh() noexcept = default
 // -----------------------------------------------------------------------------
 Result<> RegularGridSampleSurfaceMesh::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Sampling surface mesh onto regular grid...");
+
   const auto& triangleGeom = m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues->TriangleGeometryPath);
   auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ImageGeometryOutputPath);
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedEdges.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedEdges.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
@@ -83,6 +84,9 @@ const std::atomic_bool& RemoveFlaggedEdges::getCancel()
 // -----------------------------------------------------------------------------
 Result<> RemoveFlaggedEdges::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Removing flagged edges...");
+
   // Remove Edges from reduced according to removeEdgesIndex
   const auto& originalEdgeGeom = m_DataStructure.getDataRefAs<EdgeGeom>(m_InputValues->EdgeGeometry);
   std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedTriangles.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedTriangles.cpp
@@ -6,6 +6,7 @@
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -82,6 +83,9 @@ const std::atomic_bool& RemoveFlaggedTriangles::getCancel()
 // -----------------------------------------------------------------------------
 Result<> RemoveFlaggedTriangles::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Removing flagged triangles...");
+
   // Remove Triangles from reduced according to removeTrianglesIndex
   const auto& originalTriangle = m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues->TriangleGeometry);
   std::unique_ptr<MaskCompareUtilities::MaskCompare> maskCompare;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedVertices.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedVertices.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/IDataArray.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -55,6 +56,8 @@ RemoveFlaggedVertices::~RemoveFlaggedVertices() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> RemoveFlaggedVertices::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+
   const VertexGeom& vertexGeom = m_DataStructure.getDataRefAs<VertexGeom>(m_InputValues->InputVertexGeometryPath);
   const std::string vertexDataName = vertexGeom.getVertexAttributeMatrixDataPath().getTargetName();
 
@@ -80,7 +83,7 @@ Result<> RemoveFlaggedVertices::operator()()
   reducedVertexGeom.resizeVertexList(numVerticesToKeep);
   reducedVertexGeom.getVertexAttributeMatrix()->resizeTuples(tDims);
 
-  m_MessageHandler(nx::core::IFilter::Message{nx::core::IFilter::Message::Type::Info, fmt::format("Copying vertices to reduced geometry")});
+  messageHelper.sendMessage("Copying vertices to reduced geometry");
 
   size_t keepIndex = 0;
   // Loop over each vertex and only copy the vertices that were *NOT* flagged for removal
@@ -107,7 +110,7 @@ Result<> RemoveFlaggedVertices::operator()()
     const DataPath destinationPath = reducedVertexGeom.getVertexAttributeMatrixDataPath().createChildPath(src.getName());
 
     auto& dest = m_DataStructure.getDataRefAs<IDataArray>(destinationPath);
-    m_MessageHandler(nx::core::IFilter::Message{nx::core::IFilter::Message::Type::Info, fmt::format("Copying source array '{}' to reduced geometry vertex data.", src.getName())});
+    messageHelper.sendMessage(fmt::format("Copying source array '{}' to reduced geometry vertex data.", src.getName()));
 
     ExecuteDataFunction(RemoveFlaggedVerticesFunctor{}, src.getDataType(), src, dest, maskCompare, numVerticesToKeep);
   }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReplaceElementAttributesWithNeighborValues.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/NeighborUtilities.hpp"
 
 using namespace nx::core;
@@ -249,6 +250,8 @@ const std::atomic_bool& ReplaceElementAttributesWithNeighborValues::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ReplaceElementAttributesWithNeighborValues::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Replacing element attributes with neighbor values...");
 
   auto* srcIDataArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->InputArrayPath);
   const auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->SelectedImageGeometryPath);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinNumNeighbors.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RequireMinNumNeighbors.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/NeighborUtilities.hpp"
 
 using namespace nx::core;
@@ -57,6 +58,9 @@ RequireMinNumNeighbors::~RequireMinNumNeighbors() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> RequireMinNumNeighbors::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Requiring minimum number of neighbors...");
+
   // If running on a single phase, validate that the user has not entered a phase number
   // that is not in the system ; the filter would not crash otherwise, but the user should
   // be notified of unanticipated behavior ; this cannot be done in the dataCheck since

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleRectGridToImageGeom.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ResampleRectGridToImageGeom.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/DataStructure/Geometry/RectGridGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
 using namespace nx::core;
@@ -30,6 +31,8 @@ const std::atomic_bool& ResampleRectGridToImageGeom::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ResampleRectGridToImageGeom::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+
   const auto& rectGridGeom = m_DataStructure.getDataRefAs<RectGridGeom>(m_InputValues->RectilinearGridPath);
   auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ImageGeometryPath);
   imageGeom.setUnits(rectGridGeom.getUnits());
@@ -70,7 +73,7 @@ Result<> ResampleRectGridToImageGeom::operator()()
     const auto& srcArray = m_DataStructure.getDataRefAs<IArray>(srcArrayPath);
     const std::string srcName = srcArray.getName();
     auto& destDataArray = dynamic_cast<IArray&>(destCellDataAM.at(srcName));
-    m_MessageHandler(fmt::format("Resample Rect Grid To Image Geom || Copying Data Array {}", srcName));
+    messageHelper.sendMessage(fmt::format("Resample Rect Grid To Image Geom || Copying Data Array {}", srcName));
 
     CopyFromArray::RunParallelMapRectToImage(destDataArray, taskRunner, srcArray, origin, imageGeomDims, imageGeomSpacing, rectGridDims, xGridValues, yGridValues, zGridValues);
   }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReshapeDataArray.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReshapeDataArray.cpp
@@ -1,5 +1,7 @@
 #include "ReshapeDataArray.hpp"
 
+#include "simplnx/Utilities/MessageHelper.hpp"
+
 using namespace nx::core;
 
 // -----------------------------------------------------------------------------
@@ -23,6 +25,9 @@ const std::atomic_bool& ReshapeDataArray::getCancel()
 // -----------------------------------------------------------------------------
 Result<> ReshapeDataArray::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reshaping data array...");
+
   auto outputArrayPath = m_InputValues->InputArrayPath.getParent().createChildPath(fmt::format(".{}", m_InputValues->InputArrayPath.getTargetName()));
   auto& outputArray = m_DataStructure.getDataRefAs<IArray>(outputArrayPath);
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReverseTriangleWinding.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReverseTriangleWinding.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -62,6 +63,9 @@ ReverseTriangleWinding::~ReverseTriangleWinding() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> ReverseTriangleWinding::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Reversing triangle winding...");
+
   auto& triangleGeom = m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues->InputTriangleGeometryPath);
 
   ParallelDataAlgorithm dataAlg;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RobustAutomaticThreshold.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RobustAutomaticThreshold.cpp
@@ -57,6 +57,11 @@ Result<> RobustAutomaticThreshold::operator()()
   const auto& gradientStoreRef = m_DataStructure.getDataAs<Float32Array>(m_InputValues->GradientArrayPath)->getDataStoreRef();
   auto& maskStoreRef = m_DataStructure.getDataAs<BoolArray>(m_InputValues->InputArrayPath.replaceName(m_InputValues->CreatedMaskName))->getDataStoreRef();
 
+  if(m_ShouldCancel)
+  {
+    return {};
+  }
+
   ExecuteNeighborFunction(FindThresholdFunctor{}, inputArray->getDataType(), inputArray, gradientStoreRef, maskStoreRef);
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RobustAutomaticThreshold.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RobustAutomaticThreshold.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -49,6 +50,9 @@ RobustAutomaticThreshold::~RobustAutomaticThreshold() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> RobustAutomaticThreshold::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing robust automatic threshold...");
+
   const auto* inputArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->InputArrayPath);
   const auto& gradientStoreRef = m_DataStructure.getDataAs<Float32Array>(m_InputValues->GradientArrayPath)->getDataStoreRef();
   auto& maskStoreRef = m_DataStructure.getDataAs<BoolArray>(m_InputValues->InputArrayPath.replaceName(m_InputValues->CreatedMaskName))->getDataStoreRef();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RotateSampleRefFrame.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RotateSampleRefFrame.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/ImageRotationUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
@@ -72,6 +73,8 @@ Result<> RotateSampleRefFrame::operator()()
 
   ImageRotationUtilities::FilterProgressCallback filterProgressCallback(m_MessageHandler, m_ShouldCancel);
 
+  MessageHelper messageHelper(m_MessageHandler);
+
   // The actual rotating of the dataStructure arrays is done in parallel where parallel here
   // refers to the cropping of each DataArray being done on a separate thread.
   ParallelTaskAlgorithm taskRunner;
@@ -81,6 +84,8 @@ Result<> RotateSampleRefFrame::operator()()
 
   const DataPath destCellDataAMPath = destImageGeom.getCellDataPath();
 
+  usize arrayCount = 0;
+  usize totalArrays = srcCellDataAM.getSize();
   for(const auto& [dataId, srcDataObject] : srcCellDataAM)
   {
     if(m_ShouldCancel)
@@ -90,7 +95,8 @@ Result<> RotateSampleRefFrame::operator()()
 
     const auto* srcDataArray = m_DataStructure.getDataAs<IDataArray>(srcCelLDataAMPath.createChildPath(srcDataObject->getName()));
     auto* destDataArray = m_DataStructure.getDataAs<IDataArray>(destCellDataAMPath.createChildPath(srcDataObject->getName()));
-    m_MessageHandler(fmt::format("Rotating Volume || Copying Data Array {}", srcDataObject->getName()));
+    arrayCount++;
+    messageHelper.sendMessage(fmt::format("Rotating Volume || Copying Data Array {} ({}/{})", srcDataObject->getName(), arrayCount, totalArrays));
 
     ExecuteParallelFunction<ImageRotationUtilities::RotateImageGeometryWithNearestNeighbor>(srcDataArray->getDataType(), taskRunner, srcDataArray, destDataArray, rotateArgs, rotationMatrix,
                                                                                             m_InputValues->SliceBySlice, &filterProgressCallback);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ScalarSegmentFeatures.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/DataStore.hpp"
 #include "simplnx/DataStructure/Geometry/IGridGeometry.hpp"
 #include "simplnx/Filter/Actions/CreateArrayAction.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -210,6 +211,7 @@ Result<> ScalarSegmentFeatures::operator()()
   }
 
   // Run the segmentation algorithm
+  m_MessageHelper.sendMessage("Running Scalar Segmentation...");
   execute(gridGeom);
   // Sanity check the result.
   if(this->m_FoundFeatures < 1)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SharedFeatureFace.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SharedFeatureFace.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 #include <map>
@@ -152,6 +153,12 @@ Result<> SharedFeatureFace::operator()()
   std::vector<std::pair<int32, int32>> faceLabelVector;
   faceLabelVector.emplace_back(0, 0);
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalPoints);
+  progressHelper.setProgressMessageTemplate("Shared Feature Face: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   // Loop through all the Triangles and figure out how many triangles we have in each one.
   for(usize t = 0; t < totalPoints; ++t)
   {
@@ -183,6 +190,7 @@ Result<> SharedFeatureFace::operator()()
       faceSizeMap[faceId64]++;
       surfaceMeshFeatureFaceIds[t] = faceIdMap[faceId64];
     }
+    progressMessenger.sendProgressMessage(1);
   }
   if(m_ShouldCancel)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/Silhouette.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/Silhouette.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/Utilities/ClusteringUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <unordered_set>
 
@@ -179,6 +180,8 @@ Result<> Silhouette::operator()()
     std::string message = fmt::format("Mask Array DataPath does not exist or is not of the correct type (Bool | UInt8) {}", m_InputValues->MaskArrayPath.toString());
     return MakeErrorResult(-54080, message);
   }
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Computing Silhouette values...");
   RunTemplateClass<SilhouetteTemplate, types::NoBooleanType>(clusteringArray.getDataType(), clusteringArray,
                                                              m_DataStructure.getDataAs<Float64Array>(m_InputValues->SilhouetteArrayPath)->getDataStoreRef(), maskCompare, uniqueIds.size(), featureIds,
                                                              m_InputValues->DistanceMetric);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SliceTriangleGeometry.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SliceTriangleGeometry.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/Geometry/EdgeGeom.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/GeometryUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -84,6 +85,12 @@ Result<> SliceTriangleGeometry::operator()()
     triRegionIds->fill(0);
   }
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(numEdges);
+  progressHelper.setProgressMessageTemplate("Slice Triangle Geometry: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(usize i = 0; i < numEdges; i++)
   {
     edges[2 * i] = 2 * i;
@@ -99,6 +106,7 @@ Result<> SliceTriangleGeometry::operator()()
     {
       (*triRegionIds)[i] = sliceTriangleResult.RegionIds[i];
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   Result<> result = GeometryUtilities::EliminateDuplicateNodes<EdgeGeom>(edgeGeom);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SplitDataArrayByComponent.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SplitDataArrayByComponent.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 using namespace nx::core;
@@ -54,6 +55,9 @@ const std::atomic_bool& SplitDataArrayByComponent::getCancel()
 Result<> SplitDataArrayByComponent::operator()()
 {
   auto* inputArray = m_DataStructure.getDataAs<IDataArray>(m_InputValues->InputArrayPath);
+
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage(fmt::format("Splitting data array '{}' by component...", m_InputValues->InputArrayPath.getTargetName()));
 
   ExecuteDataFunction(SplitArraysFunctor{}, inputArray->getDataType(), m_DataStructure, inputArray, m_InputValues);
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SplitDataArrayByTuple.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SplitDataArrayByTuple.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
@@ -221,6 +222,9 @@ const std::atomic_bool& SplitDataArrayByTuple::getCancel()
 // -----------------------------------------------------------------------------
 Result<> SplitDataArrayByTuple::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage(fmt::format("Splitting data array '{}' by tuple...", m_InputValues->InputArrayPath.getTargetName()));
+
   const auto& inputDataArray = m_DataStructure.getDataRefAs<IArray>(m_InputValues->InputArrayPath);
   std::string arrayTypeName = inputDataArray.getTypeName();
   switch(inputDataArray.getArrayType())

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SurfaceNets.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SurfaceNets.cpp
@@ -7,6 +7,7 @@
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/Meshing/TriangleUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include "SimplnxCore/SurfaceNets/MMCellFlag.h"
 #include "SimplnxCore/SurfaceNets/MMCellMap.h"
@@ -148,6 +149,12 @@ Result<> SurfaceNets::operator()()
   auto& nodeTypes = m_DataStructure.getDataAs<Int8Array>(m_InputValues->NodeTypesDataPath)->getDataStoreRef();
   nodeTypes.resizeTuples({static_cast<usize>(nodeCount)});
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(nodeCount);
+  progressHelper.setProgressMessageTemplate("Surface Nets - Processing Vertices: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   Point3Df position = {0.0f, 0.0f, 0.0f};
 
   std::array<int, 3> vertCellIndex = {0, 0, 0};
@@ -161,6 +168,7 @@ Result<> SurfaceNets::operator()()
     cellMapPtr->getVertexCellIndex(vertIndex, vertCellIndex.data());
     MMCellMap::Cell* currentCellPtr = cellMapPtr->getCell(vertCellIndex.data());
     nodeTypes[static_cast<usize>(vertIndex)] = static_cast<int8>(currentCellPtr->flag.numJunctions());
+    progressMessenger.sendProgressMessage(1);
   }
 
   usize triangleCount = 0;
@@ -221,6 +229,11 @@ Result<> SurfaceNets::operator()()
     auto createdPath = m_InputValues->CreatedDataArrayPaths[i + numSelectedCellArrayPaths];
     ::AddFeatureTupleTransferInstance(m_DataStructure, selectedPath, createdPath, m_InputValues->FeatureIdsArrayPath, tupleTransferFunctions);
   }
+
+  progressHelper.resetProgress();
+  progressHelper.setMaxProgresss(nodeCount);
+  progressHelper.setProgressMessageTemplate("Surface Nets - Generating Triangles: {:.1f}% Complete");
+  auto progressMessenger2 = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
 
   usize faceIndex = 0;
   //   Create temporary storage for cell quads which are constructed around edges
@@ -412,6 +425,7 @@ Result<> SurfaceNets::operator()()
       }
       faceIndex++;
     }
+    progressMessenger2.sendProgressMessage(1);
   }
 
   // Now run through the FaceLabels to make them consistent with Quick Surface Mesh

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/TriangleCentroid.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/TriangleCentroid.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/IGeometry.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -82,6 +83,9 @@ Result<> TriangleCentroid::operator()()
 
   const DataPath pCentroidsPath = m_InputValues->TriangleGeometryDataPath.createChildPath(faceAttributeMatrix.getName()).createChildPath(m_InputValues->CentroidsArrayName);
   auto& centroidsStore = m_DataStructure.getDataAs<Float64Array>(pCentroidsPath)->getDataStoreRef();
+
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage(fmt::format("Computing Triangle Centroids for {} triangles...", triangleGeom->getNumberOfFaces()));
 
   // Parallel algorithm to calculate the centroids
   ParallelDataAlgorithm dataAlg;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/TriangleDihedralAngle.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/TriangleDihedralAngle.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/Common/Range.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 #include <algorithm>
@@ -114,6 +115,9 @@ Result<> TriangleDihedralAngle::operator()()
   const AttributeMatrix* faceAttributeMatrix = triangleGeom.getFaceAttributeMatrix();
   const DataPath dihedralAnglesArrayPath = pTriangleGeometryDataPath.createChildPath(faceAttributeMatrix->getName()).createChildPath(pMinDihedralAnglesName);
   auto& dihedralAnglesRef = m_DataStructure.getDataAs<Float64Array>(dihedralAnglesArrayPath)->getDataStoreRef();
+
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage(fmt::format("Computing Triangle Dihedral Angles for {} triangles...", triangleGeom.getNumberOfFaces()));
 
   ParallelDataAlgorithm dataAlg;
   dataAlg.setRange(0ULL, static_cast<size_t>(triangleGeom.getNumberOfFaces()));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/TriangleNormal.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/TriangleNormal.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/Meshing/TriangleUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -30,6 +31,9 @@ Result<> TriangleNormal::operator()()
 
   DataPath pNormalsArrayPath = pTriangleGeometryDataPath.createChildPath(faceAttributeMatrix->getName()).createChildPath(pNormalsName);
   auto& normalsRef = m_DataStructure.getDataAs<Float64Array>(pNormalsArrayPath)->getDataStoreRef();
+
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage(fmt::format("Computing Triangle Normals for {} triangles...", triangleGeom.getNumberOfFaces()));
 
   // Parallel algorithm to calculate normals
   ParallelDataAlgorithm dataAlg;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/UncertainRegularGridSampleSurfaceMesh.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/UncertainRegularGridSampleSurfaceMesh.cpp
@@ -1,6 +1,7 @@
 #include "UncertainRegularGridSampleSurfaceMesh.hpp"
 
 #include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <random>
 
@@ -36,6 +37,12 @@ void UncertainRegularGridSampleSurfaceMesh::generatePoints(std::vector<Point3Df>
 
   points.reserve(dims[0] * dims[1] * dims[2]);
 
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(dims[2]);
+  progressHelper.setProgressMessageTemplate("Generating Sample Points: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   std::mt19937 generator(m_InputValues->SeedValue); // Standard mersenne_twister_engine seeded
   std::uniform_real_distribution<float32> distribution(0.0F, 1.0F);
 
@@ -53,6 +60,7 @@ void UncertainRegularGridSampleSurfaceMesh::generatePoints(std::vector<Point3Df>
                             ((static_cast<float>(k) + 0.5f) * spacing[2]) + (uncertainty[2] * randomZ) + origin[2]);
       }
     }
+    progressMessenger.sendProgressMessage(1);
   }
 }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/VerifyTriangleWinding.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/VerifyTriangleWinding.cpp
@@ -10,6 +10,7 @@
 #include "simplnx/Utilities/DataArrayUtilities.hpp"
 #include "simplnx/Utilities/Meshing/TriangleUtilities.hpp"
 #include "simplnx/Utilities/Meshing/VertexUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 
 using namespace nx::core;
@@ -129,10 +130,11 @@ Result<> VerifyTriangleWinding::operator()()
     return result;
   }
 
-  m_MessageHandler("Checking for duplicates - sorting vertices");
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Checking for duplicates - sorting vertices");
   const MeshingUtilities::SortedVerticesList sortedVerticesList = MeshingUtilities::OrderSharedVertices(m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues->TargetGeometryPath), m_ShouldCancel);
 
-  m_MessageHandler("Checking for duplicates - validating");
+  messageHelper.sendMessage("Checking for duplicates - validating");
   auto& triGeom = m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues->TargetGeometryPath);
   if(MeshingUtilities::HasDuplicateVertices(triGeom.getVertices()->getDataStoreRef(), sortedVerticesList))
   {
@@ -149,7 +151,7 @@ Result<> VerifyTriangleWinding::operator()()
   Result<> windingResult = {};
   {
     // Generate Connectivity
-    m_MessageHandler("Generating Connectivity and Triangle Neighbors...");
+    messageHelper.sendMessage("Generating Connectivity and Triangle Neighbors...");
     triGeom.findElementNeighbors(true);
     const auto optionalId = triGeom.getElementNeighborsId();
     if(!optionalId.has_value())
@@ -158,7 +160,7 @@ Result<> VerifyTriangleWinding::operator()()
     }
     const auto& connectivity = m_DataStructure.getDataRefAs<IGeometry::ElementDynamicList>(optionalId.value());
 
-    m_MessageHandler("Repairing Windings...");
+    messageHelper.sendMessage("Repairing Windings...");
     // This is reused since it may contain warnings
     windingResult = MeshingUtilities::RepairTriangleWinding(triangles, connectivity, idsStore, m_ShouldCancel, m_MessageHandler);
     if(windingResult.invalid())
@@ -171,7 +173,7 @@ Result<> VerifyTriangleWinding::operator()()
     m_DataStructure.removeData(triGeom.getElementNeighborsId().value());
   }
 
-  m_MessageHandler("Assessing reversal - calculating feature volumes");
+  messageHelper.sendMessage("Assessing reversal - calculating feature volumes");
   // Get max group (feature id != 0)
   int32 maxFeature = 0;
   for(int32 i = 0; i < idsStore.getSize(); i++)
@@ -186,7 +188,7 @@ Result<> VerifyTriangleWinding::operator()()
     return volumeResult;
   }
 
-  m_MessageHandler("Implementing reversal in parallel");
+  messageHelper.sendMessage("Implementing reversal in parallel");
   std::vector<usize> reversalTargets = {};
   reversalTargets.reserve(volumes.size());
   for(usize i = 1; i < volumes.size(); i++) // zero is an invalid feature label
@@ -208,7 +210,7 @@ Result<> VerifyTriangleWinding::operator()()
 
   if(m_InputValues->RepairNormals)
   {
-    m_MessageHandler("Recalculating normals");
+    messageHelper.sendMessage("Recalculating normals");
     auto& normals = m_DataStructure.getDataAs<Float64Array>(m_InputValues->TriangleNormalsPath)->getDataStoreRef();
 
     // Parallel algorithm to calculate normals

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteASCIIData.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteASCIIData.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/Common/AtomicFile.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/OStreamUtilities.hpp"
 
 #include <filesystem>
@@ -39,6 +40,9 @@ WriteASCIIData::~WriteASCIIData() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> WriteASCIIData::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing ASCII data...");
+
   auto headerOption = m_InputValues->HeaderOptionIndex;
   bool includeHeaders = false;
   bool includeIndex = false;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteAbaqusHexahedron.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteAbaqusHexahedron.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include <algorithm>
@@ -363,6 +364,9 @@ void WriteAbaqusHexahedron::sendMessage(const std::string& message)
 // -----------------------------------------------------------------------------
 Result<> WriteAbaqusHexahedron::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing Abaqus Hexahedron files...");
+
   auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ImageGeometryPath);
   auto& featureIds = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsArrayPath)->getDataStoreRef();
   Vec3<usize> cDims = imageGeom.getDimensions();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteAvizoRectilinearCoordinate.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteAvizoRectilinearCoordinate.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 using namespace nx::core;
 
@@ -20,6 +21,8 @@ WriteAvizoRectilinearCoordinate::~WriteAvizoRectilinearCoordinate() noexcept = d
 // -----------------------------------------------------------------------------
 Result<> WriteAvizoRectilinearCoordinate::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing Avizo Rectilinear Coordinate file...");
   return AvizoWriter::execute();
 }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteAvizoUniformCoordinate.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteAvizoUniformCoordinate.cpp
@@ -2,6 +2,7 @@
 
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <chrono>
 #include <ctime>
@@ -21,6 +22,8 @@ WriteAvizoUniformCoordinate::~WriteAvizoUniformCoordinate() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> WriteAvizoUniformCoordinate::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing Avizo Uniform Coordinate file...");
   return AvizoWriter::execute();
 }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteBinaryData.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteBinaryData.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Common/TypeTraits.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/OStreamUtilities.hpp"
 
 #include <filesystem>
@@ -44,6 +45,9 @@ WriteBinaryData::~WriteBinaryData() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> WriteBinaryData::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing binary data...");
+
   const auto endianess = static_cast<endian>(m_InputValues->EndianIndex);
   auto selectedDataArrayPaths = m_InputValues->InputDataArrayPaths;
   for(const auto& selectedArrayPath : selectedDataArrayPaths)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteDREAM3D.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteDREAM3D.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/Pipeline/Pipeline.hpp"
 #include "simplnx/Pipeline/PipelineFilter.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp"
 
@@ -32,6 +33,9 @@ WriteDREAM3D::~WriteDREAM3D() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> WriteDREAM3D::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing DREAM3D file...");
+
   auto atomicFileResult = AtomicFile::Create(m_InputValues->ExportFilePath);
   if(atomicFileResult.invalid())
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteFeatureDataCSV.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteFeatureDataCSV.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Common/AtomicFile.hpp"
 #include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/Utilities/DataGroupUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/OStreamUtilities.hpp"
 
 #include <filesystem>
@@ -25,6 +26,9 @@ WriteFeatureDataCSV::~WriteFeatureDataCSV() noexcept = default;
 // -----------------------------------------------------------------------------
 Result<> WriteFeatureDataCSV::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing Feature Data CSV file...");
+
   auto atomicFileResult = AtomicFile::Create(m_InputValues->FeatureDataFile);
   if(atomicFileResult.invalid())
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteLosAlamosFFT.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteLosAlamosFFT.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <fstream>
 
@@ -62,8 +63,12 @@ Result<> WriteLosAlamosFFT::operator()()
 
   float phi1 = 0.0f, phi = 0.0f, phi2 = 0.0f;
 
-  auto start = std::chrono::steady_clock::now();
-  usize total = dims[0] * dims[1] * dims[2];
+  MessageHelper messageHelper(m_MessageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(dims[2]);
+  progressHelper.setProgressMessageTemplate("Writing Los Alamos FFT: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   for(usize z = 0; z < dims[2]; ++z)
   {
     for(usize y = 0; y < dims[1]; ++y)
@@ -71,11 +76,6 @@ Result<> WriteLosAlamosFFT::operator()()
       for(usize x = 0; x < dims[0]; ++x)
       {
         usize index = (z * dims[0] * dims[1]) + (dims[0] * y) + x;
-        if(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count() > 1000)
-        {
-          m_MessageHandler(fmt::format("Writing in progress: {} of {} written. Percentage: {}%", index, total, static_cast<uint32>((static_cast<float64>(index) / total) * 100.0)));
-          start = std::chrono::steady_clock::now();
-        }
 
         phi1 = cellEulerAngles[index * 3] * 180.0f * Constants::k_1OverPiF;
         phi = cellEulerAngles[index * 3 + 1] * 180.0f * Constants::k_1OverPiF;
@@ -84,6 +84,7 @@ Result<> WriteLosAlamosFFT::operator()()
                             cellPhases.getValue(index));
       }
     }
+    progressMessenger.sendProgressMessage(1);
   }
 
   file.flush();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteNodesAndElementsFiles.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteNodesAndElementsFiles.cpp
@@ -8,6 +8,7 @@
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/DataStructure/Geometry/VertexGeom.hpp"
 #include "simplnx/SIMPLNXVersion.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include <algorithm>
@@ -108,6 +109,9 @@ void WriteNodesAndElementsFiles::sendMessage(const std::string& message)
 // -----------------------------------------------------------------------------
 Result<> WriteNodesAndElementsFiles::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing Nodes and Elements files...");
+
   auto& iNodeGeometry = m_DataStructure.getDataRefAs<INodeGeometry0D>(m_InputValues->SelectedGeometryPath);
   auto geomType = iNodeGeometry.getGeomType();
   UInt64Array* cellsArray = nullptr;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteSPParksSites.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteSPParksSites.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Filter/IFilter.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 
 #include <fstream>
 
@@ -100,6 +101,9 @@ const std::atomic_bool& WriteSPParksSites::getCancel()
 // -----------------------------------------------------------------------------
 Result<> WriteSPParksSites::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing SPParks Sites file...");
+
   // Make sure any directory path is also available as the user may have just typed
   // in a path without actually creating the full path
   Result<> createDirectoriesResult = nx::core::CreateOutputDirectories(m_InputValues->OutputFile.parent_path());

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteStlFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteStlFile.cpp
@@ -6,6 +6,7 @@
 #include "simplnx/Common/AtomicFile.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
 #include "simplnx/Utilities/ParallelDataAlgorithm.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
@@ -485,6 +486,9 @@ const std::atomic_bool& WriteStlFile::getCancel()
 // -----------------------------------------------------------------------------
 Result<> WriteStlFile::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing STL file...");
+
   const auto& triangleGeom = m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues->TriangleGeomPath);
   const ::VertexStore& vertices = triangleGeom.getVertices()->getDataStoreRef();
   const ::TriStore& triangles = triangleGeom.getFaces()->getDataStoreRef();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteVtkRectilinearGrid.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteVtkRectilinearGrid.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include "SimplnxCore/utils/VtkUtilities.hpp"
@@ -31,6 +32,9 @@ const std::atomic_bool& WriteVtkRectilinearGrid::getCancel()
 // -----------------------------------------------------------------------------
 Result<> WriteVtkRectilinearGrid::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing VTK Rectilinear Grid file...");
+
   const auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ImageGeometryPath);
   SizeVec3 dims = imageGeom.getDimensions();
   FloatVec3 res = imageGeom.getSpacing();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteVtkStructuredPoints.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteVtkStructuredPoints.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
 #include "SimplnxCore/utils/VtkUtilities.hpp"
@@ -32,6 +33,9 @@ const std::atomic_bool& WriteVtkStructuredPoints::getCancel()
 // -----------------------------------------------------------------------------
 Result<> WriteVtkStructuredPoints::operator()()
 {
+  MessageHelper messageHelper(m_MessageHandler);
+  messageHelper.sendMessage("Writing VTK Structured Points file...");
+
   const auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ImageGeometryPath);
   SizeVec3 dims = imageGeom.getDimensions();
   FloatVec3 spacing = imageGeom.getSpacing();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVolumeFractionsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeVolumeFractionsFilter.cpp
@@ -7,6 +7,7 @@
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/AttributeMatrixSelectionParameter.hpp"
 
+#include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
 
 #include "simplnx/Parameters/DataObjectNameParameter.hpp"
@@ -111,11 +112,22 @@ Result<> ComputeVolumeFractionsFilter::executeImpl(DataStructure& dataStructure,
   usize totalPoints = cellPhases.getNumberOfTuples();
   usize totalEnsembles = volFractions.getNumberOfTuples();
 
+  MessageHelper messageHelper(messageHandler);
+  auto progressHelper = messageHelper.createProgressMessageHelper();
+  progressHelper.setMaxProgresss(totalPoints);
+  progressHelper.setProgressMessageTemplate("Computing Volume Fractions: {:.1f}% Complete");
+  auto progressMessenger = progressHelper.createProgressMessenger(std::chrono::milliseconds(1000));
+
   std::vector<usize> ensembleElements(totalEnsembles, 0);
   // Calculate the total number of elements in each Ensemble
   for(usize index = 0; index < totalPoints; index++)
   {
+    if(shouldCancel)
+    {
+      return {};
+    }
     ensembleElements[cellPhases[index]]++;
+    progressMessenger.sendProgressMessage(1);
   }
   // Calculate the Volume Fraction
   for(usize index = 0; index < totalEnsembles; index++)


### PR DESCRIPTION
## Summary

Audited every filter algorithm across SimplnxCore, OrientationAnalysis, and ITKImageProcessing for adequate cancel checking and progress messaging. Added `MessageHelper`-based throttled progress reporting to the 169 files that lacked it.

* Algorithms with significant data loops (3D voxel traversals, feature iterations, triangle processing) use `ProgressMessenger` for per-iteration throttled progress at 1 update/sec
* Multi-phase algorithms use `resetProgress()` between phases with descriptive phase labels
* File I/O and parallel-delegating algorithms get simple status messages via `sendMessage()`
* Replaced several old manual `std::chrono` progress patterns with `MessageHelper` equivalents (InterpolatePointCloudToRegularGrid, IterativeClosestPoint, MapPointCloudToRegularGrid, WriteLosAlamosFFT, etc.)
* Added cancel check + progress to `ComputeVolumeFractionsFilter::executeImpl`
* 26 algorithm files that already had adequate progress messaging were verified and left untouched

## Test Plan
- [x] Full build passes (1117/1117 targets, zero errors)
- [ ] Verify progress messages appear in DREAM3D-NX UI during filter execution
- [ ] Spot check cancel behavior on long-running filters