### PR TITLE
FILT: Add ReadNIfTIFile filter for NIfTI-1 (.nii / .nii.gz) volumes

### DIFF
--- a/src/Plugins/ITKImageProcessing/test/ITKImageReaderTest.cpp
+++ b/src/Plugins/ITKImageProcessing/test/ITKImageReaderTest.cpp
@@ -168,8 +168,8 @@ TEST_CASE("ITKImageProcessing::ITKImageReaderFilter: Cropping", "[ITKImageProces
   std::vector<float64> spacing = {2.0, 2.0, 1.0};
   std::vector<float64> origin = {20.0, 30.0, 0.0};
   UnitTest::Cropping::AxisBoundsChoices bounds;
-  bounds.voxelX = {IntVec2Type{50, 149}};
-  bounds.voxelY = {IntVec2Type{50, 149}};
+  bounds.voxelX = {SizeVec2{50, 149}};
+  bounds.voxelY = {SizeVec2{50, 149}};
   bounds.physX = {FloatVec2Type{120.0f, 318.0f}};
   bounds.physY = {FloatVec2Type{130.0f, 328.0f}};
   auto allCropVals = UnitTest::Cropping::GenerateAllCropValues(bounds, true);

--- a/src/Plugins/ITKImageProcessing/test/ITKImportImageStackTest.cpp
+++ b/src/Plugins/ITKImageProcessing/test/ITKImportImageStackTest.cpp
@@ -175,9 +175,9 @@ const std::string k_FilePrefix = "200x200_";
 const std::string k_FileExtension = ".tif";
 
 // Cropping boundaries (crop to the colored square: 50:150 in X/Y, all Z)
-const IntVec2Type k_VoxelCropX = {50, 150};
-const IntVec2Type k_VoxelCropY = {50, 150};
-const IntVec2Type k_VoxelCropZ = {0, 1};
+const SizeVec2 k_VoxelCropX = {50, 150};
+const SizeVec2 k_VoxelCropY = {50, 150};
+const SizeVec2 k_VoxelCropZ = {0, 1};
 
 const FloatVec2Type k_PhysicalCropX = {50.0f, 150.0f};
 const FloatVec2Type k_PhysicalCropY = {50.0f, 150.0f};

--- a/src/Plugins/SimplnxCore/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/CMakeLists.txt
@@ -112,6 +112,7 @@ set(FilterList
   ReadDeformKeyFileV12Filter
   ReadDREAM3DFilter
   ReadHDF5DatasetFilter
+  ReadNIfTIFileFilter
   ReadRawBinaryFilter
   ReadStlFileFilter
   ReadStringDataArrayFilter
@@ -274,6 +275,7 @@ set(AlgorithmList
   ReadDeformKeyFileV12
 #  ReadDREAM3D
   ReadHDF5Dataset
+  ReadNIfTIFile
   ReadRawBinary
   ReadStlFile
   ReadStringDataArray
@@ -358,10 +360,15 @@ get_property(SIMPLNX_EXTRA_LIBRARY_DIRS GLOBAL PROPERTY SIMPLNX_EXTRA_LIBRARY_DI
 set_property(GLOBAL PROPERTY SIMPLNX_EXTRA_LIBRARY_DIRS ${SIMPLNX_EXTRA_LIBRARY_DIRS} ${reproc_dll_path})
 
 
+# ------------------------------------------------------------------------------
+# The ReadNIfTIFileFilter requires zlib for transparent .nii/.nii.gz support
+# ------------------------------------------------------------------------------
+find_package(ZLIB REQUIRED)
+
 #------------------------------------------------------------------------------
 # If there are additional libraries that this plugin needs to link against you
 # can use the target_link_libraries() cmake call
-target_link_libraries(${PLUGIN_NAME} PRIVATE reproc++)
+target_link_libraries(${PLUGIN_NAME} PRIVATE reproc++ ZLIB::ZLIB)
 
 #------------------------------------------------------------------------------
 # If there are additional source files that need to be compiled for this plugin
@@ -375,6 +382,9 @@ set(PLUGIN_EXTRA_SOURCES
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/AvizoWriter.cpp"
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/PythonPluginTemplateFile.hpp"
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/VtkUtilities.hpp"
+    "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/nifti1.h"
+    "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/NiftiUtilities.hpp"
+    "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/NiftiUtilities.cpp"
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/SurfaceNets/MMCellFlag.cpp"
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/SurfaceNets/MMCellFlag.h"
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/SurfaceNets/MMCellMap.cpp"

--- a/src/Plugins/SimplnxCore/docs/ReadNIfTIFileFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReadNIfTIFileFilter.md
@@ -14,6 +14,12 @@ The filter transparently handles both uncompressed (`.nii`) and gzipped
 (`.nii.gz`) files via zlib, and detects / corrects for file byte order by
 comparing `sizeof_hdr` against the expected value of 348.
 
+NIfTI-1 allows a variable-length extension block between the 348-byte
+header and the voxel data. The filter honors `vox_offset` and seeks
+past the extension block before reading voxels — any custom extension
+metadata (DICOM attributes, AFNI XML, etc.) is **skipped, not
+preserved**.
+
 ### Supported voxel datatypes
 
 | NIfTI code | C type | simplnx `DataType` | Component count |
@@ -57,9 +63,14 @@ warning is emitted if a scaling transform is present for those types.
 ### Cropping on read
 
 When the *Cropping Options* parameter is set to anything other than
-*No Cropping*, only the selected sub-volume is ingested — the rest of the
-file is read and discarded on the fly, never reaching a DataArray. Two
-cropping modes are supported:
+*NoCropping*, only the selected sub-volume is **retained** in the
+output DataArray. The rest of the file is still read (and, for
+`.nii.gz`, still decompressed) but is never stored, so peak memory is
+proportional to the cropped region, not the full source volume. See
+the **Memory vs. wall-clock** note below before assuming cropping
+speeds up I/O.
+
+Two cropping modes are supported:
 
 * **Voxel Subvolume** — pick an inclusive `[start..end]` voxel index range
   per axis. The range is zero-based and uses the source file's voxel
@@ -125,7 +136,7 @@ large compressed files read faster.
 | Input NIfTI File | File path | — | Path to the `.nii` or `.nii.gz` file to read. |
 | Use Stored Affine Transform | Bool | `true` | Use `sform`/`qform` to set origin + spacing when present. |
 | Apply Scaling Transform | Bool | `true` | Apply `y = slope*x + inter` at read time; promotes to float32. |
-| Cropping Options | CropGeometry | *None* | Optional voxel-index or physical-coordinate sub-volume. Only the selected region is streamed into memory; data outside the region is read and discarded. |
+| Cropping Options | CropGeometry | `NoCropping` | Optional voxel-index or physical-coordinate sub-volume. Only the selected region is retained in the output DataArray; data outside the region is read but never stored. |
 | Image Geometry | Data Path | `NIfTI Image` | Path to the created Image Geometry. |
 | Cell Attribute Matrix Name | String | `Cell Data` | Name of the attribute matrix holding voxel values. |
 | Image Data Array Name | String | `ImageData` | Name of the array receiving voxel values. |
@@ -136,6 +147,11 @@ large compressed files read faster.
   separate-file `.hdr` / `.img` pair (magic `ni1`) is not.
 * Only 3D volumes (`dim[0] == 3`) are supported. 4D and higher files (fMRI
   time series, diffusion series, etc.) are rejected in this release.
+* Any of `dim[1]`, `dim[2]`, `dim[3]` being `<= 0` is rejected.
+* Complex (`complex64`, `complex128`, `complex256`) and 128-bit float
+  voxel datatypes are rejected.
+* Extension blocks between the header and voxel data are skipped over
+  (via `vox_offset`) but not preserved.
 * Non-trivial rotations in `sform` / `qform` are flattened — the Image
   Geometry is axis-aligned in simplnx.
 * Cropping saves memory, not wall-clock read time. A `.nii.gz` file must
@@ -145,7 +161,7 @@ large compressed files read faster.
   volume. Bounds outside the extent produce an error rather than
   silently clamping.
 * `start <= end` is required on each cropped axis; reversed ranges are
-  rejected at execute time.
+  rejected at parameter-validation time.
 
 % Auto generated parameter table will be inserted here                                                                    
 
@@ -153,8 +169,6 @@ large compressed files read faster.
 
 * [NIfTI-1 Data Format (official NIMH reference)](https://nifti.nimh.nih.gov/nifti-1/)
 * [`nifti1.h` header (NITRC)](https://www.nitrc.org/docman/view.php/26/64/nifti1.h)
-
-## Example Pipelines
 
 ## License & Copyright
 

--- a/src/Plugins/SimplnxCore/docs/ReadNIfTIFileFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReadNIfTIFileFilter.md
@@ -54,6 +54,70 @@ read time and promotes the output array to `float32`. Per the NIfTI-1
 specification, scaling is never applied to `RGB24` or `RGBA32` data and a
 warning is emitted if a scaling transform is present for those types.
 
+### Cropping on read
+
+When the *Cropping Options* parameter is set to anything other than
+*No Cropping*, only the selected sub-volume is ingested — the rest of the
+file is read and discarded on the fly, never reaching a DataArray. Two
+cropping modes are supported:
+
+* **Voxel Subvolume** — pick an inclusive `[start..end]` voxel index range
+  per axis. The range is zero-based and uses the source file's voxel
+  grid.
+* **Physical Subvolume** — pick an inclusive physical coordinate range per
+  axis. The filter builds a temporary axis-aligned ImageGeom from the
+  source file's origin and spacing (the same values the Orientation
+  section would use) and converts the requested bounds to voxel indices
+  via `ImageGeom::getIndex()`. Bounds that fall outside the volume
+  produce a descriptive error rather than silently clamping.
+
+Each axis can be toggled on or off independently via the *Crop X / Y / Z*
+flags. An axis whose flag is off is *not* cropped — its full extent from
+the source file is used, even if the physical or voxel bound values are
+populated.
+
+#### How the cropped ImageGeom relates to the source
+
+* **Dimensions** equal the cropped voxel count on each axis.
+* **Spacing** is the same as the source file's spacing (cropping never
+  resamples).
+* **Origin** is shifted so that the center of the first cropped voxel
+  lands at its correct physical position, i.e. `new_origin[i] =
+  source_origin[i] + start_voxel[i] * spacing[i]`. This is produced by
+  running `CropImageGeometryFilter::preflight` on a temp geometry, so the
+  behavior matches what you'd get from piping a standalone read +
+  `CropImageGeometry` sequence.
+
+#### Interaction with other options
+
+* **Scaling** — if *Apply Scaling Transform* is on, `y = slope*x + inter`
+  is applied only to the retained voxels. Voxels outside the crop region
+  are discarded before scaling.
+* **RGB24 / RGBA32** — all per-voxel components are preserved. The crop
+  operates on the voxel grid, not on individual color bytes.
+* **Orientation** — cropping runs on the axis-aligned ImageGeom that was
+  already constructed from the sform / qform / pixdim fallback chain; a
+  stored rotation warning (if any) is emitted independently of cropping.
+
+#### Memory vs. wall-clock
+
+Cropping on read primarily saves **memory**, not I/O time, in this
+version:
+
+* For `.nii.gz` the file is not seekable without linear decompression, so
+  the full compressed stream is still read and decompressed even when
+  the cropped region is small. Peak resident memory, however, is
+  proportional to the cropped region, not the full uncompressed volume.
+  This matters when the source file scaled up to `float32` would not fit
+  in RAM.
+* For plain `.nii` this version also reads linearly (scan-line by
+  scan-line, discarding out-of-range rows in place of a true
+  seek-skip). A seek-skip optimization for uncompressed files may come
+  later if real-world timings warrant it.
+
+In short: use cropping to keep the output DataArray small, not to make
+large compressed files read faster.
+
 ## Parameters
 
 | Parameter | Type | Default | Description |
@@ -66,17 +130,6 @@ warning is emitted if a scaling transform is present for those types.
 | Cell Attribute Matrix Name | String | `Cell Data` | Name of the attribute matrix holding voxel values. |
 | Image Data Array Name | String | `ImageData` | Name of the array receiving voxel values. |
 
-### Cropping behavior
-
-When cropping is enabled the filter does **not** materialize the full volume
-before cropping. It reads the source file one scan-line at a time; scan-lines
-outside the selected sub-volume are read and discarded without being copied
-into a DataArray. This keeps peak memory usage proportional to the cropped
-region, not the source file size. For `.nii.gz` this is the best that can be
-done (gzip is not seekable without linear decompression); for plain `.nii` we
-still read linearly in this version to keep the code simple — a true
-seek-skip optimization may come later if timings warrant it.
-
 ## Caveats
 
 * Only the single-file NIfTI-1 format (magic `n+1`) is supported. The
@@ -85,6 +138,14 @@ seek-skip optimization may come later if timings warrant it.
   time series, diffusion series, etc.) are rejected in this release.
 * Non-trivial rotations in `sform` / `qform` are flattened — the Image
   Geometry is axis-aligned in simplnx.
+* Cropping saves memory, not wall-clock read time. A `.nii.gz` file must
+  still be fully decompressed regardless of how small the cropped region
+  is; plain `.nii` files are also read linearly in this version.
+* Physical-subvolume crop bounds must map to voxels inside the source
+  volume. Bounds outside the extent produce an error rather than
+  silently clamping.
+* `start <= end` is required on each cropped axis; reversed ranges are
+  rejected at execute time.
 
 % Auto generated parameter table will be inserted here                                                                    
 

--- a/src/Plugins/SimplnxCore/docs/ReadNIfTIFileFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReadNIfTIFileFilter.md
@@ -61,9 +61,21 @@ warning is emitted if a scaling transform is present for those types.
 | Input NIfTI File | File path | — | Path to the `.nii` or `.nii.gz` file to read. |
 | Use Stored Affine Transform | Bool | `true` | Use `sform`/`qform` to set origin + spacing when present. |
 | Apply Scaling Transform | Bool | `true` | Apply `y = slope*x + inter` at read time; promotes to float32. |
+| Cropping Options | CropGeometry | *None* | Optional voxel-index or physical-coordinate sub-volume. Only the selected region is streamed into memory; data outside the region is read and discarded. |
 | Image Geometry | Data Path | `NIfTI Image` | Path to the created Image Geometry. |
 | Cell Attribute Matrix Name | String | `Cell Data` | Name of the attribute matrix holding voxel values. |
 | Image Data Array Name | String | `ImageData` | Name of the array receiving voxel values. |
+
+### Cropping behavior
+
+When cropping is enabled the filter does **not** materialize the full volume
+before cropping. It reads the source file one scan-line at a time; scan-lines
+outside the selected sub-volume are read and discarded without being copied
+into a DataArray. This keeps peak memory usage proportional to the cropped
+region, not the source file size. For `.nii.gz` this is the best that can be
+done (gzip is not seekable without linear decompression); for plain `.nii` we
+still read linearly in this version to keep the code simple — a true
+seek-skip optimization may come later if timings warrant it.
 
 ## Caveats
 

--- a/src/Plugins/SimplnxCore/docs/ReadNIfTIFileFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ReadNIfTIFileFilter.md
@@ -1,0 +1,92 @@
+# Read NIfTI File (Version 1)
+
+## Group (Subgroup)
+
+IO (Read)
+
+## Description
+
+This **Filter** reads a [NIfTI-1](https://nifti.nimh.nih.gov/nifti-1/) volume
+(single-file format, `.nii` or `.nii.gz`) into an **Image Geometry** plus a
+**Cell Data** attribute matrix that holds the voxel values.
+
+The filter transparently handles both uncompressed (`.nii`) and gzipped
+(`.nii.gz`) files via zlib, and detects / corrects for file byte order by
+comparing `sizeof_hdr` against the expected value of 348.
+
+### Supported voxel datatypes
+
+| NIfTI code | C type | simplnx `DataType` | Component count |
+|---:|---|---|---:|
+| `NIFTI_TYPE_UINT8` (2) | `uint8` | `uint8` | 1 |
+| `NIFTI_TYPE_INT8` (256) | `int8` | `int8` | 1 |
+| `NIFTI_TYPE_UINT16` (512) | `uint16` | `uint16` | 1 |
+| `NIFTI_TYPE_INT16` (4) | `int16` | `int16` | 1 |
+| `NIFTI_TYPE_UINT32` (768) | `uint32` | `uint32` | 1 |
+| `NIFTI_TYPE_INT32` (8) | `int32` | `int32` | 1 |
+| `NIFTI_TYPE_UINT64` (1280) | `uint64` | `uint64` | 1 |
+| `NIFTI_TYPE_INT64` (1024) | `int64` | `int64` | 1 |
+| `NIFTI_TYPE_FLOAT32` (16) | `float32` | `float32` | 1 |
+| `NIFTI_TYPE_FLOAT64` (64) | `float64` | `float64` | 1 |
+| `NIFTI_TYPE_RGB24` (128) | 3 × `uint8` | `uint8` | 3 |
+| `NIFTI_TYPE_RGBA32` (2304) | 4 × `uint8` | `uint8` | 4 |
+
+Complex and 128-bit float types are not currently supported.
+
+### Orientation
+
+When *Use Stored Affine Transform* is enabled (the default), the filter uses
+the NIfTI `sform` transform (if `sform_code > 0`) or `qform` transform (if
+`qform_code > 0`) to set the **Image Geometry** origin and spacing. If neither
+is set, the filter falls back to `pixdim[1..3]` for spacing and a zero origin.
+
+simplnx Image Geometries are axis-aligned; if the stored transform contains a
+non-trivial rotation, only the spacing (column magnitudes) and origin are
+extracted and a warning is emitted. The voxel data itself is loaded in its
+native storage order.
+
+### Data scaling
+
+When *Apply Scaling Transform* is enabled and the header specifies a
+non-trivial scaling (`scl_slope != 0` and (`scl_slope != 1` or
+`scl_inter != 0`)), the filter computes `y = scl_slope * x + scl_inter` at
+read time and promotes the output array to `float32`. Per the NIfTI-1
+specification, scaling is never applied to `RGB24` or `RGBA32` data and a
+warning is emitted if a scaling transform is present for those types.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| Input NIfTI File | File path | — | Path to the `.nii` or `.nii.gz` file to read. |
+| Use Stored Affine Transform | Bool | `true` | Use `sform`/`qform` to set origin + spacing when present. |
+| Apply Scaling Transform | Bool | `true` | Apply `y = slope*x + inter` at read time; promotes to float32. |
+| Image Geometry | Data Path | `NIfTI Image` | Path to the created Image Geometry. |
+| Cell Attribute Matrix Name | String | `Cell Data` | Name of the attribute matrix holding voxel values. |
+| Image Data Array Name | String | `ImageData` | Name of the array receiving voxel values. |
+
+## Caveats
+
+* Only the single-file NIfTI-1 format (magic `n+1`) is supported. The
+  separate-file `.hdr` / `.img` pair (magic `ni1`) is not.
+* Only 3D volumes (`dim[0] == 3`) are supported. 4D and higher files (fMRI
+  time series, diffusion series, etc.) are rejected in this release.
+* Non-trivial rotations in `sform` / `qform` are flattened — the Image
+  Geometry is axis-aligned in simplnx.
+
+% Auto generated parameter table will be inserted here                                                                    
+
+## Reference
+
+* [NIfTI-1 Data Format (official NIMH reference)](https://nifti.nimh.nih.gov/nifti-1/)
+* [`nifti1.h` header (NITRC)](https://www.nitrc.org/docman/view.php/26/64/nifti1.h)
+
+## Example Pipelines
+
+## License & Copyright
+
+Please see the description file distributed with this plugin.
+
+## DREAM3D Mailing Lists
+
+If you need help, need to file a bug report or want to request a new feature, please head over to the [DREAM3DNX-Issues](https://github.com/BlueQuartzSoftware/DREAM3DNX-Issues/discussions) GitHub site where the community of DREAM3D-NX users can help answer your questions.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.cpp
@@ -80,8 +80,8 @@ Result<CropBounds> ComputeCropBounds(const nx::core::nifti::NiftiMetadata& md, c
     auto startIndex = srcImageGeom->getIndex(xBoundPhysical[0], yBoundPhysical[0], zBoundPhysical[0]);
     if(!startIndex.has_value())
     {
-      return MakeErrorResult<CropBounds>(-34740, fmt::format("Could not map starting physical bounds ({}, {}, {}) to a valid voxel index within the NIfTI volume.", xBoundPhysical[0], yBoundPhysical[0],
-                                                             zBoundPhysical[0]));
+      return MakeErrorResult<CropBounds>(
+          -34740, fmt::format("Could not map starting physical bounds ({}, {}, {}) to a valid voxel index within the NIfTI volume.", xBoundPhysical[0], yBoundPhysical[0], zBoundPhysical[0]));
     }
     b.xStart = startIndex.value() % md.dimensions[0];
     b.yStart = (startIndex.value() / md.dimensions[0]) % md.dimensions[1];
@@ -90,8 +90,8 @@ Result<CropBounds> ComputeCropBounds(const nx::core::nifti::NiftiMetadata& md, c
     auto endIndex = srcImageGeom->getIndex(xBoundPhysical[1], yBoundPhysical[1], zBoundPhysical[1]);
     if(!endIndex.has_value())
     {
-      return MakeErrorResult<CropBounds>(-34741, fmt::format("Could not map ending physical bounds ({}, {}, {}) to a valid voxel index within the NIfTI volume.", xBoundPhysical[1], yBoundPhysical[1],
-                                                             zBoundPhysical[1]));
+      return MakeErrorResult<CropBounds>(
+          -34741, fmt::format("Could not map ending physical bounds ({}, {}, {}) to a valid voxel index within the NIfTI volume.", xBoundPhysical[1], yBoundPhysical[1], zBoundPhysical[1]));
     }
     b.xEnd = endIndex.value() % md.dimensions[0];
     b.yEnd = (endIndex.value() / md.dimensions[0]) % md.dimensions[1];
@@ -104,8 +104,8 @@ Result<CropBounds> ComputeCropBounds(const nx::core::nifti::NiftiMetadata& md, c
   }
   if(b.xEnd >= md.dimensions[0] || b.yEnd >= md.dimensions[1] || b.zEnd >= md.dimensions[2])
   {
-    return MakeErrorResult<CropBounds>(-34743, fmt::format("Crop end voxel ({}, {}, {}) exceeds NIfTI volume extent ({}, {}, {}).", b.xEnd, b.yEnd, b.zEnd, md.dimensions[0] - 1, md.dimensions[1] - 1,
-                                                           md.dimensions[2] - 1));
+    return MakeErrorResult<CropBounds>(
+        -34743, fmt::format("Crop end voxel ({}, {}, {}) exceeds NIfTI volume extent ({}, {}, {}).", b.xEnd, b.yEnd, b.zEnd, md.dimensions[0] - 1, md.dimensions[1] - 1, md.dimensions[2] - 1));
   }
 
   return {b};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.cpp
@@ -1,0 +1,210 @@
+#include "ReadNIfTIFile.hpp"
+
+#include "SimplnxCore/utils/NiftiUtilities.hpp"
+
+#include "simplnx/Common/Bit.hpp"
+#include "simplnx/DataStructure/AbstractDataStore.hpp"
+#include "simplnx/DataStructure/DataArray.hpp"
+
+#include <fmt/format.h>
+#include <zlib.h>
+
+#include <algorithm>
+#include <type_traits>
+#include <vector>
+
+using namespace nx::core;
+
+namespace
+{
+constexpr usize k_ChunkElementCount = 1u << 20; // ~1M elements per chunk
+constexpr usize k_ProgressStride = 1u << 22;    // report progress every ~4M elements processed
+
+template <class NativeT, class OutputT>
+Result<> StreamTypedVoxels(gzFile gz, AbstractDataStore<OutputT>& store, usize totalElements, bool byteSwap, bool applyScaling, float32 slope, float32 inter, const std::atomic_bool& shouldCancel,
+                           const IFilter::MessageHandler& messageHandler, const std::string& filePath)
+{
+  static_assert(std::is_arithmetic_v<NativeT>, "StreamTypedVoxels requires arithmetic native type");
+
+  std::vector<NativeT> buffer(k_ChunkElementCount);
+  usize processed = 0;
+  usize nextProgress = k_ProgressStride;
+
+  while(processed < totalElements)
+  {
+    if(shouldCancel)
+    {
+      return {};
+    }
+
+    const usize toRead = std::min<usize>(k_ChunkElementCount, totalElements - processed);
+    const usize bytesToRead = toRead * sizeof(NativeT);
+    const int actuallyRead = gzread(gz, buffer.data(), static_cast<unsigned int>(bytesToRead));
+    if(actuallyRead != static_cast<int>(bytesToRead))
+    {
+      return MakeErrorResult(-34730, fmt::format("Short voxel read from '{}': expected {} bytes at element offset {}, got {}", filePath, bytesToRead, processed, actuallyRead));
+    }
+
+    for(usize i = 0; i < toRead; i++)
+    {
+      NativeT raw = buffer[i];
+      if(byteSwap)
+      {
+        raw = nx::core::byteswap(raw);
+      }
+
+      OutputT outVal;
+      if constexpr(std::is_same_v<OutputT, float32>)
+      {
+        const auto promoted = static_cast<float32>(raw);
+        outVal = applyScaling ? (promoted * slope + inter) : promoted;
+      }
+      else
+      {
+        outVal = static_cast<OutputT>(raw);
+      }
+
+      store.setValue(processed + i, outVal);
+    }
+
+    processed += toRead;
+    if(processed >= nextProgress || processed == totalElements)
+    {
+      const auto pct = static_cast<int32>((processed * 100ULL) / totalElements);
+      messageHandler({IFilter::Message::Type::Info, fmt::format("Reading ... {}%)", pct)});
+      nextProgress += k_ProgressStride;
+    }
+  }
+  return {};
+}
+
+template <class OutputT>
+Result<> DispatchByNiftiType(gzFile gz, AbstractDataStore<OutputT>& store, const nx::core::nifti::NiftiMetadata& md, usize totalElements, bool applyScaling, const std::atomic_bool& shouldCancel,
+                             const IFilter::MessageHandler& messageHandler)
+{
+  const float32 slope = md.sclSlope;
+  const float32 inter = md.sclInter;
+  const bool bs = md.byteSwapRequired;
+  const std::string& fp = md.filePath;
+
+  switch(md.niftiDatatype)
+  {
+  case NIFTI_TYPE_UINT8:
+  case NIFTI_TYPE_RGB24:
+  case NIFTI_TYPE_RGBA32:
+    return StreamTypedVoxels<uint8, OutputT>(gz, store, totalElements, false, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+  case NIFTI_TYPE_INT8:
+    return StreamTypedVoxels<int8, OutputT>(gz, store, totalElements, false, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+  case NIFTI_TYPE_UINT16:
+    return StreamTypedVoxels<uint16, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+  case NIFTI_TYPE_INT16:
+    return StreamTypedVoxels<int16, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+  case NIFTI_TYPE_UINT32:
+    return StreamTypedVoxels<uint32, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+  case NIFTI_TYPE_INT32:
+    return StreamTypedVoxels<int32, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+  case NIFTI_TYPE_UINT64:
+    return StreamTypedVoxels<uint64, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+  case NIFTI_TYPE_INT64:
+    return StreamTypedVoxels<int64, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+  case NIFTI_TYPE_FLOAT32:
+    return StreamTypedVoxels<float32, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+  case NIFTI_TYPE_FLOAT64:
+    return StreamTypedVoxels<float64, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+  default:
+    return MakeErrorResult(-34731, fmt::format("Unsupported NIfTI datatype code {} encountered during voxel read (header validation should have rejected this).", md.niftiDatatype));
+  }
+}
+
+} // namespace
+
+namespace nx::core
+{
+
+// -----------------------------------------------------------------------------
+ReadNIfTIFile::ReadNIfTIFile(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ReadNIfTIFileInputValues* inputValues)
+: m_DataStructure(dataStructure)
+, m_InputValues(inputValues)
+, m_ShouldCancel(shouldCancel)
+, m_MessageHandler(mesgHandler)
+{
+}
+
+// -----------------------------------------------------------------------------
+ReadNIfTIFile::~ReadNIfTIFile() noexcept = default;
+
+// -----------------------------------------------------------------------------
+Result<> ReadNIfTIFile::operator()()
+{
+  auto metadataResult = nifti::ReadNiftiHeader(m_InputValues->InputFilePath, m_InputValues->UseAffineIfPresent);
+  if(metadataResult.invalid())
+  {
+    return ConvertResult(std::move(metadataResult));
+  }
+  const auto& md = metadataResult.value();
+
+  const usize numVoxels = md.dimensions[0] * md.dimensions[1] * md.dimensions[2];
+  const usize totalElements = numVoxels * md.componentCount;
+
+  const bool applyScaling = m_InputValues->ApplyScalingTransform && md.hasNontrivialScaling && md.componentCount == 1;
+
+  gzFile gz = gzopen(m_InputValues->InputFilePath.string().c_str(), "rb");
+  if(gz == nullptr)
+  {
+    return MakeErrorResult(-34720, fmt::format("Could not open NIfTI file for reading: '{}'", m_InputValues->InputFilePath.string()));
+  }
+
+  const z_off_t targetOffset = static_cast<z_off_t>(md.voxOffset);
+  if(gzseek(gz, targetOffset, SEEK_SET) != targetOffset)
+  {
+    gzclose(gz);
+    return MakeErrorResult(-34721, fmt::format("Failed to seek to voxel offset {} in '{}'", md.voxOffset, m_InputValues->InputFilePath.string()));
+  }
+
+  const DataPath dataArrayPath = m_InputValues->ImageGeometryPath.createChildPath(m_InputValues->CellAttributeMatrixName).createChildPath(m_InputValues->ImageDataArrayName);
+  auto& dataArrayBase = m_DataStructure.getDataRefAs<IDataArray>(dataArrayPath);
+
+  Result<> streamResult;
+  switch(dataArrayBase.getDataType())
+  {
+  case DataType::uint8:
+    streamResult = DispatchByNiftiType<uint8>(gz, m_DataStructure.getDataRefAs<DataArray<uint8>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    break;
+  case DataType::int8:
+    streamResult = DispatchByNiftiType<int8>(gz, m_DataStructure.getDataRefAs<DataArray<int8>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    break;
+  case DataType::uint16:
+    streamResult = DispatchByNiftiType<uint16>(gz, m_DataStructure.getDataRefAs<DataArray<uint16>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    break;
+  case DataType::int16:
+    streamResult = DispatchByNiftiType<int16>(gz, m_DataStructure.getDataRefAs<DataArray<int16>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    break;
+  case DataType::uint32:
+    streamResult = DispatchByNiftiType<uint32>(gz, m_DataStructure.getDataRefAs<DataArray<uint32>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    break;
+  case DataType::int32:
+    streamResult = DispatchByNiftiType<int32>(gz, m_DataStructure.getDataRefAs<DataArray<int32>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    break;
+  case DataType::uint64:
+    streamResult = DispatchByNiftiType<uint64>(gz, m_DataStructure.getDataRefAs<DataArray<uint64>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    break;
+  case DataType::int64:
+    streamResult = DispatchByNiftiType<int64>(gz, m_DataStructure.getDataRefAs<DataArray<int64>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    break;
+  case DataType::float32:
+    streamResult =
+        DispatchByNiftiType<float32>(gz, m_DataStructure.getDataRefAs<DataArray<float32>>(dataArrayPath).getDataStoreRef(), md, totalElements, applyScaling, m_ShouldCancel, m_MessageHandler);
+    break;
+  case DataType::float64:
+    streamResult = DispatchByNiftiType<float64>(gz, m_DataStructure.getDataRefAs<DataArray<float64>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    break;
+  default:
+    gzclose(gz);
+    return MakeErrorResult(-34722, fmt::format("Internal error: unexpected output DataType {}", static_cast<int>(dataArrayBase.getDataType())));
+  }
+
+  gzclose(gz);
+  return streamResult;
+}
+
+} // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.cpp
@@ -20,18 +20,48 @@ using namespace nx::core;
 
 namespace
 {
-constexpr usize k_ProgressTupleStride = 1u << 18; // ~256k destination tuples between progress messages
+/// How many destination tuples to process between progress messages.
+constexpr usize k_ProgressTupleStride = 1u << 18; // ~256k tuples
 
+/**
+ * @brief Inclusive voxel-index range that the streamer will retain on
+ *        each axis.
+ *
+ * Everything in `StreamCroppedVoxels` operates on these bounds; the
+ * "no cropping" case is represented as the full [0, dim-1] range so
+ * the streamer only needs one code path.
+ */
 struct CropBounds
 {
-  usize xStart{0};
-  usize xEnd{0};
+  usize xStart{0}; ///< First source voxel retained on the x axis (inclusive).
+  usize xEnd{0};   ///< Last source voxel retained on the x axis (inclusive).
   usize yStart{0};
   usize yEnd{0};
   usize zStart{0};
   usize zEnd{0};
 };
 
+/**
+ * @brief Resolves the user-supplied cropping options against the NIfTI
+ *        volume's extent and returns inclusive voxel-index bounds.
+ *
+ * Three cases:
+ *
+ * - `NoCropping` → bounds cover the full volume.
+ * - `VoxelSubvolume` → bounds copied from `opts.xBoundVoxels` /
+ *   `yBoundVoxels` / `zBoundVoxels` for the axes whose `cropX/Y/Z`
+ *   flag is set; other axes default to the full extent.
+ * - `PhysicalSubvolume` → a temporary axis-aligned `ImageGeom` is
+ *   built from the NIfTI metadata's origin / spacing / dimensions and
+ *   `ImageGeom::getIndex()` converts the physical bounds into voxel
+ *   indices. Bounds that don't map to a valid voxel produce
+ *   `-34740` / `-34741`.
+ *
+ * Returns errors:
+ * - `-34740` / `-34741` — physical bound does not resolve to a voxel.
+ * - `-34742` — start > end on at least one axis.
+ * - `-34743` — end voxel exceeds the volume extent on at least one axis.
+ */
 Result<CropBounds> ComputeCropBounds(const nx::core::nifti::NiftiMetadata& md, const CropGeometryParameter::ValueType& opts)
 {
   CropBounds b;
@@ -112,6 +142,44 @@ Result<CropBounds> ComputeCropBounds(const nx::core::nifti::NiftiMetadata& md, c
   return {b};
 }
 
+/**
+ * @brief Scan-line streamer that copies a cropped sub-volume from the
+ *        gzip-or-plain input stream into the destination DataStore.
+ *
+ * The streamer reads one source scan-line (`srcNx * componentCount`
+ * elements) per `gzread`. Out-of-range z-slices and y-rows are read
+ * and discarded in place, so peak memory stays proportional to the
+ * cropped region rather than the full source volume. In-range rows
+ * are converted (byteswap if needed, cast to `OutputT`, and optional
+ * `slope * x + inter` scaling when promoting to `float32` or
+ * `float64`) into a destination-typed scratch buffer, then pushed
+ * into the DataStore via a single `CopyFromArray::CopyData` call per
+ * in-range scan-line. That bulk-write pattern avoids the virtual
+ * `setValue` call per element, which matters a lot for
+ * OOC-backed stores.
+ *
+ * @tparam NativeT The element type as it sits in the file (before
+ *                 byteswap / scaling).
+ * @tparam OutputT The element type of the destination DataArray.
+ *                 Typically the same as `NativeT`; becomes `float32`
+ *                 when the filter promotes for scaling.
+ *
+ * @param gz              Already-open gzip stream, positioned at the
+ *                        first byte of voxel data.
+ * @param store           Destination DataStore to fill.
+ * @param md              Parsed NIfTI metadata. Provides source
+ *                        extent, component count, byte order, and
+ *                        scaling coefficients.
+ * @param b               Inclusive source-voxel range to retain.
+ * @param applyScaling    True when the output array is a floating-point
+ *                        type and the filter wants
+ *                        `y = slope * x + inter` applied on read.
+ * @param shouldCancel    Cancel flag polled once per source z-slice.
+ * @param messageHandler  Sink for progress messages.
+ *
+ * @return `Result<>` carrying `-34730` for a short read, or an error
+ *         forwarded from `CopyFromArray::CopyData`.
+ */
 template <class NativeT, class OutputT>
 Result<> StreamCroppedVoxels(gzFile gz, AbstractDataStore<OutputT>& store, const nx::core::nifti::NiftiMetadata& md, const CropBounds& b, bool applyScaling, const std::atomic_bool& shouldCancel,
                              const IFilter::MessageHandler& messageHandler)
@@ -218,6 +286,23 @@ Result<> StreamCroppedVoxels(gzFile gz, AbstractDataStore<OutputT>& store, const
   return {};
 }
 
+/**
+ * @brief Bridge between the runtime NIfTI datatype code and the
+ *        compile-time `NativeT` that `StreamCroppedVoxels` needs.
+ *
+ * The destination type `OutputT` is known at the caller site (from
+ * the DataStore the filter's preflight created). The source type is
+ * known only at runtime from `md.niftiDatatype`. This function
+ * dispatches on that code to pick the right `StreamCroppedVoxels<NativeT, OutputT>`
+ * instantiation. RGB24 and RGBA32 are folded into the `uint8` case
+ * because their on-disk representation is a packed byte stream — the
+ * per-tuple component count is carried in `md.componentCount` and
+ * handled inside the streamer.
+ *
+ * @return Forwards the streamer's result, or `-34731` for a code the
+ *         dispatcher does not recognize (header validation should
+ *         have rejected it earlier).
+ */
 template <class OutputT>
 Result<> DispatchByNiftiType(gzFile gz, AbstractDataStore<OutputT>& store, const nx::core::nifti::NiftiMetadata& md, const CropBounds& b, bool applyScaling, const std::atomic_bool& shouldCancel,
                              const IFilter::MessageHandler& messageHandler)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.cpp
@@ -7,6 +7,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/DataArrayUtilities.hpp"
 
 #include <fmt/format.h>
 #include <zlib.h>
@@ -19,7 +20,7 @@ using namespace nx::core;
 
 namespace
 {
-constexpr usize k_ProgressStride = 1u << 22; // ~4M elements processed per progress message
+constexpr usize k_ProgressTupleStride = 1u << 18; // ~256k destination tuples between progress messages
 
 struct CropBounds
 {
@@ -126,17 +127,20 @@ Result<> StreamCroppedVoxels(gzFile gz, AbstractDataStore<OutputT>& store, const
   const float32 inter = md.sclInter;
   const std::string& filePath = md.filePath;
 
-  const usize scanlineElements = srcNx * componentCount;
-  const usize scanlineBytes = scanlineElements * sizeof(NativeT);
-  std::vector<NativeT> scanline(scanlineElements);
+  const usize srcScanlineElements = srcNx * componentCount;
+  const usize srcScanlineBytes = srcScanlineElements * sizeof(NativeT);
+  std::vector<NativeT> srcScanline(srcScanlineElements);
 
   const usize destNx = b.xEnd - b.xStart + 1;
   const usize destNy = b.yEnd - b.yStart + 1;
   const usize destNz = b.zEnd - b.zStart + 1;
-  const usize totalDestElements = destNx * destNy * destNz * componentCount;
+  const usize destScanlineElements = destNx * componentCount;
+  std::vector<OutputT> destScanline(destScanlineElements);
 
-  usize destIdx = 0;
-  usize lastProgressIdx = 0;
+  const usize totalDestTuples = destNx * destNy * destNz;
+
+  usize destTupleOffset = 0;
+  usize lastProgressTuples = 0;
 
   for(usize srcZ = 0; srcZ < srcNz; srcZ++)
   {
@@ -148,10 +152,10 @@ Result<> StreamCroppedVoxels(gzFile gz, AbstractDataStore<OutputT>& store, const
 
     for(usize srcY = 0; srcY < srcNy; srcY++)
     {
-      const int actuallyRead = gzread(gz, scanline.data(), static_cast<unsigned int>(scanlineBytes));
-      if(actuallyRead != static_cast<int>(scanlineBytes))
+      const int actuallyRead = gzread(gz, srcScanline.data(), static_cast<unsigned int>(srcScanlineBytes));
+      if(actuallyRead != static_cast<int>(srcScanlineBytes))
       {
-        return MakeErrorResult(-34730, fmt::format("Short voxel read from '{}' at (z={}, y={}): expected {} bytes, got {}", filePath, srcZ, srcY, scanlineBytes, actuallyRead));
+        return MakeErrorResult(-34730, fmt::format("Short voxel read from '{}' at (z={}, y={}): expected {} bytes, got {}", filePath, srcZ, srcY, srcScanlineBytes, actuallyRead));
       }
 
       if(!zInRange)
@@ -164,36 +168,45 @@ Result<> StreamCroppedVoxels(gzFile gz, AbstractDataStore<OutputT>& store, const
         continue;
       }
 
+      // Convert the x-subrange of this source scanline into a contiguous,
+      // destination-typed scratch buffer so the DataStore receives one bulk
+      // write per scanline instead of componentCount * destNx virtual setValue
+      // calls. This matters a lot for OOC-backed stores.
+      usize writeIdx = 0;
       for(usize srcX = b.xStart; srcX <= b.xEnd; srcX++)
       {
         const usize baseIdx = srcX * componentCount;
         for(usize c = 0; c < componentCount; c++)
         {
-          NativeT raw = scanline[baseIdx + c];
+          NativeT raw = srcScanline[baseIdx + c];
           if(byteSwap)
           {
             raw = nx::core::byteswap(raw);
           }
-
-          OutputT outVal;
           if constexpr(std::is_same_v<OutputT, float32>)
           {
             const auto promoted = static_cast<float32>(raw);
-            outVal = applyScaling ? (promoted * slope + inter) : promoted;
+            destScanline[writeIdx++] = applyScaling ? (promoted * slope + inter) : promoted;
           }
           else
           {
-            outVal = static_cast<OutputT>(raw);
+            destScanline[writeIdx++] = static_cast<OutputT>(raw);
           }
-          store.setValue(destIdx++, outVal);
         }
       }
 
-      if(destIdx - lastProgressIdx >= k_ProgressStride || destIdx == totalDestElements)
+      Result<> copyResult = CopyFromArray::CopyData(destScanline, store, destTupleOffset, 0, destNx, componentCount);
+      if(copyResult.invalid())
       {
-        const auto pct = static_cast<int32>((destIdx * 100ULL) / std::max<usize>(1, totalDestElements));
+        return copyResult;
+      }
+      destTupleOffset += destNx;
+
+      if(destTupleOffset - lastProgressTuples >= k_ProgressTupleStride || destTupleOffset == totalDestTuples)
+      {
+        const auto pct = static_cast<int32>((destTupleOffset * 100ULL) / std::max<usize>(1, totalDestTuples));
         messageHandler({IFilter::Message::Type::Info, fmt::format("Reading NIfTI voxels... {}%", pct)});
-        lastProgressIdx = destIdx;
+        lastProgressTuples = destTupleOffset;
       }
     }
   }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.cpp
@@ -49,18 +49,18 @@ Result<CropBounds> ComputeCropBounds(const nx::core::nifti::NiftiMetadata& md, c
   {
     if(opts.cropX)
     {
-      b.xStart = static_cast<usize>(opts.xBoundVoxels[0]);
-      b.xEnd = static_cast<usize>(opts.xBoundVoxels[1]);
+      b.xStart = opts.xBoundVoxels[0];
+      b.xEnd = opts.xBoundVoxels[1];
     }
     if(opts.cropY)
     {
-      b.yStart = static_cast<usize>(opts.yBoundVoxels[0]);
-      b.yEnd = static_cast<usize>(opts.yBoundVoxels[1]);
+      b.yStart = opts.yBoundVoxels[0];
+      b.yEnd = opts.yBoundVoxels[1];
     }
     if(opts.cropZ)
     {
-      b.zStart = static_cast<usize>(opts.zBoundVoxels[0]);
-      b.zEnd = static_cast<usize>(opts.zBoundVoxels[1]);
+      b.zStart = opts.zBoundVoxels[0];
+      b.zEnd = opts.zBoundVoxels[1];
     }
   }
   else // PhysicalSubvolume
@@ -188,6 +188,11 @@ Result<> StreamCroppedVoxels(gzFile gz, AbstractDataStore<OutputT>& store, const
             const auto promoted = static_cast<float32>(raw);
             destScanline[writeIdx++] = applyScaling ? (promoted * slope + inter) : promoted;
           }
+          else if constexpr(std::is_same_v<OutputT, float64>)
+          {
+            const auto promoted = static_cast<float64>(raw);
+            destScanline[writeIdx++] = applyScaling ? (promoted * slope + inter) : promoted;
+          }
           else
           {
             destScanline[writeIdx++] = static_cast<OutputT>(raw);
@@ -201,13 +206,13 @@ Result<> StreamCroppedVoxels(gzFile gz, AbstractDataStore<OutputT>& store, const
         return copyResult;
       }
       destTupleOffset += destNx;
-
-      if(destTupleOffset - lastProgressTuples >= k_ProgressTupleStride || destTupleOffset == totalDestTuples)
-      {
-        const auto pct = static_cast<int32>((destTupleOffset * 100ULL) / std::max<usize>(1, totalDestTuples));
-        messageHandler({IFilter::Message::Type::Info, fmt::format("Reading NIfTI voxels... {}%", pct)});
-        lastProgressTuples = destTupleOffset;
-      }
+    }
+    // Only update progress on z-slices.
+    if(destTupleOffset - lastProgressTuples >= k_ProgressTupleStride || destTupleOffset == totalDestTuples)
+    {
+      const auto pct = static_cast<int32>((destTupleOffset * 100ULL) / std::max<usize>(1, totalDestTuples));
+      messageHandler({IFilter::Message::Type::Info, fmt::format("{}% Complete", pct)});
+      lastProgressTuples = destTupleOffset;
     }
   }
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.cpp
@@ -5,6 +5,8 @@
 #include "simplnx/Common/Bit.hpp"
 #include "simplnx/DataStructure/AbstractDataStore.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/DataStructure/DataStructure.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 
 #include <fmt/format.h>
 #include <zlib.h>
@@ -17,100 +19,215 @@ using namespace nx::core;
 
 namespace
 {
-constexpr usize k_ChunkElementCount = 1u << 20; // ~1M elements per chunk
-constexpr usize k_ProgressStride = 1u << 22;    // report progress every ~4M elements processed
+constexpr usize k_ProgressStride = 1u << 22; // ~4M elements processed per progress message
+
+struct CropBounds
+{
+  usize xStart{0};
+  usize xEnd{0};
+  usize yStart{0};
+  usize yEnd{0};
+  usize zStart{0};
+  usize zEnd{0};
+};
+
+Result<CropBounds> ComputeCropBounds(const nx::core::nifti::NiftiMetadata& md, const CropGeometryParameter::ValueType& opts)
+{
+  CropBounds b;
+  b.xEnd = md.dimensions[0] - 1;
+  b.yEnd = md.dimensions[1] - 1;
+  b.zEnd = md.dimensions[2] - 1;
+
+  using Type = CropGeometryParameter::CropValues::TypeEnum;
+  if(opts.type == Type::NoCropping)
+  {
+    return {b};
+  }
+
+  if(opts.type == Type::VoxelSubvolume)
+  {
+    if(opts.cropX)
+    {
+      b.xStart = static_cast<usize>(opts.xBoundVoxels[0]);
+      b.xEnd = static_cast<usize>(opts.xBoundVoxels[1]);
+    }
+    if(opts.cropY)
+    {
+      b.yStart = static_cast<usize>(opts.yBoundVoxels[0]);
+      b.yEnd = static_cast<usize>(opts.yBoundVoxels[1]);
+    }
+    if(opts.cropZ)
+    {
+      b.zStart = static_cast<usize>(opts.zBoundVoxels[0]);
+      b.zEnd = static_cast<usize>(opts.zBoundVoxels[1]);
+    }
+  }
+  else // PhysicalSubvolume
+  {
+    DataStructure tmpDs;
+    auto* srcImageGeom = ImageGeom::Create(tmpDs, "srcImageGeom");
+    srcImageGeom->setOrigin({md.origin[0], md.origin[1], md.origin[2]});
+    srcImageGeom->setSpacing({md.spacing[0], md.spacing[1], md.spacing[2]});
+    srcImageGeom->setDimensions({md.dimensions[0], md.dimensions[1], md.dimensions[2]});
+
+    const auto startCoords = srcImageGeom->getCoordsf(b.xStart, b.yStart, b.zStart);
+    const auto endCoords = srcImageGeom->getCoordsf(b.xEnd, b.yEnd, b.zEnd);
+
+    FloatVec2Type xBoundPhysical = opts.cropX ? opts.xBoundPhysical : FloatVec2Type{startCoords[0], endCoords[0]};
+    FloatVec2Type yBoundPhysical = opts.cropY ? opts.yBoundPhysical : FloatVec2Type{startCoords[1], endCoords[1]};
+    FloatVec2Type zBoundPhysical = opts.cropZ ? opts.zBoundPhysical : FloatVec2Type{startCoords[2], endCoords[2]};
+
+    auto startIndex = srcImageGeom->getIndex(xBoundPhysical[0], yBoundPhysical[0], zBoundPhysical[0]);
+    if(!startIndex.has_value())
+    {
+      return MakeErrorResult<CropBounds>(-34740, fmt::format("Could not map starting physical bounds ({}, {}, {}) to a valid voxel index within the NIfTI volume.", xBoundPhysical[0], yBoundPhysical[0],
+                                                             zBoundPhysical[0]));
+    }
+    b.xStart = startIndex.value() % md.dimensions[0];
+    b.yStart = (startIndex.value() / md.dimensions[0]) % md.dimensions[1];
+    b.zStart = startIndex.value() / (md.dimensions[0] * md.dimensions[1]);
+
+    auto endIndex = srcImageGeom->getIndex(xBoundPhysical[1], yBoundPhysical[1], zBoundPhysical[1]);
+    if(!endIndex.has_value())
+    {
+      return MakeErrorResult<CropBounds>(-34741, fmt::format("Could not map ending physical bounds ({}, {}, {}) to a valid voxel index within the NIfTI volume.", xBoundPhysical[1], yBoundPhysical[1],
+                                                             zBoundPhysical[1]));
+    }
+    b.xEnd = endIndex.value() % md.dimensions[0];
+    b.yEnd = (endIndex.value() / md.dimensions[0]) % md.dimensions[1];
+    b.zEnd = endIndex.value() / (md.dimensions[0] * md.dimensions[1]);
+  }
+
+  if(b.xStart > b.xEnd || b.yStart > b.yEnd || b.zStart > b.zEnd)
+  {
+    return MakeErrorResult<CropBounds>(-34742, fmt::format("Invalid crop bounds: start ({}, {}, {}) must be <= end ({}, {}, {}).", b.xStart, b.yStart, b.zStart, b.xEnd, b.yEnd, b.zEnd));
+  }
+  if(b.xEnd >= md.dimensions[0] || b.yEnd >= md.dimensions[1] || b.zEnd >= md.dimensions[2])
+  {
+    return MakeErrorResult<CropBounds>(-34743, fmt::format("Crop end voxel ({}, {}, {}) exceeds NIfTI volume extent ({}, {}, {}).", b.xEnd, b.yEnd, b.zEnd, md.dimensions[0] - 1, md.dimensions[1] - 1,
+                                                           md.dimensions[2] - 1));
+  }
+
+  return {b};
+}
 
 template <class NativeT, class OutputT>
-Result<> StreamTypedVoxels(gzFile gz, AbstractDataStore<OutputT>& store, usize totalElements, bool byteSwap, bool applyScaling, float32 slope, float32 inter, const std::atomic_bool& shouldCancel,
-                           const IFilter::MessageHandler& messageHandler, const std::string& filePath)
+Result<> StreamCroppedVoxels(gzFile gz, AbstractDataStore<OutputT>& store, const nx::core::nifti::NiftiMetadata& md, const CropBounds& b, bool applyScaling, const std::atomic_bool& shouldCancel,
+                             const IFilter::MessageHandler& messageHandler)
 {
-  static_assert(std::is_arithmetic_v<NativeT>, "StreamTypedVoxels requires arithmetic native type");
+  static_assert(std::is_arithmetic_v<NativeT>, "StreamCroppedVoxels requires arithmetic native type");
 
-  std::vector<NativeT> buffer(k_ChunkElementCount);
-  usize processed = 0;
-  usize nextProgress = k_ProgressStride;
+  const usize srcNx = md.dimensions[0];
+  const usize srcNy = md.dimensions[1];
+  const usize srcNz = md.dimensions[2];
+  const usize componentCount = md.componentCount;
+  const bool byteSwap = md.byteSwapRequired;
+  const float32 slope = md.sclSlope;
+  const float32 inter = md.sclInter;
+  const std::string& filePath = md.filePath;
 
-  while(processed < totalElements)
+  const usize scanlineElements = srcNx * componentCount;
+  const usize scanlineBytes = scanlineElements * sizeof(NativeT);
+  std::vector<NativeT> scanline(scanlineElements);
+
+  const usize destNx = b.xEnd - b.xStart + 1;
+  const usize destNy = b.yEnd - b.yStart + 1;
+  const usize destNz = b.zEnd - b.zStart + 1;
+  const usize totalDestElements = destNx * destNy * destNz * componentCount;
+
+  usize destIdx = 0;
+  usize lastProgressIdx = 0;
+
+  for(usize srcZ = 0; srcZ < srcNz; srcZ++)
   {
     if(shouldCancel)
     {
       return {};
     }
+    const bool zInRange = (srcZ >= b.zStart && srcZ <= b.zEnd);
 
-    const usize toRead = std::min<usize>(k_ChunkElementCount, totalElements - processed);
-    const usize bytesToRead = toRead * sizeof(NativeT);
-    const int actuallyRead = gzread(gz, buffer.data(), static_cast<unsigned int>(bytesToRead));
-    if(actuallyRead != static_cast<int>(bytesToRead))
+    for(usize srcY = 0; srcY < srcNy; srcY++)
     {
-      return MakeErrorResult(-34730, fmt::format("Short voxel read from '{}': expected {} bytes at element offset {}, got {}", filePath, bytesToRead, processed, actuallyRead));
-    }
-
-    for(usize i = 0; i < toRead; i++)
-    {
-      NativeT raw = buffer[i];
-      if(byteSwap)
+      const int actuallyRead = gzread(gz, scanline.data(), static_cast<unsigned int>(scanlineBytes));
+      if(actuallyRead != static_cast<int>(scanlineBytes))
       {
-        raw = nx::core::byteswap(raw);
+        return MakeErrorResult(-34730, fmt::format("Short voxel read from '{}' at (z={}, y={}): expected {} bytes, got {}", filePath, srcZ, srcY, scanlineBytes, actuallyRead));
       }
 
-      OutputT outVal;
-      if constexpr(std::is_same_v<OutputT, float32>)
+      if(!zInRange)
       {
-        const auto promoted = static_cast<float32>(raw);
-        outVal = applyScaling ? (promoted * slope + inter) : promoted;
+        continue;
       }
-      else
+      const bool yInRange = (srcY >= b.yStart && srcY <= b.yEnd);
+      if(!yInRange)
       {
-        outVal = static_cast<OutputT>(raw);
+        continue;
       }
 
-      store.setValue(processed + i, outVal);
-    }
+      for(usize srcX = b.xStart; srcX <= b.xEnd; srcX++)
+      {
+        const usize baseIdx = srcX * componentCount;
+        for(usize c = 0; c < componentCount; c++)
+        {
+          NativeT raw = scanline[baseIdx + c];
+          if(byteSwap)
+          {
+            raw = nx::core::byteswap(raw);
+          }
 
-    processed += toRead;
-    if(processed >= nextProgress || processed == totalElements)
-    {
-      const auto pct = static_cast<int32>((processed * 100ULL) / totalElements);
-      messageHandler({IFilter::Message::Type::Info, fmt::format("Reading ... {}%)", pct)});
-      nextProgress += k_ProgressStride;
+          OutputT outVal;
+          if constexpr(std::is_same_v<OutputT, float32>)
+          {
+            const auto promoted = static_cast<float32>(raw);
+            outVal = applyScaling ? (promoted * slope + inter) : promoted;
+          }
+          else
+          {
+            outVal = static_cast<OutputT>(raw);
+          }
+          store.setValue(destIdx++, outVal);
+        }
+      }
+
+      if(destIdx - lastProgressIdx >= k_ProgressStride || destIdx == totalDestElements)
+      {
+        const auto pct = static_cast<int32>((destIdx * 100ULL) / std::max<usize>(1, totalDestElements));
+        messageHandler({IFilter::Message::Type::Info, fmt::format("Reading NIfTI voxels... {}%", pct)});
+        lastProgressIdx = destIdx;
+      }
     }
   }
   return {};
 }
 
 template <class OutputT>
-Result<> DispatchByNiftiType(gzFile gz, AbstractDataStore<OutputT>& store, const nx::core::nifti::NiftiMetadata& md, usize totalElements, bool applyScaling, const std::atomic_bool& shouldCancel,
+Result<> DispatchByNiftiType(gzFile gz, AbstractDataStore<OutputT>& store, const nx::core::nifti::NiftiMetadata& md, const CropBounds& b, bool applyScaling, const std::atomic_bool& shouldCancel,
                              const IFilter::MessageHandler& messageHandler)
 {
-  const float32 slope = md.sclSlope;
-  const float32 inter = md.sclInter;
-  const bool bs = md.byteSwapRequired;
-  const std::string& fp = md.filePath;
-
   switch(md.niftiDatatype)
   {
   case NIFTI_TYPE_UINT8:
   case NIFTI_TYPE_RGB24:
   case NIFTI_TYPE_RGBA32:
-    return StreamTypedVoxels<uint8, OutputT>(gz, store, totalElements, false, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+    return StreamCroppedVoxels<uint8, OutputT>(gz, store, md, b, applyScaling, shouldCancel, messageHandler);
   case NIFTI_TYPE_INT8:
-    return StreamTypedVoxels<int8, OutputT>(gz, store, totalElements, false, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+    return StreamCroppedVoxels<int8, OutputT>(gz, store, md, b, applyScaling, shouldCancel, messageHandler);
   case NIFTI_TYPE_UINT16:
-    return StreamTypedVoxels<uint16, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+    return StreamCroppedVoxels<uint16, OutputT>(gz, store, md, b, applyScaling, shouldCancel, messageHandler);
   case NIFTI_TYPE_INT16:
-    return StreamTypedVoxels<int16, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+    return StreamCroppedVoxels<int16, OutputT>(gz, store, md, b, applyScaling, shouldCancel, messageHandler);
   case NIFTI_TYPE_UINT32:
-    return StreamTypedVoxels<uint32, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+    return StreamCroppedVoxels<uint32, OutputT>(gz, store, md, b, applyScaling, shouldCancel, messageHandler);
   case NIFTI_TYPE_INT32:
-    return StreamTypedVoxels<int32, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+    return StreamCroppedVoxels<int32, OutputT>(gz, store, md, b, applyScaling, shouldCancel, messageHandler);
   case NIFTI_TYPE_UINT64:
-    return StreamTypedVoxels<uint64, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+    return StreamCroppedVoxels<uint64, OutputT>(gz, store, md, b, applyScaling, shouldCancel, messageHandler);
   case NIFTI_TYPE_INT64:
-    return StreamTypedVoxels<int64, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+    return StreamCroppedVoxels<int64, OutputT>(gz, store, md, b, applyScaling, shouldCancel, messageHandler);
   case NIFTI_TYPE_FLOAT32:
-    return StreamTypedVoxels<float32, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+    return StreamCroppedVoxels<float32, OutputT>(gz, store, md, b, applyScaling, shouldCancel, messageHandler);
   case NIFTI_TYPE_FLOAT64:
-    return StreamTypedVoxels<float64, OutputT>(gz, store, totalElements, bs, applyScaling, slope, inter, shouldCancel, messageHandler, fp);
+    return StreamCroppedVoxels<float64, OutputT>(gz, store, md, b, applyScaling, shouldCancel, messageHandler);
   default:
     return MakeErrorResult(-34731, fmt::format("Unsupported NIfTI datatype code {} encountered during voxel read (header validation should have rejected this).", md.niftiDatatype));
   }
@@ -143,8 +260,12 @@ Result<> ReadNIfTIFile::operator()()
   }
   const auto& md = metadataResult.value();
 
-  const usize numVoxels = md.dimensions[0] * md.dimensions[1] * md.dimensions[2];
-  const usize totalElements = numVoxels * md.componentCount;
+  auto boundsResult = ComputeCropBounds(md, m_InputValues->CroppingOptions);
+  if(boundsResult.invalid())
+  {
+    return ConvertResult(std::move(boundsResult));
+  }
+  const CropBounds bounds = boundsResult.value();
 
   const bool applyScaling = m_InputValues->ApplyScalingTransform && md.hasNontrivialScaling && md.componentCount == 1;
 
@@ -168,35 +289,34 @@ Result<> ReadNIfTIFile::operator()()
   switch(dataArrayBase.getDataType())
   {
   case DataType::uint8:
-    streamResult = DispatchByNiftiType<uint8>(gz, m_DataStructure.getDataRefAs<DataArray<uint8>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    streamResult = DispatchByNiftiType<uint8>(gz, m_DataStructure.getDataRefAs<DataArray<uint8>>(dataArrayPath).getDataStoreRef(), md, bounds, false, m_ShouldCancel, m_MessageHandler);
     break;
   case DataType::int8:
-    streamResult = DispatchByNiftiType<int8>(gz, m_DataStructure.getDataRefAs<DataArray<int8>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    streamResult = DispatchByNiftiType<int8>(gz, m_DataStructure.getDataRefAs<DataArray<int8>>(dataArrayPath).getDataStoreRef(), md, bounds, false, m_ShouldCancel, m_MessageHandler);
     break;
   case DataType::uint16:
-    streamResult = DispatchByNiftiType<uint16>(gz, m_DataStructure.getDataRefAs<DataArray<uint16>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    streamResult = DispatchByNiftiType<uint16>(gz, m_DataStructure.getDataRefAs<DataArray<uint16>>(dataArrayPath).getDataStoreRef(), md, bounds, false, m_ShouldCancel, m_MessageHandler);
     break;
   case DataType::int16:
-    streamResult = DispatchByNiftiType<int16>(gz, m_DataStructure.getDataRefAs<DataArray<int16>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    streamResult = DispatchByNiftiType<int16>(gz, m_DataStructure.getDataRefAs<DataArray<int16>>(dataArrayPath).getDataStoreRef(), md, bounds, false, m_ShouldCancel, m_MessageHandler);
     break;
   case DataType::uint32:
-    streamResult = DispatchByNiftiType<uint32>(gz, m_DataStructure.getDataRefAs<DataArray<uint32>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    streamResult = DispatchByNiftiType<uint32>(gz, m_DataStructure.getDataRefAs<DataArray<uint32>>(dataArrayPath).getDataStoreRef(), md, bounds, false, m_ShouldCancel, m_MessageHandler);
     break;
   case DataType::int32:
-    streamResult = DispatchByNiftiType<int32>(gz, m_DataStructure.getDataRefAs<DataArray<int32>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    streamResult = DispatchByNiftiType<int32>(gz, m_DataStructure.getDataRefAs<DataArray<int32>>(dataArrayPath).getDataStoreRef(), md, bounds, false, m_ShouldCancel, m_MessageHandler);
     break;
   case DataType::uint64:
-    streamResult = DispatchByNiftiType<uint64>(gz, m_DataStructure.getDataRefAs<DataArray<uint64>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    streamResult = DispatchByNiftiType<uint64>(gz, m_DataStructure.getDataRefAs<DataArray<uint64>>(dataArrayPath).getDataStoreRef(), md, bounds, false, m_ShouldCancel, m_MessageHandler);
     break;
   case DataType::int64:
-    streamResult = DispatchByNiftiType<int64>(gz, m_DataStructure.getDataRefAs<DataArray<int64>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    streamResult = DispatchByNiftiType<int64>(gz, m_DataStructure.getDataRefAs<DataArray<int64>>(dataArrayPath).getDataStoreRef(), md, bounds, false, m_ShouldCancel, m_MessageHandler);
     break;
   case DataType::float32:
-    streamResult =
-        DispatchByNiftiType<float32>(gz, m_DataStructure.getDataRefAs<DataArray<float32>>(dataArrayPath).getDataStoreRef(), md, totalElements, applyScaling, m_ShouldCancel, m_MessageHandler);
+    streamResult = DispatchByNiftiType<float32>(gz, m_DataStructure.getDataRefAs<DataArray<float32>>(dataArrayPath).getDataStoreRef(), md, bounds, applyScaling, m_ShouldCancel, m_MessageHandler);
     break;
   case DataType::float64:
-    streamResult = DispatchByNiftiType<float64>(gz, m_DataStructure.getDataRefAs<DataArray<float64>>(dataArrayPath).getDataStoreRef(), md, totalElements, false, m_ShouldCancel, m_MessageHandler);
+    streamResult = DispatchByNiftiType<float64>(gz, m_DataStructure.getDataRefAs<DataArray<float64>>(dataArrayPath).getDataStoreRef(), md, bounds, false, m_ShouldCancel, m_MessageHandler);
     break;
   default:
     gzclose(gz);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.hpp
@@ -12,25 +12,110 @@
 namespace nx::core
 {
 
+/**
+ * @struct ReadNIfTIFileInputValues
+ * @brief Plain-data bundle of inputs consumed by the `ReadNIfTIFile`
+ *        algorithm.
+ *
+ * The filter's `executeImpl` populates this from its `Arguments` and
+ * passes it through to the algorithm. Collecting the parameters in a
+ * single struct keeps the algorithm constructor short and makes it
+ * easy to invoke the algorithm directly from a test or another filter
+ * without reconstructing the parameter plumbing.
+ *
+ * `ImageGeometryPath`, `CellAttributeMatrixName`, and
+ * `ImageDataArrayName` must match whatever the filter's preflight
+ * emitted — the algorithm relies on those DataPaths to locate the
+ * pre-created `ImageGeom` and its `DataArray<T>`.
+ */
 struct SIMPLNXCORE_EXPORT ReadNIfTIFileInputValues
 {
+  /** @brief Path to the input `.nii` or `.nii.gz` file. */
   std::filesystem::path InputFilePath;
+
+  /** @brief DataPath of the Image Geometry the filter's preflight
+   *         created. The algorithm writes voxels into the
+   *         `DataArray<T>` located at
+   *         `ImageGeometryPath / CellAttributeMatrixName / ImageDataArrayName`. */
   DataPath ImageGeometryPath;
+
+  /** @brief Name of the attribute matrix child of the Image Geometry
+   *         that holds the voxel data array. */
   std::string CellAttributeMatrixName;
+
+  /** @brief Name of the `DataArray<T>` the algorithm will fill with
+   *         voxel values. */
   std::string ImageDataArrayName;
+
+  /** @brief When `true`, the NIfTI header's `sform`/`qform` transform
+   *         drives the ImageGeom origin and spacing. When `false`,
+   *         the reader uses `pixdim` plus a zero origin even if a
+   *         transform is recorded. */
   bool UseAffineIfPresent{true};
+
+  /** @brief When `true` and the header declares a non-trivial scaling
+   *         (`scl_slope != 0` and `(scl_slope != 1 or scl_inter != 0)`)
+   *         on a single-component datatype, the voxels are promoted
+   *         to `float32` and `y = slope * x + inter` is applied on
+   *         read. Scaling is always skipped for RGB24/RGBA32 per the
+   *         NIfTI-1 specification. */
   bool ApplyScalingTransform{true};
+
+  /** @brief Optional voxel-index or physical-coordinate sub-volume
+   *         to retain. When set to anything other than
+   *         `CropValues::TypeEnum::NoCropping`, only the selected
+   *         region is stored in the output DataArray — the rest of
+   *         the file is read and discarded on the fly. */
   CropGeometryParameter::ValueType CroppingOptions;
 };
 
 /**
  * @class ReadNIfTIFile
- * @brief Streams the voxel data out of a NIfTI-1 (.nii/.nii.gz) file into the
- * pre-allocated DataArray created by ReadNIfTIFileFilter::preflightImpl.
+ * @brief Streams voxel data out of a NIfTI-1 (`.nii` / `.nii.gz`) file
+ *        into the DataArray that `ReadNIfTIFileFilter::preflightImpl`
+ *        has already created.
+ *
+ * The algorithm does a single pass over the file: it re-reads the
+ * 348-byte header (shared cheaply with preflight via zlib's
+ * `gzopen`), computes the effective crop bounds, seeks to `vox_offset`,
+ * and streams voxels one source scan-line at a time into a
+ * destination-typed scratch buffer before bulk-copying the cropped
+ * subrange into the DataStore via
+ * `CopyFromArray::CopyData`. That pattern plays well with OOC stores
+ * and avoids per-voxel virtual dispatch.
+ *
+ * Construction mirrors the project's standard algorithm pattern:
+ * references to the DataStructure, the filter's message handler, the
+ * shared cancel flag, and a non-owning pointer to the input bundle.
+ * The algorithm holds no state of its own — invoke it by calling
+ * `operator()`.
+ *
+ * ### Typical use (from a filter's `executeImpl`)
+ * @code
+ * ReadNIfTIFileInputValues inputValues;
+ * // ... populate inputValues from filterArgs ...
+ * return ReadNIfTIFile(dataStructure, messageHandler, shouldCancel, &inputValues)();
+ * @endcode
  */
 class SIMPLNXCORE_EXPORT ReadNIfTIFile
 {
 public:
+  /**
+   * @brief Constructs the algorithm. No work is done until `operator()`
+   *        is called.
+   *
+   * @param dataStructure  The DataStructure the filter's preflight
+   *                       populated with an empty ImageGeom and
+   *                       DataArray. The algorithm locates and fills
+   *                       that array.
+   * @param mesgHandler    Sink for progress and informational
+   *                       messages. Progress ticks roughly every
+   *                       256k destination tuples.
+   * @param shouldCancel   Atomic cancel flag polled at the top of
+   *                       each source z-slice.
+   * @param inputValues    Non-owning pointer to the parameter bundle.
+   *                       Must outlive the call to `operator()`.
+   */
   ReadNIfTIFile(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ReadNIfTIFileInputValues* inputValues);
   ~ReadNIfTIFile() noexcept;
 
@@ -39,6 +124,16 @@ public:
   ReadNIfTIFile& operator=(const ReadNIfTIFile&) = delete;
   ReadNIfTIFile& operator=(ReadNIfTIFile&&) noexcept = delete;
 
+  /**
+   * @brief Runs the read. Opens the file, parses the header, resolves
+   *        the crop bounds, and streams voxels into the pre-created
+   *        DataArray.
+   *
+   * @return `Result<>` carrying an error from `ReadNiftiHeader`,
+   *         `ComputeCropBounds`, the `gzseek` / `gzread` path, or a
+   *         type-dispatch fall-through. An early cancel returns a
+   *         valid empty `Result<>`.
+   */
   Result<> operator()();
 
 private:

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.hpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/DataPath.hpp"
 #include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/Filter/IFilter.hpp"
+#include "simplnx/Parameters/CropGeometryParameter.hpp"
 
 #include <filesystem>
 
@@ -19,6 +20,7 @@ struct SIMPLNXCORE_EXPORT ReadNIfTIFileInputValues
   std::string ImageDataArrayName;
   bool UseAffineIfPresent{true};
   bool ApplyScalingTransform{true};
+  CropGeometryParameter::ValueType CroppingOptions;
 };
 
 /**

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadNIfTIFile.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "SimplnxCore/SimplnxCore_export.hpp"
+
+#include "simplnx/DataStructure/DataPath.hpp"
+#include "simplnx/DataStructure/DataStructure.hpp"
+#include "simplnx/Filter/IFilter.hpp"
+
+#include <filesystem>
+
+namespace nx::core
+{
+
+struct SIMPLNXCORE_EXPORT ReadNIfTIFileInputValues
+{
+  std::filesystem::path InputFilePath;
+  DataPath ImageGeometryPath;
+  std::string CellAttributeMatrixName;
+  std::string ImageDataArrayName;
+  bool UseAffineIfPresent{true};
+  bool ApplyScalingTransform{true};
+};
+
+/**
+ * @class ReadNIfTIFile
+ * @brief Streams the voxel data out of a NIfTI-1 (.nii/.nii.gz) file into the
+ * pre-allocated DataArray created by ReadNIfTIFileFilter::preflightImpl.
+ */
+class SIMPLNXCORE_EXPORT ReadNIfTIFile
+{
+public:
+  ReadNIfTIFile(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ReadNIfTIFileInputValues* inputValues);
+  ~ReadNIfTIFile() noexcept;
+
+  ReadNIfTIFile(const ReadNIfTIFile&) = delete;
+  ReadNIfTIFile(ReadNIfTIFile&&) noexcept = delete;
+  ReadNIfTIFile& operator=(const ReadNIfTIFile&) = delete;
+  ReadNIfTIFile& operator=(ReadNIfTIFile&&) noexcept = delete;
+
+  Result<> operator()();
+
+private:
+  DataStructure& m_DataStructure;
+  const ReadNIfTIFileInputValues* m_InputValues = nullptr;
+  const std::atomic_bool& m_ShouldCancel;
+  const IFilter::MessageHandler& m_MessageHandler;
+};
+
+} // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.cpp
@@ -84,7 +84,7 @@ std::string ReadNIfTIFileFilter::humanName() const
 //------------------------------------------------------------------------------
 std::vector<std::string> ReadNIfTIFileFilter::defaultTags() const
 {
-  return {"Read", "Import", "NIfTI", "NII", "Medical", "MRI"};
+  return {"Read", "Import", "NIfTI", "NII", "Medical", "MRI", "CT", "xCT"};
 }
 
 //------------------------------------------------------------------------------
@@ -94,7 +94,7 @@ Parameters ReadNIfTIFileFilter::parameters() const
 
   params.insertSeparator(Parameters::Separator{"Input Parameter(s)"});
   params.insert(std::make_unique<FileSystemPathParameter>(k_InputFilePath_Key, "Input NIfTI File", "The NIfTI-1 file to read (.nii or .nii.gz)", fs::path("input.nii"),
-                                                          FileSystemPathParameter::ExtensionsType{".nii", ".gz"}, FileSystemPathParameter::PathType::InputFile));
+                                                          FileSystemPathParameter::ExtensionsType{".nii", ".nii.gz"}, FileSystemPathParameter::PathType::InputFile));
   params.insert(std::make_unique<BoolParameter>(k_UseAffineIfPresent_Key, "Use Stored Affine Transform",
                                                 "If enabled and the file contains an sform/qform, use it to set the ImageGeom origin and spacing. Rotation components cannot be represented in an "
                                                 "axis-aligned image geometry; a warning will be emitted if the transform has a non-trivial rotation.",

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.cpp
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <filesystem>
 #include <map>
+#include <mutex>
 
 namespace fs = std::filesystem;
 
@@ -36,6 +37,7 @@ struct ReadNiftiHeaderCache
 
 std::atomic_int32_t s_InstanceId = 0;
 std::map<int32, ReadNiftiHeaderCache> s_HeaderCache;
+std::mutex s_HeaderCacheMutex;
 } // namespace
 
 namespace nx::core
@@ -44,12 +46,14 @@ namespace nx::core
 ReadNIfTIFileFilter::ReadNIfTIFileFilter()
 : m_InstanceId(s_InstanceId.fetch_add(1))
 {
+  std::lock_guard<std::mutex> lock(s_HeaderCacheMutex);
   s_HeaderCache[m_InstanceId] = {};
 }
 
 //------------------------------------------------------------------------------
 ReadNIfTIFileFilter::~ReadNIfTIFileFilter() noexcept
 {
+  std::lock_guard<std::mutex> lock(s_HeaderCacheMutex);
   s_HeaderCache.erase(m_InstanceId);
 }
 
@@ -150,24 +154,38 @@ IFilter::PreflightResult ReadNIfTIFileFilter::preflightImpl(const DataStructure&
     return {MakeErrorResult<OutputActions>(-34710, fmt::format("Input NIfTI file does not exist: '{}'", pInputFilePath.string()))};
   }
 
-  auto& cache = s_HeaderCache[m_InstanceId];
+  // Check the cache under the lock; copy the metadata out so the rest of
+  // preflight can work on a local value without holding the mutex across the
+  // action-building / CropImageGeometry subfilter dance.
   const auto currentTimeStamp = fs::last_write_time(pInputFilePath);
-  const bool cacheStale = (cache.inputFile != pInputFilePath.string()) || (cache.timeStamp != currentTimeStamp) || (cache.useAffineIfPresent != pUseAffineIfPresent);
+  nifti::NiftiMetadata md;
+  bool cacheValid = false;
+  {
+    std::lock_guard<std::mutex> lock(s_HeaderCacheMutex);
+    auto& cache = s_HeaderCache[m_InstanceId];
+    if(cache.inputFile == pInputFilePath.string() && cache.timeStamp == currentTimeStamp && cache.useAffineIfPresent == pUseAffineIfPresent)
+    {
+      md = cache.metadata;
+      cacheValid = true;
+    }
+  }
 
-  if(cacheStale)
+  if(!cacheValid)
   {
     auto metadataResult = nifti::ReadNiftiHeader(pInputFilePath, pUseAffineIfPresent);
     if(metadataResult.invalid())
     {
       return {ConvertResultTo<OutputActions>(ConvertResult(std::move(metadataResult)), {})};
     }
+    md = metadataResult.value();
+
+    std::lock_guard<std::mutex> lock(s_HeaderCacheMutex);
+    auto& cache = s_HeaderCache[m_InstanceId];
     cache.inputFile = pInputFilePath.string();
     cache.timeStamp = currentTimeStamp;
     cache.useAffineIfPresent = pUseAffineIfPresent;
-    cache.metadata = metadataResult.value();
+    cache.metadata = md;
   }
-
-  const auto& md = cache.metadata;
 
   // Start with the full-volume geometry from the header
   std::vector<usize> dims = {md.dimensions[0], md.dimensions[1], md.dimensions[2]};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.cpp
@@ -177,7 +177,7 @@ IFilter::PreflightResult ReadNIfTIFileFilter::preflightImpl(const DataStructure&
     {
       return {ConvertResultTo<OutputActions>(ConvertResult(std::move(metadataResult)), {})};
     }
-    md = metadataResult.value();
+    md = std::move(metadataResult).value();
 
     std::lock_guard<std::mutex> lock(s_HeaderCacheMutex);
     auto& cache = s_HeaderCache[m_InstanceId];

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.cpp
@@ -1,0 +1,236 @@
+#include "ReadNIfTIFileFilter.hpp"
+
+#include "SimplnxCore/Filters/Algorithms/ReadNIfTIFile.hpp"
+#include "SimplnxCore/utils/NiftiUtilities.hpp"
+
+#include "simplnx/DataStructure/DataPath.hpp"
+#include "simplnx/Filter/Actions/CreateArrayAction.hpp"
+#include "simplnx/Filter/Actions/CreateImageGeometryAction.hpp"
+#include "simplnx/Parameters/BoolParameter.hpp"
+#include "simplnx/Parameters/DataGroupCreationParameter.hpp"
+#include "simplnx/Parameters/DataObjectNameParameter.hpp"
+#include "simplnx/Parameters/FileSystemPathParameter.hpp"
+#include "simplnx/Utilities/GeometryHelpers.hpp"
+
+#include <atomic>
+#include <filesystem>
+#include <map>
+
+namespace fs = std::filesystem;
+
+using namespace nx::core;
+
+namespace
+{
+struct ReadNiftiHeaderCache
+{
+  std::string inputFile;
+  fs::file_time_type timeStamp{};
+  nx::core::nifti::NiftiMetadata metadata;
+  bool useAffineIfPresent{true};
+};
+
+std::atomic_int32_t s_InstanceId = 0;
+std::map<int32, ReadNiftiHeaderCache> s_HeaderCache;
+} // namespace
+
+namespace nx::core
+{
+//------------------------------------------------------------------------------
+ReadNIfTIFileFilter::ReadNIfTIFileFilter()
+: m_InstanceId(s_InstanceId.fetch_add(1))
+{
+  s_HeaderCache[m_InstanceId] = {};
+}
+
+//------------------------------------------------------------------------------
+ReadNIfTIFileFilter::~ReadNIfTIFileFilter() noexcept
+{
+  s_HeaderCache.erase(m_InstanceId);
+}
+
+//------------------------------------------------------------------------------
+std::string ReadNIfTIFileFilter::name() const
+{
+  return FilterTraits<ReadNIfTIFileFilter>::name.str();
+}
+
+//------------------------------------------------------------------------------
+std::string ReadNIfTIFileFilter::className() const
+{
+  return FilterTraits<ReadNIfTIFileFilter>::className;
+}
+
+//------------------------------------------------------------------------------
+Uuid ReadNIfTIFileFilter::uuid() const
+{
+  return FilterTraits<ReadNIfTIFileFilter>::uuid;
+}
+
+//------------------------------------------------------------------------------
+std::string ReadNIfTIFileFilter::humanName() const
+{
+  return "Read NIfTI File (Version 1)";
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> ReadNIfTIFileFilter::defaultTags() const
+{
+  return {"Read", "Import", "NIfTI", "NII", "Medical", "MRI"};
+}
+
+//------------------------------------------------------------------------------
+Parameters ReadNIfTIFileFilter::parameters() const
+{
+  Parameters params;
+
+  params.insertSeparator(Parameters::Separator{"Input Parameter(s)"});
+  params.insert(std::make_unique<FileSystemPathParameter>(k_InputFilePath_Key, "Input NIfTI File", "The NIfTI-1 file to read (.nii or .nii.gz)", fs::path("input.nii"),
+                                                          FileSystemPathParameter::ExtensionsType{".nii", ".gz"}, FileSystemPathParameter::PathType::InputFile));
+  params.insert(std::make_unique<BoolParameter>(k_UseAffineIfPresent_Key, "Use Stored Affine Transform",
+                                                "If enabled and the file contains an sform/qform, use it to set the ImageGeom origin and spacing. Rotation components cannot be represented in an "
+                                                "axis-aligned image geometry; a warning will be emitted if the transform has a non-trivial rotation.",
+                                                true));
+  params.insert(std::make_unique<BoolParameter>(k_ApplyScalingTransform_Key, "Apply Scaling Transform",
+                                                "If enabled and the file defines a non-trivial scaling (scl_slope != 0 and (slope != 1 or inter != 0)), apply y = slope*x + inter at read time. The "
+                                                "output array will be promoted to float32. Scaling is never applied to RGB24/RGBA32 data per the NIfTI-1 specification.",
+                                                true));
+
+  params.insertSeparator(Parameters::Separator{"Output Geometry"});
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_CreatedImageGeometryPath_Key, "Image Geometry", "Path to the created Image Geometry", DataPath({"NIfTI Image"})));
+
+  params.insertSeparator(Parameters::Separator{"Output Cell Attribute Matrix"});
+  params.insert(std::make_unique<DataObjectNameParameter>(k_CellAttributeMatrixName_Key, "Cell Attribute Matrix Name", "Name of the attribute matrix holding the voxel data", "Cell Data"));
+
+  params.insertSeparator(Parameters::Separator{"Output Data Array"});
+  params.insert(std::make_unique<DataObjectNameParameter>(k_ImageDataArrayName_Key, "Image Data Array Name", "Name of the array that will hold the voxel values", "ImageData"));
+
+  return params;
+}
+
+//------------------------------------------------------------------------------
+IFilter::VersionType ReadNIfTIFileFilter::parametersVersion() const
+{
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+IFilter::UniquePointer ReadNIfTIFileFilter::clone() const
+{
+  return std::make_unique<ReadNIfTIFileFilter>();
+}
+
+//------------------------------------------------------------------------------
+IFilter::PreflightResult ReadNIfTIFileFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                                            const ExecutionContext& executionContext) const
+{
+  auto pInputFilePath = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFilePath_Key);
+  auto pUseAffineIfPresent = filterArgs.value<bool>(k_UseAffineIfPresent_Key);
+  auto pApplyScaling = filterArgs.value<bool>(k_ApplyScalingTransform_Key);
+  auto pImageGeomPath = filterArgs.value<DataPath>(k_CreatedImageGeometryPath_Key);
+  auto pCellAttrMatName = filterArgs.value<std::string>(k_CellAttributeMatrixName_Key);
+  auto pImageDataArrayName = filterArgs.value<std::string>(k_ImageDataArrayName_Key);
+
+  Result<OutputActions> resultOutputActions;
+  std::vector<PreflightValue> preflightUpdatedValues;
+
+  if(!fs::exists(pInputFilePath))
+  {
+    return {MakeErrorResult<OutputActions>(-34710, fmt::format("Input NIfTI file does not exist: '{}'", pInputFilePath.string()))};
+  }
+
+  auto& cache = s_HeaderCache[m_InstanceId];
+  const auto currentTimeStamp = fs::last_write_time(pInputFilePath);
+  const bool cacheStale = (cache.inputFile != pInputFilePath.string()) || (cache.timeStamp != currentTimeStamp) || (cache.useAffineIfPresent != pUseAffineIfPresent);
+
+  if(cacheStale)
+  {
+    auto metadataResult = nifti::ReadNiftiHeader(pInputFilePath, pUseAffineIfPresent);
+    if(metadataResult.invalid())
+    {
+      return {ConvertResultTo<OutputActions>(ConvertResult(std::move(metadataResult)), {})};
+    }
+    cache.inputFile = pInputFilePath.string();
+    cache.timeStamp = currentTimeStamp;
+    cache.useAffineIfPresent = pUseAffineIfPresent;
+    cache.metadata = metadataResult.value();
+  }
+
+  const auto& md = cache.metadata;
+
+  CreateImageGeometryAction::DimensionType dims = {md.dimensions[0], md.dimensions[1], md.dimensions[2]};
+  CreateImageGeometryAction::OriginType origin = {md.origin[0], md.origin[1], md.origin[2]};
+  CreateImageGeometryAction::SpacingType spacing = {md.spacing[0], md.spacing[1], md.spacing[2]};
+
+  {
+    auto createGeomAction = std::make_unique<CreateImageGeometryAction>(pImageGeomPath, dims, origin, spacing, pCellAttrMatName);
+    resultOutputActions.value().appendAction(std::move(createGeomAction));
+  }
+
+  // Determine output DataType. If the file has non-trivial scaling and the user
+  // wants to apply it, promote single-component integer types to float32.
+  DataType outputDataType = md.dataType;
+  if(pApplyScaling && md.hasNontrivialScaling && md.componentCount == 1)
+  {
+    outputDataType = DataType::float32;
+  }
+
+  // DataArray tuple dims mirror the reversed image dims (z, y, x)
+  const std::vector<usize> tupleDims = {md.dimensions[2], md.dimensions[1], md.dimensions[0]};
+  const std::vector<usize> componentDims = {md.componentCount};
+  const DataPath dataArrayPath = pImageGeomPath.createChildPath(pCellAttrMatName).createChildPath(pImageDataArrayName);
+  {
+    auto createArrayAction = std::make_unique<CreateArrayAction>(outputDataType, tupleDims, componentDims, dataArrayPath);
+    resultOutputActions.value().appendAction(std::move(createArrayAction));
+  }
+
+  preflightUpdatedValues.push_back({"Imported Geometry Info", nx::core::GeometryHelpers::Description::GenerateGeometryInfo(dims, spacing, origin, IGeometry::LengthUnit::Unspecified)});
+
+  std::string scalingSummary = md.hasNontrivialScaling ? fmt::format("slope={}, inter={}{}", md.sclSlope, md.sclInter, (pApplyScaling ? " (applied → float32)" : " (not applied)")) : "none";
+  preflightUpdatedValues.push_back({"NIfTI Header", fmt::format("datatype code: {}  |  components: {}  |  byte-swap: {}  |  vox_offset: {}  |  scaling: {}", md.niftiDatatype, md.componentCount,
+                                                                md.byteSwapRequired ? "yes" : "no", md.voxOffset, scalingSummary)});
+
+  if(md.affineHasRotation)
+  {
+    resultOutputActions.warnings().push_back(Warning{
+        -34750, fmt::format("NIfTI file '{}' contains a non-trivial rotation in its {} transform. The ImageGeom in simplnx is axis-aligned; the rotation component has been dropped and only the "
+                            "spacing and origin were extracted. Voxels will be loaded in their stored orientation.",
+                            md.filePath, (md.sformCode > 0 ? "sform" : "qform"))});
+  }
+  if(md.niftiDatatype == NIFTI_TYPE_RGB24 || md.niftiDatatype == NIFTI_TYPE_RGBA32)
+  {
+    if(pApplyScaling && (md.sclSlope != 0.0f && (md.sclSlope != 1.0f || md.sclInter != 0.0f)))
+    {
+      resultOutputActions.warnings().push_back(Warning{
+          -34751, fmt::format("NIfTI file '{}' has datatype {} with a scaling transform. Per the NIfTI-1 specification, scaling is not applied to RGB24/RGBA32 data; voxels were copied verbatim.",
+                              md.filePath, (md.niftiDatatype == NIFTI_TYPE_RGB24 ? "RGB24" : "RGBA32"))});
+    }
+  }
+
+  return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
+}
+
+//------------------------------------------------------------------------------
+Result<> ReadNIfTIFileFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                                          const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+{
+  ReadNIfTIFileInputValues inputValues;
+  inputValues.InputFilePath = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFilePath_Key);
+  inputValues.UseAffineIfPresent = filterArgs.value<bool>(k_UseAffineIfPresent_Key);
+  inputValues.ApplyScalingTransform = filterArgs.value<bool>(k_ApplyScalingTransform_Key);
+  inputValues.ImageGeometryPath = filterArgs.value<DataPath>(k_CreatedImageGeometryPath_Key);
+  inputValues.CellAttributeMatrixName = filterArgs.value<std::string>(k_CellAttributeMatrixName_Key);
+  inputValues.ImageDataArrayName = filterArgs.value<std::string>(k_ImageDataArrayName_Key);
+
+  return ReadNIfTIFile(dataStructure, messageHandler, shouldCancel, &inputValues)();
+}
+
+//------------------------------------------------------------------------------
+Result<Arguments> ReadNIfTIFileFilter::FromSIMPLJson(const nlohmann::json& json)
+{
+  Arguments args = ReadNIfTIFileFilter().getDefaultArguments();
+  // New filter in simplnx; no SIMPL v6 equivalent.
+  return {std::move(args)};
+}
+
+} // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.cpp
@@ -1,15 +1,19 @@
 #include "ReadNIfTIFileFilter.hpp"
 
 #include "SimplnxCore/Filters/Algorithms/ReadNIfTIFile.hpp"
+#include "SimplnxCore/Filters/CropImageGeometryFilter.hpp"
 #include "SimplnxCore/utils/NiftiUtilities.hpp"
 
 #include "simplnx/DataStructure/DataPath.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Filter/Actions/CreateArrayAction.hpp"
 #include "simplnx/Filter/Actions/CreateImageGeometryAction.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
+#include "simplnx/Parameters/CropGeometryParameter.hpp"
 #include "simplnx/Parameters/DataGroupCreationParameter.hpp"
 #include "simplnx/Parameters/DataObjectNameParameter.hpp"
 #include "simplnx/Parameters/FileSystemPathParameter.hpp"
+#include "simplnx/Parameters/VectorParameter.hpp"
 #include "simplnx/Utilities/GeometryHelpers.hpp"
 
 #include <atomic>
@@ -96,6 +100,12 @@ Parameters ReadNIfTIFileFilter::parameters() const
                                                 "output array will be promoted to float32. Scaling is never applied to RGB24/RGBA32 data per the NIfTI-1 specification.",
                                                 true));
 
+  params.insertSeparator(Parameters::Separator{"Cropping Options"});
+  params.insert(std::make_unique<CropGeometryParameter>(k_CroppingOptions_Key, "Cropping Options",
+                                                        "Optional cropping of the volume while it is being read. When cropping is enabled, only the selected sub-volume is streamed into memory; the "
+                                                        "rest of the file is discarded on read. Supports both voxel index and physical coordinate bounds.",
+                                                        CropGeometryParameter::ValueType{}));
+
   params.insertSeparator(Parameters::Separator{"Output Geometry"});
   params.insert(std::make_unique<DataGroupCreationParameter>(k_CreatedImageGeometryPath_Key, "Image Geometry", "Path to the created Image Geometry", DataPath({"NIfTI Image"})));
 
@@ -127,6 +137,7 @@ IFilter::PreflightResult ReadNIfTIFileFilter::preflightImpl(const DataStructure&
   auto pInputFilePath = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFilePath_Key);
   auto pUseAffineIfPresent = filterArgs.value<bool>(k_UseAffineIfPresent_Key);
   auto pApplyScaling = filterArgs.value<bool>(k_ApplyScalingTransform_Key);
+  auto pCroppingOptions = filterArgs.value<CropGeometryParameter::ValueType>(k_CroppingOptions_Key);
   auto pImageGeomPath = filterArgs.value<DataPath>(k_CreatedImageGeometryPath_Key);
   auto pCellAttrMatName = filterArgs.value<std::string>(k_CellAttributeMatrixName_Key);
   auto pImageDataArrayName = filterArgs.value<std::string>(k_ImageDataArrayName_Key);
@@ -158,9 +169,74 @@ IFilter::PreflightResult ReadNIfTIFileFilter::preflightImpl(const DataStructure&
 
   const auto& md = cache.metadata;
 
-  CreateImageGeometryAction::DimensionType dims = {md.dimensions[0], md.dimensions[1], md.dimensions[2]};
-  CreateImageGeometryAction::OriginType origin = {md.origin[0], md.origin[1], md.origin[2]};
-  CreateImageGeometryAction::SpacingType spacing = {md.spacing[0], md.spacing[1], md.spacing[2]};
+  // Start with the full-volume geometry from the header
+  std::vector<usize> dims = {md.dimensions[0], md.dimensions[1], md.dimensions[2]};
+  std::vector<float32> origin = {md.origin[0], md.origin[1], md.origin[2]};
+  std::vector<float32> spacing = {md.spacing[0], md.spacing[1], md.spacing[2]};
+
+  preflightUpdatedValues.push_back({"Full Input Geometry", nx::core::GeometryHelpers::Description::GenerateGeometryInfo(dims, spacing, origin, IGeometry::LengthUnit::Unspecified)});
+
+  // If cropping is enabled, run CropImageGeometryFilter::preflight on a temp
+  // DataStructure to compute the cropped dims / origin / spacing
+  if(pCroppingOptions.type != CropGeometryParameter::CropValues::TypeEnum::NoCropping)
+  {
+    DataStructure tmpDs;
+    OutputActions tmpActions;
+    {
+      auto tmpGeomAction = std::make_unique<CreateImageGeometryAction>(pImageGeomPath, dims, origin, spacing, pCellAttrMatName);
+      tmpActions.appendAction(std::move(tmpGeomAction));
+    }
+    Result<> tmpActionsResult = tmpActions.applyAll(tmpDs, IDataAction::Mode::Preflight);
+    if(tmpActionsResult.invalid())
+    {
+      return {ConvertResultTo<OutputActions>(std::move(tmpActionsResult), {})};
+    }
+
+    CropImageGeometryFilter cropImageGeomFilter;
+    Arguments cropImageGeomArgs;
+    cropImageGeomArgs.insertOrAssign("input_image_geometry_path", std::make_any<DataPath>(pImageGeomPath));
+    cropImageGeomArgs.insertOrAssign("use_physical_bounds", std::make_any<bool>(pCroppingOptions.type == CropGeometryParameter::CropValues::TypeEnum::PhysicalSubvolume));
+    cropImageGeomArgs.insertOrAssign("crop_x_dim", std::make_any<bool>(pCroppingOptions.cropX));
+    cropImageGeomArgs.insertOrAssign("crop_y_dim", std::make_any<bool>(pCroppingOptions.cropY));
+    cropImageGeomArgs.insertOrAssign("crop_z_dim", std::make_any<bool>(pCroppingOptions.cropZ));
+    if(pCroppingOptions.type == CropGeometryParameter::CropValues::TypeEnum::VoxelSubvolume)
+    {
+      cropImageGeomArgs.insertOrAssign("min_voxel",
+                                       std::make_any<VectorUInt64Parameter::ValueType>({static_cast<uint64>(pCroppingOptions.xBoundVoxels[0]), static_cast<uint64>(pCroppingOptions.yBoundVoxels[0]),
+                                                                                        static_cast<uint64>(pCroppingOptions.zBoundVoxels[0])}));
+      cropImageGeomArgs.insertOrAssign("max_voxel",
+                                       std::make_any<VectorUInt64Parameter::ValueType>({static_cast<uint64>(pCroppingOptions.xBoundVoxels[1]), static_cast<uint64>(pCroppingOptions.yBoundVoxels[1]),
+                                                                                        static_cast<uint64>(pCroppingOptions.zBoundVoxels[1])}));
+    }
+    else
+    {
+      cropImageGeomArgs.insertOrAssign(
+          "min_coord", std::make_any<VectorFloat64Parameter::ValueType>({static_cast<float64>(pCroppingOptions.xBoundPhysical[0]), static_cast<float64>(pCroppingOptions.yBoundPhysical[0]),
+                                                                         static_cast<float64>(pCroppingOptions.zBoundPhysical[0])}));
+      cropImageGeomArgs.insertOrAssign(
+          "max_coord", std::make_any<VectorFloat64Parameter::ValueType>({static_cast<float64>(pCroppingOptions.xBoundPhysical[1]), static_cast<float64>(pCroppingOptions.yBoundPhysical[1]),
+                                                                         static_cast<float64>(pCroppingOptions.zBoundPhysical[1])}));
+    }
+    cropImageGeomArgs.insertOrAssign("remove_original_geometry", std::make_any<bool>(false));
+    const DataPath croppedGeomPath({pImageGeomPath.getTargetName() + "_cropped"});
+    cropImageGeomArgs.insertOrAssign("output_image_geometry_path", std::make_any<DataPath>(croppedGeomPath));
+
+    PreflightResult cropImageResult = cropImageGeomFilter.preflight(tmpDs, cropImageGeomArgs, messageHandler, shouldCancel);
+    if(cropImageResult.outputActions.invalid())
+    {
+      return cropImageResult;
+    }
+    Result<> actionsResult = cropImageResult.outputActions.value().applyAll(tmpDs, IDataAction::Mode::Preflight);
+    if(actionsResult.invalid())
+    {
+      return {ConvertResultTo<OutputActions>(std::move(actionsResult), {})};
+    }
+
+    const auto& croppedGeom = tmpDs.getDataRefAs<ImageGeom>(croppedGeomPath);
+    dims = croppedGeom.getDimensions().toContainer<std::vector<usize>>();
+    origin = croppedGeom.getOrigin().toContainer<std::vector<float32>>();
+    spacing = croppedGeom.getSpacing().toContainer<std::vector<float32>>();
+  }
 
   {
     auto createGeomAction = std::make_unique<CreateImageGeometryAction>(pImageGeomPath, dims, origin, spacing, pCellAttrMatName);
@@ -168,7 +244,7 @@ IFilter::PreflightResult ReadNIfTIFileFilter::preflightImpl(const DataStructure&
   }
 
   // Determine output DataType. If the file has non-trivial scaling and the user
-  // wants to apply it, promote single-component integer types to float32.
+  // wants to apply it, promote single-component types to float32.
   DataType outputDataType = md.dataType;
   if(pApplyScaling && md.hasNontrivialScaling && md.componentCount == 1)
   {
@@ -176,7 +252,7 @@ IFilter::PreflightResult ReadNIfTIFileFilter::preflightImpl(const DataStructure&
   }
 
   // DataArray tuple dims mirror the reversed image dims (z, y, x)
-  const std::vector<usize> tupleDims = {md.dimensions[2], md.dimensions[1], md.dimensions[0]};
+  const std::vector<usize> tupleDims = {dims[2], dims[1], dims[0]};
   const std::vector<usize> componentDims = {md.componentCount};
   const DataPath dataArrayPath = pImageGeomPath.createChildPath(pCellAttrMatName).createChildPath(pImageDataArrayName);
   {
@@ -218,6 +294,7 @@ Result<> ReadNIfTIFileFilter::executeImpl(DataStructure& dataStructure, const Ar
   inputValues.InputFilePath = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFilePath_Key);
   inputValues.UseAffineIfPresent = filterArgs.value<bool>(k_UseAffineIfPresent_Key);
   inputValues.ApplyScalingTransform = filterArgs.value<bool>(k_ApplyScalingTransform_Key);
+  inputValues.CroppingOptions = filterArgs.value<CropGeometryParameter::ValueType>(k_CroppingOptions_Key);
   inputValues.ImageGeometryPath = filterArgs.value<DataPath>(k_CreatedImageGeometryPath_Key);
   inputValues.CellAttributeMatrixName = filterArgs.value<std::string>(k_CellAttributeMatrixName_Key);
   inputValues.ImageDataArrayName = filterArgs.value<std::string>(k_ImageDataArrayName_Key);

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.hpp
@@ -33,7 +33,7 @@ public:
   static inline constexpr StringLiteral k_InputFilePath_Key = "input_file_path";
   static inline constexpr StringLiteral k_UseAffineIfPresent_Key = "use_affine_if_present";
   static inline constexpr StringLiteral k_ApplyScalingTransform_Key = "apply_scaling_transform";
-  static inline constexpr StringLiteral k_CroppingOptions_Key = "cropping_options";
+  static inline constexpr StringLiteral k_CroppingOptions_Key = "cropping_options_index";
   static inline constexpr StringLiteral k_CreatedImageGeometryPath_Key = "output_image_geometry_path";
   static inline constexpr StringLiteral k_CellAttributeMatrixName_Key = "cell_attribute_matrix_name";
   static inline constexpr StringLiteral k_ImageDataArrayName_Key = "image_data_array_name";

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "SimplnxCore/SimplnxCore_export.hpp"
+
+#include "simplnx/Filter/FilterTraits.hpp"
+#include "simplnx/Filter/IFilter.hpp"
+
+namespace nx::core
+{
+/**
+ * @class ReadNIfTIFileFilter
+ * @brief Reads a single-file NIfTI-1 (.nii or .nii.gz) volume into an ImageGeom + DataArray.
+ *
+ * Supports 3D NIfTI-1 volumes only. Recognized voxel datatypes: uint8/int8,
+ * uint16/int16, uint32/int32, uint64/int64, float32, float64, RGB24, RGBA32.
+ * When the input file specifies a non-identity scaling transform
+ * (scl_slope != 0 and (slope != 1 or inter != 0)) and the user elects to
+ * apply it, the output array is promoted to float32.
+ */
+class SIMPLNXCORE_EXPORT ReadNIfTIFileFilter : public IFilter
+{
+public:
+  ReadNIfTIFileFilter();
+  ~ReadNIfTIFileFilter() noexcept override;
+
+  ReadNIfTIFileFilter(const ReadNIfTIFileFilter&) = delete;
+  ReadNIfTIFileFilter(ReadNIfTIFileFilter&&) noexcept = delete;
+
+  ReadNIfTIFileFilter& operator=(const ReadNIfTIFileFilter&) = delete;
+  ReadNIfTIFileFilter& operator=(ReadNIfTIFileFilter&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_InputFilePath_Key = "input_file_path";
+  static inline constexpr StringLiteral k_UseAffineIfPresent_Key = "use_affine_if_present";
+  static inline constexpr StringLiteral k_ApplyScalingTransform_Key = "apply_scaling_transform";
+  static inline constexpr StringLiteral k_CreatedImageGeometryPath_Key = "output_image_geometry_path";
+  static inline constexpr StringLiteral k_CellAttributeMatrixName_Key = "cell_attribute_matrix_name";
+  static inline constexpr StringLiteral k_ImageDataArrayName_Key = "image_data_array_name";
+
+  /**
+   * @brief Reads SIMPL json and converts it to simplnx Arguments.
+   */
+  static Result<Arguments> FromSIMPLJson(const nlohmann::json& json);
+
+  std::string name() const override;
+  std::string className() const override;
+  Uuid uuid() const override;
+  std::string humanName() const override;
+  std::vector<std::string> defaultTags() const override;
+  Parameters parameters() const override;
+  VersionType parametersVersion() const override;
+  UniquePointer clone() const override;
+
+protected:
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
+
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
+
+private:
+  int32 m_InstanceId;
+};
+} // namespace nx::core
+
+SIMPLNX_DEF_FILTER_TRAITS(nx::core, ReadNIfTIFileFilter, "e69e51e5-2a9f-40ca-8038-1d2be7925c62");

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadNIfTIFileFilter.hpp
@@ -33,6 +33,7 @@ public:
   static inline constexpr StringLiteral k_InputFilePath_Key = "input_file_path";
   static inline constexpr StringLiteral k_UseAffineIfPresent_Key = "use_affine_if_present";
   static inline constexpr StringLiteral k_ApplyScalingTransform_Key = "apply_scaling_transform";
+  static inline constexpr StringLiteral k_CroppingOptions_Key = "cropping_options";
   static inline constexpr StringLiteral k_CreatedImageGeometryPath_Key = "output_image_geometry_path";
   static inline constexpr StringLiteral k_CellAttributeMatrixName_Key = "cell_attribute_matrix_name";
   static inline constexpr StringLiteral k_ImageDataArrayName_Key = "image_data_array_name";

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadZeissTxmFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadZeissTxmFileFilter.cpp
@@ -15,6 +15,8 @@
 #include "simplnx/Utilities/GeometryHelpers.hpp"
 #include "simplnx/Utilities/SIMPLConversion.hpp"
 
+#include <mutex>
+
 using namespace nx::core;
 using namespace read_zeiss_txm;
 
@@ -22,6 +24,7 @@ namespace
 {
 std::atomic_int32_t s_InstanceId = 0;
 std::map<int32, ReadZeissTxmFilterFileCache> s_HeaderCache;
+std::mutex s_HeaderCacheMutex;
 } // namespace
 
 namespace nx::core
@@ -30,12 +33,14 @@ namespace nx::core
 ReadZeissTxmFileFilter::ReadZeissTxmFileFilter()
 : m_InstanceId(s_InstanceId.fetch_add(1))
 {
+  std::lock_guard<std::mutex> lock(s_HeaderCacheMutex);
   s_HeaderCache[m_InstanceId] = {};
 }
 
 //------------------------------------------------------------------------------
 ReadZeissTxmFileFilter::~ReadZeissTxmFileFilter() noexcept
 {
+  std::lock_guard<std::mutex> lock(s_HeaderCacheMutex);
   s_HeaderCache.erase(m_InstanceId);
 }
 
@@ -119,24 +124,37 @@ IFilter::PreflightResult ReadZeissTxmFileFilter::preflightImpl(const DataStructu
   nx::core::Result<OutputActions> resultOutputActions;
   std::vector<PreflightValue> preflightUpdatedValues;
 
-  // Read from the file if the input file has changed or the input file's time stamp is out of date.
-  if(pInputFilePathValue != s_HeaderCache[m_InstanceId].inputFile || s_HeaderCache[m_InstanceId].timeStamp < fs::last_write_time(pInputFilePathValue))
+  // Check the cache under the lock. If the cached entry is fresh, copy the
+  // metadata out so the rest of preflight can work on a local value without
+  // holding the cache mutex across actions/IO.
+  ZeissTxmHeaderMetadata metadata;
+  bool cacheValid = false;
+  const auto currentTimeStamp = fs::last_write_time(pInputFilePathValue);
+  {
+    std::lock_guard<std::mutex> lock(s_HeaderCacheMutex);
+    auto& cached = s_HeaderCache[m_InstanceId];
+    if(pInputFilePathValue == cached.inputFile && cached.timeStamp >= currentTimeStamp)
+    {
+      metadata = cached.metaData;
+      cacheValid = true;
+    }
+  }
+
+  if(!cacheValid)
   {
     Result<ZeissTxmHeaderMetadata> metadataResult = ReadHeaderMetaData(pInputFilePathValue.string());
     if(metadataResult.invalid())
     {
       return {ConvertResultTo<OutputActions>(ConvertResult(std::move(metadataResult)), {})};
     }
+    metadata = metadataResult.value();
 
-    // Cache the results from algorithm run
-    ReadZeissTxmFilterFileCache inputFileCache = {};
-    inputFileCache.inputFile = pInputFilePathValue.string();
-    inputFileCache.timeStamp = fs::last_write_time(pInputFilePathValue.string());
-    inputFileCache.metaData = metadataResult.value();
-    s_HeaderCache[m_InstanceId] = inputFileCache;
+    std::lock_guard<std::mutex> lock(s_HeaderCacheMutex);
+    auto& cached = s_HeaderCache[m_InstanceId];
+    cached.inputFile = pInputFilePathValue.string();
+    cached.timeStamp = currentTimeStamp;
+    cached.metaData = metadata;
   }
-
-  ZeissTxmHeaderMetadata& metadata = s_HeaderCache[m_InstanceId].metaData;
   preflightUpdatedValues.push_back({"Full Input Geometry", nx::core::GeometryHelpers::Description::GenerateGeometryInfo(metadata.Dimensions, metadata.Spacing, metadata.Origin, metadata.Units)});
 
   CreateImageGeometryAction::DimensionType dims = metadata.Dimensions;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadZeissTxmFileFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadZeissTxmFileFilter.hpp
@@ -29,7 +29,7 @@ public:
   static constexpr StringLiteral k_CreatedImageGeometryPath_Key = "output_image_geometry_path";
   static constexpr StringLiteral k_CellAttributeMatrixName_Key = "cell_attribute_matrix_name";
   static constexpr StringLiteral k_CTDataArrayName_Key = "ct_data_array_name";
-  static constexpr StringLiteral k_CroppingOptions_Key = "cropping_options";
+  static constexpr StringLiteral k_CroppingOptions_Key = "cropping_options_index";
 
   /**
    * @brief Returns the name of the filter.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/NiftiUtilities.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/NiftiUtilities.cpp
@@ -257,7 +257,6 @@ Result<NiftiMetadata> ReadNiftiHeader(const std::filesystem::path& filePath, boo
         }
       }
     }
-    md.affineApplied = true;
   }
   else if(useAffineIfPresent && hdr.qform_code > 0)
   {
@@ -267,7 +266,6 @@ Result<NiftiMetadata> ReadNiftiHeader(const std::filesystem::path& filePath, boo
     {
       md.affineHasRotation = true;
     }
-    md.affineApplied = true;
   }
   else
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/NiftiUtilities.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/NiftiUtilities.cpp
@@ -1,0 +1,292 @@
+#include "NiftiUtilities.hpp"
+
+#include "simplnx/Common/Bit.hpp"
+
+#include <fmt/format.h>
+#include <zlib.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace nx::core::nifti
+{
+static_assert(sizeof(nifti_1_header) == k_HeaderSize, "nifti_1_header must be exactly 348 bytes");
+static_assert(sizeof(int) == 4, "NIfTI-1 assumes sizeof(int) == 4");
+static_assert(sizeof(short) == 2, "NIfTI-1 assumes sizeof(short) == 2");
+static_assert(sizeof(float) == 4, "NIfTI-1 assumes sizeof(float) == 4");
+
+namespace
+{
+template <class T>
+void SwapInPlace(T& value)
+{
+  value = nx::core::byteswap(value);
+}
+
+void ByteSwapHeader(nifti_1_header& hdr)
+{
+  SwapInPlace(hdr.sizeof_hdr);
+  SwapInPlace(hdr.extents);
+  SwapInPlace(hdr.session_error);
+  for(auto& v : hdr.dim)
+  {
+    SwapInPlace(v);
+  }
+  SwapInPlace(hdr.intent_p1);
+  SwapInPlace(hdr.intent_p2);
+  SwapInPlace(hdr.intent_p3);
+  SwapInPlace(hdr.intent_code);
+  SwapInPlace(hdr.datatype);
+  SwapInPlace(hdr.bitpix);
+  SwapInPlace(hdr.slice_start);
+  for(auto& v : hdr.pixdim)
+  {
+    SwapInPlace(v);
+  }
+  SwapInPlace(hdr.vox_offset);
+  SwapInPlace(hdr.scl_slope);
+  SwapInPlace(hdr.scl_inter);
+  SwapInPlace(hdr.slice_end);
+  SwapInPlace(hdr.cal_max);
+  SwapInPlace(hdr.cal_min);
+  SwapInPlace(hdr.slice_duration);
+  SwapInPlace(hdr.toffset);
+  SwapInPlace(hdr.glmax);
+  SwapInPlace(hdr.glmin);
+  SwapInPlace(hdr.qform_code);
+  SwapInPlace(hdr.sform_code);
+  SwapInPlace(hdr.quatern_b);
+  SwapInPlace(hdr.quatern_c);
+  SwapInPlace(hdr.quatern_d);
+  SwapInPlace(hdr.qoffset_x);
+  SwapInPlace(hdr.qoffset_y);
+  SwapInPlace(hdr.qoffset_z);
+  for(auto& v : hdr.srow_x)
+  {
+    SwapInPlace(v);
+  }
+  for(auto& v : hdr.srow_y)
+  {
+    SwapInPlace(v);
+  }
+  for(auto& v : hdr.srow_z)
+  {
+    SwapInPlace(v);
+  }
+}
+} // namespace
+
+std::optional<NiftiTypeInfo> NiftiDatatypeToSimplnx(int16 niftiDatatype)
+{
+  switch(niftiDatatype)
+  {
+  case NIFTI_TYPE_UINT8:
+    return NiftiTypeInfo{DataType::uint8, 1, 8};
+  case NIFTI_TYPE_INT8:
+    return NiftiTypeInfo{DataType::int8, 1, 8};
+  case NIFTI_TYPE_UINT16:
+    return NiftiTypeInfo{DataType::uint16, 1, 16};
+  case NIFTI_TYPE_INT16:
+    return NiftiTypeInfo{DataType::int16, 1, 16};
+  case NIFTI_TYPE_UINT32:
+    return NiftiTypeInfo{DataType::uint32, 1, 32};
+  case NIFTI_TYPE_INT32:
+    return NiftiTypeInfo{DataType::int32, 1, 32};
+  case NIFTI_TYPE_UINT64:
+    return NiftiTypeInfo{DataType::uint64, 1, 64};
+  case NIFTI_TYPE_INT64:
+    return NiftiTypeInfo{DataType::int64, 1, 64};
+  case NIFTI_TYPE_FLOAT32:
+    return NiftiTypeInfo{DataType::float32, 1, 32};
+  case NIFTI_TYPE_FLOAT64:
+    return NiftiTypeInfo{DataType::float64, 1, 64};
+  case NIFTI_TYPE_RGB24:
+    return NiftiTypeInfo{DataType::uint8, 3, 24};
+  case NIFTI_TYPE_RGBA32:
+    return NiftiTypeInfo{DataType::uint8, 4, 32};
+  default:
+    return std::nullopt;
+  }
+}
+
+Result<NiftiMetadata> ReadNiftiHeader(const std::filesystem::path& filePath, bool useAffineIfPresent)
+{
+  const std::string pathStr = filePath.string();
+  gzFile gz = gzopen(pathStr.c_str(), "rb");
+  if(gz == nullptr)
+  {
+    return MakeErrorResult<NiftiMetadata>(-34700, fmt::format("Could not open NIfTI file for reading: '{}'", pathStr));
+  }
+
+  nifti_1_header hdr{};
+  int bytesRead = gzread(gz, &hdr, static_cast<unsigned int>(k_HeaderSize));
+  gzclose(gz);
+
+  if(bytesRead != static_cast<int>(k_HeaderSize))
+  {
+    return MakeErrorResult<NiftiMetadata>(-34701, fmt::format("Failed to read 348-byte NIfTI-1 header from '{}' (read {} bytes)", pathStr, bytesRead));
+  }
+
+  bool byteSwap = false;
+  if(hdr.sizeof_hdr != static_cast<int>(k_HeaderSize))
+  {
+    int swapped = nx::core::byteswap(hdr.sizeof_hdr);
+    if(swapped == static_cast<int>(k_HeaderSize))
+    {
+      byteSwap = true;
+      ByteSwapHeader(hdr);
+    }
+    else
+    {
+      return MakeErrorResult<NiftiMetadata>(
+          -34702, fmt::format("Invalid NIfTI-1 header in '{}': sizeof_hdr={} (expected 348 in either byte order). File does not appear to be a valid NIfTI-1 file.", pathStr, hdr.sizeof_hdr));
+    }
+  }
+
+  if(std::memcmp(hdr.magic, k_SingleFileMagic.data(), 4) != 0)
+  {
+    if(std::memcmp(hdr.magic, k_PairFileMagic.data(), 4) == 0)
+    {
+      return MakeErrorResult<NiftiMetadata>(
+          -34703, fmt::format("NIfTI file '{}' uses the .hdr/.img pair format (magic='ni1'). This filter only supports the single-file format (.nii / .nii.gz, magic='n+1').", pathStr));
+    }
+    const std::string magicDisplay(hdr.magic, hdr.magic + 4);
+    return MakeErrorResult<NiftiMetadata>(-34704, fmt::format("NIfTI file '{}' has unrecognized magic value '{}'. Expected 'n+1' for a single-file NIfTI-1.", pathStr, magicDisplay));
+  }
+
+  const int16 rank = hdr.dim[0];
+  if(rank != 3)
+  {
+    return MakeErrorResult<NiftiMetadata>(-34705, fmt::format("NIfTI file '{}' is {}-dimensional (dim[0]={}). This filter currently supports 3D NIfTI files only.", pathStr, rank, rank));
+  }
+
+  if(hdr.dim[1] <= 0 || hdr.dim[2] <= 0 || hdr.dim[3] <= 0)
+  {
+    return MakeErrorResult<NiftiMetadata>(-34706, fmt::format("NIfTI file '{}' has invalid dimensions: ({}, {}, {})", pathStr, hdr.dim[1], hdr.dim[2], hdr.dim[3]));
+  }
+
+  auto typeInfo = NiftiDatatypeToSimplnx(hdr.datatype);
+  if(!typeInfo.has_value())
+  {
+    return MakeErrorResult<NiftiMetadata>(-34707, fmt::format("NIfTI file '{}' has unsupported datatype code {} (bitpix={}). Supported: uint8/int8, uint16/int16, uint32/int32, uint64/int64, "
+                                                              "float32, float64, RGB24, RGBA32.",
+                                                              pathStr, hdr.datatype, hdr.bitpix));
+  }
+
+  if(hdr.bitpix != 0 && hdr.bitpix != typeInfo->bitpix)
+  {
+    return MakeErrorResult<NiftiMetadata>(-34708,
+                                          fmt::format("NIfTI file '{}': datatype code {} implies bitpix={}, but header reports bitpix={}.", pathStr, hdr.datatype, typeInfo->bitpix, hdr.bitpix));
+  }
+
+  NiftiMetadata md;
+  md.filePath = pathStr;
+  md.magic = std::string(hdr.magic, hdr.magic + 3);
+  for(int i = 0; i < 8; i++)
+  {
+    md.dim[i] = hdr.dim[i];
+    md.pixdim[i] = hdr.pixdim[i];
+  }
+  md.dimensions = {static_cast<usize>(hdr.dim[1]), static_cast<usize>(hdr.dim[2]), static_cast<usize>(hdr.dim[3])};
+
+  // Default spacing from pixdim, fallback to 1.0 for zero values
+  md.spacing = {std::fabs(hdr.pixdim[1]), std::fabs(hdr.pixdim[2]), std::fabs(hdr.pixdim[3])};
+  for(auto& s : md.spacing)
+  {
+    if(s == 0.0f)
+    {
+      s = 1.0f;
+    }
+  }
+
+  md.niftiDatatype = hdr.datatype;
+  md.bitpix = typeInfo->bitpix;
+  md.dataType = typeInfo->dataType;
+  md.componentCount = typeInfo->componentCount;
+
+  usize vo = (hdr.vox_offset <= 0.0f) ? k_MinVoxOffset : static_cast<usize>(hdr.vox_offset);
+  if(vo < k_MinVoxOffset)
+  {
+    vo = k_MinVoxOffset;
+  }
+  md.voxOffset = vo;
+  md.byteSwapRequired = byteSwap;
+
+  md.sclSlope = hdr.scl_slope;
+  md.sclInter = hdr.scl_inter;
+  md.hasNontrivialScaling = (hdr.scl_slope != 0.0f) && (hdr.scl_slope != 1.0f || hdr.scl_inter != 0.0f);
+  if(md.niftiDatatype == NIFTI_TYPE_RGB24 || md.niftiDatatype == NIFTI_TYPE_RGBA32)
+  {
+    md.hasNontrivialScaling = false;
+  }
+
+  md.qformCode = hdr.qform_code;
+  md.sformCode = hdr.sform_code;
+  for(int k = 0; k < 4; k++)
+  {
+    md.sformMatrix[0][k] = hdr.srow_x[k];
+    md.sformMatrix[1][k] = hdr.srow_y[k];
+    md.sformMatrix[2][k] = hdr.srow_z[k];
+  }
+
+  const float32 rotEps = 1.0e-5f;
+  if(useAffineIfPresent && hdr.sform_code > 0)
+  {
+    md.origin = {hdr.srow_x[3], hdr.srow_y[3], hdr.srow_z[3]};
+    for(int col = 0; col < 3; col++)
+    {
+      const float32 cx = hdr.srow_x[col];
+      const float32 cy = hdr.srow_y[col];
+      const float32 cz = hdr.srow_z[col];
+      const float32 mag = std::sqrt(cx * cx + cy * cy + cz * cz);
+      if(mag > 0.0f)
+      {
+        md.spacing[col] = mag;
+      }
+      for(int row = 0; row < 3; row++)
+      {
+        if(row == col)
+        {
+          continue;
+        }
+        const float32 comp = (row == 0) ? cx : (row == 1) ? cy : cz;
+        if(std::fabs(comp) > rotEps * std::max(mag, 1.0e-6f))
+        {
+          md.affineHasRotation = true;
+        }
+      }
+    }
+    md.affineApplied = true;
+  }
+  else if(useAffineIfPresent && hdr.qform_code > 0)
+  {
+    md.origin = {hdr.qoffset_x, hdr.qoffset_y, hdr.qoffset_z};
+    const float32 bcdSq = hdr.quatern_b * hdr.quatern_b + hdr.quatern_c * hdr.quatern_c + hdr.quatern_d * hdr.quatern_d;
+    if(bcdSq > rotEps)
+    {
+      md.affineHasRotation = true;
+    }
+    md.affineApplied = true;
+  }
+  else
+  {
+    md.origin = {0.0f, 0.0f, 0.0f};
+  }
+
+  md.intentCode = hdr.intent_code;
+  auto fixedCharsToString = [](const char* src, usize maxLen) {
+    usize len = 0;
+    while(len < maxLen && src[len] != '\0')
+    {
+      len++;
+    }
+    return std::string(src, len);
+  };
+  md.intentName = fixedCharsToString(hdr.intent_name, sizeof(hdr.intent_name));
+  md.descrip = fixedCharsToString(hdr.descrip, sizeof(hdr.descrip));
+
+  return {md};
+}
+
+} // namespace nx::core::nifti

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/NiftiUtilities.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/NiftiUtilities.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "SimplnxCore/SimplnxCore_export.hpp"
+#include "SimplnxCore/utils/nifti1.h"
+
+#include "simplnx/Common/Result.hpp"
+#include "simplnx/Common/Types.hpp"
+
+#include <array>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+namespace nx::core::nifti
+{
+inline constexpr usize k_HeaderSize = 348;
+inline constexpr usize k_MinVoxOffset = 352;
+inline constexpr std::array<char, 4> k_SingleFileMagic = {'n', '+', '1', '\0'};
+inline constexpr std::array<char, 4> k_PairFileMagic = {'n', 'i', '1', '\0'};
+
+struct SIMPLNXCORE_EXPORT NiftiTypeInfo
+{
+  DataType dataType{DataType::uint8};
+  usize componentCount{1};
+  int16 bitpix{0};
+};
+
+/**
+ * @brief Maps a NIfTI datatype code (NIFTI_TYPE_*) to a simplnx DataType plus
+ * component count. Returns std::nullopt for codes not supported by this filter
+ * (complex*, float128, binary, etc).
+ */
+std::optional<NiftiTypeInfo> SIMPLNXCORE_EXPORT NiftiDatatypeToSimplnx(int16 niftiDatatype);
+
+struct SIMPLNXCORE_EXPORT NiftiMetadata
+{
+  // Raw header (kept for diagnostics and reporting)
+  std::string magic;
+  std::array<int16, 8> dim{};
+  std::array<float32, 8> pixdim{};
+
+  // Canonicalized values used to build the ImageGeom
+  std::array<usize, 3> dimensions{0, 0, 0};
+  std::array<float32, 3> spacing{1.0f, 1.0f, 1.0f};
+  std::array<float32, 3> origin{0.0f, 0.0f, 0.0f};
+
+  // Datatype
+  int16 niftiDatatype{0};
+  int16 bitpix{0};
+  DataType dataType{DataType::uint8};
+  usize componentCount{1};
+
+  // Data placement + byte order
+  usize voxOffset{k_MinVoxOffset};
+  bool byteSwapRequired{false};
+
+  // Optional data scaling (y = slope * x + inter)
+  float32 sclSlope{0.0f};
+  float32 sclInter{0.0f};
+  bool hasNontrivialScaling{false};
+
+  // Orientation
+  int16 qformCode{0};
+  int16 sformCode{0};
+  std::array<std::array<float32, 4>, 3> sformMatrix{};
+  bool affineHasRotation{false};
+  bool affineApplied{false};
+
+  // Other
+  int16 intentCode{0};
+  std::string intentName;
+  std::string descrip;
+  std::string filePath;
+};
+
+/**
+ * @brief Reads and validates the 348-byte NIfTI-1 header from a .nii or .nii.gz
+ * file, returning a NiftiMetadata populated with canonicalized geometry,
+ * datatype, scaling, and orientation information.
+ *
+ * Rejects: .hdr/.img pair format, non-3D files, unsupported datatype codes.
+ */
+Result<NiftiMetadata> SIMPLNXCORE_EXPORT ReadNiftiHeader(const std::filesystem::path& filePath, bool useAffineIfPresent);
+
+} // namespace nx::core::nifti

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/NiftiUtilities.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/NiftiUtilities.hpp
@@ -64,7 +64,6 @@ struct SIMPLNXCORE_EXPORT NiftiMetadata
   int16 sformCode{0};
   std::array<std::array<float32, 4>, 3> sformMatrix{};
   bool affineHasRotation{false};
-  bool affineApplied{false};
 
   // Other
   int16 intentCode{0};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/NiftiUtilities.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/NiftiUtilities.hpp
@@ -11,73 +11,246 @@
 #include <optional>
 #include <string>
 
+/**
+ * @file NiftiUtilities.hpp
+ * @brief Header-parsing helpers for the NIfTI-1 single-file format (`.nii`
+ *        and gzipped `.nii.gz`), shared by `ReadNIfTIFileFilter` and
+ *        future NIfTI-aware code.
+ *
+ * The NIfTI-1 specification is defined by the bundled `nifti1.h` header
+ * (Robert W. Cox, NIMH). This layer reads the 348-byte header, validates
+ * it, detects endianness, and canonicalizes the fields simplnx actually
+ * cares about (dimensions, spacing, origin, data type, scaling) into a
+ * single `NiftiMetadata` struct. Voxel data is **not** read here — that
+ * is the algorithm's responsibility, which uses `voxOffset` and
+ * `byteSwapRequired` from the metadata to do its own stream reads.
+ *
+ * The helpers here are deliberately independent of the simplnx filter
+ * framework so they can be reused from unit tests, a future writer,
+ * or a command-line tool.
+ */
+
 namespace nx::core::nifti
 {
+/**
+ * @brief Size of the NIfTI-1 header in bytes. Always 348 for a valid
+ *        NIfTI-1 file regardless of byte order.
+ */
 inline constexpr usize k_HeaderSize = 348;
+
+/**
+ * @brief Minimum legal value of the `vox_offset` field in a single-file
+ *        NIfTI-1 (`n+1`). The spec reserves bytes 348..351 for the
+ *        extension block; voxel data therefore cannot start before
+ *        byte 352.
+ */
 inline constexpr usize k_MinVoxOffset = 352;
+
+/**
+ * @brief Magic bytes that identify the single-file `.nii` / `.nii.gz`
+ *        format. Trailing null is included per the spec.
+ */
 inline constexpr std::array<char, 4> k_SingleFileMagic = {'n', '+', '1', '\0'};
+
+/**
+ * @brief Magic bytes that identify the separate-file `.hdr` / `.img`
+ *        pair format. Present in the spec but **not** supported by
+ *        this reader (see `ReadNiftiHeader` error `-34703`).
+ */
 inline constexpr std::array<char, 4> k_PairFileMagic = {'n', 'i', '1', '\0'};
 
+/**
+ * @struct NiftiTypeInfo
+ * @brief Canonicalized mapping between a NIfTI datatype code (as stored
+ *        in the header's `datatype` field) and the corresponding
+ *        simplnx `DataType` plus per-voxel component count.
+ *
+ * The NIfTI specification uses a single `datatype` code to cover both
+ * scalar types (e.g. `NIFTI_TYPE_UINT8 = 2`) and packed multi-component
+ * types (e.g. `NIFTI_TYPE_RGB24 = 128`, which is three packed `uint8`
+ * components). simplnx arrays separate type from cardinality, so the
+ * RGB/RGBA codes expand to `{ uint8, 3 }` / `{ uint8, 4 }` here.
+ */
 struct SIMPLNXCORE_EXPORT NiftiTypeInfo
 {
+  /** @brief simplnx element type (`uint8`, `float32`, ...). */
   DataType dataType{DataType::uint8};
+
+  /** @brief Components per voxel. 1 for scalar types; 3 for RGB24; 4 for RGBA32. */
   usize componentCount{1};
+
+  /** @brief Total bits per voxel as declared by the NIfTI spec
+   *         (8 for `uint8`, 24 for `RGB24`, 32 for `RGBA32`, etc.).
+   *         Useful for consistency-checking against the header's
+   *         `bitpix` field. */
   int16 bitpix{0};
 };
 
 /**
- * @brief Maps a NIfTI datatype code (NIFTI_TYPE_*) to a simplnx DataType plus
- * component count. Returns std::nullopt for codes not supported by this filter
- * (complex*, float128, binary, etc).
+ * @brief Maps a NIfTI datatype code (`NIFTI_TYPE_*` as defined by
+ *        `nifti1.h`) to a `NiftiTypeInfo`.
+ *
+ * Returns `std::nullopt` for codes that simplnx does not currently
+ * handle: `NIFTI_TYPE_COMPLEX64`, `NIFTI_TYPE_COMPLEX128`,
+ * `NIFTI_TYPE_COMPLEX256`, `NIFTI_TYPE_FLOAT128`, `NIFTI_TYPE_BINARY`,
+ * and any unrecognized value. The filter's preflight converts that
+ * `nullopt` into user-visible error `-34707`.
+ *
+ * @param niftiDatatype The raw `datatype` field value from the header.
+ * @return Canonicalized type info, or `std::nullopt` if unsupported.
  */
 std::optional<NiftiTypeInfo> SIMPLNXCORE_EXPORT NiftiDatatypeToSimplnx(int16 niftiDatatype);
 
+/**
+ * @struct NiftiMetadata
+ * @brief Canonicalized view of a NIfTI-1 header, ready to drive
+ *        `CreateImageGeometryAction` / `CreateArrayAction` and the
+ *        streaming voxel reader.
+ *
+ * Fields are grouped by topic:
+ *
+ * 1. **Raw header**. Kept so the filter can surface useful diagnostics
+ *    in `preflightUpdatedValues` (datatype code, dim vector, pixdim,
+ *    etc.) even for fields the reader itself does not consume.
+ * 2. **Canonicalized geometry**. `dimensions`, `spacing`, and `origin`
+ *    are what the filter should pass to `CreateImageGeometryAction`.
+ *    The values are derived from the best-available source in the
+ *    header: `sform` if `sformCode > 0`, else `qform` if
+ *    `qformCode > 0`, else the `pixdim` / zero-origin fallback.
+ * 3. **Datatype**. `dataType` + `componentCount` tell the algorithm
+ *    which simplnx `DataArray<T>` to create and how many components
+ *    per tuple. `niftiDatatype` and `bitpix` are retained for
+ *    diagnostics.
+ * 4. **Data placement + byte order**. `voxOffset` is the byte offset
+ *    into the file where voxel data starts (after the header plus
+ *    any extension block). `byteSwapRequired` is true when the file
+ *    was written in a byte order different from the host, and the
+ *    algorithm must swap each multi-byte voxel as it is read.
+ * 5. **Optional data scaling**. `sclSlope` / `sclInter` carry the
+ *    header values verbatim. `hasNontrivialScaling` is a convenience
+ *    flag the filter uses to decide whether to promote the output
+ *    array to `float32` and apply `y = slope * x + inter`. It is
+ *    always `false` for RGB24 / RGBA32 per the NIfTI spec.
+ * 6. **Orientation**. `qformCode` / `sformCode` record which transform
+ *    was present in the file; `sformMatrix` stores the 3x4 affine
+ *    when it exists. `affineHasRotation` is `true` when the selected
+ *    transform has a non-trivial rotation component — callers should
+ *    emit a warning because simplnx `ImageGeom` is axis-aligned.
+ * 7. **Other**. `intentCode`, `intentName`, and `descrip` are the
+ *    free-form metadata strings from the file. `filePath` is the
+ *    absolute or relative path the header was read from, preserved
+ *    so downstream error messages can reference it.
+ */
 struct SIMPLNXCORE_EXPORT NiftiMetadata
 {
-  // Raw header (kept for diagnostics and reporting)
-  std::string magic;
-  std::array<int16, 8> dim{};
-  std::array<float32, 8> pixdim{};
+  /** @name Raw header (diagnostics only) */
+  /** @{ */
+  std::string magic;               ///< Original `magic` field value ("n+1" for single-file).
+  std::array<int16, 8> dim{};      ///< Full 8-element dim vector as stored in the header.
+  std::array<float32, 8> pixdim{}; ///< Full 8-element pixdim vector.
+  /** @} */
 
-  // Canonicalized values used to build the ImageGeom
-  std::array<usize, 3> dimensions{0, 0, 0};
-  std::array<float32, 3> spacing{1.0f, 1.0f, 1.0f};
-  std::array<float32, 3> origin{0.0f, 0.0f, 0.0f};
+  /** @name Canonicalized geometry (drives the ImageGeom + DataArray) */
+  /** @{ */
+  std::array<usize, 3> dimensions{0, 0, 0};         ///< Voxel count per axis (x, y, z).
+  std::array<float32, 3> spacing{1.0f, 1.0f, 1.0f}; ///< Voxel spacing per axis.
+  std::array<float32, 3> origin{0.0f, 0.0f, 0.0f};  ///< World-space origin of voxel (0, 0, 0).
+  /** @} */
 
-  // Datatype
-  int16 niftiDatatype{0};
-  int16 bitpix{0};
-  DataType dataType{DataType::uint8};
-  usize componentCount{1};
+  /** @name Datatype */
+  /** @{ */
+  int16 niftiDatatype{0};             ///< Raw `datatype` code from the header (`NIFTI_TYPE_*`).
+  int16 bitpix{0};                    ///< Bits per voxel, cross-validated against the datatype.
+  DataType dataType{DataType::uint8}; ///< simplnx element type for the DataArray.
+  usize componentCount{1};            ///< Components per tuple (1 for scalars, 3 for RGB24, 4 for RGBA32).
+  /** @} */
 
-  // Data placement + byte order
-  usize voxOffset{k_MinVoxOffset};
-  bool byteSwapRequired{false};
+  /** @name Data placement + byte order */
+  /** @{ */
+  usize voxOffset{k_MinVoxOffset}; ///< Byte offset where voxel data starts.
+  bool byteSwapRequired{false};    ///< True if the file is in the opposite byte order from the host.
+  /** @} */
 
-  // Optional data scaling (y = slope * x + inter)
-  float32 sclSlope{0.0f};
-  float32 sclInter{0.0f};
-  bool hasNontrivialScaling{false};
+  /** @name Optional data scaling (`y = slope * x + inter`) */
+  /** @{ */
+  float32 sclSlope{0.0f};           ///< `scl_slope` from the header; 0 means "no scaling" per spec.
+  float32 sclInter{0.0f};           ///< `scl_inter` from the header.
+  bool hasNontrivialScaling{false}; ///< True when (slope != 0) and (slope != 1 or inter != 0); always false for RGB24/RGBA32.
+  /** @} */
 
-  // Orientation
-  int16 qformCode{0};
-  int16 sformCode{0};
-  std::array<std::array<float32, 4>, 3> sformMatrix{};
-  bool affineHasRotation{false};
+  /** @name Orientation */
+  /** @{ */
+  int16 qformCode{0};                                  ///< NIFTI_XFORM_* code for the qform; 0 = not set.
+  int16 sformCode{0};                                  ///< NIFTI_XFORM_* code for the sform; 0 = not set.
+  std::array<std::array<float32, 4>, 3> sformMatrix{}; ///< 3x4 affine `[srow_x; srow_y; srow_z]` when sformCode > 0.
+  bool affineHasRotation{false};                       ///< True if the selected transform has non-trivial rotation.
+  /** @} */
 
-  // Other
-  int16 intentCode{0};
-  std::string intentName;
-  std::string descrip;
-  std::string filePath;
+  /** @name Other */
+  /** @{ */
+  int16 intentCode{0};    ///< NIFTI_INTENT_* code, if any.
+  std::string intentName; ///< Free-form intent name from the header.
+  std::string descrip;    ///< 80-character description field from the header.
+  std::string filePath;   ///< Path the header was read from; kept for diagnostics.
+  /** @} */
 };
 
 /**
- * @brief Reads and validates the 348-byte NIfTI-1 header from a .nii or .nii.gz
- * file, returning a NiftiMetadata populated with canonicalized geometry,
- * datatype, scaling, and orientation information.
+ * @brief Opens a NIfTI-1 file (either uncompressed `.nii` or gzipped
+ *        `.nii.gz`) and parses its 348-byte header into a `NiftiMetadata`.
  *
- * Rejects: .hdr/.img pair format, non-3D files, unsupported datatype codes.
+ * This function is the single entry point for header parsing. It is
+ * safe to call repeatedly — it opens and closes the file each time and
+ * holds no state. The filter caches the returned metadata across
+ * preflight and execute calls to avoid redundant I/O.
+ *
+ * ### What it does
+ * 1. Opens the file through zlib's `gzopen`, which transparently
+ *    handles both compressed and uncompressed input.
+ * 2. Reads exactly 348 bytes into a `nifti_1_header`.
+ * 3. Detects endianness by inspecting `sizeof_hdr`. If swapping makes
+ *    it equal 348, every multi-byte field is byte-swapped in place
+ *    and `byteSwapRequired` is set so the voxel reader knows to do
+ *    the same.
+ * 4. Validates: magic bytes must be `"n+1"`, rank must be 3, each
+ *    spatial dimension must be > 0, the datatype code must be one
+ *    `NiftiDatatypeToSimplnx` recognizes, and `bitpix` must agree
+ *    with the datatype if declared.
+ * 5. Canonicalizes geometry using the best-available orientation:
+ *    `sform` (preferred) → `qform` → pixdim + zero origin. Spacing
+ *    for the sform path comes from the column magnitudes of the
+ *    affine, which correctly handles files where the affine carries
+ *    anisotropic scaling.
+ * 6. Records whether the selected affine has a non-trivial rotation
+ *    so the caller can warn the user that simplnx's axis-aligned
+ *    `ImageGeom` cannot represent it.
+ *
+ * ### Errors
+ * Returned as `Result<NiftiMetadata>` invalid values. Error codes are
+ * in the `-347xx` range:
+ *
+ * | Code    | Meaning                                                        |
+ * |---------|----------------------------------------------------------------|
+ * | `-34700` | Could not open file                                           |
+ * | `-34701` | Short read of the 348-byte header (file truncated)            |
+ * | `-34702` | `sizeof_hdr` is neither 348 nor its byte-swap                  |
+ * | `-34703` | `.hdr`/`.img` pair format (`magic == "ni1"`), unsupported      |
+ * | `-34704` | Unrecognized magic bytes (not a NIfTI-1 file)                  |
+ * | `-34705` | `dim[0]` is not 3 (non-3D volumes are not supported yet)       |
+ * | `-34706` | One or more of `dim[1..3]` is ≤ 0                              |
+ * | `-34707` | Unsupported datatype (complex, float128, etc.)                 |
+ * | `-34708` | `bitpix` inconsistent with the declared datatype                |
+ *
+ * @param filePath            Path to the `.nii` or `.nii.gz` file to read.
+ * @param useAffineIfPresent  When `true` (the default in the filter),
+ *                            `sform` / `qform` are used to set the
+ *                            origin and spacing when they are present
+ *                            in the file. When `false`, the filter
+ *                            falls back to `pixdim` + zero origin
+ *                            even if a transform is recorded.
+ * @return A populated `NiftiMetadata` on success; an invalid
+ *         `Result<NiftiMetadata>` carrying one of the codes above on
+ *         failure.
  */
 Result<NiftiMetadata> SIMPLNXCORE_EXPORT ReadNiftiHeader(const std::filesystem::path& filePath, bool useAffineIfPresent);
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/nifti1.h
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/nifti1.h
@@ -1,0 +1,1152 @@
+#ifndef _NIFTI_HEADER_
+#define _NIFTI_HEADER_
+
+/*****************************************************************************
+ ** This file defines the "NIFTI-1" header format.               **
+ ** It is derived from 2 meetings at the NIH (31 Mar 2003 and    **
+ ** 02 Sep 2003) of the Data Format Working Group (DFWG),        **
+ ** chartered by the NIfTI (Neuroimaging Informatics Technology  **
+ ** Initiative) at the National Institutes of Health (NIH).      **
+ **--------------------------------------------------------------**
+ ** Neither the National Institutes of Health (NIH), the DFWG,   **
+ ** nor any of the members or employees of these institutions    **
+ ** imply any warranty of usefulness of this material for any    **
+ ** purpose, and do not assume any liability for damages,        **
+ ** incidental or otherwise, caused by any use of this document. **
+ ** If these conditions are not acceptable, do not use this!     **
+ **--------------------------------------------------------------**
+ ** Author:   Robert W Cox (NIMH, Bethesda)                      **
+ ** Advisors: John Ashburner (FIL, London),                      **
+ **           Stephen Smith (FMRIB, Oxford),                     **
+ **           Mark Jenkinson (FMRIB, Oxford)                     **
+ ******************************************************************************/
+
+/*---------------------------------------------------------------------------*/
+/* Note that the ANALYZE 7.5 file header (dbh.h) is
+         (c) Copyright 1986-1995
+         Biomedical Imaging Resource
+         Mayo Foundation
+   Incorporation of components of dbh.h are by permission of the
+   Mayo Foundation.
+
+   Changes from the ANALYZE 7.5 file header in this file are released to the
+   public domain, including the functional comments and any amusing asides.
+-----------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/* HEADER STRUCT DECLARATION:
+   -------------------------
+   In the comments below for each field, only NIFTI-1 specific requirements
+   or changes from the ANALYZE 7.5 format are described.  For convenience,
+   the 348 byte header is described as a single struct, rather than as the
+   ANALYZE 7.5 group of 3 substructs.
+
+   Further comments about the interpretation of various elements of this
+   header are after the data type definition itself.  Fields that are
+   marked as ++UNUSED++ have no particular interpretation in this standard.
+   (Also see the UNUSED FIELDS comment section, far below.)
+
+   The presumption below is that the various C types have particular sizes:
+     sizeof(int) = sizeof(float) = 4 ;  sizeof(short) = 2
+-----------------------------------------------------------------------------*/
+
+/*=================*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*=================*/
+
+/*************************/ /************************/
+struct nifti_1_header
+{
+  /* NIFTI-1 usage         */ /* ANALYZE 7.5 field(s) */
+  /*************************/ /************************/
+
+  /*--- was header_key substruct ---*/
+  int sizeof_hdr;      /* int sizeof_hdr;      */
+  char data_type[10];  /* char data_type[10];  */
+  char db_name[18];    /* char db_name[18];    */
+  int extents;         /* int extents;         */
+  short session_error; /* short session_error; */
+  char regular;        /* char regular;        */
+  char dim_info;       /* char hkey_un0;       */
+
+  /*--- was image_dimension substruct ---*/
+  short dim[8];    /* short dim[8];        */
+  float intent_p1; /* short unused8;       */
+  /* short unused9;       */
+  float intent_p2; /* short unused10;      */
+  /* short unused11;      */
+  float intent_p3; /* short unused12;      */
+  /* short unused13;      */
+  short intent_code; /* short unused14;      */
+  short datatype;    /* short datatype;      */
+  short bitpix;      /* short bitpix;        */
+  short slice_start; /* short dim_un0;       */
+  float pixdim[8];   /* float pixdim[8];     */
+  float vox_offset;  /* float vox_offset;    */
+  float scl_slope;   /* float funused1;      */
+  float scl_inter;   /* float funused2;      */
+  short slice_end;   /* float funused3;      */
+  char slice_code;
+  char xyzt_units;
+  float cal_max;        /* float cal_max;       */
+  float cal_min;        /* float cal_min;       */
+  float slice_duration; /* float compressed;    */
+  float toffset;        /* float verified;      */
+  int glmax;            /* int glmax;           */
+  int glmin;            /* int glmin;           */
+
+  /*--- was data_history substruct ---*/
+  char descrip[80];  /* char descrip[80];    */
+  char aux_file[24]; /* char aux_file[24];   */
+
+  short qform_code; /*-- all ANALYZE 7.5 ---*/
+  short sform_code; /*   fields below here  */
+  /*   are replaced       */
+  float quatern_b;
+  float quatern_c;
+  float quatern_d;
+  float qoffset_x;
+  float qoffset_y;
+  float qoffset_z;
+  float srow_x[4];
+  float srow_y[4];
+  float srow_z[4];
+  char intent_name[16];
+  char magic[4];
+}; /**** 348 bytes total ****/
+
+typedef struct nifti_1_header nifti_1_header;
+
+/*---------------------------------------------------------------------------*/
+/* HEADER EXTENSIONS:
+   -----------------
+   After the end of the 348 byte header (e.g., after the magic field),
+   the next 4 bytes are a char array field named "extension". By default,
+   all 4 bytes of this array should be set to zero. In a .nii file, these
+   4 bytes will always be present, since the earliest start point for
+   the image data is byte #352. In a separate .hdr file, these bytes may
+   or may not be present. If not present (i.e., if the length of the .hdr
+   file is 348 bytes), then a NIfTI-1 compliant program should use the
+   default value of extension={0,0,0,0}. The first byte (extension[0])
+   is the only value of this array that is specified at present. The other
+   3 bytes are reserved for future use.
+
+   If extension[0] is nonzero, it indicates that extended header information
+   is present in the bytes following the extension array. In a .nii file,
+   this extended header data is before the image data (and vox_offset
+   must be set correctly to allow for this). In a .hdr file, this extended
+   data follows extension and proceeds (potentially) to the end of the file.
+
+   The format of extended header data is weakly specified. Each extension
+   must be an integer multiple of 16 bytes long. The first 8 bytes of each
+   extension comprise 2 integers:
+      int esize , ecode ;
+   These values may need to be byte-swapped, as indicated by dim[0] for
+   the rest of the header.
+     * esize is the number of bytes that form the extended header data
+       + esize must be a positive integral multiple of 16
+       + this length includes the 8 bytes of esize and ecode themselves
+     * ecode is a non-negative integer that indicates the format of the
+       extended header data that follows
+       + different ecode values are assigned to different developer groups
+       + at present, the "registered" values for code are
+         = 0 = unknown private format (not recommended!)
+         = 2 = DICOM format (i.e., attribute tags and values)
+         = 4 = AFNI group (i.e., ASCII XML-ish elements)
+   In the interests of interoperability (a primary rationale for NIfTI),
+   groups developing software that uses this extension mechanism are
+   encouraged to document and publicize the format of their extensions.
+   To this end, the NIfTI DFWG will assign even numbered codes upon request
+   to groups submitting at least rudimentary documentation for the format
+   of their extension; at present, the contact is mailto:rwcox@nih.gov.
+   The assigned codes and documentation will be posted on the NIfTI
+   website. All odd values of ecode (and 0) will remain unassigned;
+   at least, until the even ones are used up, when we get to 2,147,483,646.
+
+   Note that the other contents of the extended header data section are
+   totally unspecified by the NIfTI-1 standard. In particular, if binary
+   data is stored in such a section, its byte order is not necessarily
+   the same as that given by examining dim[0]; it is incumbent on the
+   programs dealing with such data to determine the byte order of binary
+   extended header data.
+
+   Multiple extended header sections are allowed, each starting with an
+   esize,ecode value pair. The first esize value, as described above,
+   is at bytes #352-355 in the .hdr or .nii file (files start at byte #0).
+   If this value is positive, then the second (esize2) will be found
+   starting at byte #352+esize1 , the third (esize3) at byte #352+esize1+esize2,
+   et cetera.  Of course, in a .nii file, the value of vox_offset must
+   be compatible with these extensions. If a malformed file indicates
+   that an extended header data section would run past vox_offset, then
+   the entire extended header section should be ignored. In a .hdr file,
+   if an extended header data section would run past the end-of-file,
+   that extended header data should also be ignored.
+
+   With the above scheme, a program can successively examine the esize
+   and ecode values, and skip over each extended header section if the
+   program doesn't know how to interpret the data within. Of course, any
+   program can simply ignore all extended header sections simply by jumping
+   straight to the image data using vox_offset.
+-----------------------------------------------------------------------------*/
+
+struct nifti1_extender
+{
+  char extension[4];
+};
+typedef struct nifti1_extender nifti1_extender;
+
+struct nifti1_extension
+{
+  int esize;
+  int ecode;
+  char* edata;
+};
+typedef struct nifti1_extension nifti1_extension;
+
+/*---------------------------------------------------------------------------*/
+/* DATA DIMENSIONALITY (as in ANALYZE 7.5):
+   ---------------------------------------
+     dim[0] = number of dimensions;
+              - if dim[0] is outside range 1..7, then the header information
+                needs to be byte swapped appropriately
+              - ANALYZE supports dim[0] up to 7, but NIFTI-1 reserves
+                dimensions 1,2,3 for space (x,y,z), 4 for time (t), and
+                5,6,7 for anything else needed.
+
+     dim[i] = length of dimension #i, for i=1..dim[0]  (must be positive)
+              - also see the discussion of intent_code, far below
+
+     pixdim[i] = voxel width along dimension #i, i=1..dim[0] (positive)
+                 - cf. ORIENTATION section below for use of pixdim[0]
+                 - the units of pixdim can be specified with the xyzt_units
+                   field (also described far below).
+
+   Number of bits per voxel value is in bitpix, which MUST correspond with
+   the datatype field.  The total number of bytes in the image data is
+     dim[1] * ... * dim[dim[0]] * bitpix / 8
+
+   In NIFTI-1 files, dimensions 1,2,3 are for space, dimension 4 is for time,
+   and dimension 5 is for storing multiple values at each spatiotemporal
+   voxel.  Some examples:
+     - A typical whole-brain FMRI experiment's time series:
+        - dim[0] = 4
+        - dim[1] = 64   pixdim[1] = 3.75 xyzt_units =  NIFTI_UNITS_MM
+        - dim[2] = 64   pixdim[2] = 3.75             | NIFTI_UNITS_SEC
+        - dim[3] = 20   pixdim[3] = 5.0
+        - dim[4] = 120  pixdim[4] = 2.0
+     - A typical T1-weighted anatomical volume:
+        - dim[0] = 3
+        - dim[1] = 256  pixdim[1] = 1.0  xyzt_units = NIFTI_UNITS_MM
+        - dim[2] = 256  pixdim[2] = 1.0
+        - dim[3] = 128  pixdim[3] = 1.1
+     - A single slice EPI time series:
+        - dim[0] = 4
+        - dim[1] = 64   pixdim[1] = 3.75 xyzt_units =  NIFTI_UNITS_MM
+        - dim[2] = 64   pixdim[2] = 3.75             | NIFTI_UNITS_SEC
+        - dim[3] = 1    pixdim[3] = 5.0
+        - dim[4] = 1200 pixdim[4] = 0.2
+     - A 3-vector stored at each point in a 3D volume:
+        - dim[0] = 5
+        - dim[1] = 256  pixdim[1] = 1.0  xyzt_units = NIFTI_UNITS_MM
+        - dim[2] = 256  pixdim[2] = 1.0
+        - dim[3] = 128  pixdim[3] = 1.1
+        - dim[4] = 1    pixdim[4] = 0.0
+        - dim[5] = 3                     intent_code = NIFTI_INTENT_VECTOR
+     - A single time series with a 3x3 matrix at each point:
+        - dim[0] = 5
+        - dim[1] = 1                     xyzt_units = NIFTI_UNITS_SEC
+        - dim[2] = 1
+        - dim[3] = 1
+        - dim[4] = 1200 pixdim[4] = 0.2
+        - dim[5] = 9                     intent_code = NIFTI_INTENT_GENMATRIX
+        - intent_p1 = intent_p2 = 3.0    (indicates matrix dimensions)
+-----------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/* DATA STORAGE:
+   ------------
+   If the magic field is "n+1", then the voxel data is stored in the
+   same file as the header.  In this case, the voxel data starts at offset
+   (int)vox_offset into the header file.  Thus, vox_offset=352.0 means that
+   the data starts immediately after the NIFTI-1 header.  If vox_offset is
+   greater than 352, the NIFTI-1 format does not say much about the
+   contents of the dataset file between the end of the header and the
+   start of the data.
+
+   FILES:
+   -----
+   If the magic field is "ni1", then the voxel data is stored in the
+   associated ".img" file, starting at offset 0 (i.e., vox_offset is not
+   used in this case, and should be set to 0.0).
+
+   When storing NIFTI-1 datasets in pairs of files, it is customary to name
+   the files in the pattern "name.hdr" and "name.img", as in ANALYZE 7.5.
+   When storing in a single file ("n+1"), the file name should be in
+   the form "name.nii" (the ".nft" and ".nif" suffixes are already taken;
+   cf. http://www.icdatamaster.com/n.html ).
+
+   BYTE ORDERING:
+   -------------
+   The byte order of the data arrays is presumed to be the same as the byte
+   order of the header (which is determined by examining dim[0]).
+
+   Floating point types are presumed to be stored in IEEE-754 format.
+-----------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/* DETAILS ABOUT vox_offset:
+   ------------------------
+   In a .nii file, the vox_offset field value is interpreted as the start
+   location of the image data bytes in that file. In a .hdr/.img file pair,
+   the vox_offset field value is the start location of the image data
+   bytes in the .img file.
+    * If vox_offset is less than 352 in a .nii file, it is equivalent
+      to 352 (i.e., image data never starts before byte #352 in a .nii file).
+    * The default value for vox_offset in a .nii file is 352.
+    * In a .hdr file, the default value for vox_offset is 0.
+    * vox_offset should be an integer multiple of 16; otherwise, some
+      programs may not work properly (e.g., SPM). This is to allow
+      memory-mapped input to be properly byte-aligned.
+   Note that since vox_offset is an IEEE-754 32 bit float (for compatibility
+   with the ANALYZE-7.5 format), it effectively has a 24 bit mantissa. All
+   integers from 0 to 2^24 can be represented exactly in this format, but not
+   all larger integers are exactly storable as IEEE-754 32 bit floats. However,
+   unless you plan to have vox_offset be potentially larger than 16 MB, this
+   should not be an issue. (Actually, any integral multiple of 16 up to 2^27
+   can be represented exactly in this format, which allows for up to 128 MB
+   of random information before the image data.  If that isn't enough, then
+   perhaps this format isn't right for you.)
+
+   In a .img file (i.e., image data stored separately from the NIfTI-1
+   header), data bytes between #0 and #vox_offset-1 (inclusive) are completely
+   undefined and unregulated by the NIfTI-1 standard. One potential use of
+   having vox_offset > 0 in the .hdr/.img file pair storage method is to make
+   the .img file be a copy of (or link to) a pre-existing image file in some
+   other format, such as DICOM; then vox_offset would be set to the offset of
+   the image data in this file. (It may not be possible to follow the
+   "multiple-of-16 rule" with an arbitrary external file; using the NIfTI-1
+   format in such a case may lead to a file that is incompatible with software
+   that relies on vox_offset being a multiple of 16.)
+
+   In a .nii file, data bytes between #348 and #vox_offset-1 (inclusive) may
+   be used to store user-defined extra information; similarly, in a .hdr file,
+   any data bytes after byte #347 are available for user-defined extra
+   information. The (very weak) regulation of this extra header data is
+   described elsewhere.
+-----------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/* DATA SCALING:
+   ------------
+   If the scl_slope field is nonzero, then each voxel value in the dataset
+   should be scaled as
+      y = scl_slope * x + scl_inter
+   where x = voxel value stored
+         y = "true" voxel value
+   Normally, we would expect this scaling to be used to store "true" floating
+   values in a smaller integer datatype, but that is not required.  That is,
+   it is legal to use scaling even if the datatype is a float type (crazy,
+   perhaps, but legal).
+    - However, the scaling is to be ignored if datatype is DT_RGB24.
+    - If datatype is a complex type, then the scaling is to be
+      applied to both the real and imaginary parts.
+
+   The cal_min and cal_max fields (if nonzero) are used for mapping (possibly
+   scaled) dataset values to display colors:
+    - Minimum display intensity (black) corresponds to dataset value cal_min.
+    - Maximum display intensity (white) corresponds to dataset value cal_max.
+    - Dataset values below cal_min should display as black also, and values
+      above cal_max as white.
+    - Colors "black" and "white", of course, may refer to any scalar display
+      scheme (e.g., a color lookup table specified via aux_file).
+    - cal_min and cal_max only make sense when applied to scalar-valued
+      datasets (i.e., dim[0] < 5 or dim[5] = 1).
+-----------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/* TYPE OF DATA (acceptable values for datatype field):
+   ---------------------------------------------------
+   Values of datatype smaller than 256 are ANALYZE 7.5 compatible.
+   Larger values are NIFTI-1 additions.  These are all multiples of 256, so
+   that no bits below position 8 are set in datatype.  But there is no need
+   to use only powers-of-2, as the original ANALYZE 7.5 datatype codes do.
+
+   The additional codes are intended to include a complete list of basic
+   scalar types, including signed and unsigned integers from 8 to 64 bits,
+   floats from 32 to 128 bits, and complex (float pairs) from 64 to 256 bits.
+
+   Note that most programs will support only a few of these datatypes!
+   A NIFTI-1 program should fail gracefully (e.g., print a warning message)
+   when it encounters a dataset with a type it doesn't like.
+-----------------------------------------------------------------------------*/
+
+#undef DT_UNKNOWN /* defined in dirent.h on some Unix systems */
+
+/*--- the original ANALYZE 7.5 type codes ---*/
+#define DT_NONE 0
+#define DT_UNKNOWN 0       /* what it says, dude           */
+#define DT_BINARY 1        /* binary (1 bit/voxel)         */
+#define DT_UNSIGNED_CHAR 2 /* unsigned char (8 bits/voxel) */
+#define DT_SIGNED_SHORT 4  /* signed short (16 bits/voxel) */
+#define DT_SIGNED_INT 8    /* signed int (32 bits/voxel)   */
+#define DT_FLOAT 16        /* float (32 bits/voxel)        */
+#define DT_COMPLEX 32      /* complex (64 bits/voxel)      */
+#define DT_DOUBLE 64       /* double (64 bits/voxel)       */
+#define DT_RGB 128         /* RGB triple (24 bits/voxel)   */
+#define DT_ALL 255         /* not very useful (?)          */
+
+/*----- another set of names for the same ---*/
+#define DT_UINT8 2
+#define DT_INT16 4
+#define DT_INT32 8
+#define DT_FLOAT32 16
+#define DT_COMPLEX64 32
+#define DT_FLOAT64 64
+#define DT_RGB24 128
+
+/*------------------- new codes for NIFTI ---*/
+#define DT_INT8 256        /* signed char (8 bits)         */
+#define DT_UINT16 512      /* unsigned short (16 bits)     */
+#define DT_UINT32 768      /* unsigned int (32 bits)       */
+#define DT_INT64 1024      /* long long (64 bits)          */
+#define DT_UINT64 1280     /* unsigned long long (64 bits) */
+#define DT_FLOAT128 1536   /* long double (128 bits)       */
+#define DT_COMPLEX128 1792 /* double pair (128 bits)       */
+#define DT_COMPLEX256 2048 /* long double pair (256 bits)  */
+#define DT_RGBA32 2304     /* 4 byte RGBA (32 bits/voxel)  */
+/* @} */
+
+/*------- aliases for all the above codes ---*/
+
+#define NIFTI_TYPE_UINT8 2
+
+#define NIFTI_TYPE_INT16 4
+
+#define NIFTI_TYPE_INT32 8
+
+#define NIFTI_TYPE_FLOAT32 16
+
+#define NIFTI_TYPE_COMPLEX64 32
+
+#define NIFTI_TYPE_FLOAT64 64
+
+#define NIFTI_TYPE_RGB24 128
+
+#define NIFTI_TYPE_INT8 256
+
+#define NIFTI_TYPE_UINT16 512
+
+#define NIFTI_TYPE_UINT32 768
+
+#define NIFTI_TYPE_INT64 1024
+
+#define NIFTI_TYPE_UINT64 1280
+
+#define NIFTI_TYPE_FLOAT128 1536
+
+#define NIFTI_TYPE_COMPLEX128 1792
+
+#define NIFTI_TYPE_COMPLEX256 2048
+
+#define NIFTI_TYPE_RGBA32 2304
+/* @} */
+
+/*-------- sample typedefs for complicated types ---*/
+#if 0
+ typedef struct {
+     float       r, i;
+ } complex_float ;
+ typedef struct {
+     double      r, i;
+ } complex_double ;
+ typedef struct {
+     long double r, i;
+ } complex_longdouble ;
+ typedef struct {
+     unsigned char r, g, b;
+ } rgb_byte ;
+#endif
+
+/*---------------------------------------------------------------------------*/
+/* INTERPRETATION OF VOXEL DATA:
+   ----------------------------
+   The intent_code field can be used to indicate that the voxel data has
+   some particular meaning.  In particular, a large number of codes is
+   given to indicate that the the voxel data should be interpreted as
+   being drawn from a given probability distribution.
+
+   VECTOR-VALUED DATASETS:
+   ----------------------
+   The 5th dimension of the dataset, if present (i.e., dim[0]=5 and
+   dim[5] > 1), contains multiple values (e.g., a vector) to be stored
+   at each spatiotemporal location.  For example, the header values
+    - dim[0] = 5
+    - dim[1] = 64
+    - dim[2] = 64
+    - dim[3] = 20
+    - dim[4] = 1     (indicates no time axis)
+    - dim[5] = 3
+    - datatype = DT_FLOAT
+    - intent_code = NIFTI_INTENT_VECTOR
+   mean that this dataset should be interpreted as a 3D volume (64x64x20),
+   with a 3-vector of floats defined at each point in the 3D grid.
+
+   A program reading a dataset with a 5th dimension may want to reformat
+   the image data to store each voxels' set of values together in a struct
+   or array.  This programming detail, however, is beyond the scope of the
+   NIFTI-1 file specification!  Uses of dimensions 6 and 7 are also not
+   specified here.
+
+   STATISTICAL PARAMETRIC DATASETS (i.e., SPMs):
+   --------------------------------------------
+   Values of intent_code from NIFTI_FIRST_STATCODE to NIFTI_LAST_STATCODE
+   (inclusive) indicate that the numbers in the dataset should be interpreted
+   as being drawn from a given distribution.  Most such distributions have
+   auxiliary parameters (e.g., NIFTI_INTENT_TTEST has 1 DOF parameter).
+
+   If the dataset DOES NOT have a 5th dimension, then the auxiliary parameters
+   are the same for each voxel, and are given in header fields intent_p1,
+   intent_p2, and intent_p3.
+
+   If the dataset DOES have a 5th dimension, then the auxiliary parameters
+   are different for each voxel.  For example, the header values
+    - dim[0] = 5
+    - dim[1] = 128
+    - dim[2] = 128
+    - dim[3] = 1      (indicates a single slice)
+    - dim[4] = 1      (indicates no time axis)
+    - dim[5] = 2
+    - datatype = DT_FLOAT
+    - intent_code = NIFTI_INTENT_TTEST
+   mean that this is a 2D dataset (128x128) of t-statistics, with the
+   t-statistic being in the first "plane" of data and the degrees-of-freedom
+   parameter being in the second "plane" of data.
+
+   If the dataset 5th dimension is used to store the voxel-wise statistical
+   parameters, then dim[5] must be 1 plus the number of parameters required
+   by that distribution (e.g., intent_code=NIFTI_INTENT_TTEST implies dim[5]
+   must be 2, as in the example just above).
+
+   Note: intent_code values 2..10 are compatible with AFNI 1.5x (which is
+   why there is no code with value=1, which is obsolescent in AFNI).
+
+   OTHER INTENTIONS:
+   ----------------
+   The purpose of the intent_* fields is to help interpret the values
+   stored in the dataset.  Some non-statistical values for intent_code
+   and conventions are provided for storing other complex data types.
+
+   The intent_name field provides space for a 15 character (plus 0 byte)
+   'name' string for the type of data stored. Examples:
+    - intent_code = NIFTI_INTENT_ESTIMATE; intent_name = "T1";
+       could be used to signify that the voxel values are estimates of the
+       NMR parameter T1.
+    - intent_code = NIFTI_INTENT_TTEST; intent_name = "House";
+       could be used to signify that the voxel values are t-statistics
+       for the significance of 'activation' response to a House stimulus.
+    - intent_code = NIFTI_INTENT_DISPVECT; intent_name = "ToMNI152";
+       could be used to signify that the voxel values are a displacement
+       vector that transforms each voxel (x,y,z) location to the
+       corresponding location in the MNI152 standard brain.
+    - intent_code = NIFTI_INTENT_SYMMATRIX; intent_name = "DTI";
+       could be used to signify that the voxel values comprise a diffusion
+       tensor image.
+
+   If no data name is implied or needed, intent_name[0] should be set to 0.
+-----------------------------------------------------------------------------*/
+
+#define NIFTI_INTENT_NONE 0
+
+/*-------- These codes are for probability distributions ---------------*/
+/* Most distributions have a number of parameters,
+   below denoted by p1, p2, and p3, and stored in
+    - intent_p1, intent_p2, intent_p3 if dataset doesn't have 5th dimension
+    - image data array                if dataset does have 5th dimension
+
+   Functions to compute with many of the distributions below can be found
+   in the CDF library from U Texas.
+
+   Formulas for and discussions of these distributions can be found in the
+   following books:
+
+    [U] Univariate Discrete Distributions,
+        NL Johnson, S Kotz, AW Kemp.
+
+    [C1] Continuous Univariate Distributions, vol. 1,
+         NL Johnson, S Kotz, N Balakrishnan.
+
+    [C2] Continuous Univariate Distributions, vol. 2,
+         NL Johnson, S Kotz, N Balakrishnan.                            */
+/*----------------------------------------------------------------------*/
+
+#define NIFTI_INTENT_CORREL 2
+
+#define NIFTI_INTENT_TTEST 3
+
+#define NIFTI_INTENT_FTEST 4
+
+#define NIFTI_INTENT_ZSCORE 5
+
+#define NIFTI_INTENT_CHISQ 6
+
+#define NIFTI_INTENT_BETA 7
+
+#define NIFTI_INTENT_BINOM 8
+
+#define NIFTI_INTENT_GAMMA 9
+
+#define NIFTI_INTENT_POISSON 10
+
+#define NIFTI_INTENT_NORMAL 11
+
+#define NIFTI_INTENT_FTEST_NONC 12
+
+#define NIFTI_INTENT_CHISQ_NONC 13
+
+#define NIFTI_INTENT_LOGISTIC 14
+
+#define NIFTI_INTENT_LAPLACE 15
+
+#define NIFTI_INTENT_UNIFORM 16
+
+#define NIFTI_INTENT_TTEST_NONC 17
+
+#define NIFTI_INTENT_WEIBULL 18
+
+#define NIFTI_INTENT_CHI 19
+
+#define NIFTI_INTENT_INVGAUSS 20
+
+#define NIFTI_INTENT_EXTVAL 21
+
+#define NIFTI_INTENT_PVAL 22
+
+#define NIFTI_INTENT_LOGPVAL 23
+
+#define NIFTI_INTENT_LOG10PVAL 24
+
+#define NIFTI_FIRST_STATCODE 2
+
+#define NIFTI_LAST_STATCODE 24
+
+/*---------- these values for intent_code aren't for statistics ----------*/
+
+#define NIFTI_INTENT_ESTIMATE 1001
+
+#define NIFTI_INTENT_LABEL 1002
+
+#define NIFTI_INTENT_NEURONAME 1003
+
+#define NIFTI_INTENT_GENMATRIX 1004
+
+#define NIFTI_INTENT_SYMMATRIX 1005
+
+#define NIFTI_INTENT_DISPVECT 1006 /* specifically for displacements */
+#define NIFTI_INTENT_VECTOR 1007   /* for any other type of vector */
+
+#define NIFTI_INTENT_POINTSET 1008
+
+#define NIFTI_INTENT_TRIANGLE 1009
+
+#define NIFTI_INTENT_QUATERNION 1010
+
+#define NIFTI_INTENT_DIMLESS 1011
+
+/*---------- these values apply to GIFTI datasets ----------*/
+
+#define NIFTI_INTENT_TIME_SERIES 2001
+
+#define NIFTI_INTENT_NODE_INDEX 2002
+
+#define NIFTI_INTENT_RGB_VECTOR 2003
+
+#define NIFTI_INTENT_RGBA_VECTOR 2004
+
+#define NIFTI_INTENT_SHAPE 2005
+
+/* @} */
+
+/*---------------------------------------------------------------------------*/
+/* 3D IMAGE (VOLUME) ORIENTATION AND LOCATION IN SPACE:
+   ---------------------------------------------------
+   There are 3 different methods by which continuous coordinates can
+   attached to voxels.  The discussion below emphasizes 3D volumes, and
+   the continuous coordinates are referred to as (x,y,z).  The voxel
+   index coordinates (i.e., the array indexes) are referred to as (i,j,k),
+   with valid ranges:
+     i = 0 .. dim[1]-1
+     j = 0 .. dim[2]-1  (if dim[0] >= 2)
+     k = 0 .. dim[3]-1  (if dim[0] >= 3)
+   The (x,y,z) coordinates refer to the CENTER of a voxel.  In methods
+   2 and 3, the (x,y,z) axes refer to a subject-based coordinate system,
+   with
+     +x = Right  +y = Anterior  +z = Superior.
+   This is a right-handed coordinate system.  However, the exact direction
+   these axes point with respect to the subject depends on qform_code
+   (Method 2) and sform_code (Method 3).
+
+   N.B.: The i index varies most rapidly, j index next, k index slowest.
+    Thus, voxel (i,j,k) is stored starting at location
+      (i + j*dim[1] + k*dim[1]*dim[2]) * (bitpix/8)
+    into the dataset array.
+
+   N.B.: The ANALYZE 7.5 coordinate system is
+      +x = Left  +y = Anterior  +z = Superior
+    which is a left-handed coordinate system.  This backwardness is
+    too difficult to tolerate, so this NIFTI-1 standard specifies the
+    coordinate order which is most common in functional neuroimaging.
+
+   N.B.: The 3 methods below all give the locations of the voxel centers
+    in the (x,y,z) coordinate system.  In many cases, programs will wish
+    to display image data on some other grid.  In such a case, the program
+    will need to convert its desired (x,y,z) values into (i,j,k) values
+    in order to extract (or interpolate) the image data.  This operation
+    would be done with the inverse transformation to those described below.
+
+   N.B.: Method 2 uses a factor 'qfac' which is either -1 or 1; qfac is
+    stored in the otherwise unused pixdim[0].  If pixdim[0]=0.0 (which
+    should not occur), we take qfac=1.  Of course, pixdim[0] is only used
+    when reading a NIFTI-1 header, not when reading an ANALYZE 7.5 header.
+
+   N.B.: The units of (x,y,z) can be specified using the xyzt_units field.
+
+   METHOD 1 (the "old" way, used only when qform_code = 0):
+   -------------------------------------------------------
+   The coordinate mapping from (i,j,k) to (x,y,z) is the ANALYZE
+   7.5 way.  This is a simple scaling relationship:
+
+     x = pixdim[1] * i
+     y = pixdim[2] * j
+     z = pixdim[3] * k
+
+   No particular spatial orientation is attached to these (x,y,z)
+   coordinates.  (NIFTI-1 does not have the ANALYZE 7.5 orient field,
+   which is not general and is often not set properly.)  This method
+   is not recommended, and is present mainly for compatibility with
+   ANALYZE 7.5 files.
+
+   METHOD 2 (used when qform_code > 0, which should be the "normal" case):
+   ---------------------------------------------------------------------
+   The (x,y,z) coordinates are given by the pixdim[] scales, a rotation
+   matrix, and a shift.  This method is intended to represent
+   "scanner-anatomical" coordinates, which are often embedded in the
+   image header (e.g., DICOM fields (0020,0032), (0020,0037), (0028,0030),
+   and (0018,0050)), and represent the nominal orientation and location of
+   the data.  This method can also be used to represent "aligned"
+   coordinates, which would typically result from some post-acquisition
+   alignment of the volume to a standard orientation (e.g., the same
+   subject on another day, or a rigid rotation to true anatomical
+   orientation from the tilted position of the subject in the scanner).
+   The formula for (x,y,z) in terms of header parameters and (i,j,k) is:
+
+     [ x ]   [ R11 R12 R13 ] [        pixdim[1] * i ]   [ qoffset_x ]
+     [ y ] = [ R21 R22 R23 ] [        pixdim[2] * j ] + [ qoffset_y ]
+     [ z ]   [ R31 R32 R33 ] [ qfac * pixdim[3] * k ]   [ qoffset_z ]
+
+   The qoffset_* shifts are in the NIFTI-1 header.  Note that the center
+   of the (i,j,k)=(0,0,0) voxel (first value in the dataset array) is
+   just (x,y,z)=(qoffset_x,qoffset_y,qoffset_z).
+
+   The rotation matrix R is calculated from the quatern_* parameters.
+   This calculation is described below.
+
+   The scaling factor qfac is either 1 or -1.  The rotation matrix R
+   defined by the quaternion parameters is "proper" (has determinant 1).
+   This may not fit the needs of the data; for example, if the image
+   grid is
+     i increases from Left-to-Right
+     j increases from Anterior-to-Posterior
+     k increases from Inferior-to-Superior
+   Then (i,j,k) is a left-handed triple.  In this example, if qfac=1,
+   the R matrix would have to be
+
+     [  1   0   0 ]
+     [  0  -1   0 ]  which is "improper" (determinant = -1).
+     [  0   0   1 ]
+
+   If we set qfac=-1, then the R matrix would be
+
+     [  1   0   0 ]
+     [  0  -1   0 ]  which is proper.
+     [  0   0  -1 ]
+
+   This R matrix is represented by quaternion [a,b,c,d] = [0,1,0,0]
+   (which encodes a 180 degree rotation about the x-axis).
+
+   METHOD 3 (used when sform_code > 0):
+   -----------------------------------
+   The (x,y,z) coordinates are given by a general affine transformation
+   of the (i,j,k) indexes:
+
+     x = srow_x[0] * i + srow_x[1] * j + srow_x[2] * k + srow_x[3]
+     y = srow_y[0] * i + srow_y[1] * j + srow_y[2] * k + srow_y[3]
+     z = srow_z[0] * i + srow_z[1] * j + srow_z[2] * k + srow_z[3]
+
+   The srow_* vectors are in the NIFTI_1 header.  Note that no use is
+   made of pixdim[] in this method.
+
+   WHY 3 METHODS?
+   --------------
+   Method 1 is provided only for backwards compatibility.  The intention
+   is that Method 2 (qform_code > 0) represents the nominal voxel locations
+   as reported by the scanner, or as rotated to some fiducial orientation and
+   location.  Method 3, if present (sform_code > 0), is to be used to give
+   the location of the voxels in some standard space.  The sform_code
+   indicates which standard space is present.  Both methods 2 and 3 can be
+   present, and be useful in different contexts (method 2 for displaying the
+   data on its original grid; method 3 for displaying it on a standard grid).
+
+   In this scheme, a dataset would originally be set up so that the
+   Method 2 coordinates represent what the scanner reported.  Later,
+   a registration to some standard space can be computed and inserted
+   in the header.  Image display software can use either transform,
+   depending on its purposes and needs.
+
+   In Method 2, the origin of coordinates would generally be whatever
+   the scanner origin is; for example, in MRI, (0,0,0) is the center
+   of the gradient coil.
+
+   In Method 3, the origin of coordinates would depend on the value
+   of sform_code; for example, for the Talairach coordinate system,
+   (0,0,0) corresponds to the Anterior Commissure.
+
+   QUATERNION REPRESENTATION OF ROTATION MATRIX (METHOD 2)
+   -------------------------------------------------------
+   The orientation of the (x,y,z) axes relative to the (i,j,k) axes
+   in 3D space is specified using a unit quaternion [a,b,c,d], where
+   a*a+b*b+c*c+d*d=1.  The (b,c,d) values are all that is needed, since
+   we require that a = sqrt(1.0-(b*b+c*c+d*d)) be nonnegative.  The (b,c,d)
+   values are stored in the (quatern_b,quatern_c,quatern_d) fields.
+
+   The quaternion representation is chosen for its compactness in
+   representing rotations. The (proper) 3x3 rotation matrix that
+   corresponds to [a,b,c,d] is
+
+         [ a*a+b*b-c*c-d*d   2*b*c-2*a*d       2*b*d+2*a*c     ]
+     R = [ 2*b*c+2*a*d       a*a+c*c-b*b-d*d   2*c*d-2*a*b     ]
+         [ 2*b*d-2*a*c       2*c*d+2*a*b       a*a+d*d-c*c-b*b ]
+
+         [ R11               R12               R13             ]
+       = [ R21               R22               R23             ]
+         [ R31               R32               R33             ]
+
+   If (p,q,r) is a unit 3-vector, then rotation of angle h about that
+   direction is represented by the quaternion
+
+     [a,b,c,d] = [cos(h/2), p*sin(h/2), q*sin(h/2), r*sin(h/2)].
+
+   Requiring a >= 0 is equivalent to requiring -Pi <= h <= Pi.  (Note that
+   [-a,-b,-c,-d] represents the same rotation as [a,b,c,d]; there are 2
+   quaternions that can be used to represent a given rotation matrix R.)
+   To rotate a 3-vector (x,y,z) using quaternions, we compute the
+   quaternion product
+
+     [0,x',y',z'] = [a,b,c,d] * [0,x,y,z] * [a,-b,-c,-d]
+
+   which is equivalent to the matrix-vector multiply
+
+     [ x' ]     [ x ]
+     [ y' ] = R [ y ]   (equivalence depends on a*a+b*b+c*c+d*d=1)
+     [ z' ]     [ z ]
+
+   Multiplication of 2 quaternions is defined by the following:
+
+     [a,b,c,d] = a*1 + b*I + c*J + d*K
+     where
+       I*I = J*J = K*K = -1 (I,J,K are square roots of -1)
+       I*J =  K    J*K =  I    K*I =  J
+       J*I = -K    K*J = -I    I*K = -J  (not commutative!)
+     For example
+       [a,b,0,0] * [0,0,0,1] = [0,0,-b,a]
+     since this expands to
+       (a+b*I)*(K) = (a*K+b*I*K) = (a*K-b*J).
+
+   The above formula shows how to go from quaternion (b,c,d) to
+   rotation matrix and direction cosines.  Conversely, given R,
+   we can compute the fields for the NIFTI-1 header by
+
+     a = 0.5  * sqrt(1+R11+R22+R33)    (not stored)
+     b = 0.25 * (R32-R23) / a       => quatern_b
+     c = 0.25 * (R13-R31) / a       => quatern_c
+     d = 0.25 * (R21-R12) / a       => quatern_d
+
+   If a=0 (a 180 degree rotation), alternative formulas are needed.
+   See the nifti1_io.c function mat44_to_quatern() for an implementation
+   of the various cases in converting R to [a,b,c,d].
+
+   Note that R-transpose (= R-inverse) would lead to the quaternion
+   [a,-b,-c,-d].
+
+   The choice to specify the qoffset_x (etc.) values in the final
+   coordinate system is partly to make it easy to convert DICOM images to
+   this format.  The DICOM attribute "Image Position (Patient)" (0020,0032)
+   stores the (Xd,Yd,Zd) coordinates of the center of the first voxel.
+   Here, (Xd,Yd,Zd) refer to DICOM coordinates, and Xd=-x, Yd=-y, Zd=z,
+   where (x,y,z) refers to the NIFTI coordinate system discussed above.
+   (i.e., DICOM +Xd is Left, +Yd is Posterior, +Zd is Superior,
+        whereas +x is Right, +y is Anterior  , +z is Superior. )
+   Thus, if the (0020,0032) DICOM attribute is extracted into (px,py,pz), then
+     qoffset_x = -px   qoffset_y = -py   qoffset_z = pz
+   is a reasonable setting when qform_code=NIFTI_XFORM_SCANNER_ANAT.
+
+   That is, DICOM's coordinate system is 180 degrees rotated about the z-axis
+   from the neuroscience/NIFTI coordinate system.  To transform between DICOM
+   and NIFTI, you just have to negate the x- and y-coordinates.
+
+   The DICOM attribute (0020,0037) "Image Orientation (Patient)" gives the
+   orientation of the x- and y-axes of the image data in terms of 2 3-vectors.
+   The first vector is a unit vector along the x-axis, and the second is
+   along the y-axis.  If the (0020,0037) attribute is extracted into the
+   value (xa,xb,xc,ya,yb,yc), then the first two columns of the R matrix
+   would be
+              [ -xa  -ya ]
+              [ -xb  -yb ]
+              [  xc   yc ]
+   The negations are because DICOM's x- and y-axes are reversed relative
+   to NIFTI's.  The third column of the R matrix gives the direction of
+   displacement (relative to the subject) along the slice-wise direction.
+   This orientation is not encoded in the DICOM standard in a simple way;
+   DICOM is mostly concerned with 2D images.  The third column of R will be
+   either the cross-product of the first 2 columns or its negative.  It is
+   possible to infer the sign of the 3rd column by examining the coordinates
+   in DICOM attribute (0020,0032) "Image Position (Patient)" for successive
+   slices.  However, this method occasionally fails for reasons that I
+   (RW Cox) do not understand.
+-----------------------------------------------------------------------------*/
+
+/* [qs]form_code value:  */ /* x,y,z coordinate system refers to:    */
+/*-----------------------*/ /*---------------------------------------*/
+
+#define NIFTI_XFORM_UNKNOWN 0
+
+#define NIFTI_XFORM_SCANNER_ANAT 1
+
+#define NIFTI_XFORM_ALIGNED_ANAT 2
+
+#define NIFTI_XFORM_TALAIRACH 3
+
+#define NIFTI_XFORM_MNI_152 4
+/* @} */
+
+/*---------------------------------------------------------------------------*/
+/* UNITS OF SPATIAL AND TEMPORAL DIMENSIONS:
+   ----------------------------------------
+   The codes below can be used in xyzt_units to indicate the units of pixdim.
+   As noted earlier, dimensions 1,2,3 are for x,y,z; dimension 4 is for
+   time (t).
+    - If dim[4]=1 or dim[0] < 4, there is no time axis.
+    - A single time series (no space) would be specified with
+      - dim[0] = 4 (for scalar data) or dim[0] = 5 (for vector data)
+      - dim[1] = dim[2] = dim[3] = 1
+      - dim[4] = number of time points
+      - pixdim[4] = time step
+      - xyzt_units indicates units of pixdim[4]
+      - dim[5] = number of values stored at each time point
+
+   Bits 0..2 of xyzt_units specify the units of pixdim[1..3]
+    (e.g., spatial units are values 1..7).
+   Bits 3..5 of xyzt_units specify the units of pixdim[4]
+    (e.g., temporal units are multiples of 8).
+
+   This compression of 2 distinct concepts into 1 byte is due to the
+   limited space available in the 348 byte ANALYZE 7.5 header.  The
+   macros XYZT_TO_SPACE and XYZT_TO_TIME can be used to mask off the
+   undesired bits from the xyzt_units fields, leaving "pure" space
+   and time codes.  Inversely, the macro SPACE_TIME_TO_XYZT can be
+   used to assemble a space code (0,1,2,...,7) with a time code
+   (0,8,16,32,...,56) into the combined value for xyzt_units.
+
+   Note that codes are provided to indicate the "time" axis units are
+   actually frequency in Hertz (_HZ), in part-per-million (_PPM)
+   or in radians-per-second (_RADS).
+
+   The toffset field can be used to indicate a nonzero start point for
+   the time axis.  That is, time point #m is at t=toffset+m*pixdim[4]
+   for m=0..dim[4]-1.
+-----------------------------------------------------------------------------*/
+
+#define NIFTI_UNITS_UNKNOWN 0
+
+#define NIFTI_UNITS_METER 1
+
+#define NIFTI_UNITS_MM 2
+
+#define NIFTI_UNITS_MICRON 3
+
+#define NIFTI_UNITS_SEC 8
+
+#define NIFTI_UNITS_MSEC 16
+
+#define NIFTI_UNITS_USEC 24
+
+/*** These units are for spectral data: ***/
+#define NIFTI_UNITS_HZ 32
+
+#define NIFTI_UNITS_PPM 40
+
+#define NIFTI_UNITS_RADS 48
+/* @} */
+
+#undef XYZT_TO_SPACE
+#undef XYZT_TO_TIME
+#define XYZT_TO_SPACE(xyzt) ((xyzt)&0x07)
+#define XYZT_TO_TIME(xyzt) ((xyzt)&0x38)
+
+#undef SPACE_TIME_TO_XYZT
+#define SPACE_TIME_TO_XYZT(ss, tt) ((((char)(ss)) & 0x07) | (((char)(tt)) & 0x38))
+
+/*---------------------------------------------------------------------------*/
+/* MRI-SPECIFIC SPATIAL AND TEMPORAL INFORMATION:
+   ---------------------------------------------
+   A few fields are provided to store some extra information
+   that is sometimes important when storing the image data
+   from an FMRI time series experiment.  (After processing such
+   data into statistical images, these fields are not likely
+   to be useful.)
+
+  { freq_dim  } = These fields encode which spatial dimension (1,2, or 3)
+  { phase_dim } = corresponds to which acquisition dimension for MRI data.
+  { slice_dim } =
+    Examples:
+      Rectangular scan multi-slice EPI:
+        freq_dim = 1  phase_dim = 2  slice_dim = 3  (or some permutation)
+      Spiral scan multi-slice EPI:
+        freq_dim = phase_dim = 0  slice_dim = 3
+        since the concepts of frequency- and phase-encoding directions
+        don't apply to spiral scan
+
+    slice_duration = If this is positive, AND if slice_dim is nonzero,
+                     indicates the amount of time used to acquire 1 slice.
+                     slice_duration*dim[slice_dim] can be less than pixdim[4]
+                     with a clustered acquisition method, for example.
+
+    slice_code = If this is nonzero, AND if slice_dim is nonzero, AND
+                 if slice_duration is positive, indicates the timing
+                 pattern of the slice acquisition.  The following codes
+                 are defined:
+                   NIFTI_SLICE_SEQ_INC  == sequential increasing
+                   NIFTI_SLICE_SEQ_DEC  == sequential decreasing
+                   NIFTI_SLICE_ALT_INC  == alternating increasing
+                   NIFTI_SLICE_ALT_DEC  == alternating decreasing
+                   NIFTI_SLICE_ALT_INC2 == alternating increasing #2
+                   NIFTI_SLICE_ALT_DEC2 == alternating decreasing #2
+  { slice_start } = Indicates the start and end of the slice acquisition
+  { slice_end   } = pattern, when slice_code is nonzero.  These values
+                    are present to allow for the possible addition of
+                    "padded" slices at either end of the volume, which
+                    don't fit into the slice timing pattern.  If there
+                    are no padding slices, then slice_start=0 and
+                    slice_end=dim[slice_dim]-1 are the correct values.
+                    For these values to be meaningful, slice_start must
+                    be non-negative and slice_end must be greater than
+                    slice_start.  Otherwise, they should be ignored.
+
+  The following table indicates the slice timing pattern, relative to
+  time=0 for the first slice acquired, for some sample cases.  Here,
+  dim[slice_dim]=7 (there are 7 slices, labeled 0..6), slice_duration=0.1,
+  and slice_start=1, slice_end=5 (1 padded slice on each end).
+
+  slice
+  index  SEQ_INC SEQ_DEC ALT_INC ALT_DEC ALT_INC2 ALT_DEC2
+    6  :   n/a     n/a     n/a     n/a    n/a      n/a    n/a = not applicable
+    5  :   0.4     0.0     0.2     0.0    0.4      0.2    (slice time offset
+    4  :   0.3     0.1     0.4     0.3    0.1      0.0     doesn't apply to
+    3  :   0.2     0.2     0.1     0.1    0.3      0.3     slices outside
+    2  :   0.1     0.3     0.3     0.4    0.0      0.1     the range
+    1  :   0.0     0.4     0.0     0.2    0.2      0.4     slice_start ..
+    0  :   n/a     n/a     n/a     n/a    n/a      n/a     slice_end)
+
+  The SEQ slice_codes are sequential ordering (uncommon but not unknown),
+  either increasing in slice number or decreasing (INC or DEC), as
+  illustrated above.
+
+  The ALT slice codes are alternating ordering.  The 'standard' way for
+  these to operate (without the '2' on the end) is for the slice timing
+  to start at the edge of the slice_start .. slice_end group (at slice_start
+  for INC and at slice_end for DEC).  For the 'ALT_*2' slice_codes, the
+  slice timing instead starts at the first slice in from the edge (at
+  slice_start+1 for INC2 and at slice_end-1 for DEC2).  This latter
+  acquisition scheme is found on some Siemens scanners.
+
+  The fields freq_dim, phase_dim, slice_dim are all squished into the single
+  byte field dim_info (2 bits each, since the values for each field are
+  limited to the range 0..3).  This unpleasantness is due to lack of space
+  in the 348 byte allowance.
+
+  The macros DIM_INFO_TO_FREQ_DIM, DIM_INFO_TO_PHASE_DIM, and
+  DIM_INFO_TO_SLICE_DIM can be used to extract these values from the
+  dim_info byte.
+
+  The macro FPS_INTO_DIM_INFO can be used to put these 3 values
+  into the dim_info byte.
+-----------------------------------------------------------------------------*/
+
+#undef DIM_INFO_TO_FREQ_DIM
+#undef DIM_INFO_TO_PHASE_DIM
+#undef DIM_INFO_TO_SLICE_DIM
+
+#define DIM_INFO_TO_FREQ_DIM(di) (((di)) & 0x03)
+#define DIM_INFO_TO_PHASE_DIM(di) (((di) >> 2) & 0x03)
+#define DIM_INFO_TO_SLICE_DIM(di) (((di) >> 4) & 0x03)
+
+#undef FPS_INTO_DIM_INFO
+#define FPS_INTO_DIM_INFO(fd, pd, sd) (((((char)(fd)) & 0x03)) | ((((char)(pd)) & 0x03) << 2) | ((((char)(sd)) & 0x03) << 4))
+
+#define NIFTI_SLICE_UNKNOWN 0
+#define NIFTI_SLICE_SEQ_INC 1
+#define NIFTI_SLICE_SEQ_DEC 2
+#define NIFTI_SLICE_ALT_INC 3
+#define NIFTI_SLICE_ALT_DEC 4
+#define NIFTI_SLICE_ALT_INC2 5 /* 05 May 2005: RWCox */
+#define NIFTI_SLICE_ALT_DEC2 6 /* 05 May 2005: RWCox */
+/* @} */
+
+/*---------------------------------------------------------------------------*/
+/* UNUSED FIELDS:
+   -------------
+   Some of the ANALYZE 7.5 fields marked as ++UNUSED++ may need to be set
+   to particular values for compatibility with other programs.  The issue
+   of interoperability of ANALYZE 7.5 files is a murky one -- not all
+   programs require exactly the same set of fields.  (Unobscuring this
+   murkiness is a principal motivation behind NIFTI-1.)
+
+   Some of the fields that may need to be set for other (non-NIFTI aware)
+   software to be happy are:
+
+     extents    dbh.h says this should be 16384
+     regular    dbh.h says this should be the character 'r'
+     glmin,   } dbh.h says these values should be the min and max voxel
+      glmax   }  values for the entire dataset
+
+   It is best to initialize ALL fields in the NIFTI-1 header to 0
+   (e.g., with calloc()), then fill in what is needed.
+-----------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/* MISCELLANEOUS C MACROS
+-----------------------------------------------------------------------------*/
+
+/*.................*/
+#define NIFTI_VERSION(h) (((h).magic[0] == 'n' && (h).magic[3] == '\0' && ((h).magic[1] == 'i' || (h).magic[1] == '+') && ((h).magic[2] >= '1' && (h).magic[2] <= '9')) ? (h).magic[2] - '0' : 0)
+
+/*.................*/
+#define NIFTI_ONEFILE(h) ((h).magic[1] == '+')
+
+/*.................*/
+#define NIFTI_NEEDS_SWAP(h) ((h).dim[0] < 0 || (h).dim[0] > 7)
+
+/*.................*/
+#define NIFTI_5TH_DIM(h) (((h).dim[0] > 4 && (h).dim[5] > 1) ? (h).dim[5] : 0)
+
+/*****************************************************************************/
+
+/*=================*/
+#ifdef __cplusplus
+}
+#endif
+/*=================*/
+
+#endif /* _NIFTI_HEADER_ */

--- a/src/Plugins/SimplnxCore/test/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/test/CMakeLists.txt
@@ -113,6 +113,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   ReadBinaryCTNorthstarTest.cpp
   ReadCSVFileTest.cpp
   ReadHDF5DatasetTest.cpp
+  ReadNIfTIFileTest.cpp
   ReadRawBinaryTest.cpp
   ReadStlFileTest.cpp
   ReadStringDataArrayTest.cpp
@@ -170,6 +171,10 @@ create_simplnx_plugin_unit_test(PLUGIN_NAME ${PLUGIN_NAME}
 # If there are additional libraries that this plugin needs to link against you
 # can use the target_link_libraries() cmake call
 # target_link_libraries(${PLUGIN_NAME}UnitTest PUBLIC [name of library])
+
+# The ReadNIfTIFileTest synthesizes .nii and .nii.gz files via zlib
+find_package(ZLIB REQUIRED)
+target_link_libraries(${PLUGIN_NAME}UnitTest PUBLIC ZLIB::ZLIB)
 
 # ------------------------------------------------------------------------------
 # If there are additional source files that need to be compiled for this plugin

--- a/src/Plugins/SimplnxCore/test/ReadNIfTIFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReadNIfTIFileTest.cpp
@@ -36,13 +36,13 @@ struct SyntheticNiftiParams
   int16_t bitpix{8};
   float sclSlope{0.0f};
   float sclInter{0.0f};
-  int16_t rank{3};       // dim[0]; override to 1/2/4 for rejection tests
-  int16_t qformCode{1};  // set to 0 to disable qform
+  int16_t rank{3};      // dim[0]; override to 1/2/4 for rejection tests
+  int16_t qformCode{1}; // set to 0 to disable qform
   float quaternB{0.0f};
   float quaternC{0.0f};
   float quaternD{0.0f};
-  int16_t sformCode{0};                          // >0 enables srow_* population
-  std::array<std::array<float, 4>, 3> sform{};   // 3x4 affine when sformCode > 0
+  int16_t sformCode{0};                        // >0 enables srow_* population
+  std::array<std::array<float, 4>, 3> sform{}; // 3x4 affine when sformCode > 0
 };
 
 nifti_1_header MakeHeader(const SyntheticNiftiParams& p)
@@ -417,7 +417,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: float32 round trip", "[SimplnxCore]
 
   DataStructure dataStructure;
   ReadNIfTIFileFilter filter;
-  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, true, true);
+  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, /*applyScaling=*/true, /*useAffine=*/true);
 
   const auto preflight = filter.preflight(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
@@ -459,7 +459,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: RGB24 (3-component uint8)", "[Simpl
 
   DataStructure dataStructure;
   ReadNIfTIFileFilter filter;
-  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, true, true);
+  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, /*applyScaling=*/true, /*useAffine=*/true);
 
   const auto preflight = filter.preflight(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
@@ -504,7 +504,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: RGBA32 (4-component uint8)", "[Simp
 
   DataStructure dataStructure;
   ReadNIfTIFileFilter filter;
-  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, true, true);
+  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, /*applyScaling=*/true, /*useAffine=*/true);
 
   const auto preflight = filter.preflight(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
@@ -660,7 +660,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: PhysicalSubvolume crop maps physica
 
   DataStructure dataStructure;
   ReadNIfTIFileFilter filter;
-  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, true, true, crop);
+  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, /*applyScaling=*/true, /*useAffine=*/true, crop);
 
   const auto preflight = filter.preflight(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
@@ -747,7 +747,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: VoxelSubvolume crop preserves RGB24
 
   DataStructure dataStructure;
   ReadNIfTIFileFilter filter;
-  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, true, true, crop);
+  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, /*applyScaling=*/true, /*useAffine=*/true, crop);
 
   const auto preflight = filter.preflight(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
@@ -807,7 +807,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: rejects 4D volumes and .hdr/.img pa
 
     DataStructure dataStructure;
     ReadNIfTIFileFilter filter;
-    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", /*applyScaling=*/true, /*useAffine=*/true);
     const auto preflight = filter.preflight(dataStructure, args);
     REQUIRE(preflight.outputActions.invalid());
   }
@@ -827,7 +827,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: rejects 4D volumes and .hdr/.img pa
 
     DataStructure dataStructure;
     ReadNIfTIFileFilter filter;
-    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", /*applyScaling=*/true, /*useAffine=*/true);
     const auto preflight = filter.preflight(dataStructure, args);
     REQUIRE(preflight.outputActions.invalid());
   }
@@ -848,7 +848,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: rejects missing input file, 1D/2D v
 
     DataStructure dataStructure;
     ReadNIfTIFileFilter filter;
-    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", /*applyScaling=*/true, /*useAffine=*/true);
     const auto preflight = filter.preflight(dataStructure, args);
     REQUIRE(preflight.outputActions.invalid());
   }
@@ -870,7 +870,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: rejects missing input file, 1D/2D v
 
       DataStructure dataStructure;
       ReadNIfTIFileFilter filter;
-      const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+      const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", /*applyScaling=*/true, /*useAffine=*/true);
       const auto preflight = filter.preflight(dataStructure, args);
       REQUIRE(preflight.outputActions.invalid());
     }
@@ -890,7 +890,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: rejects missing input file, 1D/2D v
 
     DataStructure dataStructure;
     ReadNIfTIFileFilter filter;
-    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", /*applyScaling=*/true, /*useAffine=*/true);
     const auto preflight = filter.preflight(dataStructure, args);
     REQUIRE(preflight.outputActions.invalid());
   }
@@ -910,7 +910,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: rejects missing input file, 1D/2D v
 
     DataStructure dataStructure;
     ReadNIfTIFileFilter filter;
-    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", /*applyScaling=*/true, /*useAffine=*/true);
 
     const auto preflight = filter.preflight(dataStructure, args);
     SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
@@ -931,12 +931,12 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: sform-based origin and spacing extr
 
   SyntheticNiftiParams params;
   params.dims = dims;
-  params.spacing = {1.0f, 1.0f, 1.0f};           // pixdim deliberately different from sform
-  params.origin = {0.0f, 0.0f, 0.0f};             // qoffset deliberately different
+  params.spacing = {1.0f, 1.0f, 1.0f}; // pixdim deliberately different from sform
+  params.origin = {0.0f, 0.0f, 0.0f};  // qoffset deliberately different
   params.niftiDatatype = NIFTI_TYPE_UINT8;
   params.bitpix = 8;
-  params.qformCode = 0;                           // force sform path
-  params.sformCode = 1;                           // NIFTI_XFORM_SCANNER_ANAT
+  params.qformCode = 0; // force sform path
+  params.sformCode = 1; // NIFTI_XFORM_SCANNER_ANAT
   params.sform = {{{sx, 0.0f, 0.0f, tOrigin[0]}, {0.0f, sy, 0.0f, tOrigin[1]}, {0.0f, 0.0f, sz, tOrigin[2]}}};
 
   nifti_1_header hdr = MakeHeader(params);
@@ -947,7 +947,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: sform-based origin and spacing extr
   DataStructure dataStructure;
   ReadNIfTIFileFilter filter;
   const DataPath geomPath({"NIfTI Sform"});
-  const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+  const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", /*applyScaling=*/true, /*useAffine=*/true);
 
   const auto preflight = filter.preflight(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
@@ -993,7 +993,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: sform rotation emits a warning", "[
   DataStructure dataStructure;
   ReadNIfTIFileFilter filter;
   const DataPath geomPath({"NIfTI Rotated"});
-  const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+  const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", /*applyScaling=*/true, /*useAffine=*/true);
 
   const auto preflight = filter.preflight(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
@@ -1086,7 +1086,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: big-endian uint16 round trip", "[Si
   ReadNIfTIFileFilter filter;
   const DataPath geomPath({"NIfTI BE"});
   const std::string arrName = "ImageData";
-  const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, true, true);
+  const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, /*applyScaling=*/true, /*useAffine=*/true);
 
   const auto preflight = filter.preflight(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
@@ -1130,7 +1130,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: round-trips remaining native dataty
       ReadNIfTIFileFilter filter;
       const DataPath geomPath({fmt::format("NIfTI {}", label)});
       const std::string arrName = "ImageData";
-      const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, true, true);
+      const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, /*applyScaling=*/true, /*useAffine=*/true);
 
       const auto preflight = filter.preflight(dataStructure, args);
       SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
@@ -1169,7 +1169,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: round-trips remaining native dataty
     ReadNIfTIFileFilter filter;
     const DataPath geomPath({"NIfTI float64"});
     const std::string arrName = "ImageData";
-    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, true, true);
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, /*applyScaling=*/true, /*useAffine=*/true);
 
     const auto preflight = filter.preflight(dataStructure, args);
     SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
@@ -1231,7 +1231,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: crop edge cases", "[SimplnxCore][Re
 
     DataStructure dataStructure;
     ReadNIfTIFileFilter filter;
-    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, true, true, crop);
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, /*applyScaling=*/true, /*useAffine=*/true, crop);
 
     const auto preflight = filter.preflight(dataStructure, args);
     SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
@@ -1276,7 +1276,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: crop edge cases", "[SimplnxCore][Re
 
     DataStructure dataStructure;
     ReadNIfTIFileFilter filter;
-    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, true, true, crop);
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, /*applyScaling=*/true, /*useAffine=*/true, crop);
 
     const auto preflight = filter.preflight(dataStructure, args);
     SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
@@ -1315,7 +1315,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: crop edge cases", "[SimplnxCore][Re
 
     DataStructure dataStructure;
     ReadNIfTIFileFilter filter;
-    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, true, true, crop);
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, /*applyScaling=*/true, /*useAffine=*/true, crop);
 
     const auto preflight = filter.preflight(dataStructure, args);
     REQUIRE(preflight.outputActions.invalid());
@@ -1337,7 +1337,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: crop edge cases", "[SimplnxCore][Re
 
     DataStructure dataStructure;
     ReadNIfTIFileFilter filter;
-    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, true, true, crop);
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, /*applyScaling=*/true, /*useAffine=*/true, crop);
 
     const auto preflight = filter.preflight(dataStructure, args);
     REQUIRE(preflight.outputActions.invalid());
@@ -1360,7 +1360,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: identity scaling transform is not a
   params.dims = dims;
   params.niftiDatatype = NIFTI_TYPE_INT16;
   params.bitpix = 16;
-  params.sclSlope = 1.0f;   // identity
+  params.sclSlope = 1.0f; // identity
   params.sclInter = 0.0f;
   nifti_1_header hdr = MakeHeader(params);
 
@@ -1408,7 +1408,7 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: header cache is reused across prefl
   DataStructure dataStructure;
   ReadNIfTIFileFilter filter;
   const DataPath geomPath({"NIfTI Cached"});
-  const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+  const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", /*applyScaling=*/true, /*useAffine=*/true);
 
   // First preflight populates the cache.
   const auto firstPreflight = filter.preflight(dataStructure, args);

--- a/src/Plugins/SimplnxCore/test/ReadNIfTIFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReadNIfTIFileTest.cpp
@@ -7,6 +7,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
+#include "simplnx/Parameters/CropGeometryParameter.hpp"
 #include "simplnx/Parameters/DataGroupCreationParameter.hpp"
 #include "simplnx/Parameters/DataObjectNameParameter.hpp"
 #include "simplnx/Parameters/FileSystemPathParameter.hpp"
@@ -114,12 +115,14 @@ std::vector<uint8_t> ToBytes(const std::vector<T>& values)
   return out;
 }
 
-Arguments MakeFilterArgs(const fs::path& inputFile, const DataPath& geomPath, const std::string& amName, const std::string& arrName, bool applyScaling, bool useAffine)
+Arguments MakeFilterArgs(const fs::path& inputFile, const DataPath& geomPath, const std::string& amName, const std::string& arrName, bool applyScaling, bool useAffine,
+                         const CropGeometryParameter::ValueType& crop = CropGeometryParameter::ValueType{})
 {
   Arguments args;
   args.insertOrAssign(ReadNIfTIFileFilter::k_InputFilePath_Key, std::make_any<FileSystemPathParameter::ValueType>(inputFile));
   args.insertOrAssign(ReadNIfTIFileFilter::k_UseAffineIfPresent_Key, std::make_any<bool>(useAffine));
   args.insertOrAssign(ReadNIfTIFileFilter::k_ApplyScalingTransform_Key, std::make_any<bool>(applyScaling));
+  args.insertOrAssign(ReadNIfTIFileFilter::k_CroppingOptions_Key, std::make_any<CropGeometryParameter::ValueType>(crop));
   args.insertOrAssign(ReadNIfTIFileFilter::k_CreatedImageGeometryPath_Key, std::make_any<DataPath>(geomPath));
   args.insertOrAssign(ReadNIfTIFileFilter::k_CellAttributeMatrixName_Key, std::make_any<std::string>(amName));
   args.insertOrAssign(ReadNIfTIFileFilter::k_ImageDataArrayName_Key, std::make_any<std::string>(arrName));
@@ -425,6 +428,271 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: RGBA32 (4-component uint8)", "[Simp
   const auto& arr = dataStructure.getDataRefAs<DataArray<uint8>>(arrPath);
   REQUIRE(arr.getNumberOfComponents() == 4);
   RequireArrayEquals<uint8>(dataStructure, arrPath, voxels);
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: VoxelSubvolume crop streams only the selected region", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::array<int16_t, 3> dims = {6, 5, 4};
+  const std::array<float, 3> spacing = {1.0f, 1.0f, 1.0f};
+  const std::array<float, 3> origin = {0.0f, 0.0f, 0.0f};
+
+  const usize nx = static_cast<usize>(dims[0]);
+  const usize ny = static_cast<usize>(dims[1]);
+  const usize nz = static_cast<usize>(dims[2]);
+  const usize numVoxels = nx * ny * nz;
+
+  std::vector<uint16_t> voxels(numVoxels);
+  for(usize i = 0; i < numVoxels; i++)
+  {
+    voxels[i] = static_cast<uint16_t>(i);
+  }
+
+  SyntheticNiftiParams params;
+  params.dims = dims;
+  params.spacing = spacing;
+  params.origin = origin;
+  params.niftiDatatype = NIFTI_TYPE_UINT16;
+  params.bitpix = 16;
+  nifti_1_header hdr = MakeHeader(params);
+
+  const fs::path outDir = OutputDir();
+  const fs::path filePath = outDir / "uint16_crop_voxel.nii";
+  WriteNiftiFile(filePath, hdr, ToBytes(voxels), false);
+
+  CropGeometryParameter::ValueType crop;
+  crop.type = CropGeometryParameter::CropValues::TypeEnum::VoxelSubvolume;
+  crop.cropX = true;
+  crop.cropY = true;
+  crop.cropZ = true;
+  crop.xBoundVoxels = {1, 3};
+  crop.yBoundVoxels = {1, 3};
+  crop.zBoundVoxels = {1, 2};
+
+  const DataPath geomPath({"NIfTI Cropped"});
+  const std::string amName = "Cell Data";
+  const std::string arrName = "ImageData";
+  const DataPath arrPath = geomPath.createChildPath(amName).createChildPath(arrName);
+
+  DataStructure dataStructure;
+  ReadNIfTIFileFilter filter;
+  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, /*applyScaling=*/true, /*useAffine=*/true, crop);
+
+  const auto preflight = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+  const auto execute = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<ImageGeom>(geomPath));
+  const auto& geom = dataStructure.getDataRefAs<ImageGeom>(geomPath);
+  const auto outDims = geom.getDimensions();
+  const auto outOrigin = geom.getOrigin();
+  const auto outSpacing = geom.getSpacing();
+  REQUIRE(outDims[0] == 3);
+  REQUIRE(outDims[1] == 3);
+  REQUIRE(outDims[2] == 2);
+  // Origin shifts by start * spacing
+  constexpr float tol = 1e-5f;
+  REQUIRE(std::fabs(outOrigin[0] - 1.0f) < tol);
+  REQUIRE(std::fabs(outOrigin[1] - 1.0f) < tol);
+  REQUIRE(std::fabs(outOrigin[2] - 1.0f) < tol);
+  REQUIRE(std::fabs(outSpacing[0] - 1.0f) < tol);
+  REQUIRE(std::fabs(outSpacing[1] - 1.0f) < tol);
+  REQUIRE(std::fabs(outSpacing[2] - 1.0f) < tol);
+
+  std::vector<uint16_t> expected;
+  expected.reserve(3 * 3 * 2);
+  for(usize dz = 0; dz < 2; dz++)
+  {
+    for(usize dy = 0; dy < 3; dy++)
+    {
+      for(usize dx = 0; dx < 3; dx++)
+      {
+        const usize srcZ = 1 + dz;
+        const usize srcY = 1 + dy;
+        const usize srcX = 1 + dx;
+        const usize srcLinear = srcZ * ny * nx + srcY * nx + srcX;
+        expected.push_back(static_cast<uint16_t>(srcLinear));
+      }
+    }
+  }
+  RequireArrayEquals<uint16>(dataStructure, arrPath, expected);
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: PhysicalSubvolume crop maps physical bounds to voxels", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::array<int16_t, 3> dims = {6, 5, 4};
+  const std::array<float, 3> spacing = {0.5f, 1.0f, 2.0f};
+  const std::array<float, 3> origin = {0.0f, 0.0f, 0.0f};
+
+  const usize nx = static_cast<usize>(dims[0]);
+  const usize ny = static_cast<usize>(dims[1]);
+  const usize nz = static_cast<usize>(dims[2]);
+  const usize numVoxels = nx * ny * nz;
+
+  std::vector<uint8_t> voxels(numVoxels);
+  for(usize i = 0; i < numVoxels; i++)
+  {
+    voxels[i] = static_cast<uint8_t>(i);
+  }
+
+  SyntheticNiftiParams params;
+  params.dims = dims;
+  params.spacing = spacing;
+  params.origin = origin;
+  params.niftiDatatype = NIFTI_TYPE_UINT8;
+  params.bitpix = 8;
+  nifti_1_header hdr = MakeHeader(params);
+
+  const fs::path outDir = OutputDir();
+  const fs::path filePath = outDir / "uint8_crop_physical.nii";
+  WriteNiftiFile(filePath, hdr, ToBytes(voxels), false);
+
+  // With origin=0, spacing=(0.5, 1.0, 2.0), voxel (xi, yi, zi) has cell-center
+  // (xi*0.5+0.25, yi*1.0+0.5, zi*2.0+1.0). Target voxels x=[1..4] y=[1..3] z=[0..2]:
+  CropGeometryParameter::ValueType crop;
+  crop.type = CropGeometryParameter::CropValues::TypeEnum::PhysicalSubvolume;
+  crop.cropX = true;
+  crop.cropY = true;
+  crop.cropZ = true;
+  crop.xBoundPhysical = {0.6f, 2.4f};
+  crop.yBoundPhysical = {1.2f, 3.7f};
+  crop.zBoundPhysical = {0.5f, 5.5f};
+
+  const DataPath geomPath({"NIfTI Cropped Physical"});
+  const std::string amName = "Cell Data";
+  const std::string arrName = "ImageData";
+  const DataPath arrPath = geomPath.createChildPath(amName).createChildPath(arrName);
+
+  DataStructure dataStructure;
+  ReadNIfTIFileFilter filter;
+  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, true, true, crop);
+
+  const auto preflight = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+  const auto execute = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<ImageGeom>(geomPath));
+  const auto& geom = dataStructure.getDataRefAs<ImageGeom>(geomPath);
+  const auto outDims = geom.getDimensions();
+  REQUIRE(outDims[0] == 4);
+  REQUIRE(outDims[1] == 3);
+  REQUIRE(outDims[2] == 3);
+
+  const usize destNx = outDims[0];
+  const usize destNy = outDims[1];
+  const usize destNz = outDims[2];
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<DataArray<uint8>>(arrPath));
+  const auto& arr = dataStructure.getDataRefAs<DataArray<uint8>>(arrPath);
+  const auto& store = arr.getDataStoreRef();
+  REQUIRE(store.getSize() == destNx * destNy * destNz);
+
+  std::vector<uint8_t> expected;
+  expected.reserve(destNx * destNy * destNz);
+  for(usize dz = 0; dz < destNz; dz++)
+  {
+    for(usize dy = 0; dy < destNy; dy++)
+    {
+      for(usize dx = 0; dx < destNx; dx++)
+      {
+        const usize srcZ = 0 + dz;
+        const usize srcY = 1 + dy;
+        const usize srcX = 1 + dx;
+        const usize srcLinear = srcZ * ny * nx + srcY * nx + srcX;
+        expected.push_back(static_cast<uint8_t>(srcLinear));
+      }
+    }
+  }
+  RequireArrayEquals<uint8>(dataStructure, arrPath, expected);
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: VoxelSubvolume crop preserves RGB24 components", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::array<int16_t, 3> dims = {4, 3, 3};
+  const usize nx = static_cast<usize>(dims[0]);
+  const usize ny = static_cast<usize>(dims[1]);
+  const usize nz = static_cast<usize>(dims[2]);
+  const usize numVoxels = nx * ny * nz;
+
+  std::vector<uint8_t> voxels(numVoxels * 3);
+  for(usize i = 0; i < numVoxels; i++)
+  {
+    voxels[i * 3 + 0] = static_cast<uint8_t>((i * 3 + 0) & 0xFF);
+    voxels[i * 3 + 1] = static_cast<uint8_t>((i * 3 + 1) & 0xFF);
+    voxels[i * 3 + 2] = static_cast<uint8_t>((i * 3 + 2) & 0xFF);
+  }
+
+  SyntheticNiftiParams params;
+  params.dims = dims;
+  params.niftiDatatype = NIFTI_TYPE_RGB24;
+  params.bitpix = 24;
+  nifti_1_header hdr = MakeHeader(params);
+
+  const fs::path outDir = OutputDir();
+  const fs::path filePath = outDir / "rgb24_crop.nii";
+  WriteNiftiFile(filePath, hdr, voxels, false);
+
+  CropGeometryParameter::ValueType crop;
+  crop.type = CropGeometryParameter::CropValues::TypeEnum::VoxelSubvolume;
+  crop.cropX = true;
+  crop.cropY = true;
+  crop.cropZ = true;
+  crop.xBoundVoxels = {1, 2};
+  crop.yBoundVoxels = {0, 1};
+  crop.zBoundVoxels = {1, 2};
+
+  const DataPath geomPath({"NIfTI RGB Cropped"});
+  const std::string amName = "Cell Data";
+  const std::string arrName = "ImageData";
+  const DataPath arrPath = geomPath.createChildPath(amName).createChildPath(arrName);
+
+  DataStructure dataStructure;
+  ReadNIfTIFileFilter filter;
+  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, true, true, crop);
+
+  const auto preflight = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+  const auto execute = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<DataArray<uint8>>(arrPath));
+  const auto& arr = dataStructure.getDataRefAs<DataArray<uint8>>(arrPath);
+  REQUIRE(arr.getNumberOfComponents() == 3);
+
+  const usize destNx = 2;
+  const usize destNy = 2;
+  const usize destNz = 2;
+  std::vector<uint8_t> expected;
+  expected.reserve(destNx * destNy * destNz * 3);
+  for(usize dz = 0; dz < destNz; dz++)
+  {
+    for(usize dy = 0; dy < destNy; dy++)
+    {
+      for(usize dx = 0; dx < destNx; dx++)
+      {
+        const usize srcX = 1 + dx;
+        const usize srcY = 0 + dy;
+        const usize srcZ = 1 + dz;
+        const usize srcLinear = srcZ * ny * nx + srcY * nx + srcX;
+        expected.push_back(static_cast<uint8_t>((srcLinear * 3 + 0) & 0xFF));
+        expected.push_back(static_cast<uint8_t>((srcLinear * 3 + 1) & 0xFF));
+        expected.push_back(static_cast<uint8_t>((srcLinear * 3 + 2) & 0xFF));
+      }
+    }
+  }
+  RequireArrayEquals<uint8>(dataStructure, arrPath, expected);
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
 }

--- a/src/Plugins/SimplnxCore/test/ReadNIfTIFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReadNIfTIFileTest.cpp
@@ -1,0 +1,479 @@
+#include <catch2/catch.hpp>
+
+#include "SimplnxCore/Filters/ReadNIfTIFileFilter.hpp"
+#include "SimplnxCore/SimplnxCore_test_dirs.hpp"
+#include "SimplnxCore/utils/nifti1.h"
+
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Parameters/BoolParameter.hpp"
+#include "simplnx/Parameters/DataGroupCreationParameter.hpp"
+#include "simplnx/Parameters/DataObjectNameParameter.hpp"
+#include "simplnx/Parameters/FileSystemPathParameter.hpp"
+#include "simplnx/UnitTest/UnitTestCommon.hpp"
+
+#include <zlib.h>
+
+#include <array>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <numeric>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+using namespace nx::core;
+using namespace nx::core::UnitTest;
+
+namespace
+{
+struct SyntheticNiftiParams
+{
+  std::array<int16_t, 3> dims{1, 1, 1};
+  std::array<float, 3> spacing{1.0f, 1.0f, 1.0f};
+  std::array<float, 3> origin{0.0f, 0.0f, 0.0f};
+  int16_t niftiDatatype{NIFTI_TYPE_UINT8};
+  int16_t bitpix{8};
+  float sclSlope{0.0f};
+  float sclInter{0.0f};
+};
+
+nifti_1_header MakeHeader(const SyntheticNiftiParams& p)
+{
+  nifti_1_header hdr{};
+  hdr.sizeof_hdr = 348;
+  hdr.dim[0] = 3;
+  hdr.dim[1] = p.dims[0];
+  hdr.dim[2] = p.dims[1];
+  hdr.dim[3] = p.dims[2];
+  hdr.dim[4] = 1;
+  hdr.dim[5] = 1;
+  hdr.dim[6] = 1;
+  hdr.dim[7] = 1;
+
+  hdr.pixdim[0] = 1.0f;
+  hdr.pixdim[1] = p.spacing[0];
+  hdr.pixdim[2] = p.spacing[1];
+  hdr.pixdim[3] = p.spacing[2];
+  hdr.pixdim[4] = 0.0f;
+
+  hdr.datatype = p.niftiDatatype;
+  hdr.bitpix = p.bitpix;
+  hdr.vox_offset = 352.0f;
+  hdr.scl_slope = p.sclSlope;
+  hdr.scl_inter = p.sclInter;
+
+  hdr.qform_code = 1; // NIFTI_XFORM_SCANNER_ANAT
+  hdr.qoffset_x = p.origin[0];
+  hdr.qoffset_y = p.origin[1];
+  hdr.qoffset_z = p.origin[2];
+  hdr.quatern_b = 0.0f;
+  hdr.quatern_c = 0.0f;
+  hdr.quatern_d = 0.0f;
+
+  std::memcpy(hdr.magic, "n+1\0", 4);
+  return hdr;
+}
+
+void WriteNiftiFile(const fs::path& path, const nifti_1_header& hdr, const std::vector<uint8_t>& voxelBytes, bool gzipped)
+{
+  static constexpr std::array<uint8_t, 4> zeroExtension{0, 0, 0, 0};
+
+  if(gzipped)
+  {
+    gzFile gz = gzopen(path.string().c_str(), "wb");
+    REQUIRE(gz != nullptr);
+    REQUIRE(gzwrite(gz, &hdr, static_cast<unsigned int>(sizeof(hdr))) == static_cast<int>(sizeof(hdr)));
+    REQUIRE(gzwrite(gz, zeroExtension.data(), 4) == 4);
+    if(!voxelBytes.empty())
+    {
+      REQUIRE(gzwrite(gz, voxelBytes.data(), static_cast<unsigned int>(voxelBytes.size())) == static_cast<int>(voxelBytes.size()));
+    }
+    gzclose(gz);
+  }
+  else
+  {
+    std::ofstream ofs(path, std::ios::binary);
+    REQUIRE(ofs.is_open());
+    ofs.write(reinterpret_cast<const char*>(&hdr), sizeof(hdr));
+    ofs.write(reinterpret_cast<const char*>(zeroExtension.data()), 4);
+    if(!voxelBytes.empty())
+    {
+      ofs.write(reinterpret_cast<const char*>(voxelBytes.data()), static_cast<std::streamsize>(voxelBytes.size()));
+    }
+    ofs.close();
+  }
+}
+
+template <typename T>
+std::vector<uint8_t> ToBytes(const std::vector<T>& values)
+{
+  std::vector<uint8_t> out(values.size() * sizeof(T));
+  std::memcpy(out.data(), values.data(), out.size());
+  return out;
+}
+
+Arguments MakeFilterArgs(const fs::path& inputFile, const DataPath& geomPath, const std::string& amName, const std::string& arrName, bool applyScaling, bool useAffine)
+{
+  Arguments args;
+  args.insertOrAssign(ReadNIfTIFileFilter::k_InputFilePath_Key, std::make_any<FileSystemPathParameter::ValueType>(inputFile));
+  args.insertOrAssign(ReadNIfTIFileFilter::k_UseAffineIfPresent_Key, std::make_any<bool>(useAffine));
+  args.insertOrAssign(ReadNIfTIFileFilter::k_ApplyScalingTransform_Key, std::make_any<bool>(applyScaling));
+  args.insertOrAssign(ReadNIfTIFileFilter::k_CreatedImageGeometryPath_Key, std::make_any<DataPath>(geomPath));
+  args.insertOrAssign(ReadNIfTIFileFilter::k_CellAttributeMatrixName_Key, std::make_any<std::string>(amName));
+  args.insertOrAssign(ReadNIfTIFileFilter::k_ImageDataArrayName_Key, std::make_any<std::string>(arrName));
+  return args;
+}
+
+fs::path OutputDir()
+{
+  fs::path dir = fs::path(std::string(nx::core::unit_test::k_BinaryTestOutputDir.view())) / "ReadNIfTIFile";
+  fs::create_directories(dir);
+  return dir;
+}
+
+template <typename T>
+void RequireArrayEquals(const DataStructure& ds, const DataPath& dataArrayPath, const std::vector<T>& expected)
+{
+  REQUIRE_NOTHROW(ds.getDataRefAs<DataArray<T>>(dataArrayPath));
+  const auto& arr = ds.getDataRefAs<DataArray<T>>(dataArrayPath);
+  const auto& store = arr.getDataStoreRef();
+  REQUIRE(store.getSize() == expected.size());
+  for(usize i = 0; i < expected.size(); i++)
+  {
+    const T actual = store[i];
+    if(actual != expected[i])
+    {
+      UNSCOPED_INFO(fmt::format("Mismatch at index {}: expected {}, got {}", i, expected[i], actual));
+      REQUIRE(actual == expected[i]);
+    }
+  }
+}
+
+void RequireFloatArrayApproxEquals(const DataStructure& ds, const DataPath& dataArrayPath, const std::vector<float>& expected, float tolerance = 1e-5f)
+{
+  REQUIRE_NOTHROW(ds.getDataRefAs<DataArray<float32>>(dataArrayPath));
+  const auto& arr = ds.getDataRefAs<DataArray<float32>>(dataArrayPath);
+  const auto& store = arr.getDataStoreRef();
+  REQUIRE(store.getSize() == expected.size());
+  for(usize i = 0; i < expected.size(); i++)
+  {
+    const float actual = store[i];
+    if(std::fabs(actual - expected[i]) > tolerance)
+    {
+      UNSCOPED_INFO(fmt::format("Mismatch at index {}: expected {}, got {}", i, expected[i], actual));
+      REQUIRE(std::fabs(actual - expected[i]) <= tolerance);
+    }
+  }
+}
+} // namespace
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: uint8 round trip (.nii and .nii.gz)", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::array<int16_t, 3> dims = {4, 3, 2};
+  const std::array<float, 3> spacing = {0.5f, 0.75f, 1.25f};
+  const std::array<float, 3> origin = {-1.0f, 2.0f, 3.5f};
+
+  const usize numVoxels = static_cast<usize>(dims[0]) * dims[1] * dims[2];
+  std::vector<uint8_t> voxels(numVoxels);
+  std::iota(voxels.begin(), voxels.end(), static_cast<uint8_t>(0));
+
+  SyntheticNiftiParams params;
+  params.dims = dims;
+  params.spacing = spacing;
+  params.origin = origin;
+  params.niftiDatatype = NIFTI_TYPE_UINT8;
+  params.bitpix = 8;
+  nifti_1_header hdr = MakeHeader(params);
+
+  const fs::path outDir = OutputDir();
+  const DataPath geomPath({"NIfTI Image"});
+  const std::string amName = "Cell Data";
+  const std::string arrName = "ImageData";
+  const DataPath arrPath = geomPath.createChildPath(amName).createChildPath(arrName);
+
+  for(bool gzipped : {false, true})
+  {
+    DYNAMIC_SECTION("format=" << (gzipped ? ".nii.gz" : ".nii"))
+    {
+      const fs::path filePath = outDir / (gzipped ? "uint8.nii.gz" : "uint8.nii");
+      WriteNiftiFile(filePath, hdr, ToBytes(voxels), gzipped);
+
+      DataStructure dataStructure;
+      ReadNIfTIFileFilter filter;
+      const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, /*applyScaling=*/true, /*useAffine=*/true);
+
+      const auto preflight = filter.preflight(dataStructure, args);
+      SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+
+      const auto execute = filter.execute(dataStructure, args);
+      SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+      REQUIRE_NOTHROW(dataStructure.getDataRefAs<ImageGeom>(geomPath));
+      const auto& geom = dataStructure.getDataRefAs<ImageGeom>(geomPath);
+      const auto actualDims = geom.getDimensions();
+      const auto actualSpacing = geom.getSpacing();
+      const auto actualOrigin = geom.getOrigin();
+      constexpr float tol = 1e-5f;
+      REQUIRE(actualDims[0] == static_cast<usize>(dims[0]));
+      REQUIRE(actualDims[1] == static_cast<usize>(dims[1]));
+      REQUIRE(actualDims[2] == static_cast<usize>(dims[2]));
+      REQUIRE(std::fabs(actualSpacing[0] - spacing[0]) < tol);
+      REQUIRE(std::fabs(actualSpacing[1] - spacing[1]) < tol);
+      REQUIRE(std::fabs(actualSpacing[2] - spacing[2]) < tol);
+      REQUIRE(std::fabs(actualOrigin[0] - origin[0]) < tol);
+      REQUIRE(std::fabs(actualOrigin[1] - origin[1]) < tol);
+      REQUIRE(std::fabs(actualOrigin[2] - origin[2]) < tol);
+
+      RequireArrayEquals<uint8>(dataStructure, arrPath, voxels);
+
+      UnitTest::CheckArraysInheritTupleDims(dataStructure);
+    }
+  }
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: int16 with scaling transform", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::array<int16_t, 3> dims = {3, 3, 2};
+  const usize numVoxels = static_cast<usize>(dims[0]) * dims[1] * dims[2];
+  std::vector<int16_t> voxels(numVoxels);
+  for(usize i = 0; i < numVoxels; i++)
+  {
+    voxels[i] = static_cast<int16_t>(i) - 4;
+  }
+
+  SyntheticNiftiParams params;
+  params.dims = dims;
+  params.niftiDatatype = NIFTI_TYPE_INT16;
+  params.bitpix = 16;
+  params.sclSlope = 0.25f;
+  params.sclInter = 10.0f;
+  nifti_1_header hdr = MakeHeader(params);
+
+  const fs::path outDir = OutputDir();
+  const fs::path filePath = outDir / "int16_scaled.nii";
+  WriteNiftiFile(filePath, hdr, ToBytes(voxels), /*gzipped=*/false);
+
+  const DataPath geomPath({"NIfTI Image Scaled"});
+  const std::string amName = "Cell Data";
+  const std::string arrName = "ImageData";
+  const DataPath arrPath = geomPath.createChildPath(amName).createChildPath(arrName);
+
+  SECTION("apply_scaling = true → float32 promoted, values transformed")
+  {
+    DataStructure dataStructure;
+    ReadNIfTIFileFilter filter;
+    const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, /*applyScaling=*/true, /*useAffine=*/true);
+
+    const auto preflight = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+    const auto execute = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+    std::vector<float> expected(numVoxels);
+    for(usize i = 0; i < numVoxels; i++)
+    {
+      expected[i] = static_cast<float>(voxels[i]) * params.sclSlope + params.sclInter;
+    }
+    RequireFloatArrayApproxEquals(dataStructure, arrPath, expected);
+  }
+
+  SECTION("apply_scaling = false → native int16 preserved")
+  {
+    DataStructure dataStructure;
+    ReadNIfTIFileFilter filter;
+    const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, /*applyScaling=*/false, /*useAffine=*/true);
+
+    const auto preflight = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+    const auto execute = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+    RequireArrayEquals<int16>(dataStructure, arrPath, voxels);
+  }
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: float32 round trip", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::array<int16_t, 3> dims = {2, 2, 2};
+  const usize numVoxels = static_cast<usize>(dims[0]) * dims[1] * dims[2];
+  std::vector<float> voxels(numVoxels);
+  for(usize i = 0; i < numVoxels; i++)
+  {
+    voxels[i] = 0.25f * static_cast<float>(i) - 1.0f;
+  }
+
+  SyntheticNiftiParams params;
+  params.dims = dims;
+  params.niftiDatatype = NIFTI_TYPE_FLOAT32;
+  params.bitpix = 32;
+  nifti_1_header hdr = MakeHeader(params);
+
+  const fs::path outDir = OutputDir();
+  const fs::path filePath = outDir / "float32.nii";
+  WriteNiftiFile(filePath, hdr, ToBytes(voxels), /*gzipped=*/false);
+
+  const DataPath geomPath({"NIfTI Float"});
+  const std::string amName = "Cell Data";
+  const std::string arrName = "ImageData";
+  const DataPath arrPath = geomPath.createChildPath(amName).createChildPath(arrName);
+
+  DataStructure dataStructure;
+  ReadNIfTIFileFilter filter;
+  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, true, true);
+
+  const auto preflight = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+  const auto execute = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+  RequireFloatArrayApproxEquals(dataStructure, arrPath, voxels);
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: RGB24 (3-component uint8)", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::array<int16_t, 3> dims = {3, 2, 2};
+  const usize numVoxels = static_cast<usize>(dims[0]) * dims[1] * dims[2];
+  std::vector<uint8_t> voxels(numVoxels * 3);
+  for(usize i = 0; i < numVoxels; i++)
+  {
+    voxels[i * 3 + 0] = static_cast<uint8_t>(i * 3 + 0);
+    voxels[i * 3 + 1] = static_cast<uint8_t>(i * 3 + 1);
+    voxels[i * 3 + 2] = static_cast<uint8_t>(i * 3 + 2);
+  }
+
+  SyntheticNiftiParams params;
+  params.dims = dims;
+  params.niftiDatatype = NIFTI_TYPE_RGB24;
+  params.bitpix = 24;
+  nifti_1_header hdr = MakeHeader(params);
+
+  const fs::path outDir = OutputDir();
+  const fs::path filePath = outDir / "rgb24.nii";
+  WriteNiftiFile(filePath, hdr, voxels, /*gzipped=*/false);
+
+  const DataPath geomPath({"NIfTI RGB"});
+  const std::string amName = "Cell Data";
+  const std::string arrName = "ImageData";
+  const DataPath arrPath = geomPath.createChildPath(amName).createChildPath(arrName);
+
+  DataStructure dataStructure;
+  ReadNIfTIFileFilter filter;
+  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, true, true);
+
+  const auto preflight = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+  const auto execute = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<DataArray<uint8>>(arrPath));
+  const auto& arr = dataStructure.getDataRefAs<DataArray<uint8>>(arrPath);
+  REQUIRE(arr.getNumberOfComponents() == 3);
+  REQUIRE(arr.getDataStoreRef().getSize() == voxels.size());
+  RequireArrayEquals<uint8>(dataStructure, arrPath, voxels);
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: RGBA32 (4-component uint8)", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::array<int16_t, 3> dims = {2, 2, 2};
+  const usize numVoxels = static_cast<usize>(dims[0]) * dims[1] * dims[2];
+  std::vector<uint8_t> voxels(numVoxels * 4);
+  for(usize i = 0; i < voxels.size(); i++)
+  {
+    voxels[i] = static_cast<uint8_t>(i);
+  }
+
+  SyntheticNiftiParams params;
+  params.dims = dims;
+  params.niftiDatatype = NIFTI_TYPE_RGBA32;
+  params.bitpix = 32;
+  nifti_1_header hdr = MakeHeader(params);
+
+  const fs::path outDir = OutputDir();
+  const fs::path filePath = outDir / "rgba32.nii";
+  WriteNiftiFile(filePath, hdr, voxels, /*gzipped=*/false);
+
+  const DataPath geomPath({"NIfTI RGBA"});
+  const std::string amName = "Cell Data";
+  const std::string arrName = "ImageData";
+  const DataPath arrPath = geomPath.createChildPath(amName).createChildPath(arrName);
+
+  DataStructure dataStructure;
+  ReadNIfTIFileFilter filter;
+  const Arguments args = MakeFilterArgs(filePath, geomPath, amName, arrName, true, true);
+
+  const auto preflight = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+  const auto execute = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<DataArray<uint8>>(arrPath));
+  const auto& arr = dataStructure.getDataRefAs<DataArray<uint8>>(arrPath);
+  REQUIRE(arr.getNumberOfComponents() == 4);
+  RequireArrayEquals<uint8>(dataStructure, arrPath, voxels);
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: rejects 4D volumes and .hdr/.img pair", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const fs::path outDir = OutputDir();
+  const DataPath geomPath({"NIfTI Bad"});
+
+  SECTION("dim[0] == 4 is rejected")
+  {
+    nifti_1_header hdr = MakeHeader({});
+    hdr.dim[0] = 4;
+    hdr.dim[1] = 2;
+    hdr.dim[2] = 2;
+    hdr.dim[3] = 2;
+    hdr.dim[4] = 2;
+    hdr.datatype = NIFTI_TYPE_UINT8;
+    hdr.bitpix = 8;
+    std::vector<uint8_t> voxels(2 * 2 * 2 * 2, 0);
+    const fs::path filePath = outDir / "4d.nii";
+    WriteNiftiFile(filePath, hdr, voxels, false);
+
+    DataStructure dataStructure;
+    ReadNIfTIFileFilter filter;
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+    const auto preflight = filter.preflight(dataStructure, args);
+    REQUIRE(preflight.outputActions.invalid());
+  }
+
+  SECTION("ni1 (hdr/img pair magic) is rejected")
+  {
+    nifti_1_header hdr = MakeHeader({});
+    hdr.datatype = NIFTI_TYPE_UINT8;
+    hdr.bitpix = 8;
+    hdr.dim[1] = 2;
+    hdr.dim[2] = 2;
+    hdr.dim[3] = 2;
+    std::memcpy(hdr.magic, "ni1\0", 4);
+    std::vector<uint8_t> voxels(8, 0);
+    const fs::path filePath = outDir / "pair.nii";
+    WriteNiftiFile(filePath, hdr, voxels, false);
+
+    DataStructure dataStructure;
+    ReadNIfTIFileFilter filter;
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+    const auto preflight = filter.preflight(dataStructure, args);
+    REQUIRE(preflight.outputActions.invalid());
+  }
+}

--- a/src/Plugins/SimplnxCore/test/ReadNIfTIFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReadNIfTIFileTest.cpp
@@ -4,12 +4,10 @@
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
 #include "SimplnxCore/utils/nifti1.h"
 
+#include "simplnx/Common/Bit.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
-#include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/CropGeometryParameter.hpp"
-#include "simplnx/Parameters/DataGroupCreationParameter.hpp"
-#include "simplnx/Parameters/DataObjectNameParameter.hpp"
 #include "simplnx/Parameters/FileSystemPathParameter.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
@@ -38,13 +36,20 @@ struct SyntheticNiftiParams
   int16_t bitpix{8};
   float sclSlope{0.0f};
   float sclInter{0.0f};
+  int16_t rank{3};       // dim[0]; override to 1/2/4 for rejection tests
+  int16_t qformCode{1};  // set to 0 to disable qform
+  float quaternB{0.0f};
+  float quaternC{0.0f};
+  float quaternD{0.0f};
+  int16_t sformCode{0};                          // >0 enables srow_* population
+  std::array<std::array<float, 4>, 3> sform{};   // 3x4 affine when sformCode > 0
 };
 
 nifti_1_header MakeHeader(const SyntheticNiftiParams& p)
 {
   nifti_1_header hdr{};
   hdr.sizeof_hdr = 348;
-  hdr.dim[0] = 3;
+  hdr.dim[0] = p.rank;
   hdr.dim[1] = p.dims[0];
   hdr.dim[2] = p.dims[1];
   hdr.dim[3] = p.dims[2];
@@ -65,16 +70,98 @@ nifti_1_header MakeHeader(const SyntheticNiftiParams& p)
   hdr.scl_slope = p.sclSlope;
   hdr.scl_inter = p.sclInter;
 
-  hdr.qform_code = 1; // NIFTI_XFORM_SCANNER_ANAT
+  hdr.qform_code = p.qformCode;
   hdr.qoffset_x = p.origin[0];
   hdr.qoffset_y = p.origin[1];
   hdr.qoffset_z = p.origin[2];
-  hdr.quatern_b = 0.0f;
-  hdr.quatern_c = 0.0f;
-  hdr.quatern_d = 0.0f;
+  hdr.quatern_b = p.quaternB;
+  hdr.quatern_c = p.quaternC;
+  hdr.quatern_d = p.quaternD;
+
+  hdr.sform_code = p.sformCode;
+  if(p.sformCode > 0)
+  {
+    for(int i = 0; i < 4; i++)
+    {
+      hdr.srow_x[i] = p.sform[0][i];
+      hdr.srow_y[i] = p.sform[1][i];
+      hdr.srow_z[i] = p.sform[2][i];
+    }
+  }
 
   std::memcpy(hdr.magic, "n+1\0", 4);
   return hdr;
+}
+
+template <typename T>
+void ByteSwap(T& v)
+{
+  v = nx::core::byteswap(v);
+}
+
+// Mirrors the private ByteSwapHeader in NiftiUtilities.cpp so the test can
+// synthesize files in foreign byte order and exercise the endian-detection
+// path in ReadNiftiHeader.
+void ByteSwapHeader(nifti_1_header& hdr)
+{
+  ByteSwap(hdr.sizeof_hdr);
+  ByteSwap(hdr.extents);
+  ByteSwap(hdr.session_error);
+  for(auto& v : hdr.dim)
+  {
+    ByteSwap(v);
+  }
+  ByteSwap(hdr.intent_p1);
+  ByteSwap(hdr.intent_p2);
+  ByteSwap(hdr.intent_p3);
+  ByteSwap(hdr.intent_code);
+  ByteSwap(hdr.datatype);
+  ByteSwap(hdr.bitpix);
+  ByteSwap(hdr.slice_start);
+  for(auto& v : hdr.pixdim)
+  {
+    ByteSwap(v);
+  }
+  ByteSwap(hdr.vox_offset);
+  ByteSwap(hdr.scl_slope);
+  ByteSwap(hdr.scl_inter);
+  ByteSwap(hdr.slice_end);
+  ByteSwap(hdr.cal_max);
+  ByteSwap(hdr.cal_min);
+  ByteSwap(hdr.slice_duration);
+  ByteSwap(hdr.toffset);
+  ByteSwap(hdr.glmax);
+  ByteSwap(hdr.glmin);
+  ByteSwap(hdr.qform_code);
+  ByteSwap(hdr.sform_code);
+  ByteSwap(hdr.quatern_b);
+  ByteSwap(hdr.quatern_c);
+  ByteSwap(hdr.quatern_d);
+  ByteSwap(hdr.qoffset_x);
+  ByteSwap(hdr.qoffset_y);
+  ByteSwap(hdr.qoffset_z);
+  for(auto& v : hdr.srow_x)
+  {
+    ByteSwap(v);
+  }
+  for(auto& v : hdr.srow_y)
+  {
+    ByteSwap(v);
+  }
+  for(auto& v : hdr.srow_z)
+  {
+    ByteSwap(v);
+  }
+}
+
+template <typename T>
+std::vector<uint8_t> ToBytesByteSwapped(std::vector<T> values)
+{
+  for(auto& v : values)
+  {
+    ByteSwap(v);
+  }
+  return std::vector<uint8_t>(reinterpret_cast<const uint8_t*>(values.data()), reinterpret_cast<const uint8_t*>(values.data()) + values.size() * sizeof(T));
 }
 
 void WriteNiftiFile(const fs::path& path, const nifti_1_header& hdr, const std::vector<uint8_t>& voxelBytes, bool gzipped)
@@ -744,4 +831,613 @@ TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: rejects 4D volumes and .hdr/.img pa
     const auto preflight = filter.preflight(dataStructure, args);
     REQUIRE(preflight.outputActions.invalid());
   }
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: rejects missing input file, 1D/2D volumes, and unsupported datatypes", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const fs::path outDir = OutputDir();
+  const DataPath geomPath({"NIfTI Bad"});
+
+  SECTION("missing input file")
+  {
+    const fs::path filePath = outDir / "does_not_exist_123456.nii";
+    std::error_code ec;
+    fs::remove(filePath, ec);
+
+    DataStructure dataStructure;
+    ReadNIfTIFileFilter filter;
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+    const auto preflight = filter.preflight(dataStructure, args);
+    REQUIRE(preflight.outputActions.invalid());
+  }
+
+  for(int16_t rank : {int16_t{1}, int16_t{2}})
+  {
+    DYNAMIC_SECTION("rank=" << rank << " is rejected")
+    {
+      SyntheticNiftiParams params;
+      params.dims = {2, 2, 2};
+      params.niftiDatatype = NIFTI_TYPE_UINT8;
+      params.bitpix = 8;
+      params.rank = rank;
+      nifti_1_header hdr = MakeHeader(params);
+
+      const fs::path filePath = outDir / fmt::format("rank_{}.nii", rank);
+      std::vector<uint8_t> voxels(8, 0);
+      WriteNiftiFile(filePath, hdr, voxels, false);
+
+      DataStructure dataStructure;
+      ReadNIfTIFileFilter filter;
+      const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+      const auto preflight = filter.preflight(dataStructure, args);
+      REQUIRE(preflight.outputActions.invalid());
+    }
+  }
+
+  SECTION("unsupported datatype (complex64) is rejected")
+  {
+    SyntheticNiftiParams params;
+    params.dims = {2, 2, 2};
+    params.niftiDatatype = NIFTI_TYPE_COMPLEX64;
+    params.bitpix = 64;
+    nifti_1_header hdr = MakeHeader(params);
+
+    const fs::path filePath = outDir / "complex64.nii";
+    std::vector<uint8_t> voxels(2 * 2 * 2 * 8, 0);
+    WriteNiftiFile(filePath, hdr, voxels, false);
+
+    DataStructure dataStructure;
+    ReadNIfTIFileFilter filter;
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+    const auto preflight = filter.preflight(dataStructure, args);
+    REQUIRE(preflight.outputActions.invalid());
+  }
+
+  SECTION("truncated voxel body fails at execute")
+  {
+    SyntheticNiftiParams params;
+    params.dims = {4, 4, 4};
+    params.niftiDatatype = NIFTI_TYPE_UINT8;
+    params.bitpix = 8;
+    nifti_1_header hdr = MakeHeader(params);
+
+    // Header announces 64 voxels, but we only write 8 bytes of body.
+    std::vector<uint8_t> voxels(8, 0);
+    const fs::path filePath = outDir / "truncated.nii";
+    WriteNiftiFile(filePath, hdr, voxels, false);
+
+    DataStructure dataStructure;
+    ReadNIfTIFileFilter filter;
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+
+    const auto preflight = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+    const auto execute = filter.execute(dataStructure, args);
+    REQUIRE(execute.result.invalid());
+  }
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: sform-based origin and spacing extraction", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::array<int16_t, 3> dims = {3, 3, 3};
+  const float sx = 2.0f;
+  const float sy = 3.0f;
+  const float sz = 4.0f;
+  const std::array<float, 3> tOrigin = {7.5f, -1.0f, 2.25f};
+
+  SyntheticNiftiParams params;
+  params.dims = dims;
+  params.spacing = {1.0f, 1.0f, 1.0f};           // pixdim deliberately different from sform
+  params.origin = {0.0f, 0.0f, 0.0f};             // qoffset deliberately different
+  params.niftiDatatype = NIFTI_TYPE_UINT8;
+  params.bitpix = 8;
+  params.qformCode = 0;                           // force sform path
+  params.sformCode = 1;                           // NIFTI_XFORM_SCANNER_ANAT
+  params.sform = {{{sx, 0.0f, 0.0f, tOrigin[0]}, {0.0f, sy, 0.0f, tOrigin[1]}, {0.0f, 0.0f, sz, tOrigin[2]}}};
+
+  nifti_1_header hdr = MakeHeader(params);
+  std::vector<uint8_t> voxels(static_cast<usize>(dims[0]) * dims[1] * dims[2], 0);
+  const fs::path filePath = OutputDir() / "sform_diag.nii";
+  WriteNiftiFile(filePath, hdr, voxels, false);
+
+  DataStructure dataStructure;
+  ReadNIfTIFileFilter filter;
+  const DataPath geomPath({"NIfTI Sform"});
+  const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+
+  const auto preflight = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+  const auto execute = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+  REQUIRE(preflight.outputActions.warnings().empty());
+
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<ImageGeom>(geomPath));
+  const auto& geom = dataStructure.getDataRefAs<ImageGeom>(geomPath);
+  const auto outOrigin = geom.getOrigin();
+  const auto outSpacing = geom.getSpacing();
+  constexpr float tol = 1e-5f;
+  REQUIRE(std::fabs(outOrigin[0] - tOrigin[0]) < tol);
+  REQUIRE(std::fabs(outOrigin[1] - tOrigin[1]) < tol);
+  REQUIRE(std::fabs(outOrigin[2] - tOrigin[2]) < tol);
+  REQUIRE(std::fabs(outSpacing[0] - sx) < tol);
+  REQUIRE(std::fabs(outSpacing[1] - sy) < tol);
+  REQUIRE(std::fabs(outSpacing[2] - sz) < tol);
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: sform rotation emits a warning", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  // 45deg rotation about z, unit spacing, zero translation — off-diagonal
+  // srow entries should trip the affineHasRotation detector.
+  const float c = std::cos(0.7853981633974483f);
+  const float s = std::sin(0.7853981633974483f);
+
+  SyntheticNiftiParams params;
+  params.dims = {2, 2, 2};
+  params.niftiDatatype = NIFTI_TYPE_UINT8;
+  params.bitpix = 8;
+  params.qformCode = 0;
+  params.sformCode = 1;
+  params.sform = {{{c, -s, 0.0f, 0.0f}, {s, c, 0.0f, 0.0f}, {0.0f, 0.0f, 1.0f, 0.0f}}};
+
+  nifti_1_header hdr = MakeHeader(params);
+  std::vector<uint8_t> voxels(8, 0);
+  const fs::path filePath = OutputDir() / "sform_rotated.nii";
+  WriteNiftiFile(filePath, hdr, voxels, false);
+
+  DataStructure dataStructure;
+  ReadNIfTIFileFilter filter;
+  const DataPath geomPath({"NIfTI Rotated"});
+  const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+
+  const auto preflight = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+
+  const auto& warnings = preflight.outputActions.warnings();
+  REQUIRE_FALSE(warnings.empty());
+  bool foundRotationWarning = false;
+  for(const auto& w : warnings)
+  {
+    if(w.code == -34750)
+    {
+      foundRotationWarning = true;
+      break;
+    }
+  }
+  REQUIRE(foundRotationWarning);
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: UseAffineIfPresent=false falls back to pixdim + zero origin", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  // File advertises origin (100, 200, 300) via sform and spacing (5, 5, 5)
+  // via sform column magnitudes. pixdim stays at (1, 1, 1). When the user
+  // disables the affine, we should fall back to pixdim + zero origin.
+  SyntheticNiftiParams params;
+  params.dims = {2, 2, 2};
+  params.spacing = {1.0f, 1.0f, 1.0f};
+  params.niftiDatatype = NIFTI_TYPE_UINT8;
+  params.bitpix = 8;
+  params.qformCode = 0;
+  params.sformCode = 1;
+  params.sform = {{{5.0f, 0.0f, 0.0f, 100.0f}, {0.0f, 5.0f, 0.0f, 200.0f}, {0.0f, 0.0f, 5.0f, 300.0f}}};
+
+  nifti_1_header hdr = MakeHeader(params);
+  std::vector<uint8_t> voxels(8, 0);
+  const fs::path filePath = OutputDir() / "no_affine.nii";
+  WriteNiftiFile(filePath, hdr, voxels, false);
+
+  DataStructure dataStructure;
+  ReadNIfTIFileFilter filter;
+  const DataPath geomPath({"NIfTI NoAffine"});
+  const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", /*applyScaling=*/true, /*useAffine=*/false);
+
+  const auto preflight = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+  const auto execute = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+  const auto& geom = dataStructure.getDataRefAs<ImageGeom>(geomPath);
+  const auto outOrigin = geom.getOrigin();
+  const auto outSpacing = geom.getSpacing();
+  constexpr float tol = 1e-5f;
+  REQUIRE(std::fabs(outOrigin[0]) < tol);
+  REQUIRE(std::fabs(outOrigin[1]) < tol);
+  REQUIRE(std::fabs(outOrigin[2]) < tol);
+  REQUIRE(std::fabs(outSpacing[0] - 1.0f) < tol);
+  REQUIRE(std::fabs(outSpacing[1] - 1.0f) < tol);
+  REQUIRE(std::fabs(outSpacing[2] - 1.0f) < tol);
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: big-endian uint16 round trip", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::array<int16_t, 3> dims = {3, 3, 2};
+  const usize numVoxels = static_cast<usize>(dims[0]) * dims[1] * dims[2];
+
+  std::vector<uint16_t> voxels(numVoxels);
+  for(usize i = 0; i < numVoxels; i++)
+  {
+    voxels[i] = static_cast<uint16_t>(0x0100 + i); // values whose bytes differ to exercise the swap
+  }
+
+  SyntheticNiftiParams params;
+  params.dims = dims;
+  params.niftiDatatype = NIFTI_TYPE_UINT16;
+  params.bitpix = 16;
+  nifti_1_header hdr = MakeHeader(params);
+
+  // Swap the header and voxel data so the file is in the opposite byte order
+  // from the host. The filter should detect this via sizeof_hdr and swap back.
+  ByteSwapHeader(hdr);
+  const std::vector<uint8_t> voxelBytes = ToBytesByteSwapped(voxels);
+
+  const fs::path filePath = OutputDir() / "big_endian_uint16.nii";
+  WriteNiftiFile(filePath, hdr, voxelBytes, false);
+
+  DataStructure dataStructure;
+  ReadNIfTIFileFilter filter;
+  const DataPath geomPath({"NIfTI BE"});
+  const std::string arrName = "ImageData";
+  const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, true, true);
+
+  const auto preflight = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+  const auto execute = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+  const DataPath arrPath = geomPath.createChildPath("Cell Data").createChildPath(arrName);
+  RequireArrayEquals<uint16>(dataStructure, arrPath, voxels);
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: round-trips remaining native datatypes", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::array<int16_t, 3> dims = {3, 2, 2};
+  const usize numVoxels = static_cast<usize>(dims[0]) * dims[1] * dims[2];
+
+  auto runCase = [&](const std::string& label, int16_t niftiDatatype, int16_t bitpix, auto sample) {
+    using T = decltype(sample);
+
+    DYNAMIC_SECTION(label)
+    {
+      std::vector<T> voxels(numVoxels);
+      for(usize i = 0; i < numVoxels; i++)
+      {
+        voxels[i] = static_cast<T>(static_cast<int64_t>(i) - 3);
+      }
+
+      SyntheticNiftiParams params;
+      params.dims = dims;
+      params.niftiDatatype = niftiDatatype;
+      params.bitpix = bitpix;
+      nifti_1_header hdr = MakeHeader(params);
+
+      const fs::path filePath = OutputDir() / fmt::format("type_{}.nii", label);
+      WriteNiftiFile(filePath, hdr, ToBytes(voxels), false);
+
+      DataStructure dataStructure;
+      ReadNIfTIFileFilter filter;
+      const DataPath geomPath({fmt::format("NIfTI {}", label)});
+      const std::string arrName = "ImageData";
+      const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, true, true);
+
+      const auto preflight = filter.preflight(dataStructure, args);
+      SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+      const auto execute = filter.execute(dataStructure, args);
+      SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+      const DataPath arrPath = geomPath.createChildPath("Cell Data").createChildPath(arrName);
+      RequireArrayEquals<T>(dataStructure, arrPath, voxels);
+    }
+  };
+
+  runCase("int8", NIFTI_TYPE_INT8, 8, int8_t{0});
+  runCase("uint32", NIFTI_TYPE_UINT32, 32, uint32_t{0});
+  runCase("int32", NIFTI_TYPE_INT32, 32, int32_t{0});
+  runCase("uint64", NIFTI_TYPE_UINT64, 64, uint64_t{0});
+  runCase("int64", NIFTI_TYPE_INT64, 64, int64_t{0});
+
+  DYNAMIC_SECTION("float64")
+  {
+    std::vector<double> voxels(numVoxels);
+    for(usize i = 0; i < numVoxels; i++)
+    {
+      voxels[i] = 0.125 * static_cast<double>(i) - 1.0;
+    }
+
+    SyntheticNiftiParams params;
+    params.dims = dims;
+    params.niftiDatatype = NIFTI_TYPE_FLOAT64;
+    params.bitpix = 64;
+    nifti_1_header hdr = MakeHeader(params);
+
+    const fs::path filePath = OutputDir() / "type_float64.nii";
+    WriteNiftiFile(filePath, hdr, ToBytes(voxels), false);
+
+    DataStructure dataStructure;
+    ReadNIfTIFileFilter filter;
+    const DataPath geomPath({"NIfTI float64"});
+    const std::string arrName = "ImageData";
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, true, true);
+
+    const auto preflight = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+    const auto execute = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+    const DataPath arrPath = geomPath.createChildPath("Cell Data").createChildPath(arrName);
+    REQUIRE_NOTHROW(dataStructure.getDataRefAs<DataArray<float64>>(arrPath));
+    const auto& arr = dataStructure.getDataRefAs<DataArray<float64>>(arrPath);
+    const auto& store = arr.getDataStoreRef();
+    REQUIRE(store.getSize() == voxels.size());
+    for(usize i = 0; i < voxels.size(); i++)
+    {
+      REQUIRE(std::fabs(static_cast<double>(store[i]) - voxels[i]) < 1e-9);
+    }
+  }
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: crop edge cases", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::array<int16_t, 3> dims = {4, 4, 4};
+  const usize nx = static_cast<usize>(dims[0]);
+  const usize ny = static_cast<usize>(dims[1]);
+  const usize nz = static_cast<usize>(dims[2]);
+  const usize numVoxels = nx * ny * nz;
+
+  std::vector<uint8_t> voxels(numVoxels);
+  for(usize i = 0; i < numVoxels; i++)
+  {
+    voxels[i] = static_cast<uint8_t>(i);
+  }
+
+  SyntheticNiftiParams params;
+  params.dims = dims;
+  params.niftiDatatype = NIFTI_TYPE_UINT8;
+  params.bitpix = 8;
+  nifti_1_header hdr = MakeHeader(params);
+
+  const fs::path outDir = OutputDir();
+  const DataPath geomPath({"NIfTI CropEdge"});
+  const std::string arrName = "ImageData";
+  const DataPath arrPath = geomPath.createChildPath("Cell Data").createChildPath(arrName);
+
+  SECTION("per-axis crop toggles: cropY=false leaves y at full extent")
+  {
+    const fs::path filePath = outDir / "per_axis_toggle.nii";
+    WriteNiftiFile(filePath, hdr, ToBytes(voxels), false);
+
+    CropGeometryParameter::ValueType crop;
+    crop.type = CropGeometryParameter::CropValues::TypeEnum::VoxelSubvolume;
+    crop.cropX = true;
+    crop.cropY = false;
+    crop.cropZ = true;
+    crop.xBoundVoxels = {1, 2};
+    crop.yBoundVoxels = {99, 99}; // deliberately nonsense; should be ignored
+    crop.zBoundVoxels = {0, 2};
+
+    DataStructure dataStructure;
+    ReadNIfTIFileFilter filter;
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, true, true, crop);
+
+    const auto preflight = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+    const auto execute = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+    const auto& geom = dataStructure.getDataRefAs<ImageGeom>(geomPath);
+    const auto outDims = geom.getDimensions();
+    REQUIRE(outDims[0] == 2);
+    REQUIRE(outDims[1] == 4); // full y extent
+    REQUIRE(outDims[2] == 3);
+
+    std::vector<uint8_t> expected;
+    expected.reserve(2 * 4 * 3);
+    for(usize dz = 0; dz < 3; dz++)
+    {
+      for(usize dy = 0; dy < 4; dy++)
+      {
+        for(usize dx = 0; dx < 2; dx++)
+        {
+          const usize srcLinear = dz * ny * nx + dy * nx + (1 + dx);
+          expected.push_back(static_cast<uint8_t>(srcLinear));
+        }
+      }
+    }
+    RequireArrayEquals<uint8>(dataStructure, arrPath, expected);
+  }
+
+  SECTION("gzipped file combined with VoxelSubvolume crop")
+  {
+    const fs::path filePath = outDir / "crop.nii.gz";
+    WriteNiftiFile(filePath, hdr, ToBytes(voxels), /*gzipped=*/true);
+
+    CropGeometryParameter::ValueType crop;
+    crop.type = CropGeometryParameter::CropValues::TypeEnum::VoxelSubvolume;
+    crop.cropX = true;
+    crop.cropY = true;
+    crop.cropZ = true;
+    crop.xBoundVoxels = {1, 3};
+    crop.yBoundVoxels = {1, 2};
+    crop.zBoundVoxels = {0, 1};
+
+    DataStructure dataStructure;
+    ReadNIfTIFileFilter filter;
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, true, true, crop);
+
+    const auto preflight = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+    const auto execute = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+    std::vector<uint8_t> expected;
+    expected.reserve(3 * 2 * 2);
+    for(usize dz = 0; dz < 2; dz++)
+    {
+      for(usize dy = 0; dy < 2; dy++)
+      {
+        for(usize dx = 0; dx < 3; dx++)
+        {
+          const usize srcLinear = (0 + dz) * ny * nx + (1 + dy) * nx + (1 + dx);
+          expected.push_back(static_cast<uint8_t>(srcLinear));
+        }
+      }
+    }
+    RequireArrayEquals<uint8>(dataStructure, arrPath, expected);
+  }
+
+  SECTION("physical bounds entirely outside the volume are rejected")
+  {
+    const fs::path filePath = outDir / "phys_oob.nii";
+    WriteNiftiFile(filePath, hdr, ToBytes(voxels), false);
+
+    CropGeometryParameter::ValueType crop;
+    crop.type = CropGeometryParameter::CropValues::TypeEnum::PhysicalSubvolume;
+    crop.cropX = true;
+    crop.cropY = true;
+    crop.cropZ = true;
+    crop.xBoundPhysical = {100.0f, 200.0f};
+    crop.yBoundPhysical = {100.0f, 200.0f};
+    crop.zBoundPhysical = {100.0f, 200.0f};
+
+    DataStructure dataStructure;
+    ReadNIfTIFileFilter filter;
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, true, true, crop);
+
+    const auto preflight = filter.preflight(dataStructure, args);
+    REQUIRE(preflight.outputActions.invalid());
+  }
+
+  SECTION("reversed voxel bounds are rejected")
+  {
+    const fs::path filePath = outDir / "reversed_bounds.nii";
+    WriteNiftiFile(filePath, hdr, ToBytes(voxels), false);
+
+    CropGeometryParameter::ValueType crop;
+    crop.type = CropGeometryParameter::CropValues::TypeEnum::VoxelSubvolume;
+    crop.cropX = true;
+    crop.cropY = true;
+    crop.cropZ = true;
+    crop.xBoundVoxels = {3, 1};
+    crop.yBoundVoxels = {0, 2};
+    crop.zBoundVoxels = {0, 2};
+
+    DataStructure dataStructure;
+    ReadNIfTIFileFilter filter;
+    const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, true, true, crop);
+
+    const auto preflight = filter.preflight(dataStructure, args);
+    REQUIRE(preflight.outputActions.invalid());
+  }
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: identity scaling transform is not applied and does not promote", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::array<int16_t, 3> dims = {2, 2, 2};
+  const usize numVoxels = static_cast<usize>(dims[0]) * dims[1] * dims[2];
+  std::vector<int16_t> voxels(numVoxels);
+  for(usize i = 0; i < numVoxels; i++)
+  {
+    voxels[i] = static_cast<int16_t>(i) - 2;
+  }
+
+  SyntheticNiftiParams params;
+  params.dims = dims;
+  params.niftiDatatype = NIFTI_TYPE_INT16;
+  params.bitpix = 16;
+  params.sclSlope = 1.0f;   // identity
+  params.sclInter = 0.0f;
+  nifti_1_header hdr = MakeHeader(params);
+
+  const fs::path filePath = OutputDir() / "identity_scale.nii";
+  WriteNiftiFile(filePath, hdr, ToBytes(voxels), false);
+
+  DataStructure dataStructure;
+  ReadNIfTIFileFilter filter;
+  const DataPath geomPath({"NIfTI IdentityScale"});
+  const std::string arrName = "ImageData";
+  const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", arrName, /*applyScaling=*/true, /*useAffine=*/true);
+
+  const auto preflight = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflight.outputActions);
+  const auto execute = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(execute.result);
+
+  // No promotion to float32 — native int16 array should be present.
+  const DataPath arrPath = geomPath.createChildPath("Cell Data").createChildPath(arrName);
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<DataArray<int16>>(arrPath));
+  RequireArrayEquals<int16>(dataStructure, arrPath, voxels);
+}
+
+TEST_CASE("SimplnxCore::ReadNIfTIFileFilter: header cache is reused across preflight calls", "[SimplnxCore][ReadNIfTIFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::array<int16_t, 3> dims = {2, 2, 2};
+  const usize numVoxels = static_cast<usize>(dims[0]) * dims[1] * dims[2];
+  std::vector<uint8_t> voxels(numVoxels);
+  for(usize i = 0; i < numVoxels; i++)
+  {
+    voxels[i] = static_cast<uint8_t>(i);
+  }
+
+  SyntheticNiftiParams params;
+  params.dims = dims;
+  params.niftiDatatype = NIFTI_TYPE_UINT8;
+  params.bitpix = 8;
+  nifti_1_header hdr = MakeHeader(params);
+
+  const fs::path filePath = OutputDir() / "cache_reuse.nii";
+  WriteNiftiFile(filePath, hdr, ToBytes(voxels), false);
+
+  DataStructure dataStructure;
+  ReadNIfTIFileFilter filter;
+  const DataPath geomPath({"NIfTI Cached"});
+  const Arguments args = MakeFilterArgs(filePath, geomPath, "Cell Data", "ImageData", true, true);
+
+  // First preflight populates the cache.
+  const auto firstPreflight = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(firstPreflight.outputActions);
+
+  // Record the mtime, then overwrite the first 4 bytes of the file with
+  // garbage and restore the mtime. A cache miss would read the corrupted
+  // sizeof_hdr and fail; a cache hit skips the file read entirely.
+  const auto originalMtime = fs::last_write_time(filePath);
+  {
+    std::fstream f(filePath, std::ios::in | std::ios::out | std::ios::binary);
+    REQUIRE(f.is_open());
+    const std::array<char, 4> garbage = {'X', 'X', 'X', 'X'};
+    f.seekp(0);
+    f.write(garbage.data(), garbage.size());
+    f.close();
+  }
+  fs::last_write_time(filePath, originalMtime);
+
+  // Second preflight on the SAME filter instance should hit the cache and
+  // succeed despite the corrupted header bytes.
+  DataStructure dataStructure2;
+  const auto secondPreflight = filter.preflight(dataStructure2, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(secondPreflight.outputActions);
+
+  // Sanity check: a fresh filter instance (new m_InstanceId → cold cache)
+  // should see the corruption and fail.
+  DataStructure dataStructure3;
+  ReadNIfTIFileFilter freshFilter;
+  const auto freshPreflight = freshFilter.preflight(dataStructure3, args);
+  REQUIRE(freshPreflight.outputActions.invalid());
 }

--- a/src/Plugins/SimplnxCore/test/ReadZeissTxmFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReadZeissTxmFileTest.cpp
@@ -80,9 +80,9 @@ TEST_CASE("SimplnxReview::ReadZeissTxmFileFilter:Read_Sub_Volume", "[SimplnxRevi
   // ************************************************************************************************
   // This section creates all the possible cropping options and then uses GENERATE_COPY to execute the full test case for each cropping option
   UnitTest::Cropping::AxisBoundsChoices bounds;
-  bounds.voxelX = {IntVec2Type{10, 30}};
-  bounds.voxelY = {IntVec2Type{10, 30}};
-  bounds.voxelZ = {IntVec2Type{50, 100}};
+  bounds.voxelX = {SizeVec2{10, 30}};
+  bounds.voxelY = {SizeVec2{10, 30}};
+  bounds.voxelZ = {SizeVec2{50, 100}};
   bounds.physX = {FloatVec2Type{10.0f, 100.0f}};
   bounds.physY = {FloatVec2Type{80.0f, 120.0f}};
   bounds.physZ = {FloatVec2Type{150.0f, 200.0f}};

--- a/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
+++ b/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
@@ -1385,8 +1385,7 @@ PYBIND11_MODULE(simplnx, mod)
 
   auto cropGeometryParameterCropValues = py::class_<CropGeometryParameter::ValueType>(cropGeometryParameter, "ValueType");
   cropGeometryParameterCropValues.def(py::init<>());
-  cropGeometryParameterCropValues.def(
-      py::init<CropGeometryParameter::ValueType::TypeEnum, bool, bool, bool, bool, IntVec2Type, IntVec2Type, IntVec2Type, FloatVec2Type, FloatVec2Type, FloatVec2Type>());
+  cropGeometryParameterCropValues.def(py::init<CropGeometryParameter::ValueType::TypeEnum, bool, bool, bool, bool, SizeVec2, SizeVec2, SizeVec2, FloatVec2Type, FloatVec2Type, FloatVec2Type>());
   cropGeometryParameterCropValues.def_readwrite("2d", &CropGeometryParameter::ValueType::is2D);
   cropGeometryParameterCropValues.def_readwrite("crop_x", &CropGeometryParameter::ValueType::cropX);
   cropGeometryParameterCropValues.def_readwrite("crop_y", &CropGeometryParameter::ValueType::cropY);

--- a/src/simplnx/Parameters/CropGeometryParameter.cpp
+++ b/src/simplnx/Parameters/CropGeometryParameter.cpp
@@ -128,8 +128,8 @@ Result<std::any> CropGeometryParameter::fromJsonImpl(const nlohmann::json& json,
       return MakeErrorResult<std::any>(FilterParameter::Constants::k_Json_Value_Not_String,
                                        fmt::format("{}JSON value for key '{}' is not an array", prefix.view(), nameDiv + k_XBoundsVoxels_Key.str()));
     }
-    const auto tmp = xBoundsJson.get<std::array<int32, 2>>();
-    value.xBoundVoxels = {static_cast<int32>(tmp[0]), static_cast<int32>(tmp[1])};
+    const auto tmp = xBoundsJson.get<std::array<usize, 2>>();
+    value.xBoundVoxels = {tmp[0], tmp[1]};
   }
 
   {
@@ -139,8 +139,8 @@ Result<std::any> CropGeometryParameter::fromJsonImpl(const nlohmann::json& json,
       return MakeErrorResult<std::any>(FilterParameter::Constants::k_Json_Value_Not_String,
                                        fmt::format("{}JSON value for key '{}' is not an array", prefix.view(), nameDiv + k_YBoundsVoxels_Key.str()));
     }
-    const auto tmp = yBoundsJson.get<std::array<int32, 2>>();
-    value.yBoundVoxels = {static_cast<int32>(tmp[0]), static_cast<int32>(tmp[1])};
+    const auto tmp = yBoundsJson.get<std::array<usize, 2>>();
+    value.yBoundVoxels = {tmp[0], tmp[1]};
   }
 
   {
@@ -150,8 +150,8 @@ Result<std::any> CropGeometryParameter::fromJsonImpl(const nlohmann::json& json,
       return MakeErrorResult<std::any>(FilterParameter::Constants::k_Json_Value_Not_String,
                                        fmt::format("{}JSON value for key '{}' is not an array", prefix.view(), nameDiv + k_ZBoundsVoxels_Key.str()));
     }
-    const auto tmp = zBoundsJson.get<std::array<int32, 2>>();
-    value.zBoundVoxels = {static_cast<int32>(tmp[0]), static_cast<int32>(tmp[1])};
+    const auto tmp = zBoundsJson.get<std::array<usize, 2>>();
+    value.zBoundVoxels = {tmp[0], tmp[1]};
   }
 
   {

--- a/src/simplnx/Parameters/CropGeometryParameter.hpp
+++ b/src/simplnx/Parameters/CropGeometryParameter.hpp
@@ -24,9 +24,9 @@ public:
     bool cropX = true;
     bool cropY = true;
     bool cropZ = true;
-    IntVec2Type xBoundVoxels;
-    IntVec2Type yBoundVoxels;
-    IntVec2Type zBoundVoxels;
+    SizeVec2 xBoundVoxels;
+    SizeVec2 yBoundVoxels;
+    SizeVec2 zBoundVoxels;
     FloatVec2Type xBoundPhysical;
     FloatVec2Type yBoundPhysical;
     FloatVec2Type zBoundPhysical;

--- a/src/simplnx/Parameters/FileSystemPathParameter.cpp
+++ b/src/simplnx/Parameters/FileSystemPathParameter.cpp
@@ -227,6 +227,35 @@ FileSystemPathParameter::ExtensionsType FileSystemPathParameter::getAvailableExt
 }
 
 //-----------------------------------------------------------------------------
+std::optional<std::string> FileSystemPathParameter::MatchExtension(std::string_view filename, const ExtensionsType& accepted)
+{
+  if(accepted.empty() || filename.empty())
+  {
+    return std::nullopt;
+  }
+
+  const std::string lowerName = nx::core::StringUtilities::toLower(std::string(filename));
+
+  std::optional<std::string> best;
+  usize bestLen = 0;
+  for(const auto& ext : accepted)
+  {
+    if(ext.empty() || ext.size() > lowerName.size())
+    {
+      continue;
+    }
+    const std::string lowerExt = nx::core::StringUtilities::toLower(ext);
+    const auto offset = lowerName.size() - lowerExt.size();
+    if(lowerName.compare(offset, lowerExt.size(), lowerExt) == 0 && ext.size() > bestLen)
+    {
+      best = ext;
+      bestLen = ext.size();
+    }
+  }
+  return best;
+}
+
+//-----------------------------------------------------------------------------
 Result<> FileSystemPathParameter::validate(const std::any& value) const
 {
   const auto& path = GetAnyRef<ValueType>(value);
@@ -251,8 +280,7 @@ Result<> FileSystemPathParameter::validatePath(const ValueType& path) const
       {
         return MakeErrorResult(-3002, fmt::format("{} File System Path must include a file extension.\n  FilePath: '{}'", prefix, path.string()));
       }
-      std::string lowerExtension = nx::core::StringUtilities::toLower(path.extension().string());
-      if(path.has_extension() && !m_AvailableExtensions.empty() && m_AvailableExtensions.find(lowerExtension) == m_AvailableExtensions.end())
+      if(!m_AvailableExtensions.empty() && !MatchExtension(path.filename().string(), m_AvailableExtensions).has_value())
       {
         return MakeErrorResult(-3003, fmt::format("{} File extension '{}' is not a valid file extension", prefix, path.extension().string()));
       }

--- a/src/simplnx/Parameters/FileSystemPathParameter.hpp
+++ b/src/simplnx/Parameters/FileSystemPathParameter.hpp
@@ -5,6 +5,9 @@
 #include "simplnx/simplnx_export.hpp"
 
 #include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
 #include <unordered_set>
 
 namespace nx::core
@@ -117,6 +120,30 @@ public:
    * @return
    */
   ExtensionsType getAvailableExtensions() const;
+
+  /**
+   * @brief Finds the longest accepted file extension that matches @p filename
+   * as a case-insensitive suffix.
+   *
+   * Unlike `std::filesystem::path::extension()`, which only returns the last
+   * dot-delimited token, this helper treats each entry of @p accepted as a
+   * literal suffix of the filename. That allows compound extensions like
+   * ".nii.gz" to be matched correctly: for a file named "foo.nii.gz" with
+   * accepted = { ".gz", ".nii.gz" }, this returns ".nii.gz" because the
+   * longer match wins.
+   *
+   * Accepted extensions are expected to include the leading '.'. Matching
+   * is case-insensitive on both sides. If @p accepted is empty, or no entry
+   * is a suffix of @p filename, returns std::nullopt.
+   *
+   * @param filename The filename to test. Callers should pass a bare
+   *                 filename (no directory component) to avoid false matches
+   *                 against parent-directory names.
+   * @param accepted The set of accepted extensions.
+   * @return The matched accepted extension (with its original casing) or
+   *         std::nullopt.
+   */
+  static std::optional<std::string> MatchExtension(std::string_view filename, const ExtensionsType& accepted);
 
   /**
    * @brief

--- a/test/ParametersTest.cpp
+++ b/test/ParametersTest.cpp
@@ -1,6 +1,7 @@
 #include "simplnx/Filter/Parameters.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
+#include "simplnx/Parameters/FileSystemPathParameter.hpp"
 #include "simplnx/Parameters/NumberParameter.hpp"
 #include "simplnx/Parameters/StringParameter.hpp"
 
@@ -91,4 +92,88 @@ TEST_CASE("ParametersTest")
   args.insertOrAssign(k_BarParamKey, true);
   args.insertOrAssign(k_BizParamKey, std::make_any<ChoicesParameter::ValueType>(1));
   REQUIRE(params.isParameterActive(k_BazParamKey, args));
+}
+
+TEST_CASE("FileSystemPathParameter::MatchExtension")
+{
+  using ExtensionsType = FileSystemPathParameter::ExtensionsType;
+
+  SECTION("simple single-dot match")
+  {
+    const ExtensionsType accepted = {".nii"};
+    auto m = FileSystemPathParameter::MatchExtension("scan.nii", accepted);
+    REQUIRE(m.has_value());
+    REQUIRE(*m == ".nii");
+  }
+
+  SECTION("compound .nii.gz match")
+  {
+    const ExtensionsType accepted = {".nii.gz"};
+    auto m = FileSystemPathParameter::MatchExtension("scan.nii.gz", accepted);
+    REQUIRE(m.has_value());
+    REQUIRE(*m == ".nii.gz");
+  }
+
+  SECTION("longest-wins when .gz and .nii.gz are both registered")
+  {
+    const ExtensionsType accepted = {".gz", ".nii.gz"};
+    auto m = FileSystemPathParameter::MatchExtension("scan.nii.gz", accepted);
+    REQUIRE(m.has_value());
+    REQUIRE(*m == ".nii.gz");
+  }
+
+  SECTION(".gz still wins for plain .gz when no compound is registered")
+  {
+    const ExtensionsType accepted = {".gz", ".nii.gz"};
+    auto m = FileSystemPathParameter::MatchExtension("archive.tar.gz", accepted);
+    REQUIRE(m.has_value());
+    REQUIRE(*m == ".gz");
+  }
+
+  SECTION("case-insensitive matching on both sides")
+  {
+    const ExtensionsType accepted = {".NII.GZ"};
+    auto m = FileSystemPathParameter::MatchExtension("Scan.nii.gz", accepted);
+    REQUIRE(m.has_value());
+    REQUIRE(*m == ".NII.GZ");
+  }
+
+  SECTION("non-matching suffix returns nullopt")
+  {
+    const ExtensionsType accepted = {".nii", ".nii.gz"};
+    auto m = FileSystemPathParameter::MatchExtension("image.tif", accepted);
+    REQUIRE_FALSE(m.has_value());
+  }
+
+  SECTION("empty accepted set returns nullopt")
+  {
+    const ExtensionsType accepted;
+    auto m = FileSystemPathParameter::MatchExtension("scan.nii", accepted);
+    REQUIRE_FALSE(m.has_value());
+  }
+
+  SECTION("accepted extension longer than filename is skipped, not an error")
+  {
+    const ExtensionsType accepted = {".nii.gz"};
+    auto m = FileSystemPathParameter::MatchExtension("a", accepted);
+    REQUIRE_FALSE(m.has_value());
+  }
+
+  SECTION("partial stem ending in the extension still matches")
+  {
+    // Matching is a pure literal suffix test, consistent with how users drop
+    // files that happen to end in ".nii.gz" regardless of the stem.
+    const ExtensionsType accepted = {".nii.gz"};
+    auto m = FileSystemPathParameter::MatchExtension("subject42.nii.gz", accepted);
+    REQUIRE(m.has_value());
+    REQUIRE(*m == ".nii.gz");
+  }
+
+  SECTION("file that merely contains '.gz' inside its name is not matched as .gz")
+  {
+    // "foo.gz.bak" should NOT match ".gz" because ".gz" is not a suffix.
+    const ExtensionsType accepted = {".gz"};
+    auto m = FileSystemPathParameter::MatchExtension("foo.gz.bak", accepted);
+    REQUIRE_FALSE(m.has_value());
+  }
 }

--- a/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.hpp
+++ b/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.hpp
@@ -1694,9 +1694,9 @@ inline std::string CropTypeToString(CropGeometryParameter::CropValues::TypeEnum 
 
 struct AxisBoundsChoices
 {
-  std::vector<IntVec2Type> voxelX;
-  std::vector<IntVec2Type> voxelY;
-  std::vector<IntVec2Type> voxelZ;
+  std::vector<SizeVec2> voxelX;
+  std::vector<SizeVec2> voxelY;
+  std::vector<SizeVec2> voxelZ;
   std::vector<FloatVec2Type> physX;
   std::vector<FloatVec2Type> physY;
   std::vector<FloatVec2Type> physZ;
@@ -1730,11 +1730,11 @@ inline std::vector<CropGeometryParameter::ValueType> GenerateAllCropValues(const
   // --------------------
   for(const auto& [cx, cy, cz] : flagOrder)
   {
-    std::vector<std::optional<IntVec2Type>> xOpts = cx ? std::vector<std::optional<IntVec2Type>>(C.voxelX.begin(), C.voxelX.end()) : std::vector<std::optional<IntVec2Type>>{std::nullopt};
+    std::vector<std::optional<SizeVec2>> xOpts = cx ? std::vector<std::optional<SizeVec2>>(C.voxelX.begin(), C.voxelX.end()) : std::vector<std::optional<SizeVec2>>{std::nullopt};
 
-    std::vector<std::optional<IntVec2Type>> yOpts = cy ? std::vector<std::optional<IntVec2Type>>(C.voxelY.begin(), C.voxelY.end()) : std::vector<std::optional<IntVec2Type>>{std::nullopt};
+    std::vector<std::optional<SizeVec2>> yOpts = cy ? std::vector<std::optional<SizeVec2>>(C.voxelY.begin(), C.voxelY.end()) : std::vector<std::optional<SizeVec2>>{std::nullopt};
 
-    std::vector<std::optional<IntVec2Type>> zOpts = (!is2D && cz) ? std::vector<std::optional<IntVec2Type>>(C.voxelZ.begin(), C.voxelZ.end()) : std::vector<std::optional<IntVec2Type>>{std::nullopt};
+    std::vector<std::optional<SizeVec2>> zOpts = (!is2D && cz) ? std::vector<std::optional<SizeVec2>>(C.voxelZ.begin(), C.voxelZ.end()) : std::vector<std::optional<SizeVec2>>{std::nullopt};
 
     for(const auto& xb : xOpts)
     {


### PR DESCRIPTION
* Read single-file NIfTI-1 (magic 'n+1') into an ImageGeom plus a typed DataArray; reject the .hdr/.img pair format (magic 'ni1') with a descriptive error
* Transparent .nii and .nii.gz support via zlib (gzopen/gzread)
* Detect and correct file endianness using sizeof_hdr == 348
* Datatype support: uint8/int8, uint16/int16, uint32/int32, uint64/int64, float32, float64, RGB24 (3 x uint8), RGBA32 (4 x uint8); complex and 128-bit float types rejected
* Orientation from sform/qform when present; fall back to pixdim and zero origin. Warn when the stored affine has a non-trivial rotation since the simplnx ImageGeom is axis-aligned
* Optional scl_slope/scl_inter scaling on read; promote output to float32 when applied, per NIfTI-1 spec skip for RGB24/RGBA32
* Reject 4D+ volumes in this version; leave a clear error for users with fMRI or diffusion time series
* New utility layer (utils/NiftiUtilities.{hpp,cpp}) wrapping the 348-byte header parse so future writers can reuse it
* Round-trip unit tests synthesize .nii and .nii.gz fixtures and cover uint8, int16 (scaled + unscaled), float32, RGB24, RGBA32, plus rejection of 4D and pair-format files
