### PR TITLE
BUG: Fix SIMPL JSON conversion segfault and re-enable backwards-compatibility checks

### DIFF
--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EbsdFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadH5EbsdFilter.cpp
@@ -322,6 +322,15 @@ struct ReadH5EbsdFilterParameterConverter
 
   static Result<ValueType> convert(const nlohmann::json& json)
   {
+    static constexpr std::array<StringLiteral, 6> requiredKeys = {k_InputFileKey, k_SelectedArrayNamesKey, k_ZStartIndexKey, k_ZEndIndexKey, k_RefFrameZDirKey, k_UseTransformationsKey};
+    for(const auto& key : requiredKeys)
+    {
+      if(!json.contains(key.view()))
+      {
+        return MakeErrorResult<ValueType>(-3, fmt::format("H5EbsdReaderParameterConverter json is missing required key '{}'", key.view()));
+      }
+    }
+
     if(!json[k_InputFileKey].is_string())
     {
       return MakeErrorResult<ValueType>(-2, fmt::format("H5EbsdReaderParameterConverter json '{}' is not a string", json[k_InputFileKey].dump()));
@@ -342,9 +351,9 @@ struct ReadH5EbsdFilterParameterConverter
     {
       return MakeErrorResult<ValueType>(-1, fmt::format("H5EbsdReaderParameterConverter json '{}' is not an integer", json[k_RefFrameZDirKey].dump()));
     }
-    if(!json[k_UseTransformationsKey].is_number_integer())
+    if(!json[k_UseTransformationsKey].is_number_integer() && !json[k_UseTransformationsKey].is_boolean())
     {
-      return MakeErrorResult<ValueType>(-1, fmt::format("H5EbsdReaderParameterConverter json '{}' is not an integer", json[k_UseTransformationsKey].dump()));
+      return MakeErrorResult<ValueType>(-1, fmt::format("H5EbsdReaderParameterConverter json '{}' is not an integer or boolean", json[k_UseTransformationsKey].dump()));
     }
 
     for(const auto& iter : json[k_SelectedArrayNamesKey])
@@ -360,7 +369,7 @@ struct ReadH5EbsdFilterParameterConverter
     value.startSlice = json[k_ZStartIndexKey].get<int32>();
     value.endSlice = json[k_ZEndIndexKey].get<int32>();
     value.eulerRepresentation = json[k_RefFrameZDirKey].get<int32>() - 1;
-    value.useRecommendedTransform = static_cast<bool>(json[k_UseTransformationsKey].get<int32>());
+    value.useRecommendedTransform = json[k_UseTransformationsKey].is_boolean() ? json[k_UseTransformationsKey].get<bool>() : static_cast<bool>(json[k_UseTransformationsKey].get<int32>());
     value.selectedArrayNames = json[k_SelectedArrayNamesKey].get<std::vector<std::string>>();
 
     return {std::move(value)};
@@ -375,7 +384,7 @@ Result<Arguments> ReadH5EbsdFilter::FromSIMPLJson(const nlohmann::json& json)
 
   std::vector<Result<>> results;
 
-  results.push_back(SIMPLConversion::ConvertTopParameters<SIMPLConversionCustom::ReadH5EbsdFilterParameterConverter>(args, json, k_ReadH5EbsdParameter_Key));
+  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversionCustom::ReadH5EbsdFilterParameterConverter>(args, json, SIMPL::k_ReadH5EbsdKey, k_ReadH5EbsdParameter_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DCPathBuilderFilterParameterConverter>(args, json, SIMPL::k_DataContainerNameKey, k_CreatedImageGeometryPath_Key));
   results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::LinkedPathCreationFilterParameterConverter>(args, json, SIMPL::k_CellAttributeMatrixNameKey, k_CellAttributeMatrixName_Key));
   results.push_back(

--- a/src/Plugins/OrientationAnalysis/test/CreateEnsembleInfoTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/CreateEnsembleInfoTest.cpp
@@ -184,15 +184,16 @@ TEST_CASE("OrientationAnalysis::CreateEnsembleInfoFilter: SIMPL Backwards Compat
       REQUIRE(filter != nullptr);
       REQUIRE(filter->uuid() == FilterTraits<CreateEnsembleInfoFilter>::uuid);
 
-      // Note: Complex SIMPL parameter conversions may produce warnings
-      // pipelineFilter->getComments() may not be empty for filters with custom converters
-
       const Arguments args = pipelineFilter->getArguments();
-      // Complex type (AMPathBuilderFilterParameterConverter) - verified by successful pipeline loading
-      // Complex type (EnsembleInfoFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<std::string>(CreateEnsembleInfoFilter::k_CrystalStructuresArrayName_Key) == "TestName");
-      // CHECK(args.value<std::string>(CreateEnsembleInfoFilter::k_PhaseTypesArrayName_Key) == "TestName");
-      // CHECK(args.value<std::string>(CreateEnsembleInfoFilter::k_PhaseNamesArrayName_Key) == "TestName");
+      CHECK(args.value<std::string>(CreateEnsembleInfoFilter::k_CrystalStructuresArrayName_Key) == "TestName");
+      CHECK(args.value<std::string>(CreateEnsembleInfoFilter::k_PhaseTypesArrayName_Key) == "TestName");
+      CHECK(args.value<std::string>(CreateEnsembleInfoFilter::k_PhaseNamesArrayName_Key) == "TestName");
+      CHECK(args.value<DataPath>(CreateEnsembleInfoFilter::k_CellEnsembleAttributeMatrixPath_Key) == DataPath({"DataContainer", "CellEnsembleData"}));
+      const auto ensembleValue = args.value<EnsembleInfoParameter::ValueType>(CreateEnsembleInfoFilter::k_Ensemble_Key);
+      REQUIRE(ensembleValue.size() == 1);
+      CHECK(ensembleValue[0][0] == "Cubic-High m-3m");
+      CHECK(ensembleValue[0][1] == "Primary");
+      CHECK(ensembleValue[0][2] == "Primary");
     }
   }
 }

