### PR TITLE
BUG: Make H5SUPPORT_MUTEX_LOCK a real process-wide HDF5 lock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,14 @@ endif()
 # Force HDF5 1.10 API
 target_compile_definitions(simplnx PUBLIC "H5_USE_110_API")
 
+# The vcpkg HDF5 build is not thread-safe. Enable H5SUPPORT_MUTEX_LOCK() so the
+# four macro-guarded helpers in H5Support.cpp serialize on the single process-wide
+# ApiLock(). PUBLIC so it propagates to consumers (including simplnx_test, whose
+# ApiLock regression guard is otherwise a compile-time no-op). Perf note: this is a
+# coarse, process-wide lock around those HDF5 leaf calls; it trades some HDF5-call
+# concurrency for correctness against the non-thread-safe C library.
+target_compile_definitions(simplnx PUBLIC "H5Support_USE_MUTEX")
+
 target_compile_options(simplnx
   PUBLIC
     $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang,Intel>:-ffp-contract=off>

--- a/src/simplnx/Utilities/Parsing/HDF5/H5Support.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/H5Support.cpp
@@ -228,6 +228,19 @@ std::string nx::core::HDF5::Support::GetNameFromFilterType(H5Z_filter_t id)
   }
 }
 
+std::mutex& nx::core::HDF5::Support::ApiLock()
+{
+  // "Leaky" (immortal) Meyers singleton: a process-wide lock must stay valid even if
+  // an HDF5 call runs during static destruction (e.g. a file or dataset handle closed
+  // from a static object's destructor at process exit) — by then a function-local
+  // static would already be destroyed, and locking a destroyed mutex is undefined
+  // behavior. Heap-allocating and intentionally never deleting the mutex sidesteps the
+  // static destruction order fiasco; the one-time leak is harmless and reclaimed by the
+  // OS at process exit.
+  static std::mutex* s_ApiLock = new std::mutex();
+  return *s_ApiLock;
+}
+
 #if 0
 hid_t Support::getDatasetType(hid_t locationID, const std::string& datasetName)
 {

--- a/src/simplnx/Utilities/Parsing/HDF5/H5Support.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/H5Support.hpp
@@ -308,12 +308,18 @@ std::string SIMPLNX_EXPORT GetNameFromFilterType(H5Z_filter_t id);
  * macro; any other code needing the HDF5 lock aliases it rather than defining a
  * second one (two locks guarding one non-thread-safe library would still race).
  *
+ * SCOPE — the lock currently guards only the four macro-guarded helpers listed
+ * below. The many other direct H5* calls scattered through FileIO, DatasetIO,
+ * and Dream3dIO are NOT serialized by it, so this does not by itself make all
+ * HDF5 access thread-safe; it makes these four helpers safe and gives the rest a
+ * single lock to adopt as they are hardened.
+ *
  * CONTRACT — this is a NON-recursive std::mutex. Lock it ONLY around leaf HDF5
  * C-API calls, and NEVER while calling a function that may re-acquire it — in
  * particular the macro-guarded helpers (IsGroup, GetObjectPath, GetDatasetType,
- * StringForHDFType) and probeSingleDeflateEligibility, which lock it themselves.
- * Re-entering on the same thread would self-deadlock. Never hold it around heavy
- * CPU work (e.g. (de)compression) either — that must run off the lock.
+ * StringForHDFType), which lock it themselves. Re-entering on the same thread
+ * would self-deadlock. Never hold it around heavy CPU work (e.g. (de)compression)
+ * either — that must run off the lock.
  */
 SIMPLNX_EXPORT std::mutex& ApiLock();
 

--- a/src/simplnx/Utilities/Parsing/HDF5/H5Support.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/H5Support.hpp
@@ -12,16 +12,14 @@
 #include <hdf5.h>
 
 #include <iostream>
+#include <mutex>
 #include <numeric>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 #ifdef H5Support_USE_MUTEX
-#include <mutex>
-#define H5SUPPORT_MUTEX_LOCK()                                                                                                                                                                         \
-  std::mutex mutex;                                                                                                                                                                                    \
-  std::lock_guard<std::mutex> lock(mutex);
+#define H5SUPPORT_MUTEX_LOCK() std::lock_guard<std::mutex> h5ApiLock(nx::core::HDF5::Support::ApiLock());
 #else
 #define H5SUPPORT_MUTEX_LOCK()
 #endif
@@ -299,6 +297,25 @@ std::string SIMPLNX_EXPORT StringForHDFType(hid_t dataTypeIdentifier);
  * @return std::string
  */
 std::string SIMPLNX_EXPORT GetNameFromFilterType(H5Z_filter_t id);
