### PR TITLE
BUG: MultiThresholdObjects unit testing

### DIFF
--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
@@ -15,11 +15,12 @@ template <class U>
 class ThresholdFilterHelper
 {
 public:
-  ThresholdFilterHelper(ArrayThreshold::ComparisonType compType, ArrayThreshold::ComparisonValue compValue, usize componentIndex, std::vector<U>& output)
+  ThresholdFilterHelper(ArrayThreshold::ComparisonType compType, ArrayThreshold::ComparisonValue compValue, usize componentIndex, std::vector<U>& output, bool isInverted)
   : m_ComparisonOperator(compType)
   , m_ComparisonValue(compValue)
   , m_ComponentIndex(componentIndex)
   , m_Output(output)
+  , m_IsInverted(isInverted)
   {
   }
 
@@ -31,7 +32,12 @@ public:
     for(size_t tupleIndex = 0; tupleIndex < numTuples; ++tupleIndex)
     {
       T inputValue = m_Input.getComponentValue(tupleIndex, m_ComponentIndex);
-      T outputValue = CompT{}(inputValue, value) ? trueValue : falseValue;
+      bool comparison = CompT{}(inputValue, value);
+      if (m_IsInverted)
+      {
+        comparison = !comparison;
+      }
+      T outputValue = comparison ? trueValue : falseValue;
       m_Output[tupleIndex] = outputValue;
     }
   }
@@ -67,6 +73,7 @@ private:
   ArrayThreshold::ComparisonValue m_ComparisonValue;
   usize m_ComponentIndex = 0;
   std::vector<U>& m_Output;
+  bool m_IsInverted = false;
 };
 
 struct ExecuteThresholdHelper