--- a/src/Plugins/OrientationAnalysis/test/ReadH5EbsdTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/ReadH5EbsdTest.cpp
@@ -188,13 +188,17 @@ TEST_CASE("OrientationAnalysis::ReadH5EbsdFilter: SIMPL Backwards Compatibility"
       REQUIRE(filter != nullptr);
       REQUIRE(filter->uuid() == FilterTraits<ReadH5EbsdFilter>::uuid);
 
-      // Note: Complex SIMPL parameter conversions may produce warnings
-      // pipelineFilter->getComments() may not be empty for filters with custom converters
-
       const Arguments args = pipelineFilter->getArguments();
-      // CHECK(args.value<DataPath>(ReadH5EbsdFilter::k_CreatedImageGeometryPath_Key) == DataPath({"DataContainer"}));
-      // CHECK(args.value<std::string>(ReadH5EbsdFilter::k_CellAttributeMatrixName_Key) == "TestName");
-      // CHECK(args.value<std::string>(ReadH5EbsdFilter::k_CellEnsembleAttributeMatrixName_Key) == "TestName");
+      CHECK(args.value<DataPath>(ReadH5EbsdFilter::k_CreatedImageGeometryPath_Key) == DataPath({"DataContainer"}));
+      CHECK(args.value<std::string>(ReadH5EbsdFilter::k_CellAttributeMatrixName_Key) == "TestName");
+      CHECK(args.value<std::string>(ReadH5EbsdFilter::k_CellEnsembleAttributeMatrixName_Key) == "TestName");
+
+      const auto h5EbsdValue = args.value<ReadH5EbsdFileParameter::ValueType>(ReadH5EbsdFilter::k_ReadH5EbsdParameter_Key);
+      CHECK(h5EbsdValue.inputFilePath == "/test/path/file.h5ebsd");
+      CHECK(h5EbsdValue.startSlice == 0);
+      CHECK(h5EbsdValue.endSlice == 10);
+      CHECK(h5EbsdValue.useRecommendedTransform == true);
+      CHECK(h5EbsdValue.selectedArrayNames == std::vector<std::string>{"Confidence Index", "Image Quality"});
     }
   }
 }

--- a/src/Plugins/OrientationAnalysis/test/ReadH5EspritDataTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/ReadH5EspritDataTest.cpp
@@ -223,18 +223,16 @@ TEST_CASE("OrientationAnalysis::ReadH5EspritDataFilter: SIMPL Backwards Compatib
       REQUIRE(filter != nullptr);
       REQUIRE(filter->uuid() == FilterTraits<ReadH5EspritDataFilter>::uuid);
 
-      // Note: Complex SIMPL parameter conversions may produce warnings
-      // pipelineFilter->getComments() may not be empty for filters with custom converters
-
       const Arguments args = pipelineFilter->getArguments();
-      // Complex type (OEMEbsdScanSelectionFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<float32>(ReadH5EspritDataFilter::k_ZSpacing_Key) == 2.5f);
-      // Complex type (FloatVec3FilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<bool>(ReadH5EspritDataFilter::k_DegreesToRadians_Key) == true);
-      // CHECK(args.value<bool>(ReadH5EspritDataFilter::k_ReadPatternData_Key) == true);
-      // CHECK(args.value<DataPath>(ReadH5EspritDataFilter::k_CreatedImageGeometryPath_Key) == DataPath({"DataContainer"}));
-      // CHECK(args.value<std::string>(ReadH5EspritDataFilter::k_CellAttributeMatrixName_Key) == "TestName");
-      // CHECK(args.value<std::string>(ReadH5EspritDataFilter::k_CellEnsembleAttributeMatrixName_Key) == "TestName");
+      CHECK(args.value<float32>(ReadH5EspritDataFilter::k_ZSpacing_Key) == 2.5f);
+      CHECK(args.value<bool>(ReadH5EspritDataFilter::k_DegreesToRadians_Key) == true);
+      CHECK(args.value<bool>(ReadH5EspritDataFilter::k_ReadPatternData_Key) == true);
+      CHECK(args.value<DataPath>(ReadH5EspritDataFilter::k_CreatedImageGeometryPath_Key) == DataPath({"DataContainer"}));
+      CHECK(args.value<std::string>(ReadH5EspritDataFilter::k_CellAttributeMatrixName_Key) == "TestName");
+      CHECK(args.value<std::string>(ReadH5EspritDataFilter::k_CellEnsembleAttributeMatrixName_Key) == "TestName");
+      const auto scanSel = args.value<OEMEbsdScanSelectionParameter::ValueType>(ReadH5EspritDataFilter::k_SelectedScanNames_Key);
+      CHECK(scanSel.inputFilePath == "/test/path/file.h5");
+      CHECK(scanSel.scanNames == std::list<std::string>{"Scan1"});
     }
   }
 }