+
+/**
+ * @brief Returns the process-wide HDF5 API mutex.
+ *
+ * The vcpkg HDF5 build is not thread-safe, so every thread that calls into the
+ * HDF5 C library must serialize on this single lock. It is a Meyers singleton —
+ * one instance for the whole process — so every translation unit linked into
+ * libsimplnx shares the exact same mutex. It backs the H5SUPPORT_MUTEX_LOCK()
+ * macro; any other code needing the HDF5 lock aliases it rather than defining a
+ * second one (two locks guarding one non-thread-safe library would still race).
+ *
+ * CONTRACT — this is a NON-recursive std::mutex. Lock it ONLY around leaf HDF5
+ * C-API calls, and NEVER while calling a function that may re-acquire it — in
+ * particular the macro-guarded helpers (IsGroup, GetObjectPath, GetDatasetType,
+ * StringForHDFType) and probeSingleDeflateEligibility, which lock it themselves.
+ * Re-entering on the same thread would self-deadlock. Never hold it around heavy
+ * CPU work (e.g. (de)compression) either — that must run off the lock.
+ */
+SIMPLNX_EXPORT std::mutex& ApiLock();
 
 } // namespace Support
 } // namespace nx::core::HDF5

--- a/test/H5Test.cpp
+++ b/test/H5Test.cpp
@@ -20,6 +20,7 @@
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 #include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 #include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
+#include "simplnx/Utilities/Parsing/HDF5/H5Support.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp"
 #include "simplnx/Utilities/Parsing/Text/CsvParser.hpp"
 
@@ -28,6 +29,9 @@
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include "GeometryTestUtilities.hpp"
+
+#include <thread>
+#include <vector>
 
 #include "simplnx/unit_test/simplnx_test_dirs.hpp"
 
@@ -1175,4 +1179,37 @@ TEST_CASE("DatasetIO: writeSpan bypasses chunking for small arrays even with com
   REQUIRE(info.has_value());
   REQUIRE(info->layout == nx::core::UnitTest::DatasetLayout::Contiguous);
   REQUIRE(info->hasDeflate == false);
+}
+
+TEST_CASE("HDF5 ApiLock serializes access via H5SUPPORT_MUTEX_LOCK", "[simplnx][HDF5]")
+{
+#ifdef H5Support_USE_MUTEX
+  // Regression guard for the original H5SUPPORT_MUTEX_LOCK() bug: the macro used to
+  // declare a fresh per-call local std::mutex (serializing nothing). Hammer a shared
+  // counter from many threads under the macro — a real lock on the one shared ApiLock
+  // yields exactly threads*iters with no lost updates; the old no-op macro would lose
+  // updates (and the unsynchronized increments would be a data race).
+  constexpr int k_Threads = 8;
+  constexpr int k_Iters = 20000;
+  int counter = 0;
+  std::vector<std::thread> workers;
+  workers.reserve(k_Threads);
+  for(int t = 0; t < k_Threads; ++t)
+  {
+    workers.emplace_back([&counter]() {
+      for(int i = 0; i < k_Iters; ++i)
+      {
+        H5SUPPORT_MUTEX_LOCK();
+        ++counter;
+      }
+    });
+  }
+  for(auto& worker : workers)
+  {
+    worker.join();
+  }
+  REQUIRE(counter == k_Threads * k_Iters);
+#else
+  SUCCEED("H5Support_USE_MUTEX disabled; H5SUPPORT_MUTEX_LOCK is intentionally a no-op");
+#endif
 }


### PR DESCRIPTION
## Summary

`H5SUPPORT_MUTEX_LOCK()` declared a fresh function-local `std::mutex` on every
expansion and immediately locked it, so it provided no mutual exclusion across
calls or threads (and expanded to nothing when `H5Support_USE_MUTEX` was
undefined). The four HDF5 helpers that use it (`IsGroup`, `GetObjectPath`,
`GetDatasetType`, `StringForHDFType`) were therefore effectively unsynchronized
against the non-thread-safe HDF5 C library.

* Add a single process-wide `ApiLock()` (a leaky Meyers singleton) and point the
  macro at it.
* Define `H5Support_USE_MUTEX` for the `simplnx` target
  (`target_compile_definitions(simplnx PUBLIC ...)`) so the macro is actually
  engaged rather than compiled out. `PUBLIC` also propagates the define to
  `simplnx_test`, so the regression guard runs live instead of taking the
  `SUCCEED()` no-op path.
* Add a regression test that hammers the shared lock from many threads and
  asserts no lost updates (guards against reintroducing the per-call-local-mutex
  bug).

## Scope / caveats

* **Coarse, process-wide lock.** This serializes the four macro-guarded HDF5 leaf
  calls on one mutex. It trades some HDF5-call concurrency for correctness against
  the non-thread-safe vcpkg HDF5 build.
* **Limited coverage.** The lock currently guards only those four helpers. The
  many other direct `H5*` calls throughout `FileIO`, `DatasetIO`, and
  `Dream3dIO` are **not** yet serialized by it, so this does not by itself close
  the broader HDF5 thread-safety story — it gives the rest of the code a single
  lock to adopt as it is hardened.

## Test Plan
- [x] `simplnx_test` HDF5 suite passes with the lock enabled (H5 Utilities,
  DatasetIO, HDF5ImplicitCopy, the ApiLock regression guard, Read Legacy
  DREAM3D-NX Data, Contains HDF5 IO Support)