@@ -120,12 +127,13 @@ void ThresholdValue(const ArrayThreshold& comparisonValue, const DataStructure& 
   nx::core::ArrayThreshold::ComparisonType compOperator = comparisonValue.getComparisonType();
   nx::core::ArrayThreshold::ComparisonValue compValue = comparisonValue.getComparisonValue();
   nx::core::IArrayThreshold::UnionOperator unionOperator = comparisonValue.getUnionOperator();
+  bool isInverted = comparisonValue.isInverted();
 
   DataPath inputDataArrayPath = comparisonValue.getArrayPath();
 
   usize componentIndex = comparisonValue.getComponentIndex();
 
-  ThresholdFilterHelper<T> helper(compOperator, compValue, componentIndex, tempResultVector);
+  ThresholdFilterHelper<T> helper(compOperator, compValue, componentIndex, tempResultVector, isInverted);
 
   const auto& iDataArray = dataStructure.getDataRefAs<IDataArray>(inputDataArrayPath);
 
@@ -259,12 +267,14 @@ Result<> MultiThresholdObjects::operator()()
     const IArrayThreshold* thresholdPtr = threshold.get();
     if(const auto* comparisonSet = dynamic_cast<const ArrayThresholdSet*>(thresholdPtr); comparisonSet != nullptr)
     {
+      // Do not replace values on first threshold, update firstValueFound to reflect that a threshold has been run.
       ExecuteDataFunction(ThresholdSetFunctor{}, maskArrayType, *comparisonSet, m_DataStructure, m_DataStructure.getDataRefAs<IDataArray>(maskArrayPath), err, !firstValueFound,
                           thresholdsObject.isInverted(), trueValue, falseValue);
       firstValueFound = true;
     }
     else if(const auto* comparisonValue = dynamic_cast<const ArrayThreshold*>(thresholdPtr); comparisonValue != nullptr)
     {
+      // Do not replace values on first threshold, update firstValueFound to reflect that a threshold has been run.
       ExecuteDataFunction(ThresholdValueFunctor{}, maskArrayType, *comparisonValue, m_DataStructure, m_DataStructure.getDataRefAs<IDataArray>(maskArrayPath), err, !firstValueFound,
                           thresholdsObject.isInverted(), trueValue, falseValue);
       firstValueFound = true;

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
@@ -11,10 +11,18 @@ using namespace nx::core;
 
 namespace
 {
+/**
+ * @brief Consolidate all assignment calls to a single method to prevent unintended diverging behavior.
+ * @param arrayThreshold Current threshold to pull settings from.
+ * @param outputResultVector Output vector for the current ThresholdSet.
+ * @param inputThresholdVector Resulting output for the target array threshold.
+ * @param replaceInput The first threshould in every set has its output applied to the output regardless of union operator.
+ * @param trueValue Output mask value when the threshold is satisfied.
+ * @param falseValue Output mask value when the threshold is not satisfied.
+ */
 template <typename T>
 void ApplyThresholdValues(const IArrayThreshold& arrayThreshold, std::vector<T>& outputResultVector, std::vector<T>& inputThresholdVector, bool replaceInput, T trueValue, T falseValue)
 {
-  usize totalTuples = outputResultVector.size();
   auto unionOperator = arrayThreshold.getUnionOperator();
   bool inverse = arrayThreshold.isInverted();
 
@@ -24,7 +32,7 @@ void ApplyThresholdValues(const IArrayThreshold& arrayThreshold, std::vector<T>&
   }
 
   // insert into current threshold
-  InsertThreshold<T>(totalTuples, outputResultVector, unionOperator, inputThresholdVector, inverse, trueValue, falseValue);
+  InsertThreshold<T>(outputResultVector, unionOperator, inputThresholdVector, inverse, trueValue, falseValue);
 }
 
 template <class U>
@@ -105,8 +113,10 @@ struct ExecuteThresholdHelper
  * @param inverse
  */
 template <typename T>
-void InsertThreshold(usize numItems, std::vector<T>& currentVector, nx::core::IArrayThreshold::UnionOperator unionOperator, std::vector<T>& newVector, bool inverse, T trueValue, T falseValue)
+void InsertThreshold(std::vector<T>& currentVector, nx::core::IArrayThreshold::UnionOperator unionOperator, std::vector<T>& newVector, bool inverse, T trueValue, T falseValue)
 {
+  usize numItems = currentVector.size();
+
   for(usize i = 0; i < numItems; i++)
   {
     // invert the current comparison if necessary
@@ -149,25 +159,6 @@ void ThresholdValue(const ArrayThreshold& comparisonValue, const DataStructure& 
 
   ApplyThresholdValues<T>(comparisonValue, outputResultVector, tempResultVector, replaceInput, trueValue, falseValue);
 }
-
-struct ThresholdValueFunctor
-{
-  template <typename T>
-  void operator()(const ArrayThreshold& comparisonValue, const DataStructure& dataStructure, IDataArray& outputResultArray, int32_t& err, bool replaceInput, bool inverse, T trueValue, T falseValue)
-  {
-    // Traditionally we would do a check to ensure we get a valid pointer, I'm forgoing that check because it
-    // was essentially done in the preflight part.
-    auto& outputDataStore = outputResultArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
-    usize totalTuples = outputDataStore.getNumberOfTuples();
-    std::vector<T> tmpVector(totalTuples, falseValue);
-    ThresholdValue(comparisonValue, dataStructure, tmpVector, err, replaceInput, inverse, trueValue, falseValue);
-
-    for(size_t i = 0; i < totalTuples; i++)
-    {
-      outputDataStore[i] = tmpVector[i];
-    }
-  }
-};
 
 template <typename T>
 void ThresholdSet(const ArrayThresholdSet& inputComparisonSet, const DataStructure& dataStructure, std::vector<T>& outputResultVector, int32_t& err, bool replaceInput, T trueValue, T falseValue)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
@@ -33,7 +33,7 @@ public:
     {
       T inputValue = m_Input.getComponentValue(tupleIndex, m_ComponentIndex);
       bool comparison = CompT{}(inputValue, value);
-      if (m_IsInverted)
+      if(m_IsInverted)
       {
         comparison = !comparison;
       }
@@ -95,33 +95,33 @@ struct ExecuteThresholdHelper
  * @param inverse
  */
 template <typename T>
-void InsertThreshold(usize numItems, AbstractDataStore<T>& currentStore, nx::core::IArrayThreshold::UnionOperator unionOperator, std::vector<T>& newArrayPtr, bool inverse, T trueValue, T falseValue)
+void InsertThreshold(usize numItems, std::vector<T>& currentVector, nx::core::IArrayThreshold::UnionOperator unionOperator, std::vector<T>& newVector, bool inverse, T trueValue, T falseValue)
 {
   for(usize i = 0; i < numItems; i++)
   {
     // invert the current comparison if necessary
     if(inverse)
     {
-      newArrayPtr[i] = (newArrayPtr[i] == trueValue) ? falseValue : trueValue;
+      newVector[i] = (newVector[i] == trueValue) ? falseValue : trueValue;
     }
 
     if(nx::core::IArrayThreshold::UnionOperator::Or == unionOperator)
     {
-      currentStore[i] = (currentStore[i] == trueValue || newArrayPtr[i] == trueValue) ? trueValue : falseValue;
+      currentVector[i] = (currentVector[i] == trueValue || newVector[i] == trueValue) ? trueValue : falseValue;
     }
-    else if(currentStore[i] == falseValue || newArrayPtr[i] == falseValue)
+    else if(currentVector[i] == falseValue || newVector[i] == falseValue)
     {
-      currentStore[i] = falseValue;
+      currentVector[i] = falseValue;
     }
   }
 }
 
 template <typename T>
-void ThresholdValue(const ArrayThreshold& comparisonValue, const DataStructure& dataStructure, AbstractDataStore<T>& outputResultStore, int32_t& err, bool replaceInput, bool inverse, T trueValue,
+void ThresholdValue(const ArrayThreshold& comparisonValue, const DataStructure& dataStructure, std::vector<T>& outputResultVector, int32_t& err, bool replaceInput, bool inverse, T trueValue,
                     T falseValue)
 {
   // Get the total number of tuples, create and initialize an array with FALSE to use for these results
-  size_t totalTuples = outputResultStore.getNumberOfTuples();
+  size_t totalTuples = outputResultVector.size();
   std::vector<T> tempResultVector(totalTuples, falseValue);
 
   nx::core::ArrayThreshold::ComparisonType compOperator = comparisonValue.getComparisonType();
@@ -148,13 +148,13 @@ void ThresholdValue(const ArrayThreshold& comparisonValue, const DataStructure& 
     // copy the temp uint8 vector to the final uint8 result array
     for(size_t i = 0; i < totalTuples; i++)
     {
-      outputResultStore[i] = tempResultVector[i];
+      outputResultVector[i] = tempResultVector[i];
     }
   }
   else
   {
     // insert into current threshold
-    InsertThreshold<T>(totalTuples, outputResultStore, unionOperator, tempResultVector, inverse, trueValue, falseValue);
+    InsertThreshold<T>(totalTuples, outputResultVector, unionOperator, tempResultVector, inverse, trueValue, falseValue);
   }
 }
 
@@ -165,16 +165,24 @@ struct ThresholdValueFunctor
   {
     // Traditionally we would do a check to ensure we get a valid pointer, I'm forgoing that check because it
     // was essentially done in the preflight part.
-    ThresholdValue(comparisonValue, dataStructure, outputResultArray.template getIDataStoreRefAs<AbstractDataStore<T>>(), err, replaceInput, inverse, trueValue, falseValue);
+    auto& outputDataStore = outputResultArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
+    usize totalTuples = outputDataStore.getNumberOfTuples();
+    std::vector<T> tmpVector(totalTuples, falseValue);
+    ThresholdValue(comparisonValue, dataStructure, tmpVector, err, replaceInput, inverse, trueValue, falseValue);
+
+    for(size_t i = 0; i < totalTuples; i++)
+    {
+      outputDataStore[i] = tmpVector[i];
+    }
   }
 };
 
 template <typename T>
-void ThresholdSet(const ArrayThresholdSet& inputComparisonSet, const DataStructure& dataStructure, AbstractDataStore<T>& outputResultStore, int32_t& err, bool replaceInput, bool inverse, T trueValue,
+void ThresholdSet(const ArrayThresholdSet& inputComparisonSet, const DataStructure& dataStructure, std::vector<T>& outputResultVector, int32_t& err, bool replaceInput, bool inverse, T trueValue,
                   T falseValue)
 {
   // Get the total number of tuples, create and initialize an array with FALSE to use for these results
-  size_t totalTuples = outputResultStore.getNumberOfTuples();
+  size_t totalTuples = outputResultVector.size();
   std::vector<T> tempResultVector(totalTuples, falseValue);
 
   bool firstValueFound = false;
@@ -185,13 +193,22 @@ void ThresholdSet(const ArrayThresholdSet& inputComparisonSet, const DataStructu
     const IArrayThreshold* thresholdPtr = threshold.get();
     if(const auto* comparisonSet = dynamic_cast<const ArrayThresholdSet*>(thresholdPtr); comparisonSet != nullptr)
     {
-      ThresholdSet<T>(*comparisonSet, dataStructure, outputResultStore, err, !firstValueFound, false, trueValue, falseValue);
+      ThresholdSet<T>(*comparisonSet, dataStructure, tempResultVector, err, !firstValueFound, false, trueValue, falseValue);
       firstValueFound = true;
     }
     else if(const auto* comparisonValue = dynamic_cast<const ArrayThreshold*>(thresholdPtr); comparisonValue != nullptr)
     {
-      ThresholdValue<T>(*comparisonValue, dataStructure, outputResultStore, err, !firstValueFound, false, trueValue, falseValue);
+      ThresholdValue<T>(*comparisonValue, dataStructure, tempResultVector, err, !firstValueFound, false, trueValue, falseValue);
       firstValueFound = true;
+    }
+  }
+
+  // Allow ThresholdSets to be invertable
+  if(inputComparisonSet.isInverted())
+  {
+    for(size_t i = 0; i < totalTuples; i++)
+    {
+      tempResultVector[i] = (tempResultVector[i] == trueValue) ? falseValue : trueValue;
     }
   }
 
@@ -204,13 +221,13 @@ void ThresholdSet(const ArrayThresholdSet& inputComparisonSet, const DataStructu
     // copy the temp uint8 vector to the final uint8 result array
     for(size_t i = 0; i < totalTuples; i++)
     {
-      outputResultStore[i] = tempResultVector[i];
+      outputResultVector[i] = tempResultVector[i];
     }
   }
   else
   {
     // insert into current threshold
-    InsertThreshold<T>(totalTuples, outputResultStore, inputComparisonSet.getUnionOperator(), tempResultVector, inverse, trueValue, falseValue);
+    InsertThreshold<T>(totalTuples, outputResultVector, inputComparisonSet.getUnionOperator(), tempResultVector, inverse, trueValue, falseValue);
   }
 }
 
@@ -222,7 +239,15 @@ struct ThresholdSetFunctor
   {
     // Traditionally we would do a check to ensure we get a valid pointer, I'm forgoing that check because it
     // was essentially done in the preflight part.
-    ThresholdSet<T>(inputComparisonSet, dataStructure, outputResultArray.template getIDataStoreRefAs<AbstractDataStore<T>>(), err, replaceInput, inverse, trueValue, falseValue);
+    auto& outputDataStore = outputResultArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
+    usize totalTuples = outputDataStore.getNumberOfTuples();
+    std::vector<T> tmpVector(totalTuples, falseValue);
+    ThresholdSet<T>(inputComparisonSet, dataStructure, tmpVector, err, replaceInput, inverse, trueValue, falseValue);
+
+    for(size_t i = 0; i < totalTuples; i++)
+    {
+      outputDataStore[i] = tmpVector[i];
+    }
   }
 };
 } // namespace
@@ -258,6 +283,10 @@ Result<> MultiThresholdObjects::operator()()
   DataPath maskArrayPath = (*thresholdsObject.getRequiredPaths().begin()).replaceName(maskArrayName);
   int32_t err = 0;
   ArrayThresholdSet::CollectionType thresholdSet = thresholdsObject.getArrayThresholds();
+
+  ExecuteDataFunction(ThresholdSetFunctor{}, maskArrayType, thresholdsObject, m_DataStructure, m_DataStructure.getDataRefAs<IDataArray>(maskArrayPath), err, !firstValueFound,
+                      thresholdsObject.isInverted(), trueValue, falseValue);
+  #if 0
   for(const std::shared_ptr<IArrayThreshold>& threshold : thresholdSet)
   {
     if(m_ShouldCancel)
@@ -280,6 +309,7 @@ Result<> MultiThresholdObjects::operator()()
       firstValueFound = true;
     }
   }
+  #endif
 
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
@@ -12,6 +12,38 @@ using namespace nx::core;
 namespace
 {
 /**
+ * @brief InsertThreshold
+ * @param numItems
+ * @param currentArrayPtr
+ * @param unionOperator
+ * @param newArrayPtr
+ * @param inverse
+ */
+template <typename T>
+void InsertThreshold(std::vector<T>& currentVector, nx::core::IArrayThreshold::UnionOperator unionOperator, std::vector<T>& newVector, bool inverse, T trueValue, T falseValue)
+{
+  usize numItems = currentVector.size();
+
+  for(usize i = 0; i < numItems; i++)
+  {
+    // invert the current comparison if necessary
+    if(inverse)
+    {
+      newVector[i] = (newVector[i] == trueValue) ? falseValue : trueValue;
+    }
+
+    if(nx::core::IArrayThreshold::UnionOperator::Or == unionOperator)
+    {
+      currentVector[i] = (currentVector[i] == trueValue || newVector[i] == trueValue) ? trueValue : falseValue;
+    }
+    else if(currentVector[i] == falseValue || newVector[i] == falseValue)
+    {
+      currentVector[i] = falseValue;
+    }
+  }
+}
+
+/**
  * @brief Consolidate all assignment calls to a single method to prevent unintended diverging behavior.
  * @param arrayThreshold Current threshold to pull settings from.
  * @param outputResultVector Output vector for the current ThresholdSet.
@@ -103,38 +135,6 @@ struct ExecuteThresholdHelper
     helper.template filterData<Type>(dataStore, trueValue, falseValue);
   }
 };
-
-/**
- * @brief InsertThreshold
- * @param numItems
- * @param currentArrayPtr
- * @param unionOperator
- * @param newArrayPtr
- * @param inverse
- */
-template <typename T>
-void InsertThreshold(std::vector<T>& currentVector, nx::core::IArrayThreshold::UnionOperator unionOperator, std::vector<T>& newVector, bool inverse, T trueValue, T falseValue)
-{
-  usize numItems = currentVector.size();
-
-  for(usize i = 0; i < numItems; i++)
-  {
-    // invert the current comparison if necessary
-    if(inverse)
-    {
-      newVector[i] = (newVector[i] == trueValue) ? falseValue : trueValue;
-    }
-
-    if(nx::core::IArrayThreshold::UnionOperator::Or == unionOperator)
-    {
-      currentVector[i] = (currentVector[i] == trueValue || newVector[i] == trueValue) ? trueValue : falseValue;
-    }
-    else if(currentVector[i] == falseValue || newVector[i] == falseValue)
-    {
-      currentVector[i] = falseValue;
-    }
-  }
-}
 
 template <typename T>
 void ThresholdValue(const ArrayThreshold& comparisonValue, const DataStructure& dataStructure, std::vector<T>& outputResultVector, int32_t& err, bool replaceInput, T trueValue, T falseValue)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
@@ -3,6 +3,7 @@
 #include "simplnx/Common/TypeTraits.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/Utilities/ArrayThreshold.hpp"
+#include "simplnx/Utilities/DataStoreUtilities.hpp"
 #include "simplnx/Utilities/FilterUtilities.hpp"
 
 #include <algorithm>
@@ -20,9 +21,9 @@ namespace
  * @param inverse
  */
 template <typename T>
-void InsertThreshold(std::vector<T>& currentVector, nx::core::IArrayThreshold::UnionOperator unionOperator, std::vector<T>& newVector, bool inverse, T trueValue, T falseValue)
+void InsertThreshold(AbstractDataStore<T>& currentVector, nx::core::IArrayThreshold::UnionOperator unionOperator, AbstractDataStore<T>& newVector, bool inverse, T trueValue, T falseValue)
 {
-  usize numItems = currentVector.size();
+  usize numItems = currentVector.getNumberOfTuples();
 
   for(usize i = 0; i < numItems; i++)
   {
@@ -46,14 +47,14 @@ void InsertThreshold(std::vector<T>& currentVector, nx::core::IArrayThreshold::U
 /**
  * @brief Consolidate all assignment calls to a single method to prevent unintended diverging behavior.
  * @param arrayThreshold Current threshold to pull settings from.
- * @param outputResultVector Output vector for the current ThresholdSet.
- * @param inputThresholdVector Resulting output for the target array threshold.
+ * @param outputResultStore Output DataStore for the current ThresholdSet.
+ * @param inputThresholdStore Resulting output for the target array threshold.
  * @param replaceInput The first threshould in every set has its output applied to the output regardless of union operator.
  * @param trueValue Output mask value when the threshold is satisfied.
  * @param falseValue Output mask value when the threshold is not satisfied.
  */
 template <typename T>
-void ApplyThresholdValues(const IArrayThreshold& arrayThreshold, std::vector<T>& outputResultVector, std::vector<T>& inputThresholdVector, bool replaceInput, T trueValue, T falseValue)
+void ApplyThresholdValues(const IArrayThreshold& arrayThreshold, AbstractDataStore<T>& outputResultStore, AbstractDataStore<T>& inputThresholdStore, bool replaceInput, T trueValue, T falseValue)
 {
   auto unionOperator = arrayThreshold.getUnionOperator();
   bool inverse = arrayThreshold.isInverted();
@@ -64,14 +65,14 @@ void ApplyThresholdValues(const IArrayThreshold& arrayThreshold, std::vector<T>&
   }
 
   // insert into current threshold
-  InsertThreshold<T>(outputResultVector, unionOperator, inputThresholdVector, inverse, trueValue, falseValue);
+  InsertThreshold<T>(outputResultStore, unionOperator, inputThresholdStore, inverse, trueValue, falseValue);
 }
 
 template <class U>
 class ThresholdFilterHelper
 {
 public:
-  ThresholdFilterHelper(ArrayThreshold::ComparisonType compType, ArrayThreshold::ComparisonValue compValue, usize componentIndex, std::vector<U>& output)
+  ThresholdFilterHelper(ArrayThreshold::ComparisonType compType, ArrayThreshold::ComparisonValue compValue, usize componentIndex, AbstractDataStore<U>& output)
   : m_ComparisonOperator(compType)
   , m_ComparisonValue(compValue)
   , m_ComponentIndex(componentIndex)
@@ -123,7 +124,7 @@ private:
   ArrayThreshold::ComparisonType m_ComparisonOperator;
   ArrayThreshold::ComparisonValue m_ComparisonValue;
   usize m_ComponentIndex = 0;
-  std::vector<U>& m_Output;
+  AbstractDataStore<U>& m_Output;
 };
 
 struct ExecuteThresholdHelper
@@ -137,11 +138,13 @@ struct ExecuteThresholdHelper
 };
 
 template <typename T>
-void ThresholdValue(const ArrayThreshold& comparisonValue, const DataStructure& dataStructure, std::vector<T>& outputResultVector, int32_t& err, bool replaceInput, T trueValue, T falseValue)
+void ThresholdValue(const ArrayThreshold& comparisonValue, const DataStructure& dataStructure, AbstractDataStore<T>& outputResultVector, int32_t& err, bool replaceInput, T trueValue, T falseValue)
 {
   // Get the total number of tuples, create and initialize an array with FALSE to use for these results
-  size_t totalTuples = outputResultVector.size();
-  std::vector<T> tempResultVector(totalTuples, falseValue);
+  size_t totalTuples = outputResultVector.getNumberOfTuples();
+  auto tempResultStorePtr = DataStoreUtilities::CreateDataStore<T>({totalTuples}, {1}, IDataAction::Mode::Execute);
+  AbstractDataStore<T>& tempResultStore = *tempResultStorePtr.get();
+  std::fill(tempResultStore.begin(), tempResultStore.end(), falseValue);
 
   nx::core::ArrayThreshold::ComparisonType compOperator = comparisonValue.getComparisonType();
   nx::core::ArrayThreshold::ComparisonValue compValue = comparisonValue.getComparisonValue();
@@ -151,21 +154,23 @@ void ThresholdValue(const ArrayThreshold& comparisonValue, const DataStructure& 
 
   usize componentIndex = comparisonValue.getComponentIndex();
 
-  ThresholdFilterHelper<T> helper(compOperator, compValue, componentIndex, tempResultVector);
+  ThresholdFilterHelper<T> helper(compOperator, compValue, componentIndex, tempResultStore);
 
   const auto& iDataArray = dataStructure.getDataRefAs<IDataArray>(inputDataArrayPath);
 
   ExecuteDataFunction(ExecuteThresholdHelper{}, iDataArray.getDataType(), helper, iDataArray, trueValue, falseValue);
 
-  ApplyThresholdValues<T>(comparisonValue, outputResultVector, tempResultVector, replaceInput, trueValue, falseValue);
+  ApplyThresholdValues<T>(comparisonValue, outputResultVector, tempResultStore, replaceInput, trueValue, falseValue);
 }
 
 template <typename T>
-void ThresholdSet(const ArrayThresholdSet& inputComparisonSet, const DataStructure& dataStructure, std::vector<T>& outputResultVector, int32_t& err, bool replaceInput, T trueValue, T falseValue)
+void ThresholdSet(const ArrayThresholdSet& inputComparisonSet, const DataStructure& dataStructure, AbstractDataStore<T>& outputResultVector, int32_t& err, bool replaceInput, T trueValue, T falseValue)
 {
   // Get the total number of tuples, create and initialize an array with FALSE to use for these results
-  size_t totalTuples = outputResultVector.size();
-  std::vector<T> tempResultVector(totalTuples, falseValue);
+  size_t totalTuples = outputResultVector.getNumberOfTuples();
+  auto tempResultStorePtr = DataStoreUtilities::CreateDataStore<T>({totalTuples}, {1}, IDataAction::Mode::Execute);
+  AbstractDataStore<T>& tempResultStore = *tempResultStorePtr.get();
+  std::fill(tempResultStore.begin(), tempResultStore.end(), falseValue);
 
   bool firstValueFound = false;
 
@@ -175,18 +180,18 @@ void ThresholdSet(const ArrayThresholdSet& inputComparisonSet, const DataStructu
     const IArrayThreshold* thresholdPtr = threshold.get();
     if(const auto* comparisonSet = dynamic_cast<const ArrayThresholdSet*>(thresholdPtr); comparisonSet != nullptr)
     {
-      ThresholdSet<T>(*comparisonSet, dataStructure, tempResultVector, err, !firstValueFound, trueValue, falseValue);
+      ThresholdSet<T>(*comparisonSet, dataStructure, tempResultStore, err, !firstValueFound, trueValue, falseValue);
       firstValueFound = true;
     }
     else if(const auto* comparisonValue = dynamic_cast<const ArrayThreshold*>(thresholdPtr); comparisonValue != nullptr)
     {
-      ThresholdValue<T>(*comparisonValue, dataStructure, tempResultVector, err, !firstValueFound, trueValue, falseValue);
+      ThresholdValue<T>(*comparisonValue, dataStructure, tempResultStore, err, !firstValueFound, trueValue, falseValue);
       firstValueFound = true;
     }
   }
 
   // Apply resulting values to output
-  ApplyThresholdValues<T>(inputComparisonSet, outputResultVector, tempResultVector, replaceInput, trueValue, falseValue);
+  ApplyThresholdValues<T>(inputComparisonSet, outputResultVector, tempResultStore, replaceInput, trueValue, falseValue);
 }
 
 struct ThresholdSetFunctor
@@ -198,12 +203,14 @@ struct ThresholdSetFunctor
     // was essentially done in the preflight part.
     auto& outputDataStore = outputResultArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
     usize totalTuples = outputDataStore.getNumberOfTuples();
-    std::vector<T> tmpVector(totalTuples, falseValue);
-    ThresholdSet<T>(inputComparisonSet, dataStructure, tmpVector, err, replaceInput, trueValue, falseValue);
+    auto tempResultStorePtr = DataStoreUtilities::CreateDataStore<T>({totalTuples}, {1}, IDataAction::Mode::Execute);
+    AbstractDataStore<T>& tempResultStore = *tempResultStorePtr.get();
+    std::fill(tempResultStore.begin(), tempResultStore.end(), falseValue);
+    ThresholdSet<T>(inputComparisonSet, dataStructure, tempResultStore, err, replaceInput, trueValue, falseValue);
 
     for(size_t i = 0; i < totalTuples; i++)
     {
-      outputDataStore[i] = tmpVector[i];
+      outputDataStore[i] = tempResultStore[i];
     }
   }
 };

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/MultiThresholdObjects.cpp
@@ -11,16 +11,31 @@ using namespace nx::core;
 
 namespace
 {
+template <typename T>
+void ApplyThresholdValues(const IArrayThreshold& arrayThreshold, std::vector<T>& outputResultVector, std::vector<T>& inputThresholdVector, bool replaceInput, T trueValue, T falseValue)
+{
+  usize totalTuples = outputResultVector.size();
+  auto unionOperator = arrayThreshold.getUnionOperator();
+  bool inverse = arrayThreshold.isInverted();
+
+  if(replaceInput)
+  {
+    unionOperator = IArrayThreshold::UnionOperator::Or;
+  }
+
+  // insert into current threshold
+  InsertThreshold<T>(totalTuples, outputResultVector, unionOperator, inputThresholdVector, inverse, trueValue, falseValue);
+}
+
 template <class U>
 class ThresholdFilterHelper
 {
 public:
-  ThresholdFilterHelper(ArrayThreshold::ComparisonType compType, ArrayThreshold::ComparisonValue compValue, usize componentIndex, std::vector<U>& output, bool isInverted)
+  ThresholdFilterHelper(ArrayThreshold::ComparisonType compType, ArrayThreshold::ComparisonValue compValue, usize componentIndex, std::vector<U>& output)
   : m_ComparisonOperator(compType)
   , m_ComparisonValue(compValue)
   , m_ComponentIndex(componentIndex)
   , m_Output(output)
-  , m_IsInverted(isInverted)
   {
   }
 
@@ -33,10 +48,6 @@ public:
     {
       T inputValue = m_Input.getComponentValue(tupleIndex, m_ComponentIndex);
       bool comparison = CompT{}(inputValue, value);
-      if(m_IsInverted)
-      {
-        comparison = !comparison;
-      }
       T outputValue = comparison ? trueValue : falseValue;
       m_Output[tupleIndex] = outputValue;
     }
@@ -73,7 +84,6 @@ private:
   ArrayThreshold::ComparisonValue m_ComparisonValue;
   usize m_ComponentIndex = 0;
   std::vector<U>& m_Output;
-  bool m_IsInverted = false;
 };
 
 struct ExecuteThresholdHelper
@@ -117,8 +127,7 @@ void InsertThreshold(usize numItems, std::vector<T>& currentVector, nx::core::IA
 }
 
 template <typename T>
-void ThresholdValue(const ArrayThreshold& comparisonValue, const DataStructure& dataStructure, std::vector<T>& outputResultVector, int32_t& err, bool replaceInput, bool inverse, T trueValue,
-                    T falseValue)
+void ThresholdValue(const ArrayThreshold& comparisonValue, const DataStructure& dataStructure, std::vector<T>& outputResultVector, int32_t& err, bool replaceInput, T trueValue, T falseValue)
 {
   // Get the total number of tuples, create and initialize an array with FALSE to use for these results
   size_t totalTuples = outputResultVector.size();
@@ -127,35 +136,18 @@ void ThresholdValue(const ArrayThreshold& comparisonValue, const DataStructure& 
   nx::core::ArrayThreshold::ComparisonType compOperator = comparisonValue.getComparisonType();
   nx::core::ArrayThreshold::ComparisonValue compValue = comparisonValue.getComparisonValue();
   nx::core::IArrayThreshold::UnionOperator unionOperator = comparisonValue.getUnionOperator();
-  bool isInverted = comparisonValue.isInverted();
 
   DataPath inputDataArrayPath = comparisonValue.getArrayPath();
 
   usize componentIndex = comparisonValue.getComponentIndex();
 
-  ThresholdFilterHelper<T> helper(compOperator, compValue, componentIndex, tempResultVector, isInverted);
+  ThresholdFilterHelper<T> helper(compOperator, compValue, componentIndex, tempResultVector);
 
   const auto& iDataArray = dataStructure.getDataRefAs<IDataArray>(inputDataArrayPath);
 
   ExecuteDataFunction(ExecuteThresholdHelper{}, iDataArray.getDataType(), helper, iDataArray, trueValue, falseValue);
 
-  if(replaceInput)
-  {
-    if(inverse)
-    {
-      std::reverse(tempResultVector.begin(), tempResultVector.end());
-    }
-    // copy the temp uint8 vector to the final uint8 result array
-    for(size_t i = 0; i < totalTuples; i++)
-    {
-      outputResultVector[i] = tempResultVector[i];
-    }
-  }
-  else
-  {
-    // insert into current threshold
-    InsertThreshold<T>(totalTuples, outputResultVector, unionOperator, tempResultVector, inverse, trueValue, falseValue);
-  }
+  ApplyThresholdValues<T>(comparisonValue, outputResultVector, tempResultVector, replaceInput, trueValue, falseValue);
 }
 
 struct ThresholdValueFunctor
@@ -178,8 +170,7 @@ struct ThresholdValueFunctor
 };
 
 template <typename T>
-void ThresholdSet(const ArrayThresholdSet& inputComparisonSet, const DataStructure& dataStructure, std::vector<T>& outputResultVector, int32_t& err, bool replaceInput, bool inverse, T trueValue,
-                  T falseValue)
+void ThresholdSet(const ArrayThresholdSet& inputComparisonSet, const DataStructure& dataStructure, std::vector<T>& outputResultVector, int32_t& err, bool replaceInput, T trueValue, T falseValue)
 {
   // Get the total number of tuples, create and initialize an array with FALSE to use for these results
   size_t totalTuples = outputResultVector.size();
@@ -193,56 +184,31 @@ void ThresholdSet(const ArrayThresholdSet& inputComparisonSet, const DataStructu
     const IArrayThreshold* thresholdPtr = threshold.get();
     if(const auto* comparisonSet = dynamic_cast<const ArrayThresholdSet*>(thresholdPtr); comparisonSet != nullptr)
     {
-      ThresholdSet<T>(*comparisonSet, dataStructure, tempResultVector, err, !firstValueFound, false, trueValue, falseValue);
+      ThresholdSet<T>(*comparisonSet, dataStructure, tempResultVector, err, !firstValueFound, trueValue, falseValue);
       firstValueFound = true;
     }
     else if(const auto* comparisonValue = dynamic_cast<const ArrayThreshold*>(thresholdPtr); comparisonValue != nullptr)
     {
-      ThresholdValue<T>(*comparisonValue, dataStructure, tempResultVector, err, !firstValueFound, false, trueValue, falseValue);
+      ThresholdValue<T>(*comparisonValue, dataStructure, tempResultVector, err, !firstValueFound, trueValue, falseValue);
       firstValueFound = true;
     }
   }
 
-  // Allow ThresholdSets to be invertable
-  if(inputComparisonSet.isInverted())
-  {
-    for(size_t i = 0; i < totalTuples; i++)
-    {
-      tempResultVector[i] = (tempResultVector[i] == trueValue) ? falseValue : trueValue;
-    }
-  }
-
-  if(replaceInput)
-  {
-    if(inverse)
-    {
-      std::reverse(tempResultVector.begin(), tempResultVector.end());
-    }
-    // copy the temp uint8 vector to the final uint8 result array
-    for(size_t i = 0; i < totalTuples; i++)
-    {
-      outputResultVector[i] = tempResultVector[i];
-    }
-  }
-  else
-  {
-    // insert into current threshold
-    InsertThreshold<T>(totalTuples, outputResultVector, inputComparisonSet.getUnionOperator(), tempResultVector, inverse, trueValue, falseValue);
-  }
+  // Apply resulting values to output
+  ApplyThresholdValues<T>(inputComparisonSet, outputResultVector, tempResultVector, replaceInput, trueValue, falseValue);
 }
 
 struct ThresholdSetFunctor
 {
   template <typename T>
-  void operator()(const ArrayThresholdSet& inputComparisonSet, const DataStructure& dataStructure, IDataArray& outputResultArray, int32_t& err, bool replaceInput, bool inverse, T trueValue,
-                  T falseValue)
+  void operator()(const ArrayThresholdSet& inputComparisonSet, const DataStructure& dataStructure, IDataArray& outputResultArray, int32_t& err, bool replaceInput, T trueValue, T falseValue)
   {
     // Traditionally we would do a check to ensure we get a valid pointer, I'm forgoing that check because it
     // was essentially done in the preflight part.
     auto& outputDataStore = outputResultArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
     usize totalTuples = outputDataStore.getNumberOfTuples();
     std::vector<T> tmpVector(totalTuples, falseValue);
-    ThresholdSet<T>(inputComparisonSet, dataStructure, tmpVector, err, replaceInput, inverse, trueValue, falseValue);
+    ThresholdSet<T>(inputComparisonSet, dataStructure, tmpVector, err, replaceInput, trueValue, falseValue);
 
     for(size_t i = 0; i < totalTuples; i++)
     {
@@ -284,32 +250,7 @@ Result<> MultiThresholdObjects::operator()()
   int32_t err = 0;
   ArrayThresholdSet::CollectionType thresholdSet = thresholdsObject.getArrayThresholds();
 
-  ExecuteDataFunction(ThresholdSetFunctor{}, maskArrayType, thresholdsObject, m_DataStructure, m_DataStructure.getDataRefAs<IDataArray>(maskArrayPath), err, !firstValueFound,
-                      thresholdsObject.isInverted(), trueValue, falseValue);
-  #if 0
-  for(const std::shared_ptr<IArrayThreshold>& threshold : thresholdSet)
-  {
-    if(m_ShouldCancel)
-    {
-      return {};
-    }
-    const IArrayThreshold* thresholdPtr = threshold.get();
-    if(const auto* comparisonSet = dynamic_cast<const ArrayThresholdSet*>(thresholdPtr); comparisonSet != nullptr)
-    {
-      // Do not replace values on first threshold, update firstValueFound to reflect that a threshold has been run.
-      ExecuteDataFunction(ThresholdSetFunctor{}, maskArrayType, *comparisonSet, m_DataStructure, m_DataStructure.getDataRefAs<IDataArray>(maskArrayPath), err, !firstValueFound,
-                          thresholdsObject.isInverted(), trueValue, falseValue);
-      firstValueFound = true;
-    }
-    else if(const auto* comparisonValue = dynamic_cast<const ArrayThreshold*>(thresholdPtr); comparisonValue != nullptr)
-    {
-      // Do not replace values on first threshold, update firstValueFound to reflect that a threshold has been run.
-      ExecuteDataFunction(ThresholdValueFunctor{}, maskArrayType, *comparisonValue, m_DataStructure, m_DataStructure.getDataRefAs<IDataArray>(maskArrayPath), err, !firstValueFound,
-                          thresholdsObject.isInverted(), trueValue, falseValue);
-      firstValueFound = true;
-    }
-  }
-  #endif
+  ExecuteDataFunction(ThresholdSetFunctor{}, maskArrayType, thresholdsObject, m_DataStructure, m_DataStructure.getDataRefAs<IDataArray>(maskArrayPath), err, !firstValueFound, trueValue, falseValue);
 
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MultiThresholdObjectsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MultiThresholdObjectsFilter.cpp
@@ -223,8 +223,8 @@ IFilter::PreflightResult MultiThresholdObjectsFilter::preflightImpl(const DataSt
   }
 
   // Create the output boolean array
-  auto action =
-      std::make_unique<CreateArrayAction>(maskArrayType, dataArray.getIDataStoreRef().getTupleShape(), std::vector<usize>{1}, firstDataPath.replaceName(maskArrayName), dataArray.getDataFormat());
+  const auto& dataStore = dataArray.getIDataStoreRef();
+  auto action = std::make_unique<CreateArrayAction>(maskArrayType, dataStore.getTupleShape(), dataStore.getComponentShape(), firstDataPath.replaceName(maskArrayName), dataArray.getDataFormat());
 
   OutputActions actions;
   actions.appendAction(std::move(action));

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MultiThresholdObjectsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MultiThresholdObjectsFilter.cpp
@@ -164,7 +164,6 @@ IFilter::PreflightResult MultiThresholdObjectsFilter::preflightImpl(const DataSt
 
   // Check for same number of tuples and components
   usize numTuples = dataArray.getNumberOfTuples();
-  usize numComponents = dataArray.getNumberOfComponents();
   for(const auto& dataPath : thresholdPaths)
   {
     const auto& currentDataArray = dataStructure.getDataRefAs<IDataArray>(dataPath);
@@ -173,13 +172,6 @@ IFilter::PreflightResult MultiThresholdObjectsFilter::preflightImpl(const DataSt
     {
       auto errorMessage = fmt::format("Data Arrays do not have same equal number of tuples. '{}:{}' and '{}:{}'", firstDataPath.toString(), numTuples, dataPath.toString(), currentNumTuples);
       return MakePreflightErrorResult(to_underlying(ErrorCodes::UnequalTuples), errorMessage);
-    }
-    usize currentNumComponents = currentDataArray.getNumberOfComponents();
-    if(currentNumComponents != numComponents)
-    {
-      auto errorMessage =
-          fmt::format("Data Arrays do not have same equal number of components. '{}:{}' and '{}:{}'", firstDataPath.toString(), numComponents, dataPath.toString(), currentNumComponents);
-      return MakePreflightErrorResult(to_underlying(ErrorCodes::UnequalComponents), errorMessage);
     }
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MultiThresholdObjectsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MultiThresholdObjectsFilter.cpp
@@ -224,7 +224,7 @@ IFilter::PreflightResult MultiThresholdObjectsFilter::preflightImpl(const DataSt
 
   // Create the output boolean array
   const auto& dataStore = dataArray.getIDataStoreRef();
-  auto action = std::make_unique<CreateArrayAction>(maskArrayType, dataStore.getTupleShape(), dataStore.getComponentShape(), firstDataPath.replaceName(maskArrayName), dataArray.getDataFormat());
+  auto action = std::make_unique<CreateArrayAction>(maskArrayType, dataStore.getTupleShape(), std::vector<usize>{1}, firstDataPath.replaceName(maskArrayName), dataArray.getDataFormat());
 
   OutputActions actions;
   actions.appendAction(std::move(action));

--- a/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
@@ -347,7 +347,6 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Float", 
   double thresholdValue = GENERATE(0.0, 0.01, 0.02, 0.03, 0.04, 26.2);
   bool isInverted = GENERATE(false, true);
 
-  // RunSingleComponentThresholdTests(dataStructure, k_TestArrayIntPath, 3.0, false);
   SECTION("ArrayThreshold: >")
   {
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
@@ -740,158 +739,8 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Invalid Execution", "[SimplnxCore
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
 }
 
-/// <summary>
-/// ///////
-/// </summary>
-
-#if false
-TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Execution", "[SimplnxCore][MultiThresholdObjectsFilter]")
-{
-  UnitTest::LoadPlugins();
-
-  DataStructure dataStructure = CreateTestDataStructure();
-
-  SECTION("Float Array Threshold")
-  {
-    MultiThresholdObjectsFilter filter;
-    Arguments args;
-
-    ArrayThresholdSet thresholdSet;
-    auto threshold = std::make_shared<ArrayThreshold>();
-    threshold->setArrayPath(k_TestArrayFloatPath);
-    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold->setComparisonValue(0.1);
-    thresholdSet.setArrayThresholds({threshold});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::boolean));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
-
-    auto* thresholdArray = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-    REQUIRE(thresholdArray != nullptr);
-
-    // For the comparison value of 0.1, the threshold array elements 0 to 9 should be false and 10 through 19 should be true
-    for(usize i = 0; i < 20; i++)
-    {
-      if(i < 10)
-      {
-        REQUIRE((*thresholdArray)[i] == false);
-      }
-      else
-      {
-        REQUIRE((*thresholdArray)[i] == true);
-      }
-    }
-  }
-
-  SECTION("Int Array Threshold")
-  {
-    MultiThresholdObjectsFilter filter;
-    Arguments args;
-
-    ArrayThresholdSet thresholdSet;
-    auto threshold = std::make_shared<ArrayThreshold>();
-    threshold->setArrayPath(k_TestArrayIntPath);
-    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold->setComparisonValue(15);
-    thresholdSet.setArrayThresholds({threshold});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::boolean));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
-
-    auto* thresholdArray = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-    REQUIRE(thresholdArray != nullptr);
-
-    // For the comparison value of 0.1, the threshold array elements 0 to 9 should be false and 10 through 19 should be true
-    for(usize i = 0; i < 20; i++)
-    {
-      if(i <= 15)
-      {
-        REQUIRE((*thresholdArray)[i] == false);
-      }
-      else
-      {
-        REQUIRE((*thresholdArray)[i] == true);
-      }
-    }
-  }
-
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
-}
-
-TEMPLATE_TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Execution - Custom Values", "[SimplnxCore][MultiThresholdObjectsFilter]", int8, uint8, int16, uint16, int32, uint32, int64, uint64,
-                   float32, float64)
-{
-  UnitTest::LoadPlugins();
-
-  MultiThresholdObjectsFilter filter;
-  DataStructure dataStructure = CreateTestDataStructure();
-  Arguments args;
-
-  float64 trueValue = 25;
-  float64 falseValue = 10;
-
-  ArrayThresholdSet thresholdSet;
-  auto threshold = std::make_shared<ArrayThreshold>();
-  threshold->setArrayPath(k_TestArrayIntPath);
-  threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-  threshold->setComparisonValue(15);
-  thresholdSet.setArrayThresholds({threshold});
-
-  args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-  args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-  args.insertOrAssign(MultiThresholdObjectsFilter::k_UseCustomTrueValue, std::make_any<bool>(true));
-  args.insertOrAssign(MultiThresholdObjectsFilter::k_CustomTrueValue, std::make_any<float64>(trueValue));
-  args.insertOrAssign(MultiThresholdObjectsFilter::k_UseCustomFalseValue, std::make_any<bool>(true));
-  args.insertOrAssign(MultiThresholdObjectsFilter::k_CustomFalseValue, std::make_any<float64>(falseValue));
-  args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(GetDataType<TestType>()));
-
-  // Preflight the filter and check result
-  auto preflightResult = filter.preflight(dataStructure, args);
-  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-  // Execute the filter and check the result
-  auto executeResult = filter.execute(dataStructure, args);
-  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
-
-  auto* thresholdArray = dataStructure.getDataAs<DataArray<TestType>>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArray != nullptr);
-
-  // For the comparison value of 0.1, the threshold array elements 0 to 9 should be false and 10 through 19 should be true
-  for(usize i = 0; i < 20; i++)
-  {
-    if(i <= 15)
-    {
-      REQUIRE((*thresholdArray)[i] == falseValue);
-    }
-    else
-    {
-      REQUIRE((*thresholdArray)[i] == trueValue);
-    }
-  }
-}
-
-
-
-TEMPLATE_TEST_CASE("SimplnxCore::MultiThresholdObjects: Invalid Execution - Out of Bounds Custom Values", "[SimplnxCore][MultiThresholdObjectsFilter]", int8, uint8, int16, uint16, int32, uint32,
-                   int64, uint64, float32)
+TEMPLATE_TEST_CASE("SimplnxCore::MultiThresholdObjects: Invalid Execution - Out of Bounds Custom Values", "[SimplnxCore][MultiThresholdObjectsFilter]", int8, uint8, int16, uint16, int32, uint32, int64,
+                  uint64, float32)
 {
   UnitTest::LoadPlugins();
 
@@ -995,329 +844,33 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Invalid Execution - Boolean Custo
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
 }
 
+// DataType checks
+
 template <typename T>
 void checkMaskValues(const DataStructure& dataStructure, const DataPath& thresholdArrayPath)
 {
   auto* thresholdArrayPtr = dataStructure.getDataAs<DataArray<T>>(thresholdArrayPath);
   REQUIRE(thresholdArrayPtr != nullptr);
 
-  auto& thresholdArray = (*thresholdArrayPtr);
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
 
   // For the comparison value of 0.1, the threshold array elements 0 to 9 should be false and 10 through 19 should be true
-  for(usize i = 0; i < 20; i++)
+  for(usize i = 0; i < k_TupleCount; i++)
   {
-    if(i < 10)
+    if(i < 5)
     {
-      REQUIRE(thresholdArray[i] == static_cast<T>(0));
+      REQUIRE(thresholdStore[i] == static_cast<T>(0));
     }
     else
     {
-      REQUIRE(thresholdArray[i] == static_cast<T>(1));
+      REQUIRE(thresholdStore[i] == static_cast<T>(1));
     }
   }
 }
 
-TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Execution, DataType", "[SimplnxCore][MultiThresholdObjectsFilter]")
+template <typename T>
+void runMaskTypeFilter(MultiThresholdObjectsFilter& filter, Arguments& args, DataStructure& dataStructure)
 {
-  UnitTest::LoadPlugins();
-
-  DataStructure dataStructure = CreateTestDataStructure();
-
-  // Signed
-  SECTION("Int8 Threshold")
-  {
-    MultiThresholdObjectsFilter filter;
-    Arguments args;
-
-    ArrayThresholdSet thresholdSet;
-    auto threshold = std::make_shared<ArrayThreshold>();
-    threshold->setArrayPath(k_TestArrayFloatPath);
-    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold->setComparisonValue(0.1);
-    thresholdSet.setArrayThresholds({threshold});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::int8));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
-
-    checkMaskValues<int8>(dataStructure, k_ThresholdArrayPath);
-  }
-
-  SECTION("Int16 Threshold")
-  {
-    MultiThresholdObjectsFilter filter;
-    Arguments args;
-
-    ArrayThresholdSet thresholdSet;
-    auto threshold = std::make_shared<ArrayThreshold>();
-    threshold->setArrayPath(k_TestArrayFloatPath);
-    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold->setComparisonValue(0.1);
-    thresholdSet.setArrayThresholds({threshold});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::int16));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
-
-    checkMaskValues<int16>(dataStructure, k_ThresholdArrayPath);
-  }
-
-  SECTION("Int32 Threshold")
-  {
-    MultiThresholdObjectsFilter filter;
-    Arguments args;
-
-    ArrayThresholdSet thresholdSet;
-    auto threshold = std::make_shared<ArrayThreshold>();
-    threshold->setArrayPath(k_TestArrayFloatPath);
-    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold->setComparisonValue(0.1);
-    thresholdSet.setArrayThresholds({threshold});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::int32));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
-
-    checkMaskValues<int32>(dataStructure, k_ThresholdArrayPath);
-  }
-
-  SECTION("Int64 Threshold")
-  {
-    MultiThresholdObjectsFilter filter;
-    Arguments args;
-
-    ArrayThresholdSet thresholdSet;
-    auto threshold = std::make_shared<ArrayThreshold>();
-    threshold->setArrayPath(k_TestArrayFloatPath);
-    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold->setComparisonValue(0.1);
-    thresholdSet.setArrayThresholds({threshold});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::int64));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
-
-    checkMaskValues<int64>(dataStructure, k_ThresholdArrayPath);
-  }
-
-  // Unsigned
-  SECTION("UInt8 Threshold")
-  {
-    MultiThresholdObjectsFilter filter;
-    Arguments args;
-
-    ArrayThresholdSet thresholdSet;
-    auto threshold = std::make_shared<ArrayThreshold>();
-    threshold->setArrayPath(k_TestArrayFloatPath);
-    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold->setComparisonValue(0.1);
-    thresholdSet.setArrayThresholds({threshold});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::uint8));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
-
-    checkMaskValues<uint8>(dataStructure, k_ThresholdArrayPath);
-  }
-
-  SECTION("UInt16 Threshold")
-  {
-    MultiThresholdObjectsFilter filter;
-    Arguments args;
-
-    ArrayThresholdSet thresholdSet;
-    auto threshold = std::make_shared<ArrayThreshold>();
-    threshold->setArrayPath(k_TestArrayFloatPath);
-    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold->setComparisonValue(0.1);
-    thresholdSet.setArrayThresholds({threshold});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::uint16));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
-
-    checkMaskValues<uint16>(dataStructure, k_ThresholdArrayPath);
-  }
-
-  SECTION("UInt32 Threshold")
-  {
-    MultiThresholdObjectsFilter filter;
-    Arguments args;
-
-    ArrayThresholdSet thresholdSet;
-    auto threshold = std::make_shared<ArrayThreshold>();
-    threshold->setArrayPath(k_TestArrayFloatPath);
-    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold->setComparisonValue(0.1);
-    thresholdSet.setArrayThresholds({threshold});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::uint32));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
-
-    checkMaskValues<uint32>(dataStructure, k_ThresholdArrayPath);
-  }
-
-  SECTION("UInt64 Threshold")
-  {
-    MultiThresholdObjectsFilter filter;
-    Arguments args;
-
-    ArrayThresholdSet thresholdSet;
-    auto threshold = std::make_shared<ArrayThreshold>();
-    threshold->setArrayPath(k_TestArrayFloatPath);
-    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold->setComparisonValue(0.1);
-    thresholdSet.setArrayThresholds({threshold});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::uint64));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
-
-    checkMaskValues<uint64>(dataStructure, k_ThresholdArrayPath);
-  }
-
-  // Floating Point
-  SECTION("Float32 Threshold")
-  {
-    MultiThresholdObjectsFilter filter;
-    Arguments args;
-
-    ArrayThresholdSet thresholdSet;
-    auto threshold = std::make_shared<ArrayThreshold>();
-    threshold->setArrayPath(k_TestArrayFloatPath);
-    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold->setComparisonValue(0.1);
-    thresholdSet.setArrayThresholds({threshold});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::float32));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
-
-    checkMaskValues<float32>(dataStructure, k_ThresholdArrayPath);
-  }
-
-  SECTION("Float64 Threshold")
-  {
-    MultiThresholdObjectsFilter filter;
-    Arguments args;
-
-    ArrayThresholdSet thresholdSet;
-    auto threshold = std::make_shared<ArrayThreshold>();
-    threshold->setArrayPath(k_TestArrayFloatPath);
-    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold->setComparisonValue(0.1);
-    thresholdSet.setArrayThresholds({threshold});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::float64));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
-
-    checkMaskValues<float64>(dataStructure, k_ThresholdArrayPath);
-  }
-
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
-}
-
-TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Execution - Multicomponent", "[SimplnxCore][MultiThresholdObjectsFilter]")
-{
-  DataStructure dataStructure = CreateTestDataStructure();
-
-  MultiThresholdObjectsFilter filter;
-  Arguments args;
-
-  ArrayThresholdSet thresholdSet;
-  auto threshold = std::make_shared<ArrayThreshold>();
-  threshold->setArrayPath(k_MultiComponentArrayPath);
-  threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-  threshold->setComparisonValue(0);
-  threshold->setComponentIndex(1);
-  thresholdSet.setArrayThresholds({threshold});
-
-  args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-  args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-  args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::boolean));
-
   // Preflight the filter and check result
   auto preflightResult = filter.preflight(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
@@ -1326,64 +879,101 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Execution - Multicomponent"
   auto executeResult = filter.execute(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
 
-  auto* thresholdArray = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArray != nullptr);
+  checkMaskValues<T>(dataStructure, k_ThresholdArrayPath);
+}
 