--- a/src/Plugins/OrientationAnalysis/test/ReadH5OimDataTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/ReadH5OimDataTest.cpp
@@ -214,17 +214,15 @@ TEST_CASE("OrientationAnalysis::ReadH5OimDataFilter: SIMPL Backwards Compatibili
       REQUIRE(filter != nullptr);
       REQUIRE(filter->uuid() == FilterTraits<ReadH5OimDataFilter>::uuid);
 
-      // Note: Complex SIMPL parameter conversions may produce warnings
-      // pipelineFilter->getComments() may not be empty for filters with custom converters
-
       const Arguments args = pipelineFilter->getArguments();
-      // Complex type (OEMEbsdScanSelectionFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<float32>(ReadH5OimDataFilter::k_ZSpacing_Key) == 2.5f);
-      // Complex type (FloatVec3FilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<bool>(ReadH5OimDataFilter::k_ReadPatternData_Key) == true);
-      // CHECK(args.value<DataPath>(ReadH5OimDataFilter::k_CreatedImageGeometryPath_Key) == DataPath({"DataContainer"}));
-      // CHECK(args.value<std::string>(ReadH5OimDataFilter::k_CellAttributeMatrixName_Key) == "TestName");
-      // CHECK(args.value<std::string>(ReadH5OimDataFilter::k_CellEnsembleAttributeMatrixName_Key) == "TestName");
+      CHECK(args.value<float32>(ReadH5OimDataFilter::k_ZSpacing_Key) == 2.5f);
+      CHECK(args.value<bool>(ReadH5OimDataFilter::k_ReadPatternData_Key) == true);
+      CHECK(args.value<DataPath>(ReadH5OimDataFilter::k_CreatedImageGeometryPath_Key) == DataPath({"DataContainer"}));
+      CHECK(args.value<std::string>(ReadH5OimDataFilter::k_CellAttributeMatrixName_Key) == "TestName");
+      CHECK(args.value<std::string>(ReadH5OimDataFilter::k_CellEnsembleAttributeMatrixName_Key) == "TestName");
+      const auto scanSel = args.value<OEMEbsdScanSelectionParameter::ValueType>(ReadH5OimDataFilter::k_SelectedScanNames_Key);
+      CHECK(scanSel.inputFilePath == "/test/path/file.h5");
+      CHECK(scanSel.scanNames == std::list<std::string>{"Scan1"});
     }
   }
 }

--- a/src/Plugins/OrientationAnalysis/test/simpl_conversion/6_4/CreateEnsembleInfoFilter.json
+++ b/src/Plugins/OrientationAnalysis/test/simpl_conversion/6_4/CreateEnsembleInfoFilter.json
@@ -11,17 +11,13 @@
     "DataContainerName": {
       "Data Container Name": "DataContainer"
     },
-    "Ensemble": {
-      "CrystalStructure": [
-        999
-      ],
-      "PhaseType": [
-        999
-      ],
-      "PhaseName": [
-        "Primary"
-      ]
-    },
+    "Ensemble": [
+      {
+        "CrystalStructure": 1,
+        "PhaseType": 0,
+        "PhaseName": "Primary"
+      }
+    ],
     "CellEnsembleAttributeMatrixName": "CellEnsembleData",
     "CrystalStructuresArrayName": "TestName",
     "PhaseTypesArrayName": "TestName",

--- a/src/Plugins/OrientationAnalysis/test/simpl_conversion/6_4/ReadH5EspritDataFilter.json
+++ b/src/Plugins/OrientationAnalysis/test/simpl_conversion/6_4/ReadH5EspritDataFilter.json
@@ -9,10 +9,10 @@
     "Filter_Human_Label": "Read H5 Esprit Data",
     "Filter_Name": "ImportH5EspritData",
     "InputFile": "/test/path/file.h5",
