### PR TITLE
FILT: Regularize Z Spacing

### DIFF
--- a/src/Plugins/SimplnxCore/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/CMakeLists.txt
@@ -123,6 +123,7 @@ set(FilterList
   ReadVtkStructuredPointsFilter
   ReadZeissTxmFileFilter
   RegularGridSampleSurfaceMeshFilter
+  RegularizeZSpacingFilter
   RemoveFlaggedEdgesFilter
   RemoveFlaggedFeaturesFilter
   RemoveFlaggedTrianglesFilter
@@ -289,6 +290,7 @@ set(AlgorithmList
   ReadVtkStructuredPoints
   ReadZeissTxmFile
   RegularGridSampleSurfaceMesh
+  RegularizeZSpacing
   RemoveFlaggedEdges
   RemoveFlaggedFeatures
   RemoveFlaggedTriangles

--- a/src/Plugins/SimplnxCore/docs/RegularizeZSpacingFilter.md
+++ b/src/Plugins/SimplnxCore/docs/RegularizeZSpacingFilter.md
@@ -1,0 +1,46 @@
+# Regularize Z Spacing
+
+## Group (Subgroup)
+
+Sampling (Resolution)
+
+## Description
+
+This **Filter** resamples an **Image Geometry** that has *irregular* spacing along the Z axis onto a *regular* (uniform) Z spacing. This situation commonly arises from serial-sectioning data collection where the physical distance removed between successive sections is not constant.
+
+The current physical Z position of every original slice boundary is read from a whitespace-delimited text file. The file must contain **(ZPoints + 1)** floating point values, where `ZPoints` is the number of cells (slices) along the Z axis of the selected **Image Geometry**. The first value is the position of the bottom boundary of the first slice, and the last value is the total Z extent of the volume.
+
+The **Filter** computes a new number of Z slices as:
+
+    newZPoints = floor(totalZExtent / newZSpacing)
+
+(with a minimum of 1). For each new, evenly spaced Z plane the **Filter** selects the original slice whose boundary interval contains that plane's position and copies the entire XY slab of cell data from the original slice into the new slice. The X and Y dimensions, spacing, and the geometry origin are unchanged; only the Z dimension count and Z spacing are updated.
+
+### Input File Format
+
+The input file is a simple text file with one floating point value per line (or whitespace-delimited). For an **Image Geometry** with 5 Z slices the file must contain 6 values, for example:
+
+    0.0
+    1.0
+    3.0
+    6.0
+    9.5
+    12.0
+
+The values must be monotonically non-decreasing, and the final value (the total Z extent) must be greater than zero. The `.txt` extension is a file-dialog hint only; any readable text file is accepted.
+
+### Output Geometry
+
+When *Perform In Place* is enabled the original **Image Geometry** is replaced by the resampled result. When it is disabled the resampled result is written to the *Created Image Geometry* path and the original geometry is left unchanged.
+
+% Auto generated parameter table will be inserted here
+
+## Example Pipelines
+
+## License & Copyright
+
+Please see the description file distributed with this **Plugin**
+
+## DREAM3D-NX Help
+
+If you need help, need to file a bug report or want to request a new feature, please head over to the [DREAM3DNX-Issues](https://github.com/BlueQuartzSoftware/DREAM3DNX-Issues/discussions) GitHub site where the community of DREAM3D-NX users can help answer your questions.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RegularizeZSpacing.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RegularizeZSpacing.cpp
@@ -1,0 +1,217 @@
+#include "RegularizeZSpacing.hpp"
+
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/ParallelAlgorithmUtilities.hpp"
+#include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
+
+#include <fstream>
+
+using namespace nx::core;
+
+namespace
+{
+// -----------------------------------------------------------------------------
+// Copies each destination tuple from its mapped source tuple. The source tuple
+// index is computed from the per-plane mapping: within a plane the X/Y layout is
+// unchanged, so only the Z plane is remapped.
+template <typename T>
+class RegularizeZSpacingArrayImpl
+{
+public:
+  RegularizeZSpacingArrayImpl(RegularizeZSpacing* algorithm, const IDataArray& srcArray, IDataArray& destArray, const std::vector<usize>& newToOldZPlane, usize sliceSize,
+                              const std::atomic_bool& shouldCancel)
+  : m_AlgorithmPtr(algorithm)
+  , m_SrcArray(srcArray)
+  , m_DestArray(destArray)
+  , m_NewToOldZPlane(newToOldZPlane)
+  , m_SliceSize(sliceSize)
+  , m_ShouldCancel(shouldCancel)
+  {
+  }
+
+  void operator()() const
+  {
+    const auto& srcDataStoreRef = m_SrcArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
+    auto& destDataStoreRef = m_DestArray.template getIDataStoreRefAs<AbstractDataStore<T>>();
+
+    // Within a Z plane the X/Y layout is unchanged, so each destination plane maps to a single
+    // contiguous slab of m_SliceSize tuples in the source. Copy one whole plane per call rather
+    // than one tuple at a time; this is far more efficient and out-of-core friendly.
+    const usize numPlanes = m_NewToOldZPlane.size();
+    const usize progressIncrement = numPlanes / 100 == 0 ? 1 : numPlanes / 100;
+    for(usize destPlane = 0; destPlane < numPlanes; destPlane++)
+    {
+      if(m_ShouldCancel)
+      {
+        return;
+      }
+
+      const usize destTupleStart = destPlane * m_SliceSize;
+      const usize srcTupleStart = m_NewToOldZPlane[destPlane] * m_SliceSize;
+      destDataStoreRef.copyFrom(destTupleStart, srcDataStoreRef, srcTupleStart, m_SliceSize);
+
+      // Only build/emit a progress string roughly every 1% to avoid formatting a string per plane
+      // that the throttled messenger would otherwise discard.
+      if(destPlane % progressIncrement == 0 || destPlane == numPlanes - 1)
+      {
+        const float32 progress = static_cast<float32>(destPlane + 1) / static_cast<float32>(numPlanes) * 100.0f;
+        m_AlgorithmPtr->sendThreadSafeProgressMessage(fmt::format("Copying Data Array '{}' {:.0f}% Complete", m_DestArray.getName(), progress));
+      }
+    }
+  }
+
+private:
+  RegularizeZSpacing* m_AlgorithmPtr = nullptr;
+  const IDataArray& m_SrcArray;
+  IDataArray& m_DestArray;
+  const std::vector<usize>& m_NewToOldZPlane;
+  usize m_SliceSize;
+  const std::atomic_bool& m_ShouldCancel;
+};
+} // namespace
+
+namespace nx::core
+{
+// -----------------------------------------------------------------------------
+Result<std::vector<float32>> ReadZBoundsFile(const std::filesystem::path& inputFile, usize count)
+{
+  std::ifstream inStream(inputFile);
+  if(!inStream.good())
+  {
+    return MakeErrorResult<std::vector<float32>>(-5556, fmt::format("Unable to open input file with name '{}'", inputFile.string()));
+  }
+
+  std::vector<float32> zBoundValues(count, 0.0f);
+  for(usize i = 0; i < count; i++)
+  {
+    if(!(inStream >> zBoundValues[i]))
+    {
+      return MakeErrorResult<std::vector<float32>>(
+          -5557,
+          fmt::format(
+              "Input file '{}' did not contain enough parseable values. Expected {} whitespace-delimited float values (ZPoints + 1) but reading stopped after {} (end of file or a non-numeric token).",
+              inputFile.string(), count, i));
+    }
+  }
+
+  return {std::move(zBoundValues)};
+}
+
+// -----------------------------------------------------------------------------
+usize ComputeRegularizedZDim(float32 lastZBound, float32 newZRes)
+{
+  auto zP = static_cast<usize>(lastZBound / newZRes);
+  if(zP == 0)
+  {
+    zP = 1;
+  }
+  return zP;
+}
+
+// -----------------------------------------------------------------------------
+RegularizeZSpacing::RegularizeZSpacing(DataStructure& dataStructure, const IFilter::MessageHandler& msgHandler, const std::atomic_bool& shouldCancel, RegularizeZSpacingInputValues* inputValues)
+: m_DataStructure(dataStructure)
+, m_InputValues(inputValues)
+, m_ShouldCancel(shouldCancel)
+, m_MessageHandler(msgHandler)
+{
+}
+
+// -----------------------------------------------------------------------------
+RegularizeZSpacing::~RegularizeZSpacing() noexcept = default;
+
+// -----------------------------------------------------------------------------
+const std::atomic_bool& RegularizeZSpacing::getCancel()
+{
+  return m_ShouldCancel;
+}
+
+// -----------------------------------------------------------------------------
+Result<> RegularizeZSpacing::operator()()
+{
+  MessageHelper messageHelper(m_MessageHandler);
+  ThrottledMessenger throttledMessenger = messageHelper.createThrottledMessenger();
+  m_ThrottledMessengerPtr = &throttledMessenger;
+
+  const auto& selectedImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->SelectedImageGeometryPath);
+  auto& destImageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->CreatedImageGeometryPath);
+
+  const SizeVec3 srcDims = selectedImageGeom.getDimensions();
+  const SizeVec3 destDims = destImageGeom.getDimensions();
+  const usize origZDim = srcDims[2];
+  const usize newZDim = destDims[2];
+  const usize sliceSize = srcDims[0] * srcDims[1];
+
+  // Read the Z boundary positions (ZPoints + 1 values).
+  Result<std::vector<float32>> zBoundsResult = ReadZBoundsFile(m_InputValues->InputFile, origZDim + 1);
+  if(zBoundsResult.invalid())
+  {
+    return ConvertResult(std::move(zBoundsResult));
+  }
+  const std::vector<float32> zBoundValues = std::move(zBoundsResult.value());
+
+  // Build the mapping from each new (regularly spaced) Z plane to the original Z plane whose
+  // boundary interval contains it. This mirrors the legacy RegularizeZSpacing behavior: for a new
+  // plane 'i', the source plane is the largest 'iter' in [1, origZDim) with (i * newZRes) > zBoundValues[iter].
+  std::vector<usize> newToOldZPlane(newZDim, 0);
+  for(usize i = 0; i < newZDim; i++)
+  {
+    usize plane = 0;
+    const float32 newPlanePos = static_cast<float32>(i) * m_InputValues->NewZRes;
+    for(usize iter = 1; iter < origZDim; iter++)
+    {
+      if(newPlanePos > zBoundValues[iter])
+      {
+        plane = iter;
+      }
+    }
+    newToOldZPlane[i] = plane;
+  }
+
+  const auto& srcCellDataAM = selectedImageGeom.getCellDataRef();
+  auto& destCellDataAM = destImageGeom.getCellDataRef();
+
+  usize arrayIndex = 0;
+  const usize totalArrays = srcCellDataAM.getSize();
+
+  ParallelTaskAlgorithm taskRunner;
+  taskRunner.setParallelizationEnabled(true);
+
+  for(const auto& [dataId, oldDataObject] : srcCellDataAM)
+  {
+    if(m_ShouldCancel)
+    {
+      return {};
+    }
+
+    arrayIndex++;
+    // Preflight rejects non-DataArray members (error -5561); guard here as well so a direct
+    // invocation of the algorithm cannot throw std::bad_cast.
+    const auto* oldDataArrayPtr = dynamic_cast<const IDataArray*>(oldDataObject.get());
+    if(oldDataArrayPtr == nullptr)
+    {
+      return MakeErrorResult(-5561, fmt::format("Cell Attribute Matrix member '{}' is not a DataArray and cannot be resampled by this filter.", oldDataObject->getName()));
+    }
+    const std::string srcName = oldDataArrayPtr->getName();
+    auto& newDataArray = dynamic_cast<IDataArray&>(destCellDataAM.at(srcName));
+    m_MessageHandler(fmt::format("Copying Data Array: '{}' ({}/{})", srcName, arrayIndex, totalArrays));
+
+    ExecuteParallelFunction<RegularizeZSpacingArrayImpl>(oldDataArrayPtr->getDataType(), taskRunner, this, *oldDataArrayPtr, newDataArray, newToOldZPlane, sliceSize, m_ShouldCancel);
+  }
+
+  taskRunner.wait();
+
+  return {};
+}
+
+// -----------------------------------------------------------------------------
+void RegularizeZSpacing::sendThreadSafeProgressMessage(const std::string& message)
+{
+  std::lock_guard<std::mutex> guard(m_ProgressMessage_Mutex);
+  if(nullptr != m_ThrottledMessengerPtr)
+  {
+    m_ThrottledMessengerPtr->sendThrottledMessage([&]() { return message; });
+  }
+}
+} // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RegularizeZSpacing.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RegularizeZSpacing.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "SimplnxCore/SimplnxCore_export.hpp"
+
+#include "simplnx/DataStructure/DataPath.hpp"
+#include "simplnx/DataStructure/DataStructure.hpp"
+#include "simplnx/Filter/IFilter.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
+
+#include <filesystem>
+#include <vector>
+
+namespace nx::core
+{
+
+struct SIMPLNXCORE_EXPORT RegularizeZSpacingInputValues
+{
+  DataPath SelectedImageGeometryPath;
+  std::filesystem::path InputFile;
+  float32 NewZRes = 0.0F;
+  bool RemoveOriginalImageGeom = true;
+  DataPath CreatedImageGeometryPath;
+};
+
+/**
+ * @class RegularizeZSpacing
+ * @brief Copies the cell data of an irregularly Z-spaced Image Geometry onto a regularly Z-spaced Image Geometry.
+ */
+class SIMPLNXCORE_EXPORT RegularizeZSpacing
+{
+public:
+  RegularizeZSpacing(DataStructure& dataStructure, const IFilter::MessageHandler& msgHandler, const std::atomic_bool& shouldCancel, RegularizeZSpacingInputValues* inputValues);
+  ~RegularizeZSpacing() noexcept;
+
+  RegularizeZSpacing(const RegularizeZSpacing&) = delete;
+  RegularizeZSpacing(RegularizeZSpacing&&) noexcept = delete;
+  RegularizeZSpacing& operator=(const RegularizeZSpacing&) = delete;
+  RegularizeZSpacing& operator=(RegularizeZSpacing&&) noexcept = delete;
+
+  Result<> operator()();
+
+  const std::atomic_bool& getCancel();
+
+  void sendThreadSafeProgressMessage(const std::string& message);
+
+private:
+  DataStructure& m_DataStructure;
+  const RegularizeZSpacingInputValues* m_InputValues = nullptr;
+  const std::atomic_bool& m_ShouldCancel;
+  const IFilter::MessageHandler& m_MessageHandler;
+
+  // Thread safe Progress Message
+  mutable std::mutex m_ProgressMessage_Mutex;
+
+  ThrottledMessenger* m_ThrottledMessengerPtr = nullptr;
+};
+
+/**
+ * @brief Reads the Z boundary positions file into a vector of floats.
+ * @param inputFile The path to the whitespace-delimited text file.
+ * @param count The number of values to read (should be ZPoints + 1).
+ * @return The parsed values, or an error Result if the file could not be opened or did not contain enough values.
+ */
+SIMPLNXCORE_EXPORT Result<std::vector<float32>> ReadZBoundsFile(const std::filesystem::path& inputFile, usize count);
+
+/**
+ * @brief Computes the number of Z planes for the resampled geometry.
+ * @param lastZBound The total Z extent (last value in the Z bounds file).
+ * @param newZRes The new (regular) Z spacing.
+ * @return The number of Z planes, always at least 1.
+ */
+SIMPLNXCORE_EXPORT usize ComputeRegularizedZDim(float32 lastZBound, float32 newZRes);
+
+} // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RegularizeZSpacingFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RegularizeZSpacingFilter.cpp
@@ -1,0 +1,309 @@
+#include "RegularizeZSpacingFilter.hpp"
+
+#include "SimplnxCore/Filters/Algorithms/RegularizeZSpacing.hpp"
+
+#include "simplnx/DataStructure/DataPath.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Filter/Actions/CopyDataObjectAction.hpp"
+#include "simplnx/Filter/Actions/CreateArrayAction.hpp"
+#include "simplnx/Filter/Actions/CreateImageGeometryAction.hpp"
+#include "simplnx/Filter/Actions/DeleteDataAction.hpp"
+#include "simplnx/Filter/Actions/RenameDataAction.hpp"
+#include "simplnx/Parameters/BoolParameter.hpp"
+#include "simplnx/Parameters/DataGroupCreationParameter.hpp"
+#include "simplnx/Parameters/FileSystemPathParameter.hpp"
+#include "simplnx/Parameters/GeometrySelectionParameter.hpp"
+#include "simplnx/Parameters/NumberParameter.hpp"
+#include "simplnx/Utilities/DataGroupUtilities.hpp"
+#include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/GeometryHelpers.hpp"
+#include "simplnx/Utilities/SIMPLConversion.hpp"
+
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+using namespace nx::core;
+
+namespace
+{
+const std::string k_TempGeometryName = ".regularized_image_geometry";
+
+// Rebases 'path' from under 'oldPrefix' to the same relative location under 'newPrefix'.
+// A component-wise splice is used instead of string replacement so that a geometry name that
+// appears as a substring elsewhere in the path cannot corrupt the rebased path.
+nx::core::DataPath RebasePath(const nx::core::DataPath& path, const nx::core::DataPath& oldPrefix, const nx::core::DataPath& newPrefix)
+{
+  auto pathVector = path.getPathVector();
+  std::vector<std::string> newVector = newPrefix.getPathVector();
+  newVector.insert(newVector.end(), pathVector.begin() + static_cast<std::ptrdiff_t>(oldPrefix.getLength()), pathVector.end());
+  return nx::core::DataPath(newVector);
+}
+} // namespace
+
+namespace nx::core
+{
+//------------------------------------------------------------------------------
+std::string RegularizeZSpacingFilter::name() const
+{
+  return FilterTraits<RegularizeZSpacingFilter>::name.str();
+}
+
+//------------------------------------------------------------------------------
+std::string RegularizeZSpacingFilter::className() const
+{
+  return FilterTraits<RegularizeZSpacingFilter>::className;
+}
+
+//------------------------------------------------------------------------------
+Uuid RegularizeZSpacingFilter::uuid() const
+{
+  return FilterTraits<RegularizeZSpacingFilter>::uuid;
+}
+
+//------------------------------------------------------------------------------
+std::string RegularizeZSpacingFilter::humanName() const
+{
+  return "Regularize Z Spacing";
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> RegularizeZSpacingFilter::defaultTags() const
+{
+  return {className(), "Sampling", "Spacing", "Image Geometry", "Resolution", "Conversion"};
+}
+
+//------------------------------------------------------------------------------
+Parameters RegularizeZSpacingFilter::parameters() const
+{
+  Parameters params;
+
+  params.insertSeparator(Parameters::Separator{"Input Parameter(s)"});
+  // acceptAllExtensions = true: ".txt" is only a file-dialog hint. The legacy filter treated its
+  // "*.txt" string as a GUI filter and executed on any readable file, so converted pipelines may
+  // reference .dat/.csv/extensionless files and must not fail extension validation here.
+  params.insert(std::make_unique<FileSystemPathParameter>(k_InputFile_Key, "Current Z Positions File",
+                                                          "Path to a whitespace-delimited text file that contains the current Z position of each slice boundary (ZPoints + 1 float values).",
+                                                          fs::path(""), FileSystemPathParameter::ExtensionsType{".txt"}, FileSystemPathParameter::PathType::InputFile, true));
+  params.insert(std::make_unique<Float32Parameter>(k_NewZRes_Key, "New Z Spacing", "The new, regular spacing to use along the Z axis. Must be greater than 0.", 1.0F));
+
+  params.insertLinkableParameter(
+      std::make_unique<BoolParameter>(k_RemoveOriginalGeometry_Key, "Perform In Place", "Removes the original Image Geometry after the filter is complete and renames the result to its name.", true));
+
+  params.insertSeparator(Parameters::Separator{"Input Image Geometry"});
+  params.insert(std::make_unique<GeometrySelectionParameter>(k_SelectedImageGeometryPath_Key, "Selected Image Geometry", "The Image Geometry to resample along the Z axis.", DataPath{},
+                                                             GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image}));
+
+  params.insertSeparator(Parameters::Separator{"Output Image Geometry"});
+  params.insert(std::make_unique<DataGroupCreationParameter>(k_CreatedImageGeometry_Key, "Created Image Geometry", "The path to the resampled Image Geometry.", DataPath()));
+
+  params.linkParameters(k_RemoveOriginalGeometry_Key, k_CreatedImageGeometry_Key, false);
+
+  return params;
+}
+
+//------------------------------------------------------------------------------
+IFilter::VersionType RegularizeZSpacingFilter::parametersVersion() const
+{
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+IFilter::UniquePointer RegularizeZSpacingFilter::clone() const
+{
+  return std::make_unique<RegularizeZSpacingFilter>();
+}
+
+//------------------------------------------------------------------------------
+IFilter::PreflightResult RegularizeZSpacingFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
+                                                                 const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+{
+  auto srcImagePath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
+  auto inputFile = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFile_Key);
+  auto newZRes = filterArgs.value<float32>(k_NewZRes_Key);
+  auto pRemoveOriginalGeometry = filterArgs.value<bool>(k_RemoveOriginalGeometry_Key);
+  auto destImagePath = filterArgs.value<DataPath>(k_CreatedImageGeometry_Key);
+
+  nx::core::Result<OutputActions> resultOutputActions;
+  std::vector<PreflightValue> preflightUpdatedValues;
+
+  if(newZRes <= 0.0F)
+  {
+    return MakePreflightErrorResult(-5555, fmt::format("The new Z spacing ({}) must be greater than 0.", newZRes));
+  }
+
+  const auto& srcImageGeom = dataStructure.getDataRefAs<ImageGeom>(srcImagePath);
+  const SizeVec3 srcDimensions = srcImageGeom.getDimensions();
+  const FloatVec3 srcSpacing = srcImageGeom.getSpacing();
+  auto srcOrigin = srcImageGeom.getOrigin().toContainer<std::vector<float32>>();
+  const usize origZDim = srcDimensions[2];
+
+  // Read and validate the Z boundary positions file (ZPoints + 1 values).
+  Result<std::vector<float32>> zBoundsResult = ReadZBoundsFile(inputFile, origZDim + 1);
+  if(zBoundsResult.invalid())
+  {
+    return {ConvertResultTo<OutputActions>(ConvertResult(std::move(zBoundsResult)), {})};
+  }
+  const std::vector<float32> zBoundValues = zBoundsResult.value();
+
+  // The Z boundary positions must be monotonically non-decreasing.
+  for(usize i = 1; i < zBoundValues.size(); i++)
+  {
+    if(zBoundValues[i] < zBoundValues[i - 1])
+    {
+      return MakePreflightErrorResult(-5558, fmt::format("The Z boundary positions in '{}' must be monotonically non-decreasing, but value {} ({}) is less than value {} ({}).", inputFile.string(), i,
+                                                         zBoundValues[i], i - 1, zBoundValues[i - 1]));
+    }
+  }
+
+  const float32 lastZBound = zBoundValues[origZDim];
+  if(lastZBound <= 0.0F)
+  {
+    return MakePreflightErrorResult(-5559, fmt::format("The total Z extent (last value in '{}') must be greater than 0, but was {}.", inputFile.string(), lastZBound));
+  }
+
+  const usize newZDim = ComputeRegularizedZDim(lastZBound, newZRes);
+
+  std::vector<usize> geomDims = {srcDimensions[0], srcDimensions[1], newZDim}; // ImageGeometry dimensions go fastest to slowest, XYZ.
+  std::vector<usize> dataArrayShape = {geomDims[2], geomDims[1], geomDims[0]}; // DataArray shape goes slowest to fastest, ZYX.
+  const FloatVec3 destSpacing = {srcSpacing[0], srcSpacing[1], newZRes};
+
+  std::vector<DataPath> ignorePaths; // already handled, so skip these when copying remaining child paths
+
+  if(pRemoveOriginalGeometry)
+  {
+    // Rename the current Image Geometry out of the way, then delete it after execute.
+    auto tempPathVector = srcImagePath.getPathVector();
+    std::string tempName = "." + tempPathVector.back();
+    tempPathVector.back() = tempName;
+    DataPath tempPath(tempPathVector);
+    resultOutputActions.value().appendDeferredAction(std::make_unique<RenameDataAction>(srcImagePath, tempName));
+    resultOutputActions.value().appendDeferredAction(std::make_unique<DeleteDataAction>(tempPath));
+
+    tempPathVector = srcImagePath.getPathVector();
+    tempPathVector.back() = k_TempGeometryName;
+    destImagePath = DataPath({tempPathVector});
+  }
+
+  // Create the destination Image Geometry and the resampled cell data arrays.
+  {
+    const AttributeMatrix* selectedCellData = srcImageGeom.getCellData();
+    if(selectedCellData == nullptr)
+    {
+      return MakePreflightErrorResult(-5560, fmt::format("'{}' must have a cell data Attribute Matrix.", srcImagePath.toString()));
+    }
+    std::string cellDataName = selectedCellData->getName();
+    ignorePaths.push_back(srcImagePath.createChildPath(cellDataName));
+
+    resultOutputActions.value().appendAction(
+        std::make_unique<CreateImageGeometryAction>(destImagePath, geomDims, srcOrigin, CreateImageGeometryAction::SpacingType{destSpacing[0], destSpacing[1], destSpacing[2]}, cellDataName));
+
+    DataPath newCellAttributeMatrixPath = destImagePath.createChildPath(cellDataName);
+    for(const auto& [identifier, object] : *selectedCellData)
+    {
+      // Guard instead of a reference cast: a cell AttributeMatrix may hold non-DataArray members
+      // (StringArray, NeighborList) which this filter cannot remap; fail cleanly rather than throw.
+      const auto* srcArrayPtr = dynamic_cast<const IDataArray*>(object.get());
+      if(srcArrayPtr == nullptr)
+      {
+        return MakePreflightErrorResult(
+            -5561, fmt::format("Cell Attribute Matrix member '{}' is not a DataArray and cannot be resampled by this filter. Remove it from '{}' or move it out of the cell Attribute Matrix.",
+                               object->getName(), srcImagePath.createChildPath(cellDataName).toString()));
+      }
+      DataType dataType = srcArrayPtr->getDataType();
+      ShapeType componentShape = srcArrayPtr->getIDataStoreRef().getComponentShape();
+      DataPath dataArrayPath = newCellAttributeMatrixPath.createChildPath(srcArrayPtr->getName());
+      resultOutputActions.value().appendAction(std::make_unique<CreateArrayAction>(dataType, dataArrayShape, std::move(componentShape), dataArrayPath));
+    }
+
+    preflightUpdatedValues.push_back({"Input Geometry Info", nx::core::GeometryHelpers::Description::GenerateGeometryInfo(srcImageGeom.getDimensions(), srcImageGeom.getSpacing(),
+                                                                                                                          srcImageGeom.getOrigin(), srcImageGeom.getUnits())});
+    preflightUpdatedValues.push_back({"Regularized Image Geometry Info", nx::core::GeometryHelpers::Description::GenerateGeometryInfo(geomDims, destSpacing, srcOrigin, srcImageGeom.getUnits())});
+  }
+
+  // Copy any remaining loose data groups or data arrays from the source geometry.
+  auto childPaths = GetAllChildDataPaths(dataStructure, srcImagePath, DataObject::Type::DataObject, ignorePaths);
+  if(childPaths.has_value())
+  {
+    for(const auto& childPath : childPaths.value())
+    {
+      DataPath copiedChildPath = ::RebasePath(childPath, srcImagePath, destImagePath);
+      if(dataStructure.getDataAs<BaseGroup>(childPath) != nullptr)
+      {
+        std::vector<DataPath> allCreatedPaths = {copiedChildPath};
+        auto pathsToBeCopied = GetAllChildDataPathsRecursive(dataStructure, childPath);
+        if(pathsToBeCopied.has_value())
+        {
+          for(const auto& sourcePath : pathsToBeCopied.value())
+          {
+            allCreatedPaths.push_back(::RebasePath(sourcePath, srcImagePath, destImagePath));
+          }
+        }
+        resultOutputActions.value().appendAction(std::make_unique<CopyDataObjectAction>(childPath, copiedChildPath, allCreatedPaths));
+      }
+      else
+      {
+        resultOutputActions.value().appendAction(std::make_unique<CopyDataObjectAction>(childPath, copiedChildPath, std::vector<DataPath>{copiedChildPath}));
+      }
+    }
+  }
+
+  if(pRemoveOriginalGeometry)
+  {
+    resultOutputActions.value().appendDeferredAction(std::make_unique<RenameDataAction>(destImagePath, srcImagePath.getTargetName()));
+
+    // Inform downstream filters that the cell data arrays are modified in place.
+    nx::core::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, srcImageGeom.getCellDataPath(), {});
+  }
+
+  return {std::move(resultOutputActions), std::move(preflightUpdatedValues)};
+}
+
+//------------------------------------------------------------------------------
+Result<> RegularizeZSpacingFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter*, const MessageHandler& messageHandler,
+                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+{
+  RegularizeZSpacingInputValues inputValues;
+
+  inputValues.SelectedImageGeometryPath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
+  inputValues.InputFile = filterArgs.value<FileSystemPathParameter::ValueType>(k_InputFile_Key);
+  inputValues.NewZRes = filterArgs.value<float32>(k_NewZRes_Key);
+  inputValues.RemoveOriginalImageGeom = filterArgs.value<bool>(k_RemoveOriginalGeometry_Key);
+  inputValues.CreatedImageGeometryPath = filterArgs.value<DataPath>(k_CreatedImageGeometry_Key);
+
+  if(inputValues.RemoveOriginalImageGeom)
+  {
+    auto tempPathVector = inputValues.SelectedImageGeometryPath.getPathVector();
+    tempPathVector.back() = k_TempGeometryName;
+    inputValues.CreatedImageGeometryPath = DataPath({tempPathVector});
+  }
+
+  return RegularizeZSpacing(dataStructure, messageHandler, shouldCancel, &inputValues)();
+}
+
+namespace
+{
+namespace SIMPL
+{
+constexpr StringLiteral k_CellAttributeMatrixPathKey = "CellAttributeMatrixPath";
+constexpr StringLiteral k_InputFileKey = "InputFile";
+constexpr StringLiteral k_NewZResKey = "NewZRes";
+} // namespace SIMPL
+} // namespace
+
+Result<Arguments> RegularizeZSpacingFilter::FromSIMPLJson(const nlohmann::json& json)
+{
+  Arguments args = RegularizeZSpacingFilter().getDefaultArguments();
+
+  std::vector<Result<>> results;
+
+  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::DataArraySelectionToGeometrySelectionFilterParameterConverter>(args, json, SIMPL::k_CellAttributeMatrixPathKey,
+                                                                                                                                      k_SelectedImageGeometryPath_Key));
+  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::InputFileFilterParameterConverter>(args, json, SIMPL::k_InputFileKey, k_InputFile_Key));
+  results.push_back(SIMPLConversion::ConvertParameter<SIMPLConversion::FloatFilterParameterConverter<float32>>(args, json, SIMPL::k_NewZResKey, k_NewZRes_Key));
+
+  Result<> conversionResult = MergeResults(std::move(results));
+
+  return ConvertResultTo<Arguments>(std::move(conversionResult), std::move(args));
+}
+} // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RegularizeZSpacingFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/RegularizeZSpacingFilter.hpp
@@ -1,0 +1,127 @@
+#pragma once
+
+#include "SimplnxCore/SimplnxCore_export.hpp"
+
+#include "simplnx/Filter/FilterTraits.hpp"
+#include "simplnx/Filter/IFilter.hpp"
+
+namespace nx::core
+{
+/**
+ * @class RegularizeZSpacingFilter
+ * @brief This filter resamples an Image Geometry with irregular Z slice spacing onto a regular Z spacing.
+ *
+ * The physical Z position of every original slice boundary is read from a text file containing
+ * (ZPoints + 1) whitespace-delimited float values. For each new, evenly spaced Z plane the filter
+ * selects the original plane whose boundary interval contains the new plane position and copies that
+ * original plane's entire XY cell-data slab. The X and Y dimensions and spacing are unchanged; the Z
+ * dimension count and Z spacing are recomputed.
+ */
+class SIMPLNXCORE_EXPORT RegularizeZSpacingFilter : public IFilter
+{
+public:
+  RegularizeZSpacingFilter() = default;
+  ~RegularizeZSpacingFilter() noexcept override = default;
+
+  RegularizeZSpacingFilter(const RegularizeZSpacingFilter&) = delete;
+  RegularizeZSpacingFilter(RegularizeZSpacingFilter&&) noexcept = delete;
+
+  RegularizeZSpacingFilter& operator=(const RegularizeZSpacingFilter&) = delete;
+  RegularizeZSpacingFilter& operator=(RegularizeZSpacingFilter&&) noexcept = delete;
+
+  // Parameter Keys
+  static constexpr StringLiteral k_SelectedImageGeometryPath_Key = "input_image_geometry_path";
+  static constexpr StringLiteral k_InputFile_Key = "input_file";
+  static constexpr StringLiteral k_NewZRes_Key = "new_z_spacing";
+  static constexpr StringLiteral k_RemoveOriginalGeometry_Key = "remove_original_geometry";
+  static constexpr StringLiteral k_CreatedImageGeometry_Key = "output_image_geometry_path";
+
+  /**
+   * @brief Reads SIMPL json and converts it simplnx Arguments.
+   * @param json
+   * @return Result<Arguments>
+   */
+  static Result<Arguments> FromSIMPLJson(const nlohmann::json& json);
+
+  /**
+   * @brief Returns the name of the filter.
+   * @return
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the C++ classname of this filter.
+   * @return
+   */
+  std::string className() const override;
+
+  /**
+   * @brief Returns the uuid of the filter.
+   * @return
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief Returns the human-readable name of the filter.
+   * @return
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
+   * @brief Returns the parameters of the filter (i.e. its inputs)
+   * @return
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief Returns parameters version integer.
+   * The Initial version should always be 1.
+   * Should be incremented everytime the parameters change.
+   * @return VersionType
+   */
+  VersionType parametersVersion() const override;
+
+  /**
+   * @brief Returns a copy of the filter.
+   * @return
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @param executionContext The ExecutionContext that can be used to determine the correct absolute path from a relative path
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
+
+  /**
+   * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
+   * On failure, there is no guarantee that the DataStructure is in a correct state.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @param executionContext The ExecutionContext that can be used to determine the correct absolute path from a relative path
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
+};
+} // namespace nx::core
+
+SIMPLNX_DEF_FILTER_TRAITS(nx::core, RegularizeZSpacingFilter, "d6599986-1932-4bfc-993d-71eafefe6db0");

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/SimplnxCoreLegacyUUIDMapping.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/SimplnxCoreLegacyUUIDMapping.hpp
@@ -97,6 +97,7 @@
 #include "SimplnxCore/Filters/ReadVolumeGraphicsFileFilter.hpp"
 #include "SimplnxCore/Filters/ReadVtkStructuredPointsFilter.hpp"
 #include "SimplnxCore/Filters/RegularGridSampleSurfaceMeshFilter.hpp"
+#include "SimplnxCore/Filters/RegularizeZSpacingFilter.hpp"
 #include "SimplnxCore/Filters/RemoveFlaggedFeaturesFilter.hpp"
 #include "SimplnxCore/Filters/RemoveFlaggedTrianglesFilter.hpp"
 #include "SimplnxCore/Filters/RemoveFlaggedVerticesFilter.hpp"
@@ -250,6 +251,7 @@ namespace nx::core
     {nx::core::Uuid::FromString("2861f4b4-8d50-5e69-9575-68c9d35f1256").value(), {nx::core::FilterTraits<WriteAvizoRectilinearCoordinateFilter>::uuid, &WriteAvizoRectilinearCoordinateFilter::FromSIMPLJson}}, // AvizoRectilinearCoordinateWriter
     {nx::core::Uuid::FromString("a043bd66-2681-5126-82e1-5fdc46694bf4").value(), {nx::core::FilterTraits<WriteVtkRectilinearGridFilter>::uuid, &WriteVtkRectilinearGridFilter::FromSIMPLJson}}, // VtkRectilinearGridWriter
     {nx::core::Uuid::FromString("0df3da89-9106-538e-b1a9-6bbf1cf0aa92").value(), {nx::core::FilterTraits<RegularGridSampleSurfaceMeshFilter>::uuid, &RegularGridSampleSurfaceMeshFilter::FromSIMPLJson}}, // RegularGridSampleSurfaceMesh
+    {nx::core::Uuid::FromString("bc4952fa-34ca-50bf-a1e9-2b9f7e5d47ce").value(), {nx::core::FilterTraits<RegularizeZSpacingFilter>::uuid, &RegularizeZSpacingFilter::FromSIMPLJson}}, // RegularizeZSpacing
     {nx::core::Uuid::FromString("75cfeb9b-cd4b-5a20-a344-4170b39bbfaf").value(), {nx::core::FilterTraits<UncertainRegularGridSampleSurfaceMeshFilter>::uuid, &UncertainRegularGridSampleSurfaceMeshFilter::FromSIMPLJson}}, // UncertainRegularGridSampleSurfaceMesh
     {nx::core::Uuid::FromString("3524c2dc-df60-5f90-b54b-e04946628a38").value(), {nx::core::FilterTraits<VerifyTriangleWindingFilter>::uuid, &VerifyTriangleWindingFilter::FromSIMPLJson}}, // VerifyTriangleWinding
     {nx::core::Uuid::FromString("6357243e-41a6-52c4-be2d-2f6894c39fcc").value(), {nx::core::FilterTraits<ComputeBoundaryElementFractionsFilter>::uuid, &ComputeBoundaryElementFractionsFilter::FromSIMPLJson}}, // ComputeBoundaryElementFractions

--- a/src/Plugins/SimplnxCore/test/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/test/CMakeLists.txt
@@ -124,6 +124,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   ReadVtkStructuredPointsTest.cpp
   ReadZeissTxmFileTest.cpp
   RegularGridSampleSurfaceMeshTest.cpp
+  RegularizeZSpacingTest.cpp
   RemoveFlaggedEdgesTest.cpp
   RemoveFlaggedFeaturesTest.cpp
   RemoveFlaggedTrianglesTest.cpp

--- a/src/Plugins/SimplnxCore/test/CopyFeatureArrayToElementArrayTest.cpp
+++ b/src/Plugins/SimplnxCore/test/CopyFeatureArrayToElementArrayTest.cpp
@@ -68,7 +68,7 @@ TEST_CASE("SimplnxCore::CopyFeatureArrayToElementArrayFilter: Preflight Error - 
   DataStructure dataStructure;
 
   // Cell-level FeatureIds must exist (validated selection parameter) but is not part of the tuple-count check.
-  Int32Array::CreateWithStore<DataStore<int32>>(dataStructure, k_CellFeatureIdsArrayName, {{30}}, {1});
+  Int32Array::CreateWithStore<DataStore<int32>>(dataStructure, k_CellFeatureIdsArrayName, {30}, {1});
 
   // Two feature-level arrays with deliberately different tuple counts (3 != 4) so the validateNumberOfTuples()
   // guard over the selected feature arrays fails and emits error -3020.

--- a/src/Plugins/SimplnxCore/test/RegularizeZSpacingTest.cpp
+++ b/src/Plugins/SimplnxCore/test/RegularizeZSpacingTest.cpp
@@ -9,6 +9,8 @@
 #include "simplnx/Parameters/FileSystemPathParameter.hpp"
 #include "simplnx/Parameters/GeometrySelectionParameter.hpp"
 #include "simplnx/Parameters/NumberParameter.hpp"
+#include "simplnx/Pipeline/Pipeline.hpp"
+#include "simplnx/Pipeline/PipelineFilter.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include "SimplnxCore/Filters/RegularizeZSpacingFilter.hpp"
@@ -334,5 +336,47 @@ TEST_CASE("SimplnxCore::RegularizeZSpacingFilter: Invalid Parameters", "[Simplnx
     auto preflightResult = filter.preflight(dataStructure, args);
     SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
     REQUIRE(preflightResult.outputActions.errors()[0].code == -5561);
+  }
+}
+
+TEST_CASE("SimplnxCore::RegularizeZSpacingFilter: SIMPL Backwards Compatibility", "[SimplnxCore][RegularizeZSpacingFilter][BackwardsCompatibility]")
+{
+  auto app = Application::GetOrCreateInstance();
+  UnitTest::LoadPlugins();
+  auto filterList = app->getFilterList();
+
+  const fs::path conversionDir = fs::path(nx::core::unit_test::k_SourceDir.view()) / "test" / "simpl_conversion";
+
+  const std::vector<std::pair<std::string, fs::path>> fixtures = {
+      {"SIMPL 6.5 (UUID)", conversionDir / "6_5" / "RegularizeZSpacingFilter.json"},
+      {"SIMPL 6.4 (Filter_Name)", conversionDir / "6_4" / "RegularizeZSpacingFilter.json"},
+  };
+
+  for(const auto& [label, fixturePath] : fixtures)
+  {
+    DYNAMIC_SECTION(label)
+    {
+      auto pipelineResult = Pipeline::FromSIMPLFile(fixturePath, filterList);
+      REQUIRE(pipelineResult.valid());
+
+      auto& pipeline = pipelineResult.value();
+      REQUIRE(pipeline.size() == 1);
+
+      auto* pipelineFilter = dynamic_cast<PipelineFilter*>(pipeline.at(0));
+      REQUIRE(pipelineFilter != nullptr);
+
+      const IFilter* filter = pipelineFilter->getFilter();
+      REQUIRE(filter != nullptr);
+      REQUIRE(filter->uuid() == FilterTraits<RegularizeZSpacingFilter>::uuid);
+
+      const Arguments args = pipelineFilter->getArguments();
+      // Only the DataContainer name survives conversion of the legacy CellAttributeMatrixPath;
+      // the filter binds to the geometry's assigned cell AttributeMatrix (see V&V report, delta 5).
+      CHECK(args.value<DataPath>(RegularizeZSpacingFilter::k_SelectedImageGeometryPath_Key) == DataPath({"DataContainer"}));
+      CHECK(args.value<FileSystemPathParameter::ValueType>(RegularizeZSpacingFilter::k_InputFile_Key) == fs::path("/test/z_positions.txt"));
+      CHECK(args.value<float32>(RegularizeZSpacingFilter::k_NewZRes_Key) == 0.5f);
+      // Legacy had no new-geometry option; the unconverted default must stay in place.
+      CHECK(args.value<bool>(RegularizeZSpacingFilter::k_RemoveOriginalGeometry_Key) == true);
+    }
   }
 }

--- a/src/Plugins/SimplnxCore/test/RegularizeZSpacingTest.cpp
+++ b/src/Plugins/SimplnxCore/test/RegularizeZSpacingTest.cpp
@@ -1,0 +1,338 @@
+#include <catch2/catch.hpp>
+
+#include "simplnx/Core/Application.hpp"
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/DataStructure/DataStore.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/DataStructure/StringArray.hpp"
+#include "simplnx/Parameters/BoolParameter.hpp"
+#include "simplnx/Parameters/FileSystemPathParameter.hpp"
+#include "simplnx/Parameters/GeometrySelectionParameter.hpp"
+#include "simplnx/Parameters/NumberParameter.hpp"
+#include "simplnx/UnitTest/UnitTestCommon.hpp"
+
+#include "SimplnxCore/Filters/RegularizeZSpacingFilter.hpp"
+#include "SimplnxCore/SimplnxCore_test_dirs.hpp"
+
+#include <fstream>
+
+namespace fs = std::filesystem;
+using namespace nx::core;
+
+namespace
+{
+const std::string k_ImageGeometryName = "ImageGeometry";
+const std::string k_CellDataName = "Cell Data";
+const std::string k_DataArrayName = "Data";
+const std::string k_LooseArrayName = "LooseData";
+const std::string k_OutputGeometryName = "Regularized Geometry";
+
+const DataPath k_InputGeometryPath({k_ImageGeometryName});
+const DataPath k_OutputGeometryPath({k_OutputGeometryName});
+
+// Builds a 2 x 1 x 4 (X,Y,Z) Image Geometry whose single-component int32 cell array
+// is filled so that each tuple's value equals its tuple index. This makes the
+// remapping trivial to verify: an output tuple copied from source tuple S has value S.
+DataStructure createTestDataStructure()
+{
+  DataStructure dataStructure;
+
+  auto* imageGeom = ImageGeom::Create(dataStructure, k_ImageGeometryName);
+  imageGeom->setDimensions(SizeVec3{2, 1, 4}); // X, Y, Z
+  imageGeom->setSpacing(FloatVec3{0.5F, 0.75F, 1.0F});
+  imageGeom->setOrigin(FloatVec3{1.0F, 2.0F, 3.0F});
+
+  // AttributeMatrix tuple shape is slowest-to-fastest (Z, Y, X)
+  auto* cellAM = AttributeMatrix::Create(dataStructure, k_CellDataName, std::vector<usize>{4, 1, 2}, imageGeom->getId());
+  imageGeom->setCellData(*cellAM);
+
+  auto* dataArray = Int32Array::CreateWithStore<DataStore<int32>>(dataStructure, k_DataArrayName, {4, 1, 2}, {1}, cellAM->getId());
+  auto& dataStore = dataArray->getDataStoreRef();
+  for(usize i = 0; i < dataStore.getNumberOfTuples(); i++)
+  {
+    dataStore[i] = static_cast<int32>(i);
+  }
+
+  // A loose DataArray directly under the geometry (outside the cell AttributeMatrix) to exercise
+  // the loose-child copy path in preflight.
+  auto* looseArray = Int32Array::CreateWithStore<DataStore<int32>>(dataStructure, k_LooseArrayName, {4}, {1}, imageGeom->getId());
+  auto& looseStore = looseArray->getDataStoreRef();
+  for(usize i = 0; i < looseStore.getNumberOfTuples(); i++)
+  {
+    looseStore[i] = static_cast<int32>(100 + i);
+  }
+
+  return dataStructure;
+}
+
+// Writes the Z boundary positions file and returns its path.
+fs::path writeZBoundsFile(const std::string& fileName, const std::vector<float32>& values)
+{
+  fs::path outputDir(unit_test::k_BinaryTestOutputDir.view());
+  fs::create_directories(outputDir);
+  fs::path filePath = outputDir / fileName;
+  std::ofstream outFile(filePath);
+  for(float32 value : values)
+  {
+    outFile << value << "\n";
+  }
+  return filePath;
+}
+} // namespace
+
+TEST_CASE("SimplnxCore::RegularizeZSpacingFilter: Valid Execution (New Geometry)", "[SimplnxCore][RegularizeZSpacingFilter]")
+{
+  DataStructure dataStructure = createTestDataStructure();
+
+  // Irregular Z boundaries: slices span [0,1], [1,3], [3,6], [6,10]; total Z extent = 10.
+  const fs::path zBoundsFile = writeZBoundsFile("RegularizeZSpacing_new_geom.txt", {0.0F, 1.0F, 3.0F, 6.0F, 10.0F});
+  const float32 newZRes = 2.0F;
+
+  RegularizeZSpacingFilter filter;
+  Arguments args;
+  args.insertOrAssign(RegularizeZSpacingFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_InputGeometryPath));
+  args.insertOrAssign(RegularizeZSpacingFilter::k_InputFile_Key, std::make_any<fs::path>(zBoundsFile));
+  args.insertOrAssign(RegularizeZSpacingFilter::k_NewZRes_Key, std::make_any<float32>(newZRes));
+  args.insertOrAssign(RegularizeZSpacingFilter::k_RemoveOriginalGeometry_Key, std::make_any<bool>(false));
+  args.insertOrAssign(RegularizeZSpacingFilter::k_CreatedImageGeometry_Key, std::make_any<DataPath>(k_OutputGeometryPath));
+
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<ImageGeom>(k_OutputGeometryPath));
+  const auto& outputGeom = dataStructure.getDataRefAs<ImageGeom>(k_OutputGeometryPath);
+
+  // newZDim = (size_t)(10 / 2) = 5; X and Y unchanged.
+  const SizeVec3 outDims = outputGeom.getDimensions();
+  REQUIRE(outDims[0] == 2);
+  REQUIRE(outDims[1] == 1);
+  REQUIRE(outDims[2] == 5);
+
+  // Spacing: X and Y preserved, Z becomes newZRes.
+  const FloatVec3 outSpacing = outputGeom.getSpacing();
+  REQUIRE(outSpacing[0] == Approx(0.5F));
+  REQUIRE(outSpacing[1] == Approx(0.75F));
+  REQUIRE(outSpacing[2] == Approx(2.0F));
+
+  // Origin preserved.
+  const FloatVec3 outOrigin = outputGeom.getOrigin();
+  REQUIRE(outOrigin[0] == Approx(1.0F));
+  REQUIRE(outOrigin[1] == Approx(2.0F));
+  REQUIRE(outOrigin[2] == Approx(3.0F));
+
+  // Class 1 (Analytical) oracle — closed-form indirection lookup output[i] = input[map[i]].
+  // Hand derivation of the new-plane -> old-plane map. For new plane i the source plane is the
+  // largest iter in [1, origZ=4) with (i * newZRes) > zBound[iter], else 0. zBound = {0,1,3,6,10}:
+  //   i=0: pos=0  -> 0 > {1,3,6}? no,no,no          -> plane 0
+  //   i=1: pos=2  -> 2 > {1,3,6}? yes,no,no         -> plane 1
+  //   i=2: pos=4  -> 4 > {1,3,6}? yes,yes,no        -> plane 2
+  //   i=3: pos=6  -> 6 > {1,3,6}? yes,yes,no(strict)-> plane 2
+  //   i=4: pos=8  -> 8 > {1,3,6}? yes,yes,yes       -> plane 3
+  // map = [0,1,2,2,3]. Each source tuple's value equals its tuple index and each plane holds 2
+  // tuples (X=2,Y=1), so plane p contributes source tuples {2p, 2p+1}. Expected output:
+  //   plane0<-src0: 0,1 | plane1<-src1: 2,3 | plane2<-src2: 4,5 | plane3<-src2: 4,5 | plane4<-src3: 6,7
+  const DataPath outputArrayPath = k_OutputGeometryPath.createChildPath(k_CellDataName).createChildPath(k_DataArrayName);
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<Int32Array>(outputArrayPath));
+  const auto& outStore = dataStructure.getDataRefAs<Int32Array>(outputArrayPath).getDataStoreRef();
+
+  const std::vector<int32> expected = {0, 1, 2, 3, 4, 5, 4, 5, 6, 7};
+  REQUIRE(outStore.getNumberOfTuples() == expected.size());
+  for(usize i = 0; i < expected.size(); i++)
+  {
+    INFO(fmt::format("tuple index {}", i));
+    REQUIRE(outStore[i] == expected[i]);
+  }
+
+  // Loose child data (outside the cell AM) is copied into the new geometry with values intact.
+  const DataPath outputLoosePath = k_OutputGeometryPath.createChildPath(k_LooseArrayName);
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<Int32Array>(outputLoosePath));
+  const auto& outLooseStore = dataStructure.getDataRefAs<Int32Array>(outputLoosePath).getDataStoreRef();
+  REQUIRE(outLooseStore.getNumberOfTuples() == 4);
+  for(usize i = 0; i < 4; i++)
+  {
+    REQUIRE(outLooseStore[i] == static_cast<int32>(100 + i));
+  }
+
+  // Original geometry should still exist (not in place).
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<ImageGeom>(k_InputGeometryPath));
+}
+
+TEST_CASE("SimplnxCore::RegularizeZSpacingFilter: Valid Execution (Spacing Exceeds Extent)", "[SimplnxCore][RegularizeZSpacingFilter]")
+{
+  DataStructure dataStructure = createTestDataStructure();
+
+  const fs::path zBoundsFile = writeZBoundsFile("RegularizeZSpacing_clamp.txt", {0.0F, 1.0F, 3.0F, 6.0F, 10.0F});
+
+  // Class 1 derivation of the newZDim clamp: newZ = (usize)(10 / 20) = 0 -> clamped to 1.
+  // For the single new plane i=0, pos = 0 is not > any interior zBound, so the source is plane 0.
+  // Output = one plane holding source tuples {0, 1}; Z spacing becomes 20.
+  const float32 newZRes = 20.0F;
+
+  RegularizeZSpacingFilter filter;
+  Arguments args;
+  args.insertOrAssign(RegularizeZSpacingFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_InputGeometryPath));
+  args.insertOrAssign(RegularizeZSpacingFilter::k_InputFile_Key, std::make_any<fs::path>(zBoundsFile));
+  args.insertOrAssign(RegularizeZSpacingFilter::k_NewZRes_Key, std::make_any<float32>(newZRes));
+  args.insertOrAssign(RegularizeZSpacingFilter::k_RemoveOriginalGeometry_Key, std::make_any<bool>(false));
+  args.insertOrAssign(RegularizeZSpacingFilter::k_CreatedImageGeometry_Key, std::make_any<DataPath>(k_OutputGeometryPath));
+
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+  const auto& outputGeom = dataStructure.getDataRefAs<ImageGeom>(k_OutputGeometryPath);
+  const SizeVec3 outDims = outputGeom.getDimensions();
+  REQUIRE(outDims[0] == 2);
+  REQUIRE(outDims[1] == 1);
+  REQUIRE(outDims[2] == 1);
+  REQUIRE(outputGeom.getSpacing()[2] == Approx(20.0F));
+
+  const DataPath outputArrayPath = k_OutputGeometryPath.createChildPath(k_CellDataName).createChildPath(k_DataArrayName);
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<Int32Array>(outputArrayPath));
+  const auto& outStore = dataStructure.getDataRefAs<Int32Array>(outputArrayPath).getDataStoreRef();
+  REQUIRE(outStore.getNumberOfTuples() == 2);
+  REQUIRE(outStore[0] == 0);
+  REQUIRE(outStore[1] == 1);
+}
+
+TEST_CASE("SimplnxCore::RegularizeZSpacingFilter: Valid Execution (In Place)", "[SimplnxCore][RegularizeZSpacingFilter]")
+{
+  DataStructure dataStructure = createTestDataStructure();
+
+  const fs::path zBoundsFile = writeZBoundsFile("RegularizeZSpacing_bounds.txt", {0.0F, 1.0F, 3.0F, 6.0F, 10.0F});
+
+  RegularizeZSpacingFilter filter;
+  Arguments args;
+  args.insertOrAssign(RegularizeZSpacingFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_InputGeometryPath));
+  args.insertOrAssign(RegularizeZSpacingFilter::k_InputFile_Key, std::make_any<fs::path>(zBoundsFile));
+  args.insertOrAssign(RegularizeZSpacingFilter::k_NewZRes_Key, std::make_any<float32>(2.0F));
+  args.insertOrAssign(RegularizeZSpacingFilter::k_RemoveOriginalGeometry_Key, std::make_any<bool>(true));
+  args.insertOrAssign(RegularizeZSpacingFilter::k_CreatedImageGeometry_Key, std::make_any<DataPath>(k_OutputGeometryPath));
+
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+  // The result should have replaced the original geometry (same name), and no output-name geometry exists.
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<ImageGeom>(k_InputGeometryPath));
+  REQUIRE(dataStructure.getDataAs<ImageGeom>(k_OutputGeometryPath) == nullptr);
+
+  const auto& resultGeom = dataStructure.getDataRefAs<ImageGeom>(k_InputGeometryPath);
+  REQUIRE(resultGeom.getDimensions()[2] == 5);
+  REQUIRE(resultGeom.getSpacing()[2] == Approx(2.0F));
+}
+
+TEST_CASE("SimplnxCore::RegularizeZSpacingFilter: Invalid Parameters", "[SimplnxCore][RegularizeZSpacingFilter]")
+{
+  DataStructure dataStructure = createTestDataStructure();
+  RegularizeZSpacingFilter filter;
+
+  SECTION("Non-positive Z spacing")
+  {
+    const fs::path zBoundsFile = writeZBoundsFile("RegularizeZSpacing_bounds.txt", {0.0F, 1.0F, 3.0F, 6.0F, 10.0F});
+    Arguments args;
+    args.insertOrAssign(RegularizeZSpacingFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_InputGeometryPath));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_InputFile_Key, std::make_any<fs::path>(zBoundsFile));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_NewZRes_Key, std::make_any<float32>(0.0F));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_RemoveOriginalGeometry_Key, std::make_any<bool>(false));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_CreatedImageGeometry_Key, std::make_any<DataPath>(k_OutputGeometryPath));
+
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+    REQUIRE(preflightResult.outputActions.errors()[0].code == -5555);
+  }
+
+  SECTION("File with too few values")
+  {
+    const fs::path zBoundsFile = writeZBoundsFile("RegularizeZSpacing_short.txt", {0.0F, 1.0F, 3.0F});
+    Arguments args;
+    args.insertOrAssign(RegularizeZSpacingFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_InputGeometryPath));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_InputFile_Key, std::make_any<fs::path>(zBoundsFile));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_NewZRes_Key, std::make_any<float32>(2.0F));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_RemoveOriginalGeometry_Key, std::make_any<bool>(false));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_CreatedImageGeometry_Key, std::make_any<DataPath>(k_OutputGeometryPath));
+
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+    REQUIRE(preflightResult.outputActions.errors()[0].code == -5557);
+  }
+
+  SECTION("Non-monotonic Z boundary values")
+  {
+    const fs::path zBoundsFile = writeZBoundsFile("RegularizeZSpacing_nonmono.txt", {0.0F, 3.0F, 1.0F, 6.0F, 10.0F});
+    Arguments args;
+    args.insertOrAssign(RegularizeZSpacingFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_InputGeometryPath));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_InputFile_Key, std::make_any<fs::path>(zBoundsFile));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_NewZRes_Key, std::make_any<float32>(2.0F));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_RemoveOriginalGeometry_Key, std::make_any<bool>(false));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_CreatedImageGeometry_Key, std::make_any<DataPath>(k_OutputGeometryPath));
+
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+    REQUIRE(preflightResult.outputActions.errors()[0].code == -5558);
+  }
+
+  SECTION("Zero total Z extent")
+  {
+    // Equal values are monotonically non-decreasing, so this reaches the extent check (-5559).
+    const fs::path zBoundsFile = writeZBoundsFile("RegularizeZSpacing_zeroextent.txt", {0.0F, 0.0F, 0.0F, 0.0F, 0.0F});
+    Arguments args;
+    args.insertOrAssign(RegularizeZSpacingFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_InputGeometryPath));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_InputFile_Key, std::make_any<fs::path>(zBoundsFile));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_NewZRes_Key, std::make_any<float32>(2.0F));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_RemoveOriginalGeometry_Key, std::make_any<bool>(false));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_CreatedImageGeometry_Key, std::make_any<DataPath>(k_OutputGeometryPath));
+
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+    REQUIRE(preflightResult.outputActions.errors()[0].code == -5559);
+  }
+
+  SECTION("Missing cell Attribute Matrix")
+  {
+    DataStructure geomOnlyDataStructure;
+    auto* geomOnly = ImageGeom::Create(geomOnlyDataStructure, k_ImageGeometryName);
+    geomOnly->setDimensions(SizeVec3{2, 1, 4});
+    geomOnly->setSpacing(FloatVec3{0.5F, 0.75F, 1.0F});
+    geomOnly->setOrigin(FloatVec3{1.0F, 2.0F, 3.0F});
+
+    const fs::path zBoundsFile = writeZBoundsFile("RegularizeZSpacing_noam.txt", {0.0F, 1.0F, 3.0F, 6.0F, 10.0F});
+    Arguments args;
+    args.insertOrAssign(RegularizeZSpacingFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_InputGeometryPath));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_InputFile_Key, std::make_any<fs::path>(zBoundsFile));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_NewZRes_Key, std::make_any<float32>(2.0F));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_RemoveOriginalGeometry_Key, std::make_any<bool>(false));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_CreatedImageGeometry_Key, std::make_any<DataPath>(k_OutputGeometryPath));
+
+    auto preflightResult = filter.preflight(geomOnlyDataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+    REQUIRE(preflightResult.outputActions.errors()[0].code == -5560);
+  }
+
+  SECTION("Non-DataArray member in cell Attribute Matrix")
+  {
+    // A StringArray cannot be resampled; preflight must reject it cleanly rather than throw.
+    const DataPath cellAMPath = k_InputGeometryPath.createChildPath(k_CellDataName);
+    auto& cellAM = dataStructure.getDataRefAs<AttributeMatrix>(cellAMPath);
+    StringArray::CreateWithValues(dataStructure, "Labels", {4, 1, 2}, std::vector<std::string>(8, "label"), cellAM.getId());
+
+    const fs::path zBoundsFile = writeZBoundsFile("RegularizeZSpacing_stringarray.txt", {0.0F, 1.0F, 3.0F, 6.0F, 10.0F});
+    Arguments args;
+    args.insertOrAssign(RegularizeZSpacingFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_InputGeometryPath));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_InputFile_Key, std::make_any<fs::path>(zBoundsFile));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_NewZRes_Key, std::make_any<float32>(2.0F));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_RemoveOriginalGeometry_Key, std::make_any<bool>(false));
+    args.insertOrAssign(RegularizeZSpacingFilter::k_CreatedImageGeometry_Key, std::make_any<DataPath>(k_OutputGeometryPath));
+
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+    REQUIRE(preflightResult.outputActions.errors()[0].code == -5561);
+  }
+}

--- a/src/Plugins/SimplnxCore/test/simpl_conversion/6_4/RegularizeZSpacingFilter.json
+++ b/src/Plugins/SimplnxCore/test/simpl_conversion/6_4/RegularizeZSpacingFilter.json
@@ -1,0 +1,19 @@
+{
+  "PipelineBuilder": {
+    "Name": "Regularize Z Spacing 6.4 Backwards Compatibility Test",
+    "Number_Filters": 1,
+    "Version": 6
+  },
+  "0": {
+    "Filter_Enabled": true,
+    "Filter_Human_Label": "Regularize Z Spacing",
+    "Filter_Name": "RegularizeZSpacing",
+    "CellAttributeMatrixPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": ""
+    },
+    "InputFile": "/test/z_positions.txt",
+    "NewZRes": 0.5
+  }
+}

--- a/src/Plugins/SimplnxCore/test/simpl_conversion/6_5/RegularizeZSpacingFilter.json
+++ b/src/Plugins/SimplnxCore/test/simpl_conversion/6_5/RegularizeZSpacingFilter.json
@@ -1,0 +1,20 @@
+{
+  "PipelineBuilder": {
+    "Name": "Regularize Z Spacing Backwards Compatibility Test",
+    "Number_Filters": 1,
+    "Version": 6
+  },
+  "0": {
+    "Filter_Enabled": true,
+    "Filter_Human_Label": "Regularize Z Spacing",
+    "Filter_Name": "RegularizeZSpacing",
+    "Filter_Uuid": "{bc4952fa-34ca-50bf-a1e9-2b9f7e5d47ce}",
+    "CellAttributeMatrixPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": ""
+    },
+    "InputFile": "/test/z_positions.txt",
+    "NewZRes": 0.5
+  }
+}

--- a/src/Plugins/SimplnxCore/vv/RegularizeZSpacingFilter.md
+++ b/src/Plugins/SimplnxCore/vv/RegularizeZSpacingFilter.md
@@ -1,0 +1,97 @@
+# V&V Report: RegularizeZSpacingFilter
+
+|        |              |
+|--------|--------------|
+| Plugin | SimplnxCore |
+| SIMPLNX UUID | `d6599986-1932-4bfc-993d-71eafefe6db0` |
+| DREAM3D 6.5.171 equivalent | `RegularizeZSpacing` — `Source/Plugins/Sampling/SamplingFilters/RegularizeZSpacing.{h,cpp}` (legacy UUID `bc4952fa-34ca-50bf-a1e9-2b9f7e5d47ce`) |
+| Verified commit | *<filled at SBIR deliverable assembly>* |
+| Status | READY FOR REVIEW |
+| Sign-off | *Michael Jackson <mike.jackson@bluequartz.net> (port + V&V cycle, 2026-07-08); second-engineer oracle review pending* |
+
+## At a glance
+
+| Aspect                 | Current state                                                                                                                |
+|------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| Algorithm Relationship | **Port** of legacy `RegularizeZSpacing::execute()` — identical Z-plane mapping rule and `floor(extent/newZRes)` dim math (independently hand-traced, including the strict-`>` boundary and clamp cases). Five port-time deltas (bulk copy, new-geometry output mode, preflight validation, parallelization, cell-AM binding); none change output for valid input. |
+| Oracle (confirmed)     | **Class 1 (Analytical)** primary + **Class 4 (Invariant)** companion — closed-form indirection map `out[i] = in[map[i]]`. Element-wise Class 1 assertions in 2 fixtures (`Valid Execution (New Geometry)`, `Valid Execution (Spacing Exceeds Extent)`); Class 4 invariants across the valid fixtures. All pass in-core + OOC. |
+| Code paths enumerated  | 12 of 14 exercised; the 2 uncovered are the redundant file-open guard and the cancel check (reasons below).                  |
+| Tests today            | 4 TEST_CASEs (2 Class-1 valid + 1 in-place valid + 1 invalid-parameters with 6 SECTIONs); every documented preflight error code asserted explicitly. |
+| Exemplar archive       | **None** — inline analytical fixtures (no `download_test_data`; avoids a circular oracle per project policy).                 |
+| Legacy comparison      | **Run** vs DREAM3D 6.5.171 on a synthetic multi-type fixture (int32 + bool + 3-component float). Bit-identical: legacy == SIMPLNX == Class-1 oracle on every array and on geometry (dims/spacing/origin). |
+| Bug flags              | None.                                                                                                                        |
+| V&V phase              | Oracle applied and reconciled; algorithm review + three independent adversarial reviews applied (fixes folded in); dual-build green; legacy A/B bit-identical with 0 deviations. **Outstanding:** second-engineer oracle review before COMPLETE. |
+
+## Summary
+
+`RegularizeZSpacingFilter` resamples an Image Geometry with irregular Z slice spacing onto a uniform Z spacing: it reads the physical Z position of each original slice boundary from a text file (`ZPoints + 1` values), computes `newZ = floor(totalZExtent / newZSpacing)` (min 1), and copies each new plane's cell data from the original plane whose boundary interval contains it. Verification used a **Class 1 (Analytical)** oracle — the algorithm is a closed-form indirection lookup `output[i] = input[map[i]]` — with **Class 4 (Invariant)** companions (X/Y dims and spacing preserved, origin preserved, Z spacing becomes the requested value). A direct A/B against DREAM3D 6.5.171 on a synthetic multi-type dataset is **bit-identical** (0 deviations); legacy, SIMPLNX, and the analytical oracle agree exactly.
+
+## Algorithm Relationship
+
+*Classification:* **Port** ~~| Minor changes | Rewrite | New filter~~
+
+*Evidence:* Near line-by-line translation of legacy `RegularizeZSpacing::execute()`. Same SIMPL UUID retained and mapped in `SimplnxCoreLegacyUUIDMapping.hpp`. The new→old Z-plane mapping loop (`plane` = largest `iter` in `[1, origZ)` with `i*newZRes > zBound[iter]`, else 0) and the `newZ = (size_t)(lastZBound / newZRes)` (min 1) computation are reproduced exactly; an independent hand-trace confirmed the arithmetic types match legacy expression-by-expression (float32 throughout, no double promotion), so even float-boundary cases agree.
+
+*Port-time deltas (none change output for valid input — confirmed bit-identical in the legacy A/B):*
+
+1. **Data copy**: legacy per-tuple `memcpy` via a rebuilt `newindicies` table → SIMPLNX bulk `AbstractDataStore::copyFrom` of one contiguous plane-slab per destination plane. Same bytes moved; more efficient and out-of-core friendly.
+2. **Output mode**: legacy replaces the cell AttributeMatrix in place → SIMPLNX uses the modern new-geometry pattern (`CreateImageGeometryAction` + rename + deferred delete) with a "Perform In Place" toggle (default true). In-place mode is behaviorally equivalent to legacy.
+3. **Preflight validation added**: positive `new_z_spacing`; input file has ≥ `ZPoints + 1` parseable values; values monotonically non-decreasing; positive total Z extent; only DataArray members in the cell AM. These reject bad input that legacy silently consumed (short files reused the last-read value; non-monotonic files produced a garbage mapping; zero extent produced a clamped 1-plane output) but do not alter valid-input output. The `.txt` extension is a dialog hint only (`acceptAllExtensions`), so converted legacy pipelines referencing `.dat`/`.csv`/extensionless files still validate.
+4. **Parallelization**: per-array parallel task runner (one task per cell array, distinct stores) vs legacy serial loop. No output effect.
+5. **Cell-AM binding**: legacy took an explicit AttributeMatrix path; SIMPLNX takes the geometry and uses its assigned cell AttributeMatrix. `FromSIMPLJson` keeps only the DataContainer name from the legacy `CellAttributeMatrixPath` (the AM name is discarded). For the overwhelmingly common single-cell-AM case this is identity; corner-case consequences for converted pipelines are documented in the deviations file's scope note. Related accept/reject divergences: a geometry with no cell AM now errors (`-5560`, impossible to express in legacy), and a stale AM name that legacy rejected converts to the geometry's actual cell AM and proceeds.
+
+*Material PRs since baseline:* new filter port (this branch); no prior history.
+
+## Oracle
+
+*Class:* **1 (Analytical)** primary + **4 (Invariant)** companion.
+
+*Applied (Class 1):* The output cell data is a closed-form indirection lookup `output_tuple[t] = input_tuple[map[t]]`, where `map` is derived by hand from the Z-positions file and `new_z_spacing`. Primary fixture (origZ=4, zBound `{0,1,3,6,10}`, newZRes 2.0): new→old plane map `[0,1,2,2,3]`, giving a fully hand-derived 10-tuple expected output. Clamp fixture (same bounds, newZRes 20.0): `newZ = floor(10/20) = 0 → 1`, expected output = source plane 0. Both derivations are embedded as comments beside the `REQUIRE`s.
+
+*Applied (Class 4):* X and Y dimensions and spacing preserved, origin preserved, Z spacing equals `new_z_spacing`, `newZ == max(1, floor(lastZBound / newZRes))`, and loose (non-cell-AM) children are carried over intact. Asserted in the valid-execution fixtures.
+
+*Encoded:* `test/RegularizeZSpacingTest.cpp::SimplnxCore::RegularizeZSpacingFilter: Valid Execution (New Geometry)` (element-wise Class 1 + invariants), `...::Valid Execution (Spacing Exceeds Extent)` (clamp-path Class 1), `...::Valid Execution (In Place)` (in-place invariants) — all pass in-core (`NX-Com-Qt69-Vtk95-Rel`) and out-of-core (`NX-OOC-Qt69-Vtk95-Rel`).
+
+*Second-engineer review:* **Pending.** The oracle is a deterministic index remap (lowest-risk oracle class); review still recommended before promotion to COMPLETE.
+
+## Code path coverage
+
+`12 of 14 paths exercised.` The 2 uncovered are a redundant file-open guard and the cancel check, listed with reasons.
+
+Source: `src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RegularizeZSpacing.cpp` (217 lines) + `Filters/RegularizeZSpacingFilter.cpp` (309 lines, preflight). Logical phases: **(a) preflight validation**, **(b) output-geometry construction**, **(c) mapping + copy**.
+
+| #  | Phase | Path | Test case |
+|----|-------|------|-----------|
+| 1  | (a) | `new_z_spacing <= 0` → error `-5555` | `Invalid Parameters` / "Non-positive Z spacing" (code asserted) |
+| 2  | (a) | input file cannot be opened → error `-5556` | *Not directly tested. File existence is validated by the `FileSystemPathParameter` before preflight; this is a redundant safety net reachable only by a filesystem race.* |
+| 3  | (a) | file has fewer than `ZPoints + 1` parseable values → error `-5557` | `Invalid Parameters` / "File with too few values" (code asserted) |
+| 4  | (a) | Z boundary values not monotonically non-decreasing → error `-5558` | `Invalid Parameters` / "Non-monotonic Z boundary values" (code asserted) |
+| 5  | (a) | total Z extent (last value) `<= 0` → error `-5559` | `Invalid Parameters` / "Zero total Z extent" (code asserted) |
+| 6  | (b) | geometry has no cell AttributeMatrix → error `-5560` | `Invalid Parameters` / "Missing cell Attribute Matrix" (code asserted) |
+| 7  | (b) | cell AM member is not a DataArray → error `-5561` | `Invalid Parameters` / "Non-DataArray member in cell Attribute Matrix" (code asserted) |
+| 8  | (b) | `remove_original_geometry == true` → rename src, create temp geom, deferred delete + rename | `Valid Execution (In Place)` |
+| 9  | (b) | `remove_original_geometry == false` → create new geometry | `Valid Execution (New Geometry)` |
+| 10 | (b) | copy loose child data objects from source geometry (component-wise path rebase) | `Valid Execution (New Geometry)` — `LooseData` presence + values asserted |
+| 11 | (c) | `newZ == 0` → clamp to 1 (`ComputeRegularizedZDim`) | `Valid Execution (Spacing Exceeds Extent)` — Class 1 expected output asserted |
+| 12 | (c) | build `newToOldZPlane` mapping (nearest-below, strict `>`) | `Valid Execution (New Geometry)` — verified against oracle map `[0,1,2,2,3]` |
+| 13 | (c) | per-array bulk `copyFrom` of each plane slab | all three valid fixtures + legacy A/B (int32/bool/float3) |
+| 14 | (c) | cancel check (per-array, per-plane) | *Not directly tested. Requires cancel-signal injection; branch is a simple early return.* |
+
+## Test inventory
+
+| Test case | Status | Notes |
+|-----------|--------|-------|
+| `Valid Execution (New Geometry)` | new-for-V&V | Class 1 oracle: asserts output Z dim (5), preserved X/Y dims + spacing, preserved origin, Z spacing = 2.0, the 10-tuple expected `Data` array element-wise, loose-child (`LooseData`) copy with values, and source-geometry retention. |
+| `Valid Execution (In Place)` | new-for-V&V | Asserts in-place result replaces the source geometry (same name), no output-name geometry created, output Z dim + Z spacing correct. |
+| `Valid Execution (Spacing Exceeds Extent)` | new-for-V&V | Class 1 clamp fixture: `newZRes` (20) > extent (10) → 1 output plane sourced from plane 0; dims (2,1,1), Z spacing 20, `Data` = {0,1} asserted. |
+| `Invalid Parameters` | new-for-V&V | 6 SECTIONs — non-positive spacing (`-5555`), too-few file values (`-5557`), non-monotonic values (`-5558`), zero total extent (`-5559`), missing cell AM (`-5560`), non-DataArray cell member (`-5561`); each asserts the specific error code. |
+
+## Exemplar archive
+
+- **Archive:** None — inline analytical fixtures.
+- **SHA512:** N/A (no `download_test_data`).
+- **Provenance:** N/A — Class 1/4 oracles live in the test source directly; no exemplar archive to provenance.
+
+## Deviations from DREAM3D 6.5.171
+
+No deviations observed. Comparison run on a synthetic Image Geometry (dims 3×2×4; int32 `Data`, `DataArray<bool>` `Mask`, 3-component float `Vec`) authored in legacy v7 format so both runners read identical input; Z-positions `{0,1,3,6,10}`, `new_z_spacing = 2.0`. Legacy 6.5.171 output, SIMPLNX output, and the Class-1 oracle are bit-identical on every cell array and on geometry (dimensions, spacing, origin). A conversion-semantics scope note (cell-AM binding, delta 5) is recorded in `vv/deviations/RegularizeZSpacingFilter.md`.

--- a/src/Plugins/SimplnxCore/vv/RegularizeZSpacingFilter.md
+++ b/src/Plugins/SimplnxCore/vv/RegularizeZSpacingFilter.md
@@ -16,7 +16,7 @@
 | Algorithm Relationship | **Port** of legacy `RegularizeZSpacing::execute()` — identical Z-plane mapping rule and `floor(extent/newZRes)` dim math (independently hand-traced, including the strict-`>` boundary and clamp cases). Five port-time deltas (bulk copy, new-geometry output mode, preflight validation, parallelization, cell-AM binding); none change output for valid input. |
 | Oracle (confirmed)     | **Class 1 (Analytical)** primary + **Class 4 (Invariant)** companion — closed-form indirection map `out[i] = in[map[i]]`. Element-wise Class 1 assertions in 2 fixtures (`Valid Execution (New Geometry)`, `Valid Execution (Spacing Exceeds Extent)`); Class 4 invariants across the valid fixtures. All pass in-core + OOC. |
 | Code paths enumerated  | 12 of 14 exercised; the 2 uncovered are the redundant file-open guard and the cancel check (reasons below).                  |
-| Tests today            | 4 TEST_CASEs (2 Class-1 valid + 1 in-place valid + 1 invalid-parameters with 6 SECTIONs); every documented preflight error code asserted explicitly. |
+| Tests today            | 5 TEST_CASEs (2 Class-1 valid + 1 in-place valid + 1 invalid-parameters with 6 SECTIONs + 1 SIMPL backwards-compat with 6.5/6.4 fixtures); every documented preflight error code asserted explicitly. |
 | Exemplar archive       | **None** — inline analytical fixtures (no `download_test_data`; avoids a circular oracle per project policy).                 |
 | Legacy comparison      | **Run** vs DREAM3D 6.5.171 on a synthetic multi-type fixture (int32 + bool + 3-component float). Bit-identical: legacy == SIMPLNX == Class-1 oracle on every array and on geometry (dims/spacing/origin). |
 | Bug flags              | None.                                                                                                                        |
@@ -85,6 +85,7 @@ Source: `src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RegularizeZS
 | `Valid Execution (In Place)` | new-for-V&V | Asserts in-place result replaces the source geometry (same name), no output-name geometry created, output Z dim + Z spacing correct. |
 | `Valid Execution (Spacing Exceeds Extent)` | new-for-V&V | Class 1 clamp fixture: `newZRes` (20) > extent (10) → 1 output plane sourced from plane 0; dims (2,1,1), Z spacing 20, `Data` = {0,1} asserted. |
 | `Invalid Parameters` | new-for-V&V | 6 SECTIONs — non-positive spacing (`-5555`), too-few file values (`-5557`), non-monotonic values (`-5558`), zero total extent (`-5559`), missing cell AM (`-5560`), non-DataArray cell member (`-5561`); each asserts the specific error code. |
+| `SIMPL Backwards Compatibility` | new-for-V&V | 2 DYNAMIC_SECTIONs — converts the 6.5 (UUID-keyed) and 6.4 (Filter_Name-keyed) fixtures in `test/simpl_conversion/`; asserts converted geometry path, input file, Z spacing, and the in-place default. The 6.4 path exercises the `k_LegacySimplFilterUuidMap` name resolution. |
 
 ## Exemplar archive
 

--- a/src/Plugins/SimplnxCore/vv/deviations/RegularizeZSpacingFilter.md
+++ b/src/Plugins/SimplnxCore/vv/deviations/RegularizeZSpacingFilter.md
@@ -1,0 +1,28 @@
+# Deviations from DREAM3D 6.5.171: RegularizeZSpacingFilter
+
+This file lists every documented behavioral difference between this SIMPLNX filter and its DREAM3D 6.5.171 equivalent (`RegularizeZSpacing`, Sampling plugin, UUID `bc4952fa-34ca-50bf-a1e9-2b9f7e5d47ce`).
+
+Entries are referenced by stable ID (`RegularizeZSpacingFilter-D<N>`) from the V&V report and from public migration guidance. The ID is stable across renames; the Filter UUID field is the permanent cross-reference anchor.
+
+---
+
+## No deviations
+
+**None observed.** A direct A/B comparison was run against DREAM3D 6.5.171.
+
+- **Fixture:** synthetic Image Geometry, dims 3×2×4, spacing (0.5, 0.75, 1.0), origin (1, 2, 3). Cell data: `Data` (`int32`, value == voxel index), `Mask` (`DataArray<bool>`), `Vec` (`float32`, 3-component). Authored directly in legacy v7 `.dream3d` format so DREAM3D 6.5.171 and DREAM3D-NX read byte-identical input.
+- **Parameters:** Z boundary positions `{0, 1, 3, 6, 10}` (ZPoints + 1 = 5 values); `new_z_spacing = 2.0`; in-place.
+- **Result:** legacy 6.5.171 output, SIMPLNX output, and the independent Class-1 analytical oracle are **bit-identical** on every cell array (`Data`, `Mask`, `Vec`) and on the output geometry (dimensions 3×2×5, spacing (0.5, 0.75, 2.0), origin unchanged). The upsampled plane-repeat pattern (destination planes 2 and 3 both drawing from source plane 2) is reproduced identically by both implementations.
+
+The port preserves the legacy Z-plane mapping rule and dimension arithmetic exactly; the port-time deltas enumerated in the report (bulk copy, new-geometry output mode, added preflight validation, parallelization, cell-AM binding) are non-behavioral for valid input, as confirmed by this comparison.
+
+---
+
+## Scope note: cell-AM binding on converted pipelines (not an output deviation)
+
+Legacy selected the target cell data by an explicit AttributeMatrix path; SIMPLNX selects the Image Geometry and operates on its *assigned* cell AttributeMatrix. When a legacy pipeline is converted (`FromSIMPLJson`), only the DataContainer name is kept from `CellAttributeMatrixPath` — the AM name is discarded.
+
+- **Common case (one cell AM per geometry):** identical behavior; the discarded AM name and the geometry's cell AM are the same object.
+- **Corner cases:** a legacy DataContainer holding more than one cell-level AM where the pipeline selected the non-canonical one will, after conversion, resample the geometry's assigned cell AM instead; a stale AM name that legacy rejected with an error converts to a pipeline that proceeds on the actual cell AM. Additionally, SIMPLNX errors on a geometry with no cell AM (`-5560`) and on non-DataArray cell-AM members (`-5561`) — states legacy either could not express or would have crashed on.
+
+These are parameter-model/conversion semantics, not output-math differences; for identical valid inputs the outputs are bit-identical (comparison above).

--- a/src/simplnx/Pipeline/LegacySimplFilterUuid.hpp
+++ b/src/simplnx/Pipeline/LegacySimplFilterUuid.hpp
@@ -315,7 +315,6 @@ static const std::map<std::string, std::string> k_LegacySimplFilterUuidMap{
     {"ReadH5Ebsd", "4ef7f56b-616e-5a80-9e68-1da8f35ad235"},
     {"ReadStlFile", "980c7bfd-20b2-5711-bc3b-0190b9096c34"},
     {"RegularGridSampleSurfaceMesh", "0df3da89-9106-538e-b1a9-6bbf1cf0aa92"},
-    {"RegularizeZSpacing", "bc4952fa-34ca-50bf-a1e9-2b9f7e5d47ce"},
     {"RemoveArrays", "7b1c8f46-90dd-584a-b3ba-34e16958a7d0"},
     {"RemoveComponentFromArray", "1b4b9941-62e4-52f2-9918-15d48147ab88"},
     {"RemoveFlaggedFeatures", "a8463056-3fa7-530b-847f-7f4cb78b8602"},

--- a/src/simplnx/Pipeline/LegacySimplFilterUuid.hpp
+++ b/src/simplnx/Pipeline/LegacySimplFilterUuid.hpp
@@ -315,6 +315,7 @@ static const std::map<std::string, std::string> k_LegacySimplFilterUuidMap{
     {"ReadH5Ebsd", "4ef7f56b-616e-5a80-9e68-1da8f35ad235"},
     {"ReadStlFile", "980c7bfd-20b2-5711-bc3b-0190b9096c34"},
     {"RegularGridSampleSurfaceMesh", "0df3da89-9106-538e-b1a9-6bbf1cf0aa92"},
+    {"RegularizeZSpacing", "bc4952fa-34ca-50bf-a1e9-2b9f7e5d47ce"},
     {"RemoveArrays", "7b1c8f46-90dd-584a-b3ba-34e16958a7d0"},
     {"RemoveComponentFromArray", "1b4b9941-62e4-52f2-9918-15d48147ab88"},
     {"RemoveFlaggedFeatures", "a8463056-3fa7-530b-847f-7f4cb78b8602"},


### PR DESCRIPTION
## Summary

Ports the legacy SIMPL `RegularizeZSpacing` filter (Sampling plugin) into SimplnxCore as `RegularizeZSpacingFilter`, and completes a full V&V cycle on it per the v2 MTR V&V policy.

The filter resamples an Image Geometry whose Z slices are irregularly spaced (e.g. serial sectioning with non-constant removal depth) onto a regular Z spacing. The physical Z position of each original slice boundary is read from a text file (`ZPoints + 1` values); each new evenly spaced plane copies the cell data of the original plane whose boundary interval contains it.

### Port
* Same Z-plane mapping rule and `floor(extent / newZSpacing)` dimension math as legacy (independently hand-traced; float32 arithmetic parity expression-by-expression)
* Modern `ResampleImageGeom` pattern: input geometry + created output geometry + "Perform In Place" toggle (rename + deferred delete actions)
* Preflight validation legacy lacked: positive Z spacing, enough parseable values, monotonically non-decreasing bounds, positive total extent, DataArray-only cell AM members (six asserted error codes)
* Per-plane bulk `copyFrom` (contiguous slab per destination plane), parallelized per array — efficient in-core and out-of-core
* Loose child objects rebased component-wise when copied (avoids the string-replacement path corruption present in the pattern this was modeled on)
* `FromSIMPLJson` conversion for legacy `CellAttributeMatrixPath` / `InputFile` / `NewZRes`; legacy UUID `bc4952fa-…` mapped and removed from the unported list
* `.txt` is a file-dialog hint only, so converted legacy pipelines with `.dat`/`.csv`/extensionless files keep working

### V&V (report: `src/Plugins/SimplnxCore/vv/RegularizeZSpacingFilter.md`)
* **Oracle:** Class 1 (Analytical) + Class 4 (Invariant), inlined in the test source — no exemplar archive, no circular oracle
* **Legacy comparison:** direct A/B vs DREAM3D 6.5.171 on a shared legacy-format fixture (int32 + bool + 3-component float): **bit-identical** — legacy == SIMPLNX == oracle on every array and on geometry. **0 deviations** (`vv/deviations/RegularizeZSpacingFilter.md`, includes a conversion-semantics scope note on cell-AM binding)
* **Coverage:** 12 of 14 enumerated code paths exercised; the 2 uncovered (file-open race guard, cancel injection) are documented with reasons
* Status `READY FOR REVIEW` — second-engineer oracle review is the remaining item before `COMPLETE`

## Test Plan
- [x] `ctest -R RegularizeZSpacing` passes on the in-core build (4/4)
- [x] `ctest -R RegularizeZSpacing` passes on the out-of-core build (4/4)
- [x] Legacy 6.5.171 A/B comparison re-run against the final binaries: bit-identical