-  usize numTuples = thresholdArray->getNumberOfTuples();
+TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Execution, Mask DataType", "[SimplnxCore][MultiThresholdObjectsFilter]")
+{
+  UnitTest::LoadPlugins();
 
-  // (x, y, z)
-  // y > 0
-  // even tuple indices should be true except 0
-  REQUIRE_FALSE((*thresholdArray)[0]);
-  for(usize i = 1; i < numTuples; i++)
+  DataStructure dataStructure = CreateTestDataStructure();
+
+  // Shared filter setup
+  MultiThresholdObjectsFilter filter;
+  Arguments args;
+
+  ArrayThresholdSet thresholdSet;
+  auto threshold = std::make_shared<ArrayThreshold>();
+  threshold->setArrayPath(k_TestArrayFloatPath);
+  threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
+  threshold->setComparisonValue(0.05);
+  thresholdSet.setArrayThresholds({threshold});
+
+  args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
+  args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
+
+  // Signed
+  SECTION("Int8 Threshold")
   {
-    bool value = (*thresholdArray)[i];
-    if(i % 2 == 0)
-    {
-      REQUIRE(value);
-    }
-    else
-    {
-      REQUIRE_FALSE(value);
-    }
+    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::int8));
+
+    runMaskTypeFilter<int8>(filter, args, dataStructure);
+  }
+
+  SECTION("Int16 Threshold")
+  {
+    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::int16));
+
+    runMaskTypeFilter<int16>(filter, args, dataStructure);
+  }
+
+  SECTION("Int32 Threshold")
+  {
+    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::int32));
+
+    runMaskTypeFilter<int32>(filter, args, dataStructure);
+  }
+
+  SECTION("Int64 Threshold")
+  {
+    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::int64));
+
+    runMaskTypeFilter<int64>(filter, args, dataStructure);
+  }
+
+  // Unsigned
+  SECTION("UInt8 Threshold")
+  {
+    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::uint8));
+
+    runMaskTypeFilter<uint8>(filter, args, dataStructure);
+  }
+
+  SECTION("UInt16 Threshold")
+  {
+    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::uint16));
+
+    runMaskTypeFilter<uint16>(filter, args, dataStructure);
+  }
+
+  SECTION("UInt32 Threshold")
+  {
+    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::uint32));
+
+    runMaskTypeFilter<uint32>(filter, args, dataStructure);
+  }
+
+  SECTION("UInt64 Threshold")
+  {
+    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::uint64));
+
+    runMaskTypeFilter<uint64>(filter, args, dataStructure);
+  }
+
+  // Floating Point
+  SECTION("Float32 Threshold")
+  {
+    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::float32));
+
+    runMaskTypeFilter<float32>(filter, args, dataStructure);
+  }
+
+  SECTION("Float64 Threshold")
+  {
+    args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::float64));
+
+    runMaskTypeFilter<float64>(filter, args, dataStructure);
   }
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
-}
-#endif
-
-TEST_CASE("SimplnxCore::MultiThresholdObjectsFilter: SIMPL Backwards Compatibility", "[SimplnxCore][MultiThresholdObjectsFilter][BackwardsCompatibility]")
-{
-  auto app = Application::GetOrCreateInstance();
-  UnitTest::LoadPlugins();
-  auto filterList = app->getFilterList();
-
-  const fs::path conversionDir = fs::path(nx::core::unit_test::k_SourceDir.view()) / "test" / "simpl_conversion";
-
-  const std::vector<std::pair<std::string, fs::path>> fixtures = {
-      {"SIMPL 6.5 (UUID)", conversionDir / "6_5" / "MultiThresholdObjectsFilter.json"},
-      {"SIMPL 6.4 (Filter_Name)", conversionDir / "6_4" / "MultiThresholdObjectsFilter.json"},
-  };
-
-  for(const auto& [label, fixturePath] : fixtures)
-  {
-    DYNAMIC_SECTION(label)
-    {
-      auto pipelineResult = Pipeline::FromSIMPLFile(fixturePath, filterList);
-      REQUIRE(pipelineResult.valid());
-
-      auto& pipeline = pipelineResult.value();
-      REQUIRE(pipeline.size() == 1);
-
-      auto* pipelineFilter = dynamic_cast<PipelineFilter*>(pipeline.at(0));
-      REQUIRE(pipelineFilter != nullptr);
-
-      const IFilter* filter = pipelineFilter->getFilter();
-      REQUIRE(filter != nullptr);
-      REQUIRE(filter->uuid() == FilterTraits<MultiThresholdObjectsFilter>::uuid);
-
-      const Arguments args = pipelineFilter->getArguments();
-      CHECK(args.value<std::string>(MultiThresholdObjectsFilter::k_CreatedDataName_Key) == "TestName");
-    }
-  }
 }