-    "SelectedScanNames": {
-      "1": "Scan1"
-    },
-    "ZSpacing": 1.0,
+    "SelectedScanNames": [
+      "Scan1"
+    ],
+    "ZSpacing": 2.5,
     "Origin": {
       "x": 0.0,
       "y": 0.0,

--- a/src/Plugins/OrientationAnalysis/test/simpl_conversion/6_4/ReadH5OimDataFilter.json
+++ b/src/Plugins/OrientationAnalysis/test/simpl_conversion/6_4/ReadH5OimDataFilter.json
@@ -9,10 +9,10 @@
     "Filter_Human_Label": "Read H5 Oim Data",
     "Filter_Name": "ImportH5OimData",
     "InputFile": "/test/path/file.h5",
-    "SelectedScanNames": {
-      "1": "Scan1"
-    },
-    "ZSpacing": 1.0,
+    "SelectedScanNames": [
+      "Scan1"
+    ],
+    "ZSpacing": 2.5,
     "Origin": {
       "x": 0.0,
       "y": 0.0,

--- a/src/Plugins/OrientationAnalysis/test/simpl_conversion/6_5/CreateEnsembleInfoFilter.json
+++ b/src/Plugins/OrientationAnalysis/test/simpl_conversion/6_5/CreateEnsembleInfoFilter.json
@@ -12,17 +12,13 @@
     "DataContainerName": {
       "Data Container Name": "DataContainer"
     },
-    "Ensemble": {
-      "CrystalStructure": [
-        999
-      ],
-      "PhaseType": [
-        999
-      ],
-      "PhaseName": [
-        "Primary"
-      ]
-    },
+    "Ensemble": [
+      {
+        "CrystalStructure": 1,
+        "PhaseType": 0,
+        "PhaseName": "Primary"
+      }
+    ],
     "CellEnsembleAttributeMatrixName": "CellEnsembleData",
     "CrystalStructuresArrayName": "TestName",
     "PhaseTypesArrayName": "TestName",

--- a/src/Plugins/OrientationAnalysis/test/simpl_conversion/6_5/ReadH5EspritDataFilter.json
+++ b/src/Plugins/OrientationAnalysis/test/simpl_conversion/6_5/ReadH5EspritDataFilter.json
@@ -10,10 +10,10 @@
     "Filter_Name": "ImportH5EspritData",
     "Filter_Uuid": "{8abdea7d-f715-5a24-8165-7f946bbc2fe9}",
     "InputFile": "/test/path/file.h5",
-    "SelectedScanNames": {
-      "1": "Scan1"
-    },
-    "ZSpacing": 1.0,
+    "SelectedScanNames": [
+      "Scan1"
+    ],
+    "ZSpacing": 2.5,
     "Origin": {
       "x": 0.0,
       "y": 0.0,

--- a/src/Plugins/OrientationAnalysis/test/simpl_conversion/6_5/ReadH5OimDataFilter.json
+++ b/src/Plugins/OrientationAnalysis/test/simpl_conversion/6_5/ReadH5OimDataFilter.json
@@ -10,10 +10,10 @@
     "Filter_Name": "ImportH5OimData",
     "Filter_Uuid": "{3ff4701b-3a0c-52e3-910a-fa927aa6584c}",
     "InputFile": "/test/path/file.h5",
-    "SelectedScanNames": {
-      "1": "Scan1"
-    },
-    "ZSpacing": 1.0,
+    "SelectedScanNames": [
+      "Scan1"
+    ],
+    "ZSpacing": 2.5,
     "Origin": {
       "x": 0.0,
       "y": 0.0,

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MultiThresholdObjectsFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/MultiThresholdObjectsFilter.cpp
@@ -262,7 +262,9 @@ Result<Arguments> MultiThresholdObjectsFilter::FromSIMPLJson(const nlohmann::jso
 {
   Arguments args = MultiThresholdObjectsFilter().getDefaultArguments();
   static constexpr StringLiteral k_FilterUuidKey = "Filter_Uuid";
+  static constexpr StringLiteral k_FilterClassNameKey = "Filter_Name";
   static constexpr StringLiteral v1Uuid = "{014b7300-cf36-5ede-a751-5faf9b119dae}";
+  static constexpr StringLiteral v1ClassName = "MultiThresholdObjects";
 
   std::vector<Result<>> results;
 
@@ -270,6 +272,11 @@ Result<Arguments> MultiThresholdObjectsFilter::FromSIMPLJson(const nlohmann::jso
   if(json.contains(k_FilterUuidKey))
   {
     isAdvanced = json[k_FilterUuidKey].get<std::string>() != v1Uuid;
+  }
+  else if(json.contains(k_FilterClassNameKey))
+  {
+    // SIMPL 6.4 pipelines do not include Filter_Uuid; fall back to the legacy class name.
+    isAdvanced = json[k_FilterClassNameKey].get<std::string>() != v1ClassName;
   }
   if(isAdvanced)
   {

--- a/src/Plugins/SimplnxCore/test/ConditionalSetValueTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ConditionalSetValueTest.cpp
@@ -434,15 +434,10 @@ TEST_CASE("SimplnxCore::ConditionalSetValueFilter: SIMPL Backwards Compatibility
       REQUIRE(filter != nullptr);
       REQUIRE(filter->uuid() == FilterTraits<ConditionalSetValueFilter>::uuid);
 
-      // Note: Complex SIMPL parameter conversions may produce warnings
-      // pipelineFilter->getComments() may not be empty for filters with custom converters
-
       const Arguments args = pipelineFilter->getArguments();
-      // Complex type (DoubleToStringFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<DataPath>(ConditionalSetValueFilter::k_SelectedArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // CHECK(args.value<DataPath>(ConditionalSetValueFilter::k_ConditionalArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // CHECK(args.value<DataPath>(ConditionalSetValueFilter::k_SelectedArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // Complex type (DoubleToStringFilterParameterConverter) - verified by successful pipeline loading
+      CHECK(args.value<DataPath>(ConditionalSetValueFilter::k_SelectedArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<DataPath>(ConditionalSetValueFilter::k_ConditionalArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<std::string>(ConditionalSetValueFilter::k_ReplaceValue_Key) == "3.500000");
     }
   }
 }

--- a/src/Plugins/SimplnxCore/test/CopyDataObjectTest.cpp
+++ b/src/Plugins/SimplnxCore/test/CopyDataObjectTest.cpp
@@ -165,14 +165,8 @@ TEST_CASE("SimplnxCore::CopyDataObjectFilter: SIMPL Backwards Compatibility", "[
       REQUIRE(filter != nullptr);
       REQUIRE(filter->uuid() == FilterTraits<CopyDataObjectFilter>::uuid);
 
-      // Note: Complex SIMPL parameter conversions may produce warnings
-      // pipelineFilter->getComments() may not be empty for filters with custom converters
-
       const Arguments args = pipelineFilter->getArguments();
-      // Complex type (SingleToMultiDataPathSelectionFilterParameterConverter) - verified by successful pipeline loading
-      // Complex type (SingleToMultiDataPathSelectionFilterParameterConverter) - verified by successful pipeline loading
-      // Complex type (SingleToMultiDataPathSelectionFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<std::string>(CopyDataObjectFilter::k_NewPathSuffix_Key) == "TestName");
+      CHECK(args.value<std::string>(CopyDataObjectFilter::k_NewPathSuffix_Key) == "TestName");
     }
   }
 }

--- a/src/Plugins/SimplnxCore/test/CreateGeometryTest.cpp
+++ b/src/Plugins/SimplnxCore/test/CreateGeometryTest.cpp
@@ -3111,44 +3111,12 @@ TEST_CASE("SimplnxCore::CreateGeometryFilter: SIMPL Backwards Compatibility", "[
       REQUIRE(filter != nullptr);
       REQUIRE(filter->uuid() == FilterTraits<CreateGeometryFilter>::uuid);
 
-      // Note: Complex SIMPL parameter conversions may produce warnings
-      // pipelineFilter->getComments() may not be empty for filters with custom converters
-
       const Arguments args = pipelineFilter->getArguments();
-      // Complex type (AttributeMatrixNameFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_VertexListPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // Complex type (AttributeMatrixNameFilterParameterConverter) - verified by successful pipeline loading
-      // Complex type (AttributeMatrixNameFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_VertexListPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // Complex type (AttributeMatrixNameFilterParameterConverter) - verified by successful pipeline loading
-      // Complex type (AttributeMatrixNameFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_VertexListPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // Complex type (AttributeMatrixNameFilterParameterConverter) - verified by successful pipeline loading
-      // Complex type (AttributeMatrixNameFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_VertexListPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // Complex type (AttributeMatrixNameFilterParameterConverter) - verified by successful pipeline loading
-      // Complex type (AttributeMatrixNameFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_VertexListPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // Complex type (AttributeMatrixNameFilterParameterConverter) - verified by successful pipeline loading
-      // Complex type (AttributeMatrixNameFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_VertexListPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // Complex type (AttributeMatrixNameFilterParameterConverter) - verified by successful pipeline loading
-      // Complex type (AttributeMatrixNameFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<bool>(CreateGeometryFilter::k_WarningsAsErrors_Key) == true);
-      // CHECK(args.value<ChoicesParameter::ValueType>(CreateGeometryFilter::k_ArrayHandling_Key) == 0);
-      // Complex type (Vec3FilterParameterConverter<uint64>) - verified by successful pipeline loading
-      // Complex type (Vec3FilterParameterConverter<float32>) - verified by successful pipeline loading
-      // Complex type (FloatVec3FilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_XBoundsPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_YBoundsPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_ZBoundsPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_EdgeListPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_TriangleListPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_QuadrilateralListPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_TetrahedralListPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_HexahedralListPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // CHECK(args.value<DataPath>(CreateGeometryFilter::k_GeometryPath_Key) == DataPath({"DataContainer"}));
-      // Complex type (AttributeMatrixNameFilterParameterConverter) - verified by successful pipeline loading
+      // Fixture uses GeometryType=0 (Image); only common params + image-specific CellAttributeMatrixName are populated.
+      CHECK(args.value<ChoicesParameter::ValueType>(CreateGeometryFilter::k_GeometryType_Key) == 0);
+      CHECK(args.value<bool>(CreateGeometryFilter::k_WarningsAsErrors_Key) == true);
+      CHECK(args.value<ChoicesParameter::ValueType>(CreateGeometryFilter::k_ArrayHandling_Key) == 0);
+      CHECK(args.value<DataPath>(CreateGeometryFilter::k_GeometryPath_Key) == DataPath({"DataContainer"}));
     }
   }
 }

--- a/src/Plugins/SimplnxCore/test/InitializeImageGeomCellDataTest.cpp
+++ b/src/Plugins/SimplnxCore/test/InitializeImageGeomCellDataTest.cpp
@@ -263,17 +263,12 @@ TEST_CASE("SimplnxCore::InitializeImageGeomCellDataFilter: SIMPL Backwards Compa
       REQUIRE(filter != nullptr);
       REQUIRE(filter->uuid() == FilterTraits<InitializeImageGeomCellDataFilter>::uuid);
 
-      // Note: Complex SIMPL parameter conversions may produce warnings
-      // pipelineFilter->getComments() may not be empty for filters with custom converters
-
       const Arguments args = pipelineFilter->getArguments();
-      // Complex type (UInt64ToVec3FilterParameterConverter) - verified by successful pipeline loading
-      // Complex type (UInt64ToVec3FilterParameterConverter) - verified by successful pipeline loading
-      // Complex type (DataContainerFromMultiSelectionFilterParameterConverter) - verified by successful pipeline loading
-      // Complex type (MultiDataArraySelectionFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<ChoicesParameter::ValueType>(InitializeImageGeomCellDataFilter::k_InitType_Key) == 0);
-      // CHECK(args.value<float64>(InitializeImageGeomCellDataFilter::k_InitValue_Key) == 2.5);
-      // Complex type (RangeFilterParameterConverter) - verified by successful pipeline loading
+      CHECK(args.value<ChoicesParameter::ValueType>(InitializeImageGeomCellDataFilter::k_InitType_Key) == 0);
+      CHECK(args.value<float64>(InitializeImageGeomCellDataFilter::k_InitValue_Key) == 2.5);
+      CHECK(args.value<std::vector<float64>>(InitializeImageGeomCellDataFilter::k_InitRange_Key) == std::vector<float64>{0.0, 1.0});
+      CHECK(args.value<std::vector<uint64>>(InitializeImageGeomCellDataFilter::k_MinPoint_Key) == std::vector<uint64>{0, 0, 0});
+      CHECK(args.value<std::vector<uint64>>(InitializeImageGeomCellDataFilter::k_MaxPoint_Key) == std::vector<uint64>{5, 5, 5});
     }
   }
 }

--- a/src/Plugins/SimplnxCore/test/MoveDataTest.cpp
+++ b/src/Plugins/SimplnxCore/test/MoveDataTest.cpp
@@ -194,14 +194,11 @@ TEST_CASE("SimplnxCore::MoveDataFilter: SIMPL Backwards Compatibility", "[Simpln
       REQUIRE(filter != nullptr);
       REQUIRE(filter->uuid() == FilterTraits<MoveDataFilter>::uuid);
 
-      // Note: Complex SIMPL parameter conversions may produce warnings
-      // pipelineFilter->getComments() may not be empty for filters with custom converters
-
       const Arguments args = pipelineFilter->getArguments();
-      // Complex type (SingleToMultiDataPathSelectionFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<DataPath>(MoveDataFilter::k_DestinationParentPath_Key) == DataPath({"DataContainer"}));
-      // Complex type (SingleToMultiDataPathSelectionFilterParameterConverter) - verified by successful pipeline loading
-      // CHECK(args.value<DataPath>(MoveDataFilter::k_DestinationParentPath_Key) == DataPath({"DataContainer", "CellData"}));
+      // Fixture has WhatToMove=0 (move attribute matrix): source is the AttributeMatrixSource path,
+      // destination is the DataContainerDestination path.
+      CHECK(args.value<DataPath>(MoveDataFilter::k_DestinationParentPath_Key) == DataPath({"DataContainer"}));
+      CHECK(args.value<std::vector<DataPath>>(MoveDataFilter::k_SourceDataPaths_Key) == std::vector<DataPath>{DataPath({"DataContainer", "CellData"})});
     }
   }
 }

