### PR TITLE
VERS: Updated vcpkg baseline for hwloc windows cmake build

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/bluequartzsoftware/simplnx-registry",
-      "baseline": "4dd8a2b973349943e23b58237a986785bfc6d7de",
+      "baseline": "ca7046ad28b4885b018e4ab5fcf43333460d82b2",
       "packages": [
         "benchmark",
         "blosc",


### PR DESCRIPTION
No version or functionality changes. Changes hwloc port to use cmake on windows. And updates tbb port so it can properly find hwloc.