--- a/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
@@ -92,25 +92,26 @@ DataStructure CreateTestDataStructure()
   return dataStructure;
 }
 
-ArrayThresholdSet CreateSingleThreshold(const DataPath& arrayPath, ArrayThreshold::ComparisonType comparisonType, double value, bool isInverted)
+ArrayThresholdSet CreateSingleThreshold(const DataPath& arrayPath, ArrayThreshold::ComparisonType comparisonType, double value, bool isInverted, int componentIndex)
 {
   ArrayThresholdSet thresholdSet;
   auto threshold = std::make_shared<ArrayThreshold>();
   threshold->setArrayPath(arrayPath);
   threshold->setComparisonType(comparisonType);
   threshold->setComparisonValue(value);
+  threshold->setComponentIndex(componentIndex);
   threshold->setInverted(isInverted);
   thresholdSet.setArrayThresholds({threshold});
 
   return thresholdSet;
 }
 
-void RunSingleThresholdTest(DataStructure& dataStructure, const DataPath& arrayPath, ArrayThreshold::ComparisonType comparisonType, double value, bool isInverted)
+void RunSingleThresholdTest(DataStructure& dataStructure, const DataPath& arrayPath, ArrayThreshold::ComparisonType comparisonType, double value, bool isInverted, int32 componentIndex = 0)
 {
   MultiThresholdObjectsFilter filter;
   Arguments args;
 
-  auto thresholdSet = CreateSingleThreshold(arrayPath, comparisonType, value, isInverted);
+  auto thresholdSet = CreateSingleThreshold(arrayPath, comparisonType, value, isInverted, componentIndex);
 
   args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
   args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
@@ -124,12 +125,11 @@ void RunSingleThresholdTest(DataStructure& dataStructure, const DataPath& arrayP
   auto executeResult = filter.execute(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
 
-  // Require the input and output arrays to have an equal number of components
+  // Require that the mask array only has one component
   const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
   REQUIRE(thresholdArrayPtr != nullptr);
 
-  const auto* inputArrayPtr = dataStructure.getDataAs<IDataArray>(arrayPath);
-  REQUIRE(inputArrayPtr->getNumberOfComponents() == thresholdArrayPtr->getNumberOfComponents());
+  REQUIRE(thresholdArrayPtr->getNumberOfComponents() == 1);
 }
 
 void CheckIntTestDataGreaterThanSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
@@ -171,30 +171,6 @@ void CheckFloatTestDataGreaterThanSingleComponent(const DataStructure& dataStruc
     }
 
     REQUIRE(value == expected);
-  }
-}
-
-void CheckIntTestDataGreaterThanMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
-{
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
-
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
-  {
-    for(usize j = 0; j < k_MultiComponentCount; j++)
-    {
-      bool value = thresholdStore[i * k_MultiComponentCount + j];
-      bool expected = InputIntComponentValue(i, j) > thresholdValue;
-
-      if(isInverted)
-      {
-        expected = !expected;
-      }
-
-      REQUIRE(value == expected);
-    }
   }
 }
 
@@ -241,30 +217,6 @@ void CheckFloatTestDataLessThanSingleComponent(const DataStructure& dataStructur
   }
 }
 
-void CheckIntTestDataLessThanMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
-{
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
-
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
-  {
-    for(usize j = 0; j < k_MultiComponentCount; j++)
-    {
-      bool value = thresholdStore[i * k_MultiComponentCount + j];
-      bool expected = InputIntComponentValue(i, j) < thresholdValue;
-
-      if(isInverted)
-      {
-        expected = !expected;
-      }
-
-      REQUIRE(value == expected);
-    }
-  }
-}
-
 void CheckIntTestDataEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
 {
   const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
@@ -283,33 +235,6 @@ void CheckIntTestDataEqualToSingleComponent(const DataStructure& dataStructure, 
     }
 
     REQUIRE(value == expected);
-  }
-}
-
-void CheckIntTestDataEqualToMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
-{
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
-
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  const auto& inputStore = dataStructure.getDataAs<Int32Array>(k_MultiComponentArrayPath)->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
-  {
-    for(usize j = 0; j < k_MultiComponentCount; j++)
-    {
-      int32 inputValue = inputStore[i * k_MultiComponentCount + j];
-      bool value = thresholdStore[i * k_MultiComponentCount + j];
-      bool expected = InputIntComponentValue(i, j) == thresholdValue;
-
-      if(isInverted)
-      {
-        expected = !expected;
-      }
-
-      //REQUIRE(value == expected);
-    }
   }
 }
 
@@ -355,7 +280,9 @@ void CheckIntTestDataNotEqualToSingleComponent(const DataStructure& dataStructur
   }
 }
 
-void CheckIntTestDataNotEqualToMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+// Multi-component checks
+
+void CheckIntTestDataGreaterThanMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted, int32 componentIndex)
 {
   const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
   REQUIRE(thresholdArrayPtr != nullptr);
@@ -364,17 +291,85 @@ void CheckIntTestDataNotEqualToMultiComponent(const DataStructure& dataStructure
 
   for(usize i = 0; i < k_TupleCount; i++)
   {
-    for(usize j = 0; j < k_MultiComponentCount; j++)
-    {
-      bool value = thresholdStore[i * k_MultiComponentCount + j];
-      bool expected = InputIntComponentValue(i, j) != thresholdValue;
-      if(isInverted)
-      {
-        expected = !expected;
-      }
+    usize arrayIndex = i * k_MultiComponentCount + componentIndex;
+    bool value = thresholdStore[arrayIndex];
+    bool expected = InputIntComponentValue(i, componentIndex) > thresholdValue;
 
-      REQUIRE(value == expected);
+    if(isInverted)
+    {
+      expected = !expected;
     }
+
+    REQUIRE(value == expected);
+  }
+}
+
+void CheckIntTestDataLessThanMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted, int32 componentIndex)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    usize arrayIndex = i * k_MultiComponentCount + componentIndex;
+    bool value = thresholdStore[arrayIndex];
+    bool expected = InputIntComponentValue(i, componentIndex) < thresholdValue;
+
+    if(isInverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(value == expected);
+  }
+}
+
+void CheckIntTestDataEqualToMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted, int32 componentIndex)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  const auto& inputStore = dataStructure.getDataAs<Int32Array>(k_MultiComponentArrayPath)->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    usize arrayIndex = i * k_MultiComponentCount + componentIndex;
+    int32 inputValue = inputStore[arrayIndex]; // store value for breakpoint testing purposes.
+    bool value = thresholdStore[arrayIndex];
+    bool expected = InputIntComponentValue(i, componentIndex) == thresholdValue;
+
+    if(isInverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(value == expected);
+  }
+}
+
+void CheckIntTestDataNotEqualToMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted, int32 componentIndex)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    usize arrayIndex = i * k_MultiComponentCount + componentIndex;
+    bool value = thresholdStore[arrayIndex];
+    bool expected = InputIntComponentValue(i, componentIndex) != thresholdValue;
+
+    if(isInverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(value == expected);
   }
 }
 
@@ -389,6 +384,7 @@ void CheckFloatTestDataNotEqualToSingleComponent(const DataStructure& dataStruct
   {
     bool value = thresholdStore[i];
     bool expected = InputFloatValue(i) != thresholdValue;
+
     if(isInverted)
     {
       expected = !expected;
@@ -581,34 +577,35 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Int Mult
   DataStructure dataStructure = CreateTestDataStructure();
   const DataPath targetArray = k_MultiComponentArrayPath;
   bool isInverted = false;
+  int32 componentIndex = GENERATE(0, 1, 2);
 
   SECTION("ArrayThreshold: >")
   {
     const double thresholdValue = 2.0;
-    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
-    CheckIntTestDataGreaterThanMultiComponent(dataStructure, thresholdValue, isInverted);
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted, componentIndex);
+    CheckIntTestDataGreaterThanMultiComponent(dataStructure, thresholdValue, isInverted, componentIndex);
   }
 
   SECTION("ArrayThreshold: <")
   {
     const double thresholdValue = 3.0;
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
-    CheckIntTestDataLessThanMultiComponent(dataStructure, thresholdValue, isInverted);
+    CheckIntTestDataLessThanMultiComponent(dataStructure, thresholdValue, isInverted, componentIndex);
   }
 
   SECTION("ArrayThreshold: ==")
   {
     const double thresholdValue = 3.0;
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
-    CheckIntTestDataEqualToMultiComponent(dataStructure, thresholdValue, isInverted);
-    CheckIntTestDataNotEqualToMultiComponent(dataStructure, thresholdValue, !isInverted);
+    CheckIntTestDataEqualToMultiComponent(dataStructure, thresholdValue, isInverted, componentIndex);
+    CheckIntTestDataNotEqualToMultiComponent(dataStructure, thresholdValue, !isInverted, componentIndex);
   }
   SECTION("ArrayThreshold: !=")
   {
     const double thresholdValue = 4.0;
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
-    CheckIntTestDataEqualToMultiComponent(dataStructure, thresholdValue, !isInverted);
-    CheckIntTestDataNotEqualToMultiComponent(dataStructure, thresholdValue, isInverted);
+    CheckIntTestDataEqualToMultiComponent(dataStructure, thresholdValue, !isInverted, componentIndex);
+    CheckIntTestDataNotEqualToMultiComponent(dataStructure, thresholdValue, isInverted, componentIndex);
   }
 }
 

--- a/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
@@ -573,7 +573,7 @@ void CheckThresholdSet3(DataStructure& dataStructure, bool inverted)
     bool expectedMask2 = ExpectedThresholdSet2Mask(i, false);
 
     bool expected = expectedMask1 && expectedMask2;
-    if (inverted)
+    if(inverted)
     {
       expected = !expected;
     }
@@ -631,8 +631,7 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Threshold Sets", "[SimplnxC
   UnitTest::LoadPlugins();
 
   DataStructure dataStructure = CreateTestDataStructure();
-  //bool isInverted = GENERATE(false, true);
-  bool isInverted = true;
+  bool isInverted = GENERATE(false, true);
 
   SECTION("ArraySet 1")
   {

--- a/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
@@ -674,6 +674,72 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Threshold Sets", "[SimplnxC
   }
 }
 
+// Invalid executions
+
+TEST_CASE("SimplnxCore::MultiThresholdObjects: Invalid Execution", "[SimplnxCore][MultiThresholdObjectsFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  MultiThresholdObjectsFilter filter;
+  DataStructure dataStructure = CreateTestDataStructure();
+  Arguments args;
+  args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
+
+  SECTION("Empty ArrayThresholdSet")
+  {
+    ArrayThresholdSet thresholdSet;
+
+    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
+  }
+  SECTION("Empty ArrayThreshold DataPath")
+  {
+    ArrayThresholdSet thresholdSet;
+    auto threshold = std::make_shared<ArrayThreshold>();
+    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
+    threshold->setComparisonValue(0.1);
+    thresholdSet.setArrayThresholds({threshold});
+
+    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
+  }
+  SECTION("Out of Bounds Component Index")
+  {
+    ArrayThresholdSet thresholdSet;
+    auto threshold = std::make_shared<ArrayThreshold>();
+    threshold->setArrayPath(k_TestArrayFloatPath);
+    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
+    threshold->setComparisonValue(0.1);
+    threshold->setComponentIndex(1);
+    thresholdSet.setArrayThresholds({threshold});
+
+    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
+  }
+  SECTION("Mismatching Tuples in Threshold Arrays")
+  {
+    ArrayThresholdSet thresholdSet;
+    auto threshold1 = std::make_shared<ArrayThreshold>();
+    threshold1->setArrayPath(k_TestArrayFloatPath);
+    threshold1->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
+    threshold1->setComparisonValue(0.1);
+    auto threshold2 = std::make_shared<ArrayThreshold>();
+    threshold2->setArrayPath(k_MismatchingTuplesArrayPath);
+    threshold2->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
+    threshold2->setComparisonValue(0.1);
+    thresholdSet.setArrayThresholds({threshold1, threshold2});
+
+    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
+  }
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions)
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result)
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
 /// <summary>
 /// ///////
 /// </summary>
@@ -822,84 +888,7 @@ TEMPLATE_TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Execution - Custom
   }
 }
 
-TEST_CASE("SimplnxCore::MultiThresholdObjects: Invalid Execution", "[SimplnxCore][MultiThresholdObjectsFilter]")
-{
-  UnitTest::LoadPlugins();
 
-  MultiThresholdObjectsFilter filter;
-  DataStructure dataStructure = CreateTestDataStructure();
-  Arguments args;
-  args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
-
-  SECTION("Empty ArrayThresholdSet")
-  {
-    ArrayThresholdSet thresholdSet;
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-  }
-  SECTION("Empty ArrayThreshold DataPath")
-  {
-    ArrayThresholdSet thresholdSet;
-    auto threshold = std::make_shared<ArrayThreshold>();
-    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold->setComparisonValue(0.1);
-    thresholdSet.setArrayThresholds({threshold});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-  }
-  SECTION("Mismatching Components in Threshold Arrays")
-  {
-    ArrayThresholdSet thresholdSet;
-    auto threshold1 = std::make_shared<ArrayThreshold>();
-    threshold1->setArrayPath(k_TestArrayFloatPath);
-    threshold1->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold1->setComparisonValue(0.1);
-    auto threshold2 = std::make_shared<ArrayThreshold>();
-    threshold2->setArrayPath(k_MismatchingComponentsArrayPath);
-    threshold2->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold2->setComparisonValue(0.1);
-    thresholdSet.setArrayThresholds({threshold1, threshold2});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-  }
-  SECTION("Out of Bounds Component Index")
-  {
-    ArrayThresholdSet thresholdSet;
-    auto threshold = std::make_shared<ArrayThreshold>();
-    threshold->setArrayPath(k_TestArrayFloatPath);
-    threshold->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold->setComparisonValue(0.1);
-    threshold->setComponentIndex(1);
-    thresholdSet.setArrayThresholds({threshold});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-  }
-  SECTION("Mismatching Tuples in Threshold Arrays")
-  {
-    ArrayThresholdSet thresholdSet;
-    auto threshold1 = std::make_shared<ArrayThreshold>();
-    threshold1->setArrayPath(k_TestArrayFloatPath);
-    threshold1->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold1->setComparisonValue(0.1);
-    auto threshold2 = std::make_shared<ArrayThreshold>();
-    threshold2->setArrayPath(k_MismatchingTuplesArrayPath);
-    threshold2->setComparisonType(ArrayThreshold::ComparisonType::GreaterThan);
-    threshold2->setComparisonValue(0.1);
-    thresholdSet.setArrayThresholds({threshold1, threshold2});
-
-    args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
-  }
-
-  // Preflight the filter and check result
-  auto preflightResult = filter.preflight(dataStructure, args);
-  SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions)
-
-  // Execute the filter and check the result
-  auto executeResult = filter.execute(dataStructure, args);
-  SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result)
-
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
-}
 
 TEMPLATE_TEST_CASE("SimplnxCore::MultiThresholdObjects: Invalid Execution - Out of Bounds Custom Values", "[SimplnxCore][MultiThresholdObjectsFilter]", int8, uint8, int16, uint16, int32, uint32,
                    int64, uint64, float32)

--- a/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
@@ -739,8 +739,8 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Invalid Execution", "[SimplnxCore
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
 }
 
-TEMPLATE_TEST_CASE("SimplnxCore::MultiThresholdObjects: Invalid Execution - Out of Bounds Custom Values", "[SimplnxCore][MultiThresholdObjectsFilter]", int8, uint8, int16, uint16, int32, uint32, int64,
-                  uint64, float32)
+TEMPLATE_TEST_CASE("SimplnxCore::MultiThresholdObjects: Invalid Execution - Out of Bounds Custom Values", "[SimplnxCore][MultiThresholdObjectsFilter]", int8, uint8, int16, uint16, int32, uint32,
+                   int64, uint64, float32)
 {
   UnitTest::LoadPlugins();
 

--- a/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
@@ -92,6 +92,14 @@ DataStructure CreateTestDataStructure()
   return dataStructure;
 }
 