--- a/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
+++ b/src/Plugins/SimplnxCore/test/MultiThresholdObjectsTest.cpp
@@ -810,15 +810,8 @@ TEST_CASE("SimplnxCore::MultiThresholdObjectsFilter: SIMPL Backwards Compatibili
       REQUIRE(filter != nullptr);
       REQUIRE(filter->uuid() == FilterTraits<MultiThresholdObjectsFilter>::uuid);
 
-      // Note: Complex SIMPL parameter conversions may produce warnings
-      // pipelineFilter->getComments() may not be empty for filters with custom converters
-
       const Arguments args = pipelineFilter->getArguments();
-      if(label == "SIMPL 6.5 (UUID)")
-      {
-        // Complex type - verified by successful pipeline loading
-      }
-      // CHECK(args.value<std::string>(MultiThresholdObjectsFilter::k_CreatedDataName_Key) == "TestName");
+      CHECK(args.value<std::string>(MultiThresholdObjectsFilter::k_CreatedDataName_Key) == "TestName");
     }
   }
 }

--- a/src/Plugins/SimplnxCore/test/ReadCSVFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReadCSVFileTest.cpp
@@ -662,13 +662,9 @@ TEST_CASE("SimplnxCore::ReadCSVFileFilter: SIMPL Backwards Compatibility", "[Sim
       REQUIRE(filter != nullptr);
       REQUIRE(filter->uuid() == FilterTraits<ReadCSVFileFilter>::uuid);
 
-      // Note: Complex SIMPL parameter conversions may produce warnings
-      // pipelineFilter->getComments() may not be empty for filters with custom converters
-
       const Arguments args = pipelineFilter->getArguments();
-      // CHECK(args.value<DataPath>(ReadCSVFileFilter::k_CreatedDataGroup_Key) == DataPath({"DataContainer", "CellData"}));
-      // CHECK(args.value<DataPath>(ReadCSVFileFilter::k_CreatedDataGroup_Key) == DataPath({"DataContainer", "CellData"}));
-      // CHECK(args.value<DataPath>(ReadCSVFileFilter::k_SelectedAttributeMatrixPath_Key) == DataPath({"DataContainer", "CellData"}));
+      // Fixture has Wizard_AutomaticAM=1, so the CreationFilter branch fires and sets k_CreatedDataGroup_Key.
+      CHECK(args.value<DataPath>(ReadCSVFileFilter::k_CreatedDataGroup_Key) == DataPath({"DataContainer", "CellData"}));
     }
   }
 }

