### PR TITLE
DOC: Update Python Tutorial URLs from old `.py` to new `.ipynb`

### DIFF
--- a/wrapping/python/docs/source/Tutorial_1.rst
+++ b/wrapping/python/docs/source/Tutorial_1.rst
@@ -304,5 +304,5 @@ to do this one would run the :ref:`WriteDREAM3DFilter <WriteDREAM3DFilter>`. App
 
 Full example of this tutorial is located at:
 
-https://github.com/BlueQuartzSoftware/NXWorkshop/blob/develop/PythonTutorial/tutorial_1.py
+https://github.com/BlueQuartzSoftware/NXWorkshop/blob/develop/PythonTutorial/tutorial_1.ipynb
 

--- a/wrapping/python/docs/source/Tutorial_2.rst
+++ b/wrapping/python/docs/source/Tutorial_2.rst
@@ -284,11 +284,9 @@ The `check_pipeline_result` method from :ref:`Section 2.7.3 <2.7.3>` and the `mo
 The code above will generate IPF maps for SmallIN100 slices 1-6.
 
 ##################
-2.10 Full Examples
+2.10 Full Example
 ##################
 
-Full examples of the concepts in this tutorial are located at:
+Full example of this tutorial is located at:
 
-https://github.com/BlueQuartzSoftware/NXWorkshop/blob/develop/PythonTutorial/tutorial_2a.py
-https://github.com/BlueQuartzSoftware/NXWorkshop/blob/develop/PythonTutorial/tutorial_2b.py
-https://github.com/BlueQuartzSoftware/NXWorkshop/blob/develop/PythonTutorial/tutorial_2c.py
+https://github.com/BlueQuartzSoftware/NXWorkshop/blob/develop/PythonTutorial/tutorial_2.ipynb


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the simplnx repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start simplnx commit messages with a standard prefix (and a space):

 * FILTER: When adding a new filter to code 
 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge


Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

I noticed the links to the "Full Example" code were dead links for tutorials 1 and 2. After looking at the `NXWorkshop` repo I found it was because those tutorials had been changed from `.py` to `.ipynb`. This PR updates the links for both, as well as the sentence structure & grammar for tutorial 2 from multiple example `.py` files to a single `.ipynb`.

<!-- **Thanks for contributing to simplnx!** -->