+/**
+* @brief Creates a single threshold for the filter to use.
+* @param arrayPath Input DataArray path
+* @param comparisonType type of comparison
+* @param value Value to threshold against
+* @param isInverted Should the threshold output be inverted
+* componentIndex Component index of the array to threshold against.
+*/
 ArrayThresholdSet CreateSingleThreshold(const DataPath& arrayPath, ArrayThreshold::ComparisonType comparisonType, double value, bool isInverted, int componentIndex)
 {
   ArrayThresholdSet thresholdSet;
@@ -106,6 +114,15 @@ ArrayThresholdSet CreateSingleThreshold(const DataPath& arrayPath, ArrayThreshol
   return thresholdSet;
 }
 
+/**
+ * @brief
+ * @param dataStructure
+ * @param arrayPath Path to use for the threshold DataArray
+ * @param comparisonType Type of comparison to perform
+ * @param value Value to threshold against
+ * @param isInverted should the output mask value be inverted
+ * @param componentIndex Which component of the array the threshold should use.
+ */
 void RunSingleThresholdTest(DataStructure& dataStructure, const DataPath& arrayPath, ArrayThreshold::ComparisonType comparisonType, double value, bool isInverted, int32 componentIndex = 0)
 {
   MultiThresholdObjectsFilter filter;
@@ -132,6 +149,7 @@ void RunSingleThresholdTest(DataStructure& dataStructure, const DataPath& arrayP
   REQUIRE(thresholdArrayPtr->getNumberOfComponents() == 1);
 }
 
+// Integer checks
 void CheckIntTestDataGreaterThanSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
 {
   const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
@@ -153,6 +171,71 @@ void CheckIntTestDataGreaterThanSingleComponent(const DataStructure& dataStructu
   }
 }
 
+void CheckIntTestDataLessThanSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    bool value = thresholdStore[i];
+    bool expected = InputIntValue(i) < thresholdValue;
+
+    if(isInverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(value == expected);
+  }
+}
+
+void CheckIntTestDataEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    bool value = thresholdStore[i];
+    bool expected = InputIntValue(i) == thresholdValue;
+
+    if(isInverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(value == expected);
+  }
+}
+
+void CheckIntTestDataNotEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    bool value = thresholdStore[i];
+    bool expected = InputIntValue(i) != thresholdValue;
+
+    if(isInverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(value == expected);
+  }
+}
+
+// Floating point checks
+
 void CheckFloatTestDataGreaterThanSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
 {
   const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
@@ -164,27 +247,6 @@ void CheckFloatTestDataGreaterThanSingleComponent(const DataStructure& dataStruc
   {
     bool value = thresholdStore[i];
     bool expected = InputFloatValue(i) > thresholdValue;
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
-  }
-}
-
-void CheckIntTestDataLessThanSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
-{
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
-
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
-  {
-    bool value = thresholdStore[i];
-    bool expected = i < static_cast<int>(thresholdValue);
 
     if(isInverted)
     {
@@ -217,27 +279,6 @@ void CheckFloatTestDataLessThanSingleComponent(const DataStructure& dataStructur
   }
 }
 
-void CheckIntTestDataEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
-{
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
-
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
-  {
-    bool value = thresholdStore[i];
-    bool expected = i == static_cast<int>(thresholdValue);
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
-  }
-}
-
 void CheckFloatTestDataEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
 {
   const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
@@ -259,7 +300,7 @@ void CheckFloatTestDataEqualToSingleComponent(const DataStructure& dataStructure
   }
 }
 
-void CheckIntTestDataNotEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+void CheckFloatTestDataNotEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
 {
   const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
   REQUIRE(thresholdArrayPtr != nullptr);
@@ -269,7 +310,7 @@ void CheckIntTestDataNotEqualToSingleComponent(const DataStructure& dataStructur
   for(usize i = 0; i < k_TupleCount; i++)
   {
     bool value = thresholdStore[i];
-    bool expected = i != thresholdValue;
+    bool expected = InputFloatValue(i) != thresholdValue;
 
     if(isInverted)
     {
@@ -291,8 +332,7 @@ void CheckIntTestDataGreaterThanMultiComponent(const DataStructure& dataStructur
 
   for(usize i = 0; i < k_TupleCount; i++)
   {
-    usize arrayIndex = i * k_MultiComponentCount + componentIndex;
-    bool value = thresholdStore[arrayIndex];
+    bool value = thresholdStore[i];
     bool expected = InputIntComponentValue(i, componentIndex) > thresholdValue;
 
     if(isInverted)
@@ -313,8 +353,7 @@ void CheckIntTestDataLessThanMultiComponent(const DataStructure& dataStructure, 
 
   for(usize i = 0; i < k_TupleCount; i++)
   {
-    usize arrayIndex = i * k_MultiComponentCount + componentIndex;
-    bool value = thresholdStore[arrayIndex];
+    bool value = thresholdStore[i];
     bool expected = InputIntComponentValue(i, componentIndex) < thresholdValue;
 
     if(isInverted)
@@ -333,13 +372,9 @@ void CheckIntTestDataEqualToMultiComponent(const DataStructure& dataStructure, d
 
   auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
 
-  const auto& inputStore = dataStructure.getDataAs<Int32Array>(k_MultiComponentArrayPath)->getDataStoreRef();
-
   for(usize i = 0; i < k_TupleCount; i++)
   {
-    usize arrayIndex = i * k_MultiComponentCount + componentIndex;
-    int32 inputValue = inputStore[arrayIndex]; // store value for breakpoint testing purposes.
-    bool value = thresholdStore[arrayIndex];
+    bool value = thresholdStore[i];
     bool expected = InputIntComponentValue(i, componentIndex) == thresholdValue;
 
     if(isInverted)
@@ -360,30 +395,8 @@ void CheckIntTestDataNotEqualToMultiComponent(const DataStructure& dataStructure
 
   for(usize i = 0; i < k_TupleCount; i++)
   {
-    usize arrayIndex = i * k_MultiComponentCount + componentIndex;
-    bool value = thresholdStore[arrayIndex];
-    bool expected = InputIntComponentValue(i, componentIndex) != thresholdValue;
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
-  }
-}
-
-void CheckFloatTestDataNotEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
-{
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
-
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
-  {
     bool value = thresholdStore[i];
-    bool expected = InputFloatValue(i) != thresholdValue;
+    bool expected = InputIntComponentValue(i, componentIndex) != thresholdValue;
 
     if(isInverted)
     {
@@ -422,70 +435,29 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Int", "[
 
   DataStructure dataStructure = CreateTestDataStructure();
   const DataPath targetArray = k_TestArrayIntPath;
-  bool isInverted = false;
+  double thresholdValue = GENERATE(-1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 22.0, 5.5);
+  bool isInverted = GENERATE(false, true);
 
   SECTION("ArrayThreshold: >")
   {
-    const double thresholdValue = 2.0;
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
     CheckIntTestDataGreaterThanSingleComponent(dataStructure, thresholdValue, isInverted);
   }
 
   SECTION("ArrayThreshold: <")
   {
-    const double thresholdValue = 3.0;
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
     CheckIntTestDataLessThanSingleComponent(dataStructure, thresholdValue, isInverted);
   }
 
   SECTION("ArrayThreshold: ==")
   {
-    const double thresholdValue = 3.0;
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
     CheckIntTestDataEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
     CheckIntTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
   }
   SECTION("ArrayThreshold: !=")
   {
-    const double thresholdValue = 4.0;
-    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
-    CheckIntTestDataEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
-    CheckIntTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
-  }
-}
-
-TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Int Inverted", "[SimplnxCore][MultiThresholdObjectsFilter]")
-{
-  UnitTest::LoadPlugins();
-
-  DataStructure dataStructure = CreateTestDataStructure();
-  const DataPath targetArray = k_TestArrayIntPath;
-  bool isInverted = true;
-
-  SECTION("ArrayThreshold: >")
-  {
-    const double thresholdValue = 2.0;
-    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
-    CheckIntTestDataGreaterThanSingleComponent(dataStructure, thresholdValue, isInverted);
-  }
-
-  SECTION("ArrayThreshold: <")
-  {
-    const double thresholdValue = 3.0;
-    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
-    CheckIntTestDataLessThanSingleComponent(dataStructure, thresholdValue, isInverted);
-  }
-
-  SECTION("ArrayThreshold: ==")
-  {
-    const double thresholdValue = 3.0;
-    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
-    CheckIntTestDataEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
-    CheckIntTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
-  }
-  SECTION("ArrayThreshold: !=")
-  {
-    const double thresholdValue = 4.0;
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
     CheckIntTestDataEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
     CheckIntTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
@@ -498,72 +470,30 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Float", 
 
   DataStructure dataStructure = CreateTestDataStructure();
   const DataPath targetArray = k_TestArrayFloatPath;
-  bool isInverted = false;
+  double thresholdValue = GENERATE(0.0, 0.01, 0.02, 0.03, 0.04, 26.2);
+  bool isInverted = GENERATE(false, true);
 
   // RunSingleComponentThresholdTests(dataStructure, k_TestArrayIntPath, 3.0, false);
   SECTION("ArrayThreshold: >")
   {
-    const double thresholdValue = 0.04;
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
     CheckFloatTestDataGreaterThanSingleComponent(dataStructure, thresholdValue, isInverted);
   }
 
   SECTION("ArrayThreshold: <")
   {
-    const double thresholdValue = 0.02;
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
     CheckFloatTestDataLessThanSingleComponent(dataStructure, thresholdValue, isInverted);
   }
 
   SECTION("ArrayThreshold: ==")
   {
-    const double thresholdValue = 0.03;
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
     CheckFloatTestDataEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
     CheckFloatTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
   }
   SECTION("ArrayThreshold: !=")
   {
-    const double thresholdValue = 0.02;
-    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
-    CheckFloatTestDataEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
-    CheckFloatTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
-  }
-}
-
-TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Float Inverted", "[SimplnxCore][MultiThresholdObjectsFilter]")
-{
-  UnitTest::LoadPlugins();
-
-  DataStructure dataStructure = CreateTestDataStructure();
-  const DataPath targetArray = k_TestArrayFloatPath;
-  bool isInverted = true;
-
-  // RunSingleComponentThresholdTests(dataStructure, k_TestArrayIntPath, 3.0, false);
-  SECTION("ArrayThreshold: >")
-  {
-    const double thresholdValue = 0.02;
-    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
-    CheckFloatTestDataGreaterThanSingleComponent(dataStructure, thresholdValue, isInverted);
-  }
-
-  SECTION("ArrayThreshold: <")
-  {
-    const double thresholdValue = 0.03;
-    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
-    CheckFloatTestDataLessThanSingleComponent(dataStructure, thresholdValue, isInverted);
-  }
-
-  SECTION("ArrayThreshold: ==")
-  {
-    const double thresholdValue = 0.02;
-    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
-    CheckFloatTestDataEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
-    CheckFloatTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
-  }
-  SECTION("ArrayThreshold: !=")
-  {
-    const double thresholdValue = 0.01;
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
     CheckFloatTestDataEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
     CheckFloatTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
@@ -576,34 +506,31 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Int Mult
 
   DataStructure dataStructure = CreateTestDataStructure();
   const DataPath targetArray = k_MultiComponentArrayPath;
-  bool isInverted = false;
+  double thresholdValue = GENERATE(-1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 22.0, 5.5);
+  bool isInverted = GENERATE(false, true);
   int32 componentIndex = GENERATE(0, 1, 2);
 
   SECTION("ArrayThreshold: >")
   {
-    const double thresholdValue = 2.0;
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted, componentIndex);
     CheckIntTestDataGreaterThanMultiComponent(dataStructure, thresholdValue, isInverted, componentIndex);
   }
 
   SECTION("ArrayThreshold: <")
   {
-    const double thresholdValue = 3.0;
-    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted, componentIndex);
     CheckIntTestDataLessThanMultiComponent(dataStructure, thresholdValue, isInverted, componentIndex);
   }
 
   SECTION("ArrayThreshold: ==")
   {
-    const double thresholdValue = 3.0;
-    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted, componentIndex);
     CheckIntTestDataEqualToMultiComponent(dataStructure, thresholdValue, isInverted, componentIndex);
     CheckIntTestDataNotEqualToMultiComponent(dataStructure, thresholdValue, !isInverted, componentIndex);
   }
   SECTION("ArrayThreshold: !=")
   {
-    const double thresholdValue = 4.0;
-    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted, componentIndex);
     CheckIntTestDataEqualToMultiComponent(dataStructure, thresholdValue, !isInverted, componentIndex);
     CheckIntTestDataNotEqualToMultiComponent(dataStructure, thresholdValue, isInverted, componentIndex);
   }

--- a/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
@@ -31,20 +31,39 @@ const DataPath k_ThresholdArrayPath = k_ImageCellDataName.createChildPath(k_Thre
 const DataPath k_MismatchingComponentsArrayPath = k_ImageCellDataName.createChildPath("MismatchingComponentsArray");
 const DataPath k_MismatchingTuplesArrayPath({"MismatchingTuplesArray"});
 
+constexpr int8 k_TupleCount = 5;
+constexpr int8 k_MultiComponentCount = 3;
+
+constexpr float64 k_FloatValueIncrement = 0.01;
+
+constexpr int32 InputIntValue(int32 index)
+{
+  return index;
+}
+
+constexpr int32 InputIntComponentValue(int32 tuple, int32 component)
+{
+  return (tuple + component) % 2 == 0 ? -tuple : tuple;
+}
+
+constexpr float64 InputFloatValue(int32 index)
+{
+  return (index + 1) * k_FloatValueIncrement;
+}
+
 DataStructure CreateTestDataStructure()
 {
   DataStructure dataStructure;
   // Create two test arrays, a float array and a int array
   // Set up geometry for tuples, a cuboid with dimensions 20, 10, 1
   ImageGeom* image = ImageGeom::Create(dataStructure, k_ImageGeometry);
-  std::vector<usize> dims = {20, 1, 1};
+  std::vector<usize> dims = {k_TupleCount, 1, 1};
   image->setDimensions(dims);
 
-  ShapeType tDims = {20};
+  ShapeType tDims = {k_TupleCount};
   ShapeType cDims = {1};
-  ShapeType cDimsMulti = {3};
-  float fnum = 0.0f;
-  int inum = 0;
+  ShapeType cDimsMulti = {k_MultiComponentCount};
+
   AttributeMatrix* am = AttributeMatrix::Create(dataStructure, k_CellData, tDims, image->getId());
   Float32Array* data = Float32Array::CreateWithStore<Float32DataStore>(dataStructure, k_TestArrayFloatName, tDims, cDims, am->getId());
   Int32Array* data1 = Int32Array::CreateWithStore<Int32DataStore>(dataStructure, k_TestArrayIntName, tDims, cDims, am->getId());
@@ -56,23 +75,327 @@ DataStructure CreateTestDataStructure()
   invalid2->fill(2.0);
 
   usize numComponents = multiComponentData->getNumberOfComponents();
-  int32 sign = 1;
 
-  // Fill the float array with {.01,.02,.03,.04,.05,.06,.07,.08,.09,.10,.11,.12,.13,.14,.15.,16,.17,.18,.19,.20}
-  // Fill the int array with { 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19 }
-  // Fill multi-component array with {{0, 0, 0}, {1, -1, 1}, {-2, 2, -2}, ..., {17, -17, 17}, {-18, 18, -18}, {19, -19, 19}}
-  for(usize i = 0; i < 20; i++)
+  // Fill the float array with {.01,.02,.03,.04,.05}
+  // Fill the int array with { 0,1,2,3,4}
+  // Fill multi-component array with {{0, 0, 0}, {1, -1, 1}, {-2, 2, -2}, {3, -3, 3}, {-4, 4, -4}}
+  for(usize i = 0; i < k_TupleCount; i++)
   {
-    fnum += 0.01f;
-    (*data)[i] = fnum;  // float array
-    (*data1)[i] = inum; // int array
-    multiComponentData->setComponent(i, 0, i * -sign);
-    multiComponentData->setComponent(i, 1, i * sign);
-    multiComponentData->setComponent(i, 2, i * -sign);
-    sign *= -1;
-    ++inum;
+    (*data)[i] = InputFloatValue(i); // float array
+    (*data1)[i] = InputIntValue(i);  // int array
+
+    for(usize j = 0; j < k_MultiComponentCount; j++)
+    {
+      multiComponentData->setComponent(i, j, InputIntComponentValue(i, j));
+    }
   }
   return dataStructure;
+}
+
+ArrayThresholdSet CreateSingleThreshold(const DataPath& arrayPath, ArrayThreshold::ComparisonType comparisonType, double value, bool isInverted)
+{
+  ArrayThresholdSet thresholdSet;
+  auto threshold = std::make_shared<ArrayThreshold>();
+  threshold->setArrayPath(arrayPath);
+  threshold->setComparisonType(comparisonType);
+  threshold->setComparisonValue(value);
+  threshold->setInverted(isInverted);
+  thresholdSet.setArrayThresholds({threshold});
+
+  return thresholdSet;
+}
+
+void RunSingleThresholdTest(DataStructure& dataStructure, const DataPath& arrayPath, ArrayThreshold::ComparisonType comparisonType, double value, bool isInverted)
+{
+  MultiThresholdObjectsFilter filter;
+  Arguments args;
+
+  auto thresholdSet = CreateSingleThreshold(arrayPath, comparisonType, value, isInverted);
+
+  args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
+  args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
+  args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedMaskType_Key, std::make_any<DataType>(DataType::boolean));
+
+  // Preflight the filter and check result
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+
+  // Execute the filter and check the result
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+
+  // Require the input and output arrays to have an equal number of components
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  const auto* inputArrayPtr = dataStructure.getDataAs<IDataArray>(arrayPath);
+  REQUIRE(inputArrayPtr->getNumberOfComponents() == thresholdArrayPtr->getNumberOfComponents());
+}
+
+void CheckIntTestDataGreaterThanSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    bool value = thresholdStore[i];
+    bool expected = InputIntValue(i) > thresholdValue;
+
+    if(isInverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(value == expected);
+  }
+}
+
+void CheckFloatTestDataGreaterThanSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    bool value = thresholdStore[i];
+    bool expected = InputFloatValue(i) > thresholdValue;
+
+    if(isInverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(value == expected);
+  }
+}
+
+void CheckIntTestDataGreaterThanMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    for(usize j = 0; j < k_MultiComponentCount; j++)
+    {
+      bool value = thresholdStore[i * k_MultiComponentCount + j];
+      bool expected = InputIntComponentValue(i, j) > thresholdValue;
+
+      if(isInverted)
+      {
+        expected = !expected;
+      }
+
+      REQUIRE(value == expected);
+    }
+  }
+}
+
+void CheckIntTestDataLessThanSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    bool value = thresholdStore[i];
+    bool expected = i < static_cast<int>(thresholdValue);
+
+    if(isInverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(value == expected);
+  }
+}
+
+void CheckFloatTestDataLessThanSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    float64 expectedValue = InputFloatValue(i);
+    bool value = thresholdStore[i];
+    bool expected = InputFloatValue(i) < thresholdValue;
+
+    if(isInverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(value == expected);
+  }
+}
+
+void CheckIntTestDataLessThanMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    for(usize j = 0; j < k_MultiComponentCount; j++)
+    {
+      bool value = thresholdStore[i * k_MultiComponentCount + j];
+      bool expected = InputIntComponentValue(i, j) < thresholdValue;
+
+      if(isInverted)
+      {
+        expected = !expected;
+      }
+
+      REQUIRE(value == expected);
+    }
+  }
+}
+
+void CheckIntTestDataEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    bool value = thresholdStore[i];
+    bool expected = i == static_cast<int>(thresholdValue);
+
+    if(isInverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(value == expected);
+  }
+}
+
+void CheckIntTestDataEqualToMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  const auto& inputStore = dataStructure.getDataAs<Int32Array>(k_MultiComponentArrayPath)->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    for(usize j = 0; j < k_MultiComponentCount; j++)
+    {
+      int32 inputValue = inputStore[i * k_MultiComponentCount + j];
+      bool value = thresholdStore[i * k_MultiComponentCount + j];
+      bool expected = InputIntComponentValue(i, j) == thresholdValue;
+
+      if(isInverted)
+      {
+        expected = !expected;
+      }
+
+      //REQUIRE(value == expected);
+    }
+  }
+}
+
+void CheckFloatTestDataEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    bool value = thresholdStore[i];
+    bool expected = InputFloatValue(i) == thresholdValue;
+
+    if(isInverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(value == expected);
+  }
+}
+
+void CheckIntTestDataNotEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    bool value = thresholdStore[i];
+    bool expected = i != thresholdValue;
+
+    if(isInverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(value == expected);
+  }
+}
+
+void CheckIntTestDataNotEqualToMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    for(usize j = 0; j < k_MultiComponentCount; j++)
+    {
+      bool value = thresholdStore[i * k_MultiComponentCount + j];
+      bool expected = InputIntComponentValue(i, j) != thresholdValue;
+      if(isInverted)
+      {
+        expected = !expected;
+      }
+
+      REQUIRE(value == expected);
+    }
+  }
+}
+
+void CheckFloatTestDataNotEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    bool value = thresholdStore[i];
+    bool expected = InputFloatValue(i) != thresholdValue;
+    if(isInverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(value == expected);
+  }
 }
 
 template <typename T>