--- a/src/Plugins/SimplnxCore/test/RenameDataObjectTest.cpp
+++ b/src/Plugins/SimplnxCore/test/RenameDataObjectTest.cpp
@@ -208,16 +208,9 @@ TEST_CASE("SimplnxCore::RenameDataObjectFilter: SIMPL Backwards Compatibility", 
       REQUIRE(filter != nullptr);
       REQUIRE(filter->uuid() == FilterTraits<RenameDataObjectFilter>::uuid);
 
-      // Note: Complex SIMPL parameter conversions may produce warnings
-      // pipelineFilter->getComments() may not be empty for filters with custom converters
-
       const Arguments args = pipelineFilter->getArguments();
-      // CHECK(args.value<DataPath>(RenameDataObjectFilter::k_SourceDataObjectPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
-      // CHECK(args.value<std::string>(RenameDataObjectFilter::k_NewName_Key) == "TestName");
-      // CHECK(args.value<DataPath>(RenameDataObjectFilter::k_SourceDataObjectPath_Key) == DataPath({"DataContainer", "CellData"}));
-      // CHECK(args.value<std::string>(RenameDataObjectFilter::k_NewName_Key) == "TestName");
-      // CHECK(args.value<DataPath>(RenameDataObjectFilter::k_SourceDataObjectPath_Key) == DataPath({"DataContainer"}));
-      // Complex type (DataContainerNameFilterParameterConverter) - verified by successful pipeline loading
+      CHECK(args.value<DataPath>(RenameDataObjectFilter::k_SourceDataObjectPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<std::string>(RenameDataObjectFilter::k_NewName_Key) == "TestName");
     }
   }
 }

