### PR TITLE
Fix UniversalHermannMauguin dataset parsing in GrainMapper3D reader

### DIFF
--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadGrainMapper3D.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadGrainMapper3D.cpp
@@ -71,6 +71,7 @@ Result<> ReadGrainMapper3D::copyPhaseInformation(GrainMapperReader& reader, hid_
   auto& materialNames = m_DataStructure.getDataRefAs<StringArray>(cellEnsembleAMPath.createChildPath(GM3DConstants::k_MaterialName));
   auto& latticeConstantsArray = m_DataStructure.getDataRefAs<Float32Array>(cellEnsembleAMPath.createChildPath(GM3DConstants::k_LatticeConstants));
   Float32Array::store_type* latticeConstants = latticeConstantsArray.getDataStore();
+  auto& universalHermannMauguin = m_DataStructure.getDataRefAs<StringArray>(cellEnsembleAMPath.createChildPath(GM3DConstants::k_UniversalHermannMauguin));
 
   crystalStructures[0] = ebsdlib::CrystalStructure::UnknownCrystalStructure;
   materialNames[0] = "Invalid Phase";
@@ -80,6 +81,7 @@ Result<> ReadGrainMapper3D::copyPhaseInformation(GrainMapperReader& reader, hid_
   latticeConstants->setComponent(0, 3, 0.0f);
   latticeConstants->setComponent(0, 4, 0.0f);
   latticeConstants->setComponent(0, 5, 0.0f);
+  universalHermannMauguin[0] = "Invalid Phase";
   int32 index = 1;
   for(const auto& phase : phases)
   {
@@ -94,6 +96,8 @@ Result<> ReadGrainMapper3D::copyPhaseInformation(GrainMapperReader& reader, hid_
     latticeConstants->setComponent(phaseId, 3, static_cast<float32>(lc[3]));
     latticeConstants->setComponent(phaseId, 4, static_cast<float32>(lc[4]));
     latticeConstants->setComponent(phaseId, 5, static_cast<float32>(lc[5]));
+
+    universalHermannMauguin[phaseId] = phase.UniversalHermannMauguin;
   }
 
   return {};

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadGrainMapper3D.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ReadGrainMapper3D.hpp
@@ -35,6 +35,7 @@ namespace GM3DConstants
 const std::string k_CrystalStructures("CrystalStructures");
 const std::string k_LatticeConstants("LatticeConstants");
 const std::string k_MaterialName("MaterialName");
+const std::string k_UniversalHermannMauguin("UniversalHermannMauguin");
 } // namespace GM3DConstants
 /**
  * @class ReadGrainMapper3D

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadGrainMapper3DFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ReadGrainMapper3DFilter.cpp
@@ -233,6 +233,10 @@ IFilter::PreflightResult ReadGrainMapper3DFilter::preflightImpl(const DataStruct
       auto createArrayAction = std::make_unique<CreateStringArrayAction>(ensembleTupleDims, cellEnsembleAMPath.createChildPath(GM3DConstants::k_MaterialName));
       resultOutputActions.value().appendAction(std::move(createArrayAction));
     }
+    {
+      auto createArrayAction = std::make_unique<CreateStringArrayAction>(ensembleTupleDims, cellEnsembleAMPath.createChildPath(GM3DConstants::k_UniversalHermannMauguin));
+      resultOutputActions.value().appendAction(std::move(createArrayAction));
+    }
   }
 
   // **************************************************************************

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/utilities/GrainMapper3DUtilities.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/utilities/GrainMapper3DUtilities.cpp
@@ -398,7 +398,7 @@ herr_t GrainMapperReader::readPhaseInfo(hid_t parentId)
       return error;
     }
 
-    error = H5Lite::readStringDataset(phaseGid, Constants::k_Name, phase.UniversalHermannMauguin);
+    error = H5Lite::readStringDataset(phaseGid, Constants::k_UniversalHermannMauguinName, phase.UniversalHermannMauguin);
     if(error < 0)
     {
       return error;

--- a/src/Plugins/OrientationAnalysis/test/ReadGrainMapper3DTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/ReadGrainMapper3DTest.cpp
@@ -49,7 +49,7 @@ TEST_CASE("OrientationAnalysis::ReadGrainMapper3D:Default_Parameters", "[Orienta
     args.insertOrAssign(ReadGrainMapper3DFilter::k_ReadLabDCT_Key, std::make_any<bool>(true));
     args.insertOrAssign(ReadGrainMapper3DFilter::k_CreatedDCTImageGeometryPath_Key, std::make_any<DataPath>(computedDCTGeometryPath));
     args.insertOrAssign(ReadGrainMapper3DFilter::k_CellAttributeMatrixName_Key, std::make_any<std::string>(k_Cell_Data));
-    args.insertOrAssign(ReadGrainMapper3DFilter::k_CellEnsembleAttributeMatrixName_Key, std::make_any<std::string>(k_EnsembleAttributeMatrix));
+    args.insertOrAssign(ReadGrainMapper3DFilter::k_CellEnsembleAttributeMatrixName_Key, std::make_any<std::string>(k_Cell_Ensemble_Data));
 
     args.insertOrAssign(ReadGrainMapper3DFilter::k_ConvertPhaseToInt32_Key, std::make_any<bool>(true));
     args.insertOrAssign(ReadGrainMapper3DFilter::k_ConvertOrientationData_Key, std::make_any<bool>(true));
@@ -78,6 +78,8 @@ TEST_CASE("OrientationAnalysis::ReadGrainMapper3D:Default_Parameters", "[Orienta
   UnitTest::CompareExemplarToGenerateAttributeMatrix(dataStructure, exemplarDCTGeometryPath.createChildPath(k_Cell_Data), dataStructure, computedDCTGeometryPath.createChildPath(k_Cell_Data));
   UnitTest::CompareExemplarToGenerateAttributeMatrix(dataStructure, exemplarAbsorptionCTGeometryPath.createChildPath(k_Cell_Data), dataStructure,
                                                      computedAbsorptionCTGeometryPath.createChildPath(k_Cell_Data));
+  UnitTest::CompareExemplarToGenerateAttributeMatrix(dataStructure, exemplarDCTGeometryPath.createChildPath(k_Cell_Ensemble_Data), dataStructure,
+                                                     computedDCTGeometryPath.createChildPath(k_Cell_Ensemble_Data));
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
 }
@@ -110,7 +112,7 @@ TEST_CASE("OrientationAnalysis::ReadGrainMapper3D:NonCompatible_Parameters", "[O
     args.insertOrAssign(ReadGrainMapper3DFilter::k_ReadLabDCT_Key, std::make_any<bool>(true));
     args.insertOrAssign(ReadGrainMapper3DFilter::k_CreatedDCTImageGeometryPath_Key, std::make_any<DataPath>(computedDCTGeometryPath));
     args.insertOrAssign(ReadGrainMapper3DFilter::k_CellAttributeMatrixName_Key, std::make_any<std::string>(k_Cell_Data));
-    args.insertOrAssign(ReadGrainMapper3DFilter::k_CellEnsembleAttributeMatrixName_Key, std::make_any<std::string>(k_EnsembleAttributeMatrix));
+    args.insertOrAssign(ReadGrainMapper3DFilter::k_CellEnsembleAttributeMatrixName_Key, std::make_any<std::string>(k_Cell_Ensemble_Data));
 
     args.insertOrAssign(ReadGrainMapper3DFilter::k_ConvertPhaseToInt32_Key, std::make_any<bool>(false));
     args.insertOrAssign(ReadGrainMapper3DFilter::k_ConvertOrientationData_Key, std::make_any<bool>(false));
@@ -138,6 +140,8 @@ TEST_CASE("OrientationAnalysis::ReadGrainMapper3D:NonCompatible_Parameters", "[O
   UnitTest::CompareExemplarToGenerateAttributeMatrix(dataStructure, exemplarDCTGeometryPath.createChildPath(k_Cell_Data), dataStructure, computedDCTGeometryPath.createChildPath(k_Cell_Data));
   UnitTest::CompareExemplarToGenerateAttributeMatrix(dataStructure, exemplarAbsorptionCTGeometryPath.createChildPath(k_Cell_Data), dataStructure,
                                                      computedAbsorptionCTGeometryPath.createChildPath(k_Cell_Data));
+  UnitTest::CompareExemplarToGenerateAttributeMatrix(dataStructure, exemplarDCTGeometryPath.createChildPath(k_Cell_Ensemble_Data), dataStructure,
+                                                     computedDCTGeometryPath.createChildPath(k_Cell_Ensemble_Data));
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
 }

--- a/src/Plugins/OrientationAnalysis/test/ReadGrainMapper3DTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/ReadGrainMapper3DTest.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch.hpp>
 
+#include "simplnx/DataStructure/StringArray.hpp"
 #include "simplnx/Parameters/ArrayCreationParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/FileSystemPathParameter.hpp"
@@ -80,6 +81,24 @@ TEST_CASE("OrientationAnalysis::ReadGrainMapper3D:Default_Parameters", "[Orienta
                                                      computedAbsorptionCTGeometryPath.createChildPath(k_Cell_Data));
   UnitTest::CompareExemplarToGenerateAttributeMatrix(dataStructure, exemplarDCTGeometryPath.createChildPath(k_Cell_Ensemble_Data), dataStructure,
                                                      computedDCTGeometryPath.createChildPath(k_Cell_Ensemble_Data));
+
+  // The exemplar .dream3d predates the UniversalHermannMauguin ensemble array and therefore cannot be used
+  // to compare it. Verify the parsed values directly against the known phase metadata so a regression in the
+  // dataset that is read (UniversalHermannMauguin vs. Name) is caught. Index 0 is the reserved invalid phase.
+  {
+    const std::vector<std::string> expectedHermannMauguin = {
+        "Invalid Phase",    "F d -3 m :2 (a-1/8,b-1/8,c-1/8)", "F d -3 m :2 (a-1/8,b-1/8,c-1/8)", "P 63/m m c", "P 42/m n m", "R -3 c :H (-y+z,x+z,-x+y+z)", "P 32 2 1", "P b c n", "C 1 2/m 1",
+        "P -1 (a+b,a-b,-c)"};
+    const DataPath hermannMauguinPath = computedDCTGeometryPath.createChildPath(k_Cell_Ensemble_Data).createChildPath("UniversalHermannMauguin");
+    REQUIRE_NOTHROW(dataStructure.getDataRefAs<StringArray>(hermannMauguinPath));
+    const auto& hermannMauguinArray = dataStructure.getDataRefAs<StringArray>(hermannMauguinPath);
+    REQUIRE(hermannMauguinArray.getNumberOfTuples() == expectedHermannMauguin.size());
+    for(usize i = 0; i < expectedHermannMauguin.size(); i++)
+    {
+      CAPTURE(i);
+      REQUIRE(hermannMauguinArray[i] == expectedHermannMauguin[i]);
+    }
+  }
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
 }


### PR DESCRIPTION
## Summary

This PR fixes a likely typo/bug in `GrainMapperReader::readPhaseInfo()` (in `GrainMapper3DUtilities.cpp`).

Previously, `phase.UniversalHermannMauguin` was incorrectly assigned using `k_Name` instead of `k_UniversalHermannMauguin`.

As a result, the `UniversalHermannMauguin` field always duplicated the phase name instead of reading the intended HDF5 dataset.

This fix updates the reader to correctly load the `UniversalHermannMauguin` dataset.

---

## Additional Question / Discussion

While tracing the full metadata flow and looking through the test case example, I noticed that this field is currently never written into the SIMPLNX `DataStructure`.

At the moment, only:

* `MaterialName`
* `CrystalStructures`
* `LatticeConstants`

are written into the ensemble arrays.

I wanted to ask whether omitting `UniversalHermannMauguin` was:

* intentional for compatibility/minimal metadata reasons,
* or simply an unfinished implementation.

My understanding is that some information is already reduced when converting the full space group into a Laue group / crystal structure representation. Preserving `UniversalHermannMauguin` would help retain the original crystallographic metadata when translating GrainMapper3D data into DREAM3D/SIMPLNX format.

On the other hand, if the intention was to keep ensemble metadata minimal, then it may also make sense to avoid reading metadata that is never persisted, since that would make the workflow and intent of the code clearer.

For that reason, I have intentionally kept this PR limited to fixing the dataset read itself and have not modified the code to write this metadata into the SIMPLNX `DataStructure`.

If support for writing this metadata is desired, I would be happy to open a follow-up PR to store it as an ensemble `StringArray`, as I have already wrapped my head around the metadata flow through the reader and ensemble creation logic.