@@ -97,6 +420,203 @@ float64 GetOutOfBoundsMaximumValue()
 }
 } // namespace
 
+TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Int", "[SimplnxCore][MultiThresholdObjectsFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  DataStructure dataStructure = CreateTestDataStructure();
+  const DataPath targetArray = k_TestArrayIntPath;
+  bool isInverted = false;
+
+  SECTION("ArrayThreshold: >")
+  {
+    const double thresholdValue = 2.0;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
+    CheckIntTestDataGreaterThanSingleComponent(dataStructure, thresholdValue, isInverted);
+  }
+
+  SECTION("ArrayThreshold: <")
+  {
+    const double thresholdValue = 3.0;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
+    CheckIntTestDataLessThanSingleComponent(dataStructure, thresholdValue, isInverted);
+  }
+
+  SECTION("ArrayThreshold: ==")
+  {
+    const double thresholdValue = 3.0;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
+    CheckIntTestDataEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
+    CheckIntTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
+  }
+  SECTION("ArrayThreshold: !=")
+  {
+    const double thresholdValue = 4.0;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
+    CheckIntTestDataEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
+    CheckIntTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
+  }
+}
+
+TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Int Inverted", "[SimplnxCore][MultiThresholdObjectsFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  DataStructure dataStructure = CreateTestDataStructure();
+  const DataPath targetArray = k_TestArrayIntPath;
+  bool isInverted = true;
+
+  SECTION("ArrayThreshold: >")
+  {
+    const double thresholdValue = 2.0;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
+    CheckIntTestDataGreaterThanSingleComponent(dataStructure, thresholdValue, isInverted);
+  }
+
+  SECTION("ArrayThreshold: <")
+  {
+    const double thresholdValue = 3.0;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
+    CheckIntTestDataLessThanSingleComponent(dataStructure, thresholdValue, isInverted);
+  }
+
+  SECTION("ArrayThreshold: ==")
+  {
+    const double thresholdValue = 3.0;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
+    CheckIntTestDataEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
+    CheckIntTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
+  }
+  SECTION("ArrayThreshold: !=")
+  {
+    const double thresholdValue = 4.0;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
+    CheckIntTestDataEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
+    CheckIntTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
+  }
+}
+
+TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Float", "[SimplnxCore][MultiThresholdObjectsFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  DataStructure dataStructure = CreateTestDataStructure();
+  const DataPath targetArray = k_TestArrayFloatPath;
+  bool isInverted = false;
+
+  // RunSingleComponentThresholdTests(dataStructure, k_TestArrayIntPath, 3.0, false);
+  SECTION("ArrayThreshold: >")
+  {
+    const double thresholdValue = 0.04;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
+    CheckFloatTestDataGreaterThanSingleComponent(dataStructure, thresholdValue, isInverted);
+  }
+
+  SECTION("ArrayThreshold: <")
+  {
+    const double thresholdValue = 0.02;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
+    CheckFloatTestDataLessThanSingleComponent(dataStructure, thresholdValue, isInverted);
+  }
+
+  SECTION("ArrayThreshold: ==")
+  {
+    const double thresholdValue = 0.03;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
+    CheckFloatTestDataEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
+    CheckFloatTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
+  }
+  SECTION("ArrayThreshold: !=")
+  {
+    const double thresholdValue = 0.02;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
+    CheckFloatTestDataEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
+    CheckFloatTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
+  }
+}
+
+TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Float Inverted", "[SimplnxCore][MultiThresholdObjectsFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  DataStructure dataStructure = CreateTestDataStructure();
+  const DataPath targetArray = k_TestArrayFloatPath;
+  bool isInverted = true;
+
+  // RunSingleComponentThresholdTests(dataStructure, k_TestArrayIntPath, 3.0, false);
+  SECTION("ArrayThreshold: >")
+  {
+    const double thresholdValue = 0.02;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
+    CheckFloatTestDataGreaterThanSingleComponent(dataStructure, thresholdValue, isInverted);
+  }
+
+  SECTION("ArrayThreshold: <")
+  {
+    const double thresholdValue = 0.03;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
+    CheckFloatTestDataLessThanSingleComponent(dataStructure, thresholdValue, isInverted);
+  }
+
+  SECTION("ArrayThreshold: ==")
+  {
+    const double thresholdValue = 0.02;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
+    CheckFloatTestDataEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
+    CheckFloatTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
+  }
+  SECTION("ArrayThreshold: !=")
+  {
+    const double thresholdValue = 0.01;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
+    CheckFloatTestDataEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
+    CheckFloatTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
+  }
+}
+
+TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Int Multi-Component", "[SimplnxCore][MultiThresholdObjectsFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  DataStructure dataStructure = CreateTestDataStructure();
+  const DataPath targetArray = k_MultiComponentArrayPath;
+  bool isInverted = false;
+
+  SECTION("ArrayThreshold: >")
+  {
+    const double thresholdValue = 2.0;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
+    CheckIntTestDataGreaterThanMultiComponent(dataStructure, thresholdValue, isInverted);
+  }
+
+  SECTION("ArrayThreshold: <")
+  {
+    const double thresholdValue = 3.0;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
+    CheckIntTestDataLessThanMultiComponent(dataStructure, thresholdValue, isInverted);
+  }
+
+  SECTION("ArrayThreshold: ==")
+  {
+    const double thresholdValue = 3.0;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
+    CheckIntTestDataEqualToMultiComponent(dataStructure, thresholdValue, isInverted);
+    CheckIntTestDataNotEqualToMultiComponent(dataStructure, thresholdValue, !isInverted);
+  }
+  SECTION("ArrayThreshold: !=")
+  {
+    const double thresholdValue = 4.0;
+    RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
+    CheckIntTestDataEqualToMultiComponent(dataStructure, thresholdValue, !isInverted);
+    CheckIntTestDataNotEqualToMultiComponent(dataStructure, thresholdValue, isInverted);
+  }
+}
+
+/// <summary>
+/// ///////
+/// </summary>
+
+#if false
 TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Execution", "[SimplnxCore][MultiThresholdObjectsFilter]")
 {
   UnitTest::LoadPlugins();
@@ -779,6 +1299,7 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Execution - Multicomponent"
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
 }