--- a/src/Plugins/SimplnxCore/test/simpl_conversion/6_4/InitializeImageGeomCellDataFilter.json
+++ b/src/Plugins/SimplnxCore/test/simpl_conversion/6_4/InitializeImageGeomCellDataFilter.json
@@ -23,6 +23,9 @@
     "ZMax": 5,
     "InitType": 0,
     "InitValue": 2.5,
-    "InitRange": "0;1"
+    "InitRange": {
+      "Min": 0,
+      "Max": 1
+    }
   }
 }

--- a/src/Plugins/SimplnxCore/test/simpl_conversion/6_5/InitializeImageGeomCellDataFilter.json
+++ b/src/Plugins/SimplnxCore/test/simpl_conversion/6_5/InitializeImageGeomCellDataFilter.json
@@ -24,6 +24,9 @@
     "ZMax": 5,
     "InitType": 0,
     "InitValue": 2.5,
-    "InitRange": "0;1"
+    "InitRange": {
+      "Min": 0,
+      "Max": 1
+    }
   }
 }

--- a/src/simplnx/Parameters/MultiPathSelectionParameter.cpp
+++ b/src/simplnx/Parameters/MultiPathSelectionParameter.cpp
@@ -145,6 +145,9 @@ namespace SIMPLConversion
 {
 Result<SingleToMultiDataPathSelectionFilterParameterConverter::ValueType> SingleToMultiDataPathSelectionFilterParameterConverter::convert(const nlohmann::json& json)
 {
+  static constexpr StringLiteral k_AttributeMatrixNameKey = "Attribute Matrix Name";
+  static constexpr StringLiteral k_DataArrayNameKey = "Data Array Name";
+
   if(!json.is_object())
   {
     return MakeErrorResult<ValueType>(-1, fmt::format("MultiDataArraySelectionParameter json '{}' is not an array", json.dump()));
@@ -159,25 +162,33 @@ Result<SingleToMultiDataPathSelectionFilterParameterConverter::ValueType> Single
   }
   DataPath dataPath({std::move(dataContainerNameResult.value())});
 
-  auto attributeMatrixNameResult = ReadAttributeMatrixName(json, "DataArrayCreationFilterParameter");
-  if(attributeMatrixNameResult.invalid())
+  // Attribute Matrix Name is optional — a DataContainerSelectionFilterParameter has only Data Container Name.
+  if(json.contains(k_AttributeMatrixNameKey))
   {
-    return ConvertInvalidResult<ValueType>(std::move(attributeMatrixNameResult));
-  }
-
-  if(attributeMatrixNameResult.value().empty() == false)
-  {
-    dataPath = dataPath.createChildPath(std::move(attributeMatrixNameResult.value()));
-
-    auto dataArrayNameResult = ReadDataArrayName(json, "DataArrayCreationFilterParameter");
-    if(dataArrayNameResult.invalid())
+    auto attributeMatrixNameResult = ReadAttributeMatrixName(json, "AttributeMatrixSelectionFilterParameter");
+    if(attributeMatrixNameResult.invalid())
     {
-      return ConvertInvalidResult<ValueType>(std::move(dataArrayNameResult));
+      return ConvertInvalidResult<ValueType>(std::move(attributeMatrixNameResult));
     }
 
-    if(dataArrayNameResult.value().empty() == false)
+    if(attributeMatrixNameResult.value().empty() == false)
     {
-      dataPath = dataPath.createChildPath(std::move(dataArrayNameResult.value()));
+      dataPath = dataPath.createChildPath(std::move(attributeMatrixNameResult.value()));
+
+      // Data Array Name is optional — an AttributeMatrixSelectionFilterParameter does not include it.
+      if(json.contains(k_DataArrayNameKey))
+      {
+        auto dataArrayNameResult = ReadDataArrayName(json, "DataArraySelectionFilterParameter");
+        if(dataArrayNameResult.invalid())
+        {
+          return ConvertInvalidResult<ValueType>(std::move(dataArrayNameResult));
+        }
+
+        if(dataArrayNameResult.value().empty() == false)
+        {
+          dataPath = dataPath.createChildPath(std::move(dataArrayNameResult.value()));
+        }
+      }
     }
   }
 

--- a/test/ConversionTest/SIMPLMapInventoryTest.cpp
+++ b/test/ConversionTest/SIMPLMapInventoryTest.cpp
@@ -161,14 +161,11 @@ TEST_CASE("SIMPL Map Inventory: Validate Coverage", "[BackwardsCompatibility][In
     }
   }
 
-  if(!missingFixtures.empty())
+  std::string message = fmt::format("{} filters are missing backwards compatibility fixtures:\n", missingFixtures.size());
+  for(const auto& name : missingFixtures)
   {
-    std::string message = fmt::format("{} filters are missing backwards compatibility fixtures:\n", missingFixtures.size());
-    for(const auto& name : missingFixtures)
-    {
-      message += fmt::format("  - {}\n", name);
-    }
-    CAPTURE(message);
+    message += fmt::format("  - {}\n", name);
   }
+  INFO(message);
   CHECK(missingFixtures.empty());
 }