+#endif
 
 TEST_CASE("SimplnxCore::MultiThresholdObjectsFilter: SIMPL Backwards Compatibility", "[SimplnxCore][MultiThresholdObjectsFilter][BackwardsCompatibility]")
 {

--- a/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
@@ -93,13 +93,13 @@ DataStructure CreateTestDataStructure()
 }
 
 /**
-* @brief Creates a single threshold for the filter to use.
-* @param arrayPath Input DataArray path
-* @param comparisonType type of comparison
-* @param value Value to threshold against
-* @param isInverted Should the threshold output be inverted
-* componentIndex Component index of the array to threshold against.
-*/
+ * @brief Creates a single threshold for the filter to use.
+ * @param arrayPath Input DataArray path
+ * @param comparisonType type of comparison
+ * @param value Value to threshold against
+ * @param isInverted Should the threshold output be inverted
+ * componentIndex Component index of the array to threshold against.
+ */
 ArrayThresholdSet CreateSingleThreshold(const DataPath& arrayPath, ArrayThreshold::ComparisonType comparisonType, double value, bool isInverted, int componentIndex)
 {
   ArrayThresholdSet thresholdSet;
@@ -115,20 +115,14 @@ ArrayThresholdSet CreateSingleThreshold(const DataPath& arrayPath, ArrayThreshol
 }
 
 /**
- * @brief
+ * @brief Runs the MultiThresholdObjects filter on the provided threshold set
  * @param dataStructure
- * @param arrayPath Path to use for the threshold DataArray
- * @param comparisonType Type of comparison to perform
- * @param value Value to threshold against
- * @param isInverted should the output mask value be inverted
- * @param componentIndex Which component of the array the threshold should use.
+ * @param thresholdSet ThresholdSet to use for the MultiThresholdObjectsFilter
  */
-void RunSingleThresholdTest(DataStructure& dataStructure, const DataPath& arrayPath, ArrayThreshold::ComparisonType comparisonType, double value, bool isInverted, int32 componentIndex = 0)
+void RunThresholdSetTest(DataStructure& dataStructure, ArrayThresholdSet thresholdSet)
 {
   MultiThresholdObjectsFilter filter;
   Arguments args;
-
-  auto thresholdSet = CreateSingleThreshold(arrayPath, comparisonType, value, isInverted, componentIndex);
 
   args.insertOrAssign(MultiThresholdObjectsFilter::k_ArrayThresholdsObject_Key, std::make_any<ArrayThresholdSet>(thresholdSet));
   args.insertOrAssign(MultiThresholdObjectsFilter::k_CreatedDataName_Key, std::make_any<std::string>(k_ThresholdArrayName));
@@ -149,29 +143,50 @@ void RunSingleThresholdTest(DataStructure& dataStructure, const DataPath& arrayP
   REQUIRE(thresholdArrayPtr->getNumberOfComponents() == 1);
 }
 
+/**
+ * @brief Runs the MultiThresholdObjects filter on the provided DataStructure using a single array threshold.
+ * @param dataStructure
+ * @param arrayPath Path to use for the threshold DataArray
+ * @param comparisonType Type of comparison to perform
+ * @param value Value to threshold against
+ * @param isInverted should the output mask value be inverted
+ * @param componentIndex Which component of the array the threshold should use.
+ */
+void RunSingleThresholdTest(DataStructure& dataStructure, const DataPath& arrayPath, ArrayThreshold::ComparisonType comparisonType, double value, bool isInverted, int32 componentIndex = 0)
+{
+  auto thresholdSet = CreateSingleThreshold(arrayPath, comparisonType, value, isInverted, componentIndex);
+  RunThresholdSetTest(dataStructure, thresholdSet);
+}
+
 // Integer checks
-void CheckIntTestDataGreaterThanSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+bool ExpectedIntSingleComponentMask(ArrayThreshold::ComparisonType comparisonType, int32 i, double thresholdValue, bool isInverted)
 {
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
+  bool expected = false;
 
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
+  switch(comparisonType)
   {
-    bool value = thresholdStore[i];
-    bool expected = InputIntValue(i) > thresholdValue;
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
+  case ArrayThreshold::ComparisonType::GreaterThan:
+    expected = InputIntValue(i) > thresholdValue;
+    break;
+  case ArrayThreshold::ComparisonType::LessThan:
+    expected = InputIntValue(i) < thresholdValue;
+    break;
+  case ArrayThreshold::ComparisonType::Operator_Equal:
+    expected = InputIntValue(i) == thresholdValue;
+    break;
+  case ArrayThreshold::ComparisonType::Operator_NotEqual:
+    expected = InputIntValue(i) != thresholdValue;
+    break;
   }
+
+  if(isInverted)
+  {
+    expected = !expected;
+  }
+  return expected;
 }
 
-void CheckIntTestDataLessThanSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+void CheckIntTestDataSingleComponent(const DataStructure& dataStructure, ArrayThreshold::ComparisonType comparisonType, double thresholdValue, bool isInverted)
 {
   const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
   REQUIRE(thresholdArrayPtr != nullptr);
@@ -180,84 +195,39 @@ void CheckIntTestDataLessThanSingleComponent(const DataStructure& dataStructure,
 
   for(usize i = 0; i < k_TupleCount; i++)
   {
-    bool value = thresholdStore[i];
-    bool expected = InputIntValue(i) < thresholdValue;
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
-  }
-}
-
-void CheckIntTestDataEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
-{
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
-
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
-  {
-    bool value = thresholdStore[i];
-    bool expected = InputIntValue(i) == thresholdValue;
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
-  }
-}
-
-void CheckIntTestDataNotEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
-{
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
-
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
-  {
-    bool value = thresholdStore[i];
-    bool expected = InputIntValue(i) != thresholdValue;
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
+    REQUIRE(thresholdStore[i] == ExpectedIntSingleComponentMask(comparisonType, i, thresholdValue, isInverted));
   }
 }
 
 // Floating point checks
-
-void CheckFloatTestDataGreaterThanSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+bool ExpectedFloatSingleComponentMask(ArrayThreshold::ComparisonType comparisonType, int32 i, double thresholdValue, bool isInverted)
 {
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
+  bool expected = false;
 
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
+  switch(comparisonType)
   {
-    bool value = thresholdStore[i];
-    bool expected = InputFloatValue(i) > thresholdValue;
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
+  case ArrayThreshold::ComparisonType::GreaterThan:
+    expected = InputFloatValue(i) > thresholdValue;
+    break;
+  case ArrayThreshold::ComparisonType::LessThan:
+    expected = InputFloatValue(i) < thresholdValue;
+    break;
+  case ArrayThreshold::ComparisonType::Operator_Equal:
+    expected = InputFloatValue(i) == thresholdValue;
+    break;
+  case ArrayThreshold::ComparisonType::Operator_NotEqual:
+    expected = InputFloatValue(i) != thresholdValue;
+    break;
   }
+
+  if(isInverted)
+  {
+    expected = !expected;
+  }
+  return expected;
 }
 
-void CheckFloatTestDataLessThanSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
+void CheckFloatTestDataSingleComponent(const DataStructure& dataStructure, ArrayThreshold::ComparisonType comparisonType, double thresholdValue, bool isInverted)
 {
   const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
   REQUIRE(thresholdArrayPtr != nullptr);
@@ -266,85 +236,39 @@ void CheckFloatTestDataLessThanSingleComponent(const DataStructure& dataStructur
 
   for(usize i = 0; i < k_TupleCount; i++)
   {
-    float64 expectedValue = InputFloatValue(i);
-    bool value = thresholdStore[i];
-    bool expected = InputFloatValue(i) < thresholdValue;
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
-  }
-}
-
-void CheckFloatTestDataEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
-{
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
-
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
-  {
-    bool value = thresholdStore[i];
-    bool expected = InputFloatValue(i) == thresholdValue;
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
-  }
-}
-
-void CheckFloatTestDataNotEqualToSingleComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted)
-{
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
-
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
-  {
-    bool value = thresholdStore[i];
-    bool expected = InputFloatValue(i) != thresholdValue;
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
+    REQUIRE(thresholdStore[i] == ExpectedFloatSingleComponentMask(comparisonType, i, thresholdValue, isInverted));
   }
 }
 
 // Multi-component checks
-
-void CheckIntTestDataGreaterThanMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted, int32 componentIndex)
+bool ExpectedIntMultiComponentMask(ArrayThreshold::ComparisonType comparisonType, int32 i, double thresholdValue, bool isInverted, int32 componentIndex)
 {
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
+  bool expected = false;
 
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
+  switch(comparisonType)
   {
-    bool value = thresholdStore[i];
-    bool expected = InputIntComponentValue(i, componentIndex) > thresholdValue;
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
+  case ArrayThreshold::ComparisonType::GreaterThan:
+    expected = InputIntComponentValue(i, componentIndex) > thresholdValue;
+    break;
+  case ArrayThreshold::ComparisonType::LessThan:
+    expected = InputIntComponentValue(i, componentIndex) < thresholdValue;
+    break;
+  case ArrayThreshold::ComparisonType::Operator_Equal:
+    expected = InputIntComponentValue(i, componentIndex) == thresholdValue;
+    break;
+  case ArrayThreshold::ComparisonType::Operator_NotEqual:
+    expected = InputIntComponentValue(i, componentIndex) != thresholdValue;
+    break;
   }
+
+  if(isInverted)
+  {
+    expected = !expected;
+  }
+  return expected;
 }
 
-void CheckIntTestDataLessThanMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted, int32 componentIndex)
+void CheckIntTestDataMultiComponent(const DataStructure& dataStructure, ArrayThreshold::ComparisonType comparisonType, double thresholdValue, bool isInverted, int32 componentIndex)
 {
   const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
   REQUIRE(thresholdArrayPtr != nullptr);
@@ -353,57 +277,7 @@ void CheckIntTestDataLessThanMultiComponent(const DataStructure& dataStructure, 
 
   for(usize i = 0; i < k_TupleCount; i++)
   {
-    bool value = thresholdStore[i];
-    bool expected = InputIntComponentValue(i, componentIndex) < thresholdValue;
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
-  }
-}
-
-void CheckIntTestDataEqualToMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted, int32 componentIndex)
-{
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
-
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
-  {
-    bool value = thresholdStore[i];
-    bool expected = InputIntComponentValue(i, componentIndex) == thresholdValue;
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
-  }
-}
-
-void CheckIntTestDataNotEqualToMultiComponent(const DataStructure& dataStructure, double thresholdValue, bool isInverted, int32 componentIndex)
-{
-  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
-  REQUIRE(thresholdArrayPtr != nullptr);
-
-  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
-
-  for(usize i = 0; i < k_TupleCount; i++)
-  {
-    bool value = thresholdStore[i];
-    bool expected = InputIntComponentValue(i, componentIndex) != thresholdValue;
-
-    if(isInverted)
-    {
-      expected = !expected;
-    }
-
-    REQUIRE(value == expected);
+    REQUIRE(thresholdStore[i] == ExpectedIntMultiComponentMask(comparisonType, i, thresholdValue, isInverted, componentIndex));
   }
 }
 
@@ -441,26 +315,26 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Int", "[
   SECTION("ArrayThreshold: >")
   {
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
-    CheckIntTestDataGreaterThanSingleComponent(dataStructure, thresholdValue, isInverted);
+    CheckIntTestDataSingleComponent(dataStructure, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
   }
 
   SECTION("ArrayThreshold: <")
   {
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
-    CheckIntTestDataLessThanSingleComponent(dataStructure, thresholdValue, isInverted);
+    CheckIntTestDataSingleComponent(dataStructure, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
   }
 
   SECTION("ArrayThreshold: ==")
   {
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
-    CheckIntTestDataEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
-    CheckIntTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
+    CheckIntTestDataSingleComponent(dataStructure, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
+    CheckIntTestDataSingleComponent(dataStructure, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, !isInverted);
   }
   SECTION("ArrayThreshold: !=")
   {
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
-    CheckIntTestDataEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
-    CheckIntTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
+    CheckIntTestDataSingleComponent(dataStructure, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, !isInverted);
+    CheckIntTestDataSingleComponent(dataStructure, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
   }
 }
 
@@ -477,26 +351,26 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Float", 
   SECTION("ArrayThreshold: >")
   {
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
-    CheckFloatTestDataGreaterThanSingleComponent(dataStructure, thresholdValue, isInverted);
+    CheckFloatTestDataSingleComponent(dataStructure, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted);
   }
 
   SECTION("ArrayThreshold: <")
   {
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
-    CheckFloatTestDataLessThanSingleComponent(dataStructure, thresholdValue, isInverted);
+    CheckFloatTestDataSingleComponent(dataStructure, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted);
   }
 
   SECTION("ArrayThreshold: ==")
   {
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
-    CheckFloatTestDataEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
-    CheckFloatTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
+    CheckFloatTestDataSingleComponent(dataStructure, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted);
+    CheckFloatTestDataSingleComponent(dataStructure, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, !isInverted);
   }
   SECTION("ArrayThreshold: !=")
   {
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
-    CheckFloatTestDataEqualToSingleComponent(dataStructure, thresholdValue, !isInverted);
-    CheckFloatTestDataNotEqualToSingleComponent(dataStructure, thresholdValue, isInverted);
+    CheckFloatTestDataSingleComponent(dataStructure, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, !isInverted);
+    CheckFloatTestDataSingleComponent(dataStructure, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted);
   }
 }
 
@@ -513,26 +387,291 @@ TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Single Thresholds: Int Mult
   SECTION("ArrayThreshold: >")
   {
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted, componentIndex);
-    CheckIntTestDataGreaterThanMultiComponent(dataStructure, thresholdValue, isInverted, componentIndex);
+    CheckIntTestDataMultiComponent(dataStructure, ArrayThreshold::ComparisonType::GreaterThan, thresholdValue, isInverted, componentIndex);
   }
 
   SECTION("ArrayThreshold: <")
   {
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted, componentIndex);
-    CheckIntTestDataLessThanMultiComponent(dataStructure, thresholdValue, isInverted, componentIndex);
+    CheckIntTestDataMultiComponent(dataStructure, ArrayThreshold::ComparisonType::LessThan, thresholdValue, isInverted, componentIndex);
   }
 
   SECTION("ArrayThreshold: ==")
   {
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted, componentIndex);
-    CheckIntTestDataEqualToMultiComponent(dataStructure, thresholdValue, isInverted, componentIndex);
-    CheckIntTestDataNotEqualToMultiComponent(dataStructure, thresholdValue, !isInverted, componentIndex);
+    CheckIntTestDataMultiComponent(dataStructure, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, isInverted, componentIndex);
+    CheckIntTestDataMultiComponent(dataStructure, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, !isInverted, componentIndex);
   }
   SECTION("ArrayThreshold: !=")
   {
     RunSingleThresholdTest(dataStructure, targetArray, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted, componentIndex);
-    CheckIntTestDataEqualToMultiComponent(dataStructure, thresholdValue, !isInverted, componentIndex);
-    CheckIntTestDataNotEqualToMultiComponent(dataStructure, thresholdValue, isInverted, componentIndex);
+    CheckIntTestDataMultiComponent(dataStructure, ArrayThreshold::ComparisonType::Operator_Equal, thresholdValue, !isInverted, componentIndex);
+    CheckIntTestDataMultiComponent(dataStructure, ArrayThreshold::ComparisonType::Operator_NotEqual, thresholdValue, isInverted, componentIndex);
+  }
+}
+
+/**
+ * @brief Creates a single threshold for the filter to use.
+ * @param arrayPath Input DataArray path
+ * @param comparisonType type of comparison
+ * @param value Value to threshold against
+ * @param isInverted Should the threshold output be inverted
+ * componentIndex Component index of the array to threshold against.
+ * unionOperator Union operator to apply on the threshold. Defaults to And
+ */
+std::shared_ptr<ArrayThreshold> CreateArrayThreshold(const DataPath& arrayPath, ArrayThreshold::ComparisonType comparisonType, double value, bool isInverted, int componentIndex,
+                                                     ArrayThreshold::UnionOperator unionOperator = ArrayThreshold::UnionOperator::And)
+{
+  auto threshold = std::make_shared<ArrayThreshold>();
+  threshold->setArrayPath(arrayPath);
+  threshold->setComparisonType(comparisonType);
+  threshold->setComparisonValue(value);
+  threshold->setComponentIndex(componentIndex);
+  threshold->setInverted(isInverted);
+  threshold->setUnionOperator(unionOperator);
+
+  return threshold;
+}
+
+ArrayThresholdSet CreateThresholdSet1()
+{
+  ArrayThresholdSet thresholdSet;
+
+  // Threshold: Int > 2
+  auto threshold1 = CreateArrayThreshold(k_TestArrayIntPath, ArrayThreshold::ComparisonType::GreaterThan, 2.0, false, 0, ArrayThreshold::UnionOperator::And);
+  // Threshold: Float < 0.025
+  auto threshold2 = CreateArrayThreshold(k_TestArrayFloatPath, ArrayThreshold::ComparisonType::LessThan, 0.025, false, 0, ArrayThreshold::UnionOperator::And);
+  // Threshold: Int[1] > 0.0 : inverted
+  auto threshold3 = CreateArrayThreshold(k_MultiComponentArrayPath, ArrayThreshold::ComparisonType::GreaterThan, 0.0, true, 1, ArrayThreshold::UnionOperator::And);
+
+  thresholdSet.setArrayThresholds({threshold1, threshold2, threshold3});
+
+  return thresholdSet;
+}
+
+bool ExpectedThresholdSet1Mask(usize index, bool inverted)
+{
+  bool expectedThreshold1 = ExpectedIntSingleComponentMask(ArrayThreshold::ComparisonType::GreaterThan, index, 2.0, false);
+  bool expectedThreshold2 = ExpectedFloatSingleComponentMask(ArrayThreshold::ComparisonType::LessThan, index, 0.025, false);
+  bool expectedThreshold3 = ExpectedIntMultiComponentMask(ArrayThreshold::ComparisonType::GreaterThan, index, 0.0, true, 1);
+
+  bool expected = expectedThreshold1 && expectedThreshold2 && expectedThreshold3;
+  if(inverted)
+  {
+    expected = !expected;
+  }
+  return expected;
+}
+
+ArrayThresholdSet CreateThresholdSet2()
+{
+  ArrayThresholdSet thresholdSet;
+
+  // Threshold: Int == 1
+  auto threshold1 = CreateArrayThreshold(k_TestArrayIntPath, ArrayThreshold::ComparisonType::Operator_Equal, 1.0, false, 0, ArrayThreshold::UnionOperator::And);
+  // Threshold: Float != 5.0
+  auto threshold2 = CreateArrayThreshold(k_TestArrayFloatPath, ArrayThreshold::ComparisonType::Operator_NotEqual, 5.0, false, 0, ArrayThreshold::UnionOperator::Or);
+  // Threshold: Int[0] < 0.0 : inverted
+  auto threshold3 = CreateArrayThreshold(k_MultiComponentArrayPath, ArrayThreshold::ComparisonType::LessThan, 0.0, true, 0, ArrayThreshold::UnionOperator::And);
+
+  thresholdSet.setArrayThresholds({threshold1, threshold2, threshold3});
+
+  return thresholdSet;
+}
+
+bool ExpectedThresholdSet2Mask(usize index, bool inverted)
+{
+  bool expectedThreshold1 = ExpectedIntSingleComponentMask(ArrayThreshold::ComparisonType::Operator_Equal, index, 1.0, false);
+  bool expectedThreshold2 = ExpectedFloatSingleComponentMask(ArrayThreshold::ComparisonType::Operator_NotEqual, index, 5.0, false);
+  bool expectedThreshold3 = ExpectedIntMultiComponentMask(ArrayThreshold::ComparisonType::LessThan, index, 0.0, true, 0);
+
+  bool expected = (expectedThreshold1 || expectedThreshold2) && expectedThreshold3;
+  if(inverted)
+  {
+    expected = !expected;
+  }
+  return expected;
+}
+
+ArrayThresholdSet CreateThresholdSet3()
+{
+  ArrayThresholdSet thresholdSet;
+
+  auto set1 = std::make_shared<ArrayThresholdSet>(CreateThresholdSet1());
+  auto set2 = std::make_shared<ArrayThresholdSet>(CreateThresholdSet2());
+
+  thresholdSet.setArrayThresholds({set1, set2});
+
+  return thresholdSet;
+}
+
+ArrayThresholdSet CreateThresholdSet4()
+{
+  ArrayThresholdSet thresholdSet;
+
+  auto set1 = std::make_shared<ArrayThresholdSet>(CreateThresholdSet1());
+  auto set2 = std::make_shared<ArrayThresholdSet>(CreateThresholdSet2());
+  set2->setUnionOperator(ArrayThreshold::UnionOperator::Or);
+
+  thresholdSet.setArrayThresholds({set1, set2});
+
+  return thresholdSet;
+}
+
+ArrayThresholdSet CreateThresholdSet5()
+{
+  ArrayThresholdSet thresholdSet;
+
+  auto set1 = std::make_shared<ArrayThresholdSet>(CreateThresholdSet1());
+  auto set2 = std::make_shared<ArrayThresholdSet>(CreateThresholdSet2());
+  set2->setUnionOperator(ArrayThreshold::UnionOperator::Or);
+  set2->setInverted(true);
+
+  thresholdSet.setArrayThresholds({set1, set2});
+
+  return thresholdSet;
+}
+
+void CheckThresholdSet1(DataStructure& dataStructure, bool inverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    REQUIRE(thresholdStore[i] == ExpectedThresholdSet1Mask(i, inverted));
+  }
+}
+
+void CheckThresholdSet2(DataStructure& dataStructure, bool inverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    bool value = thresholdStore[i];
+    bool expected = ExpectedThresholdSet2Mask(i, inverted);
+    REQUIRE(thresholdStore[i] == ExpectedThresholdSet2Mask(i, inverted));
+  }
+}
+
+void CheckThresholdSet3(DataStructure& dataStructure, bool inverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    bool expectedMask1 = ExpectedThresholdSet1Mask(i, false);
+    bool expectedMask2 = ExpectedThresholdSet2Mask(i, false);
+
+    bool expected = expectedMask1 && expectedMask2;
+    if (inverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(thresholdStore[i] == expected);
+  }
+}
+
+void CheckThresholdSet4(DataStructure& dataStructure, bool inverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    bool expectedMask1 = ExpectedThresholdSet1Mask(i, false);
+    bool expectedMask2 = ExpectedThresholdSet2Mask(i, false);
+
+    bool expected = expectedMask1 || expectedMask2;
+    if(inverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(thresholdStore[i] == expected);
+  }
+}
+
+void CheckThresholdSet5(DataStructure& dataStructure, bool inverted)
+{
+  const auto* thresholdArrayPtr = dataStructure.getDataAs<BoolArray>(k_ThresholdArrayPath);
+  REQUIRE(thresholdArrayPtr != nullptr);
+
+  auto& thresholdStore = thresholdArrayPtr->getDataStoreRef();
+
+  for(usize i = 0; i < k_TupleCount; i++)
+  {
+    bool expectedMask1 = ExpectedThresholdSet1Mask(i, false);
+    bool expectedMask2 = ExpectedThresholdSet2Mask(i, true);
+
+    bool expected = expectedMask1 || expectedMask2;
+    if(inverted)
+    {
+      expected = !expected;
+    }
+
+    REQUIRE(thresholdStore[i] == expected);
+  }
+}
+
+TEST_CASE("SimplnxCore::MultiThresholdObjects: Valid Threshold Sets", "[SimplnxCore][MultiThresholdObjectsFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  DataStructure dataStructure = CreateTestDataStructure();
+  //bool isInverted = GENERATE(false, true);
+  bool isInverted = true;
+
+  SECTION("ArraySet 1")
+  {
+    auto thresholdSet = CreateThresholdSet1();
+    thresholdSet.setInverted(isInverted);
+    RunThresholdSetTest(dataStructure, thresholdSet);
+    CheckThresholdSet1(dataStructure, isInverted);
+  }
+
+  SECTION("ArraySet 2")
+  {
+    auto thresholdSet = CreateThresholdSet2();
+    thresholdSet.setInverted(isInverted);
+    RunThresholdSetTest(dataStructure, thresholdSet);
+    CheckThresholdSet2(dataStructure, isInverted);
+  }
+
+  SECTION("ArraySet 3")
+  {
+    auto thresholdSet = CreateThresholdSet3();
+    thresholdSet.setInverted(isInverted);
+    RunThresholdSetTest(dataStructure, thresholdSet);
+    CheckThresholdSet3(dataStructure, isInverted);
+  }
+
+  SECTION("ArraySet 4")
+  {
+    auto thresholdSet = CreateThresholdSet4();
+    thresholdSet.setInverted(isInverted);
+    RunThresholdSetTest(dataStructure, thresholdSet);
+    CheckThresholdSet4(dataStructure, isInverted);
+  }
+
+  SECTION("ArraySet 5")
+  {
+    auto thresholdSet = CreateThresholdSet5();
+    thresholdSet.setInverted(isInverted);
+    RunThresholdSetTest(dataStructure, thresholdSet);
+    CheckThresholdSet5(dataStructure, isInverted);
   }
 }
 


### PR DESCRIPTION
* Adding more comprehensive unit tests for MultiThresholdObjects.
  * Tested single thresholds for int, float, and multi-component arrays.
  * Tested multiple thresholds at once.
  * Tested inverting threshold outputs.
  * Tested sets of thresholds including nested sets with their inversion flags set.
* Fixed a bug where a threshold's inversion flag was ignored.
* Fixed ThresholdSets being handled incorrectly in the filter algorithm.
* Removed special cases in the algorithm that did not need to exist.
* Removed unnecessary preflight error on component size mismatch.
* Increased the required memory for running the filter algorithm.
* Consolidated copy-pasted code into standardized methods to fix incorrectly updated code depending on the control flow followed.