### PR DESCRIPTION
* Fix Linux segfault in ReadH5EbsdFilter SIMPL conversion path. The custom ReadH5EbsdFilterParameterConverter was invoked via ConvertTopParameters, which passed the whole filter JSON to a converter that indexed missing top-level keys with const operator[]. Under NDEBUG this strips the nlohmann::json assertion and dereferences end(), producing UB that manifests as a segfault on Linux. Switch to ConvertParameter with SIMPL::k_ReadH5EbsdKey so the converter receives the inner JSON it expects, add a contains() precheck for all required keys, and accept both boolean and integer for UseTransformations.

* Make SingleToMultiDataPathSelectionFilterParameterConverter tolerant of optional Attribute Matrix Name and Data Array Name fields so DataPaths of varying depth (DataContainer / AttributeMatrix / DataArray) all convert correctly. Real SIMPL serialized DataContainerSelection, AttributeMatrixSelection, and DataArraySelection parameters with the same JSON shape and progressively more fields; the converter now mirrors that.

* Add Filter_Name fallback in MultiThresholdObjectsFilter::FromSIMPLJson so SIMPL 6.4 pipelines (which lack Filter_Uuid) route to the correct advanced vs v1 ComparisonSelection converter based on class name.

* Repair fixtures generated with incorrect SIMPL formats:
  - InitRange object instead of "0;1" string
  - SelectedScanNames array instead of object
  - EnsembleInfo as array of phase objects with valid enum indices
  - ZSpacing values that match the test expectations

* Re-enable previously commented-out CHECK statements across 11 backwards- compatibility test files. Where multiple CHECKs were stubbed for alternate fixture branches, keep only the ones that match the active fixture's UUID; expand coverage with additional CHECKs for path builders, vector parameters, and custom value types so the tests actually validate the converted Arguments rather than just confirming the pipeline loads.
