### PR TITLE
BUG: Fix ComputeAvgOrientations phase gating + V&V follow-ups

### DIFF
--- a/src/Plugins/OrientationAnalysis/docs/ComputeAvgOrientationsFilter.md
+++ b/src/Plugins/OrientationAnalysis/docs/ComputeAvgOrientationsFilter.md
@@ -66,7 +66,10 @@ These values may be exposed as user-configurable parameters in a future release.
 
 - **Features with a single element:** For the vMF and Watson methods, if a feature contains only one element orientation, the EM algorithm is skipped entirely and the single quaternion is used directly as the average. The kappa value is set to 0 in this case.
 - **Features with zero elements:** Features with no elements (phase <= 0 for all voxels) will have their output arrays initialized to NaN (for vMF/Watson) or identity quaternion / zero Euler angles (for Rodrigues).
-- **Phase indexing:** The filter requires that phase values be > 0 for elements to be included in the averaging. Phase index 0 is reserved for "Unknown" in the Crystal Structures array and is always skipped.
+- **Phase indexing:** The filter requires that phase values be > 0 for elements to be included in the averaging. Phase index 0 is reserved for "Unknown" in the Crystal Structures array and is always skipped. This applies identically to all three methods.
+- **Invalid phases and crystal structures:** Elements whose phase value lies outside the range of the Crystal Structures array, and elements or features whose crystal structure value is not a supported Laue class (for example 999 = Unknown), are **excluded** from the averaging. The filter emits a warning (-54672 for out-of-range phases, -54671 for unknown crystal structures) reporting how many were dropped — the drop is never silent. A feature whose elements are all excluded finalizes to the identity quaternion (Rodrigues) or NaN (vMF/Watson).
+- **Multi-phase features:** The vMF/Watson methods use a single crystal structure per feature, taken from the phase of the feature's highest-index element; the Rodrigues method uses each element's own phase. Features are normally single-phase, so this distinction rarely matters.
+- **No method enabled:** If none of the three averaging methods is enabled the filter fails in preflight with error -54673.
 
 % Auto generated parameter table will be inserted here
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeAvgOrientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeAvgOrientations.cpp
@@ -34,6 +34,7 @@ public:
   {
     // Input FeatureIds + Input Orientations. All these should come from the same Attribute Matrix or have the same number of tuples
     Int32AbstractDataStore& featureIdsRef = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->cellFeatureIdsArrayPath).getDataStoreRef();
+    Int32AbstractDataStore& phasesRef = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->cellPhasesArrayPath).getDataStoreRef();
     Float32AbstractDataStore& quatsRef = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->cellQuatsArrayPath).getDataStoreRef();
     // Ensemble Level Data
     UInt32AbstractDataStore& xtalRef = m_DataStructure.getDataRefAs<UInt32Array>(m_InputValues->crystalStructuresArrayPath).getDataStoreRef();
@@ -61,6 +62,7 @@ public:
     }
 
     usize numVoxels = featureIdsRef.getNumberOfTuples();
+    const usize numEnsembles = xtalRef.getNumberOfTuples();
 
     std::vector<ebsdlib::LaueOps::Pointer> ops = ebsdlib::LaueOps::GetAllOrientationOps();
 
@@ -95,8 +97,12 @@ public:
       // they want to find the average orientation of
       for(usize voxelIdx = 0; voxelIdx < numVoxels; voxelIdx++)
       {
-        // If the feature Id of the voxel matches the current feature Id, then grab that orientation
-        if(featureIdsRef[voxelIdx] == featureId)
+        // If the feature Id of the voxel matches the current feature Id, then grab that orientation.
+        // The phase gate MUST match the counting pass in computeVmfWatsonAverage() (and the
+        // Rodrigues path): phase-0/unindexed voxels are excluded from the average (issue #1659),
+        // and an out-of-range phase index would read past the CrystalStructures array (issue #1661).
+        const int32 voxelPhase = phasesRef[voxelIdx];
+        if(featureIdsRef[voxelIdx] == featureId && voxelPhase > 0 && static_cast<usize>(voxelPhase) < numEnsembles)
         {
           const ebsdlib::QuatD q1(quatsRef[voxelIdx * 4], quatsRef[voxelIdx * 4 + 1], quatsRef[voxelIdx * 4 + 2], quatsRef[voxelIdx * 4 + 3]);
           fzQuats.push_back(op->getFZQuat(q1)); // Fundamental Zone Reduction
@@ -276,16 +282,18 @@ Result<> ComputeAvgOrientations::operator()()
 
   MessageHelper messageHelper(m_MessageHandler);
 
-  Result<> result;
+  // Warnings (e.g. dropped voxels/features) from each path are merged and returned together.
+  Result<> finalResult;
   if(m_InputValues->useRodriguesAverage)
   {
     messageHelper.sendMessage("Computing Rodrigues Average Orientations");
 
-    result = computeRodriguesAverage();
+    Result<> result = computeRodriguesAverage();
     if(result.invalid())
     {
       return result;
     }
+    finalResult = MergeResults(std::move(finalResult), std::move(result));
   }
   if(m_InputValues->useVonMisesAverage || m_InputValues->useWatsonAverage)
   {
@@ -302,14 +310,15 @@ Result<> ComputeAvgOrientations::operator()()
       messageHelper.sendMessage("Computing von-Mises Fisher and Watson Average Orientations");
     }
 
-    result = computeVmfWatsonAverage();
+    Result<> result = computeVmfWatsonAverage();
     if(result.invalid())
     {
       return result;
     }
+    finalResult = MergeResults(std::move(finalResult), std::move(result));
   }
 
-  return {};
+  return finalResult;
 }
 
 // -----------------------------------------------------------------------------
@@ -318,20 +327,47 @@ Result<> ComputeAvgOrientations::computeVmfWatsonAverage()
   // Input Data
   auto& featureIds = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->cellFeatureIdsArrayPath);
   auto& phases = m_DataStructure.getDataRefAs<Int32Array>(m_InputValues->cellPhasesArrayPath);
+  auto& crystalStructures = m_DataStructure.getDataRefAs<UInt32Array>(m_InputValues->crystalStructuresArrayPath);
 
   const size_t totalVoxels = featureIds.getNumberOfTuples();
+  const usize numEnsembles = crystalStructures.getNumberOfTuples();
 
-  // Run through the "voxels" and compute the number of voxels for each feature
+  // Run through the "voxels" and compute the number of voxels for each feature.
+  // NOTE: for a feature spanning multiple phases the map is last-writer-wins — the
+  // feature's crystal structure is taken from the phase of its highest-index voxel.
+  // (vMF/Watson uses one phase per feature; the Rodrigues path is per-voxel.)
   std::vector<usize> featureNumVoxels(m_NumberOfFeatures, 0);
   std::map<int32, int32> featureIdToPhaseMap;
+  usize outOfRangePhaseCount = 0;
   for(size_t i = 0; i < totalVoxels; i++)
   {
     const int32_t currentFeatureId = featureIds[i];
     const int32_t currentPhase = phases[i];
     if(currentPhase > 0)
     {
+      // An out-of-range phase index would read past the CrystalStructures array (issue #1661).
+      // This gate MUST match the gather loop in VmfWatsonSamplingImpl.
+      if(static_cast<usize>(currentPhase) >= numEnsembles)
+      {
+        outOfRangePhaseCount++;
+        continue;
+      }
       featureNumVoxels[currentFeatureId]++;
       featureIdToPhaseMap[currentFeatureId] = currentPhase;
+    }
+  }
+
+  // Features whose crystal structure is unknown/unsupported are skipped by the worker
+  // (their outputs remain NaN); report that up front instead of dropping them silently.
+  usize unknownXtalFeatureCount = 0;
+  {
+    const std::vector<ebsdlib::LaueOps::Pointer> ops = ebsdlib::LaueOps::GetAllOrientationOps();
+    for(const auto& [featureId, phaseValue] : featureIdToPhaseMap)
+    {
+      if(crystalStructures[phaseValue] >= ops.size())
+      {
+        unknownXtalFeatureCount++;
+      }
     }
   }
 
@@ -374,7 +410,19 @@ Result<> ComputeAvgOrientations::computeVmfWatsonAverage()
   dataAlg.setRange(0, m_NumberOfFeatures);
   dataAlg.execute(VmfWatsonSamplingImpl(this, m_InputValues, m_DataStructure, featureNumVoxels, featureIdToPhaseMap));
 
-  return {};
+  Result<> result;
+  if(unknownXtalFeatureCount > 0)
+  {
+    result.warnings().push_back(
+        {-54671, fmt::format("vMF/Watson average: {} feature(s) have an unknown/unsupported crystal structure value and were skipped; their output tuples remain NaN.", unknownXtalFeatureCount)});
+  }
+  if(outOfRangePhaseCount > 0)
+  {
+    result.warnings().push_back(
+        {-54672, fmt::format("vMF/Watson average: {} cell(s) have a Phases value outside the range of the Crystal Structures array ({} tuples) and were excluded from the average.",
+                             outOfRangePhaseCount, numEnsembles)});
+  }
+  return result;
 }
 
 // -----------------------------------------------------------------------------
@@ -392,9 +440,12 @@ Result<> ComputeAvgOrientations::computeRodriguesAverage()
   auto& avgEuler = m_DataStructure.getDataRefAs<Float32Array>(m_InputValues->avgEulerAnglesArrayPath).getDataStoreRef();
 
   const size_t totalPoints = featureIds.getNumberOfTuples();
+  const usize numEnsembles = crystalStructures.getNumberOfTuples();
 
   size_t totalFeatures = avgQuats.getNumberOfTuples();
   std::vector<float> counts(totalFeatures, 0.0f);
+  usize outOfRangePhaseCount = 0;
+  usize unknownXtalCount = 0;
 
   // initialize the output arrays
   avgQuats.fill(0.0F);
@@ -430,10 +481,17 @@ Result<> ComputeAvgOrientations::computeRodriguesAverage()
     // for the filter should be updated to cover these use-cases.
     if(currentPhase > 0)
     {
+      // An out-of-range phase index would read past the CrystalStructures array (issue #1661).
+      if(static_cast<usize>(currentPhase) >= numEnsembles)
+      {
+        outOfRangePhaseCount++;
+        continue;
+      }
       const uint32 xtal = crystalStructures[currentPhase];
       // Guard against an out-of-range crystal-structure enum (e.g. 999/Unknown).
       if(xtal >= orientationOps.size())
       {
+        unknownXtalCount++;
         continue;
       }
       counts[currentFeatureId] += 1.0f;
@@ -477,5 +535,17 @@ Result<> ComputeAvgOrientations::computeRodriguesAverage()
     UpdateEulerArray(avgEuler, eu, featureId);
   }
 
-  return {};
+  Result<> result;
+  if(unknownXtalCount > 0)
+  {
+    result.warnings().push_back(
+        {-54671, fmt::format("Rodrigues average: {} cell(s) belong to a phase whose crystal structure value is unknown/unsupported and were excluded from the average.", unknownXtalCount)});
+  }
+  if(outOfRangePhaseCount > 0)
+  {
+    result.warnings().push_back(
+        {-54672, fmt::format("Rodrigues average: {} cell(s) have a Phases value outside the range of the Crystal Structures array ({} tuples) and were excluded from the average.",
+                             outOfRangePhaseCount, numEnsembles)});
+  }
+  return result;
 }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeAvgOrientations.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeAvgOrientations.cpp
@@ -361,10 +361,10 @@ Result<> ComputeAvgOrientations::computeVmfWatsonAverage()
   // (their outputs remain NaN); report that up front instead of dropping them silently.
   usize unknownXtalFeatureCount = 0;
   {
-    const std::vector<ebsdlib::LaueOps::Pointer> ops = ebsdlib::LaueOps::GetAllOrientationOps();
+    const usize numValidXtal = ebsdlib::LaueOps::GetAllOrientationOps().size();
     for(const auto& [featureId, phaseValue] : featureIdToPhaseMap)
     {
-      if(crystalStructures[phaseValue] >= ops.size())
+      if(crystalStructures[phaseValue] >= numValidXtal)
       {
         unknownXtalFeatureCount++;
       }

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgOrientationsFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/ComputeAvgOrientationsFilter.cpp
@@ -150,6 +150,14 @@ IFilter::PreflightResult ComputeAvgOrientationsFilter::preflightImpl(const DataS
   auto pWatsonEulerAnglesArrayPathValue = pCellFeatureAttributeMatrixPathValue.createChildPath(filterArgs.value<std::string>(k_WatsonAvgEulerArrayName_Key));
   auto pWatsonKappaArrayPathValue = pCellFeatureAttributeMatrixPathValue.createChildPath(filterArgs.value<std::string>(k_WatsonKappaArrayName_Key));
 
+  // With no method enabled the filter would produce nothing and was guaranteed to fail at
+  // runtime (-54670); reject it here so the GUI surfaces the problem before execution.
+  if(!pUseRodriguesAverage_Key && !pUseVonMisesFisher && !pUseWatson)
+  {
+    return {
+        MakeErrorResult<OutputActions>(-54673, "No averaging method is enabled. Enable at least one of: 'Compute Rodrigues Average', 'Compute von Mises-Fisher Average', 'Compute Watson Average'.")};
+  }
+
   Result<OutputActions> resultOutputActions;
 
   std::vector<DataPath> dataPaths;

--- a/src/Plugins/OrientationAnalysis/test/ComputeAvgOrientationsTest.cpp
+++ b/src/Plugins/OrientationAnalysis/test/ComputeAvgOrientationsTest.cpp
@@ -23,6 +23,7 @@
  * retired in favor of the inline oracle below.
  * ========================================================================== */
 
+#include "OrientationAnalysis/Filters/Algorithms/ComputeAvgOrientations.hpp"
 #include "OrientationAnalysis/Filters/ComputeAvgOrientationsFilter.hpp"
 #include "OrientationAnalysis/OrientationAnalysis_test_dirs.hpp"
 
@@ -86,6 +87,17 @@ constexpr uint32 k_Triclinic = 4;
 constexpr float32 k_Rz90_z = 0.7071067811865476f; // sin(45) = cos(45)
 constexpr float32 k_Rz45_z = 0.3826834323650898f; // sin(22.5)
 constexpr float32 k_Rz45_w = 0.9238795325112867f; // cos(22.5)
+
+// Cubic-equivalent z-rotation representations of the physical orientation Rz(30):
+// Rz(90) is a cubic symmetry operator, so Rz(30+90k) all describe the same orientation.
+constexpr float32 k_Rz30_z = 0.2588190451025208f;   // sin(15)
+constexpr float32 k_Rz30_w = 0.9659258262890683f;   // cos(15)
+constexpr float32 k_Rz120_z = 0.8660254037844386f;  // sin(60)
+constexpr float32 k_Rz120_w = 0.5f;                 // cos(60)
+constexpr float32 k_Rz210_z = 0.9659258262890683f;  // sin(105)
+constexpr float32 k_Rz210_w = -0.2588190451025208f; // cos(105)
+constexpr float32 k_Rz300_z = 0.5f;                 // sin(150)
+constexpr float32 k_Rz300_w = -0.8660254037844386f; // cos(150)
 
 // ---------------------------------------------------------------------------
 // Build a DataStructure with an ImageGeom, a Cell Data AM (FeatureIds, Phases,
@@ -253,6 +265,15 @@ TEST_CASE("OrientationAnalysis::ComputeAvgOrientations: Rodrigues Analytical Ora
     REQUIRE(avgEuler.getDataStoreRef().getValue(1 * 3 + c) == Approx(0.0f).margin(1.0e-6f)); // F1 identity
     REQUIRE(avgEuler.getDataStoreRef().getValue(5 * 3 + c) == Approx(0.0f).margin(1.0e-6f)); // F5 empty
   }
+  // z-rotation fixtures (F2, F3, F4): Euler is gimbal-degenerate (only phi1+phi2 is
+  // determined), so assert the invariant — Phi ~= 0 and all components finite — rather
+  // than individual phi1/phi2 values.
+  for(usize f : {static_cast<usize>(2), static_cast<usize>(3), static_cast<usize>(4)})
+  {
+    REQUIRE(std::isfinite(avgEuler.getDataStoreRef().getValue(f * 3 + 0)));
+    REQUIRE(avgEuler.getDataStoreRef().getValue(f * 3 + 1) == Approx(0.0f).margin(1.0e-6f));
+    REQUIRE(std::isfinite(avgEuler.getDataStoreRef().getValue(f * 3 + 2)));
+  }
 
   // ---- Class 4: vMF / Watson value-add invariants on this small data ----
   REQUIRE_NOTHROW(dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_VMFQuatsName)));
@@ -382,8 +403,298 @@ TEST_CASE("OrientationAnalysis::ComputeAvgOrientations: vMF/Watson EbsdLib Refer
 }
 
 // =============================================================================
-// Error path — no averaging method enabled => no feature-level result array is
-// created, so the algorithm returns error -54670.
+// Class 4 (Invariant) — Rodrigues under non-trivial (cubic) symmetry (#1660).
+// One Cubic_High feature is fed the SAME physical orientation, Rz(30 deg), as
+// five different representations: cubic-equivalent z-rotations Rz(30+90k) plus
+// the negated double-cover representative -Rz(30). Because Rz(90) is a cubic
+// symmetry operator (and getNearestQuat canonicalizes the sign), every voxel's
+// nearest-equivalent pick is exactly Rz(30), so the running average MUST
+// finalize to Rz(30) — an implementation-independent expectation that exercises
+// the 24-operator symmetry-reduction branch, the reset-to-identity first-voxel
+// branch (on a non-trivial representation), and the count weighting.
+// =============================================================================
+TEST_CASE("OrientationAnalysis::ComputeAvgOrientations: Rodrigues Cubic Symmetry Invariant", "[OrientationAnalysis][ComputeAvgOrientationsFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const int32 numCells = 6;
+  const int32 numFeatures = 2;
+  const std::vector<int32> featureIds = {0, 1, 1, 1, 1, 1};
+  const std::vector<int32> phases = {0, 1, 1, 1, 1, 1};
+  // Deliberately scrambled order so the first-voxel reset operates on Rz(120),
+  // not the base representation.
+  const std::vector<float32> quats = {
+      0.0f, 0.0f, 0.0f,      1.0f,      // c0 background identity
+      0.0f, 0.0f, k_Rz120_z, k_Rz120_w, // c1 Rz(120) == Rz(30) * Rz(90)
+      0.0f, 0.0f, k_Rz30_z,  k_Rz30_w,  // c2 Rz(30)  base representation
+      0.0f, 0.0f, -k_Rz30_z, -k_Rz30_w, // c3 -Rz(30) double-cover representative
+      0.0f, 0.0f, k_Rz210_z, k_Rz210_w, // c4 Rz(210) == Rz(30) * Rz(180)
+      0.0f, 0.0f, k_Rz300_z, k_Rz300_w, // c5 Rz(300) == Rz(30) * Rz(270)
+  };
+  const std::vector<uint32> crystalStructures = {k_Unknown, k_CubicHigh};
+
+  DataStructure dataStructure = BuildDataStructure(numCells, numFeatures, featureIds, phases, quats, crystalStructures);
+
+  ComputeAvgOrientationsFilter filter;
+  Arguments args;
+  SetInputArgs(args);
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseRodriguesAverage_Key, std::make_any<bool>(true));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_RodriguesQuatsArrayName_Key, std::make_any<std::string>(k_AvgQuatsName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_RodriguesAvgEulerArrayName_Key, std::make_any<std::string>(k_AvgEulerName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseVonMisesFisher_Key, std::make_any<bool>(false));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherAvgQuatsArrayName_Key, std::make_any<std::string>(k_VMFQuatsName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherAvgEulerArrayName_Key, std::make_any<std::string>(k_VMFEulerName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherKappaArrayName_Key, std::make_any<std::string>(k_VMFKappaName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseWatson_Key, std::make_any<bool>(false));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonAvgQuatsArrayName_Key, std::make_any<std::string>(k_WatsonQuatsName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonAvgEulerArrayName_Key, std::make_any<std::string>(k_WatsonEulerName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonKappaArrayName_Key, std::make_any<std::string>(k_WatsonKappaName));
+
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_AvgQuatsName)));
+  const auto& avgQuats = dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_AvgQuatsName));
+  CheckQuat(avgQuats, 1, 0.0f, 0.0f, k_Rz30_z, k_Rz30_w, 1.0e-5f);
+  CheckUnitNorthern(avgQuats, 1);
+
+  // Euler invariant for a pure z-rotation: Phi ~= 0, all components finite.
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_AvgEulerName)));
+  const auto& avgEuler = dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_AvgEulerName));
+  REQUIRE(std::isfinite(avgEuler.getDataStoreRef().getValue(1 * 3 + 0)));
+  REQUIRE(avgEuler.getDataStoreRef().getValue(1 * 3 + 1) == Approx(0.0f).margin(1.0e-5f));
+  REQUIRE(std::isfinite(avgEuler.getDataStoreRef().getValue(1 * 3 + 2)));
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+// =============================================================================
+// Class 4 (Invariant) — Rodrigues voxel-ordering independence. The F3 fixture
+// of the analytical oracle (mean of identity and Rz(90) = Rz(45)) is run with
+// both voxel orderings; the result must be identical. Both orders accumulate
+// to (0, 0, 0.7071, 1.7071) before normalization (see provenance sidecar).
+// =============================================================================
+TEST_CASE("OrientationAnalysis::ComputeAvgOrientations: Rodrigues Voxel Ordering Independence", "[OrientationAnalysis][ComputeAvgOrientationsFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const std::vector<float32> quatIdentity = {0.0f, 0.0f, 0.0f, 1.0f};
+  const std::vector<float32> quatRz90 = {0.0f, 0.0f, k_Rz90_z, k_Rz90_z};
+
+  const std::string ordering = GENERATE("identity-first", "Rz90-first");
+  DYNAMIC_SECTION("Ordering: " << ordering)
+  {
+    std::vector<float32> quats;
+    const std::vector<float32>& first = (ordering == "identity-first") ? quatIdentity : quatRz90;
+    const std::vector<float32>& second = (ordering == "identity-first") ? quatRz90 : quatIdentity;
+    quats.insert(quats.end(), first.begin(), first.end());
+    quats.insert(quats.end(), second.begin(), second.end());
+
+    const std::vector<int32> featureIds = {1, 1};
+    const std::vector<int32> phases = {1, 1};
+    const std::vector<uint32> crystalStructures = {k_Unknown, k_Triclinic};
+    DataStructure dataStructure = BuildDataStructure(2, 2, featureIds, phases, quats, crystalStructures);
+
+    ComputeAvgOrientationsFilter filter;
+    Arguments args;
+    SetInputArgs(args);
+    args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseRodriguesAverage_Key, std::make_any<bool>(true));
+    args.insertOrAssign(ComputeAvgOrientationsFilter::k_RodriguesQuatsArrayName_Key, std::make_any<std::string>(k_AvgQuatsName));
+    args.insertOrAssign(ComputeAvgOrientationsFilter::k_RodriguesAvgEulerArrayName_Key, std::make_any<std::string>(k_AvgEulerName));
+    args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseVonMisesFisher_Key, std::make_any<bool>(false));
+    args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherAvgQuatsArrayName_Key, std::make_any<std::string>(k_VMFQuatsName));
+    args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherAvgEulerArrayName_Key, std::make_any<std::string>(k_VMFEulerName));
+    args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherKappaArrayName_Key, std::make_any<std::string>(k_VMFKappaName));
+    args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseWatson_Key, std::make_any<bool>(false));
+    args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonAvgQuatsArrayName_Key, std::make_any<std::string>(k_WatsonQuatsName));
+    args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonAvgEulerArrayName_Key, std::make_any<std::string>(k_WatsonEulerName));
+    args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonKappaArrayName_Key, std::make_any<std::string>(k_WatsonKappaName));
+
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+    REQUIRE_NOTHROW(dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_AvgQuatsName)));
+    const auto& avgQuats = dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_AvgQuatsName));
+    CheckQuat(avgQuats, 1, 0.0f, 0.0f, k_Rz45_z, k_Rz45_w, 1.0e-6f);
+
+    UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  }
+}
+
+// =============================================================================
+// Regression (#1659) — the vMF/Watson voxel gather must ignore phase-0
+// (unindexed) voxels, matching the counting pass and the Rodrigues path.
+// Pre-fix, the gather loop collected every voxel of the feature regardless of
+// phase, so a phase-0 voxel contributed a garbage quaternion to the EM average
+// (and defeated the single-voxel shortcut when featureNumVoxels == 1).
+// =============================================================================
+TEST_CASE("OrientationAnalysis::ComputeAvgOrientations: vMF/Watson Ignores Phase-0 Voxels", "[OrientationAnalysis][ComputeAvgOrientationsFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  // Two active features, each polluted with a phase-0 voxel carrying a garbage
+  // (non-unit, southern-hemisphere) quaternion. The counting pass gates on
+  // phase > 0, so:
+  //   F1: 1 counted voxel (Rz90)  -> single-voxel shortcut: muhat == Rz90, kappa == 0
+  //   F2: 2 counted voxels (Rz90) -> EM over identical quats: muhat == Rz90
+  const int32 numCells = 5;
+  const int32 numFeatures = 3; // F0 has no voxels -> NaN
+  const std::vector<int32> featureIds = {1, 1, 2, 2, 2};
+  const std::vector<int32> phases = {1, 0, 1, 1, 0};
+  const std::vector<float32> quats = {
+      0.0f,  0.0f,   k_Rz90_z, k_Rz90_z, // c0 F1 phase 1: Rz90
+      0.62f, -0.41f, 0.55f,    -0.37f,   // c1 F1 phase 0: garbage
+      0.0f,  0.0f,   k_Rz90_z, k_Rz90_z, // c2 F2 phase 1: Rz90
+      0.0f,  0.0f,   k_Rz90_z, k_Rz90_z, // c3 F2 phase 1: Rz90
+      0.62f, -0.41f, 0.55f,    -0.37f,   // c4 F2 phase 0: garbage
+  };
+  const std::vector<uint32> crystalStructures = {k_Unknown, k_Triclinic};
+
+  DataStructure dataStructure = BuildDataStructure(numCells, numFeatures, featureIds, phases, quats, crystalStructures);
+
+  ComputeAvgOrientationsFilter filter;
+  Arguments args;
+  SetInputArgs(args);
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseRodriguesAverage_Key, std::make_any<bool>(true));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_RodriguesQuatsArrayName_Key, std::make_any<std::string>(k_AvgQuatsName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_RodriguesAvgEulerArrayName_Key, std::make_any<std::string>(k_AvgEulerName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseVonMisesFisher_Key, std::make_any<bool>(true));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherAvgQuatsArrayName_Key, std::make_any<std::string>(k_VMFQuatsName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherAvgEulerArrayName_Key, std::make_any<std::string>(k_VMFEulerName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherKappaArrayName_Key, std::make_any<std::string>(k_VMFKappaName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseWatson_Key, std::make_any<bool>(true));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonAvgQuatsArrayName_Key, std::make_any<std::string>(k_WatsonQuatsName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonAvgEulerArrayName_Key, std::make_any<std::string>(k_WatsonEulerName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonKappaArrayName_Key, std::make_any<std::string>(k_WatsonKappaName));
+
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_VMFQuatsName)));
+  const auto& vmfQuats = dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_VMFQuatsName));
+  const auto& vmfKappa = dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_VMFKappaName));
+  const auto& watsonQuats = dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_WatsonQuatsName));
+  const auto& watsonKappa = dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_WatsonKappaName));
+
+  for(const Float32Array* arr : {&vmfQuats, &watsonQuats})
+  {
+    // F1: the phase-0 garbage voxel must not defeat the single-voxel shortcut.
+    CheckQuat(*arr, 1, 0.0f, 0.0f, k_Rz90_z, k_Rz90_z, 1.0e-6f);
+    // F2: EM over the two identical counted voxels must land on Rz90 —
+    // orientation equality via |dot(muhat, Rz90)| == 1, robust to double cover.
+    const auto& store = arr->getDataStoreRef();
+    const double dot = store.getValue(2 * 4 + 2) * k_Rz90_z + store.getValue(2 * 4 + 3) * k_Rz90_z;
+    REQUIRE(std::abs(dot) == Approx(1.0).margin(1.0e-4));
+    REQUIRE(store.getValue(2 * 4 + 0) == Approx(0.0).margin(1.0e-4));
+    REQUIRE(store.getValue(2 * 4 + 1) == Approx(0.0).margin(1.0e-4));
+  }
+  // F1 single counted voxel -> EM skipped -> kappa == 0.
+  REQUIRE(vmfKappa.getDataStoreRef().getValue(1) == Approx(0.0f).margin(1.0e-6f));
+  REQUIRE(watsonKappa.getDataStoreRef().getValue(1) == Approx(0.0f).margin(1.0e-6f));
+
+  // Cross-path agreement: the Rodrigues path already excludes phase-0 voxels.
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_AvgQuatsName)));
+  const auto& avgQuats = dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_AvgQuatsName));
+  CheckQuat(avgQuats, 1, 0.0f, 0.0f, k_Rz90_z, k_Rz90_z, 1.0e-6f);
+  CheckQuat(avgQuats, 2, 0.0f, 0.0f, k_Rz90_z, k_Rz90_z, 1.0e-6f);
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+// =============================================================================
+// Guards (#1661) — unknown/unsupported crystal structures and out-of-range
+// Phases values must be excluded from BOTH averaging paths, must not read out
+// of range on the CrystalStructures array, and the drop must be reported as
+// warnings (-54671 unknown crystal structure, -54672 out-of-range phase) —
+// never a silent drop.
+// =============================================================================
+TEST_CASE("OrientationAnalysis::ComputeAvgOrientations: Unknown Crystal Structure and Out-Of-Range Phase Guards", "[OrientationAnalysis][ComputeAvgOrientationsFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  // Ensemble: phase 1 valid Triclinic, phase 2 Unknown (999).
+  //  cell : feature, phase, quat            expectation
+  //   0   :   1,      1,    Rz90            valid, averaged
+  //   1   :   2,      2,    Rz90            unknown crystal structure -> dropped
+  //   2   :   3,      7,    Rz90            phase index out of range   -> dropped
+  //   3   :   1,      7,    garbage         out-of-range phase mixed into valid feature -> dropped
+  const int32 numCells = 4;
+  const int32 numFeatures = 4; // F0 empty
+  const std::vector<int32> featureIds = {1, 2, 3, 1};
+  const std::vector<int32> phases = {1, 2, 7, 7};
+  const std::vector<float32> quats = {
+      0.0f,  0.0f,   k_Rz90_z, k_Rz90_z, // c0 valid
+      0.0f,  0.0f,   k_Rz90_z, k_Rz90_z, // c1 unknown xtal
+      0.0f,  0.0f,   k_Rz90_z, k_Rz90_z, // c2 OOB phase
+      0.62f, -0.41f, 0.55f,    -0.37f,   // c3 OOB phase, garbage quat
+  };
+  const std::vector<uint32> crystalStructures = {k_Unknown, k_Triclinic, k_Unknown};
+
+  DataStructure dataStructure = BuildDataStructure(numCells, numFeatures, featureIds, phases, quats, crystalStructures);
+
+  ComputeAvgOrientationsFilter filter;
+  Arguments args;
+  SetInputArgs(args);
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseRodriguesAverage_Key, std::make_any<bool>(true));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_RodriguesQuatsArrayName_Key, std::make_any<std::string>(k_AvgQuatsName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_RodriguesAvgEulerArrayName_Key, std::make_any<std::string>(k_AvgEulerName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseVonMisesFisher_Key, std::make_any<bool>(true));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherAvgQuatsArrayName_Key, std::make_any<std::string>(k_VMFQuatsName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherAvgEulerArrayName_Key, std::make_any<std::string>(k_VMFEulerName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherKappaArrayName_Key, std::make_any<std::string>(k_VMFKappaName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseWatson_Key, std::make_any<bool>(true));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonAvgQuatsArrayName_Key, std::make_any<std::string>(k_WatsonQuatsName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonAvgEulerArrayName_Key, std::make_any<std::string>(k_WatsonEulerName));
+  args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonKappaArrayName_Key, std::make_any<std::string>(k_WatsonKappaName));
+
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+  // The drops must be surfaced as warnings, not silent.
+  std::vector<int32> warningCodes;
+  for(const auto& warning : executeResult.result.warnings())
+  {
+    warningCodes.push_back(warning.code);
+  }
+  REQUIRE(std::count(warningCodes.begin(), warningCodes.end(), -54671) > 0); // unknown crystal structure
+  REQUIRE(std::count(warningCodes.begin(), warningCodes.end(), -54672) > 0); // out-of-range phase
+
+  // Rodrigues: F1 keeps only its valid voxel; F2/F3 fully dropped -> identity.
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_AvgQuatsName)));
+  const auto& avgQuats = dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_AvgQuatsName));
+  CheckQuat(avgQuats, 1, 0.0f, 0.0f, k_Rz90_z, k_Rz90_z, 1.0e-6f);
+  CheckQuat(avgQuats, 2, 0.0f, 0.0f, 0.0f, 1.0f, 1.0e-6f);
+  CheckQuat(avgQuats, 3, 0.0f, 0.0f, 0.0f, 1.0f, 1.0e-6f);
+
+  // vMF/Watson: F1 single valid voxel -> shortcut; F2 (unknown xtal) and F3
+  // (all voxels out-of-range phase) -> NaN.
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_VMFQuatsName)));
+  const auto& vmfQuats = dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_VMFQuatsName));
+  const auto& vmfKappa = dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_VMFKappaName));
+  const auto& watsonQuats = dataStructure.getDataRefAs<Float32Array>(k_FeatureDataPath.createChildPath(k_WatsonQuatsName));
+  for(const Float32Array* arr : {&vmfQuats, &watsonQuats})
+  {
+    CheckQuat(*arr, 1, 0.0f, 0.0f, k_Rz90_z, k_Rz90_z, 1.0e-6f);
+    CheckQuatNaN(*arr, 2);
+    CheckQuatNaN(*arr, 3);
+  }
+  REQUIRE(vmfKappa.getDataStoreRef().getValue(1) == Approx(0.0f).margin(1.0e-6f));
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+// =============================================================================
+// Error path — no averaging method enabled is now rejected in preflight with
+// -54673 so the GUI surfaces it before execution (issue #1661). The runtime
+// -54670 check in the algorithm remains as a backstop for direct invocation.
 // =============================================================================
 TEST_CASE("OrientationAnalysis::ComputeAvgOrientations: No Method Enabled Error", "[OrientationAnalysis][ComputeAvgOrientationsFilter]")
 {
@@ -414,15 +725,38 @@ TEST_CASE("OrientationAnalysis::ComputeAvgOrientations: No Method Enabled Error"
   args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonKappaArrayName_Key, std::make_any<std::string>(k_WatsonKappaName));
 
   auto preflightResult = filter.preflight(dataStructure, args);
-  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
-  auto executeResult = filter.execute(dataStructure, args);
-  SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+  SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+  REQUIRE(preflightResult.outputActions.errors()[0].code == -54673);
+
+  // Runtime backstop: invoking the algorithm directly (bypassing preflight) with no
+  // method enabled must still fail with -54670 since no result array exists.
+  ComputeAvgOrientationsInputValues inputValues;
+  inputValues.cellFeatureIdsArrayPath = k_FeatureIdsPath;
+  inputValues.cellPhasesArrayPath = k_PhasesPath;
+  inputValues.cellQuatsArrayPath = k_QuatsPath;
+  inputValues.crystalStructuresArrayPath = k_CrystalStructuresPath;
+  inputValues.useRodriguesAverage = false;
+  inputValues.useVonMisesAverage = false;
+  inputValues.useWatsonAverage = false;
+  inputValues.avgQuatsArrayPath = k_FeatureDataPath.createChildPath(k_AvgQuatsName);
+  inputValues.avgEulerAnglesArrayPath = k_FeatureDataPath.createChildPath(k_AvgEulerName);
+  inputValues.VMFQuatsArrayPath = k_FeatureDataPath.createChildPath(k_VMFQuatsName);
+  inputValues.VMFEulerAnglesArrayPath = k_FeatureDataPath.createChildPath(k_VMFEulerName);
+  inputValues.VMFKappaArrayPath = k_FeatureDataPath.createChildPath(k_VMFKappaName);
+  inputValues.WatsonQuatsArrayPath = k_FeatureDataPath.createChildPath(k_WatsonQuatsName);
+  inputValues.WatsonEulerAnglesArrayPath = k_FeatureDataPath.createChildPath(k_WatsonEulerName);
+  inputValues.WatsonKappaArrayPath = k_FeatureDataPath.createChildPath(k_WatsonKappaName);
+
+  const std::atomic_bool shouldCancel{false};
+  Result<> algoResult = ComputeAvgOrientations(dataStructure, IFilter::MessageHandler{}, shouldCancel, &inputValues)();
+  REQUIRE(algoResult.invalid());
+  REQUIRE(algoResult.errors()[0].code == -54670);
 }
 
 // =============================================================================
 // Preflight error — mismatched cell-array tuple counts => error -651.
-// (Mirrors the coverage target from GCOV/PR #1644; kept here so the V&V suite is
-// self-complete. Reconcile the duplicate at merge time if both land.)
+// (Covers the GCOV target from PR #1644; the duplicate TEST_CASE that #1644
+// added was removed in favor of this one — issue #1661.)
 // =============================================================================
 TEST_CASE("OrientationAnalysis::ComputeAvgOrientations: Cell Array Tuple Mismatch Error (-651)", "[OrientationAnalysis][ComputeAvgOrientationsFilter]")
 {
@@ -463,64 +797,13 @@ TEST_CASE("OrientationAnalysis::ComputeAvgOrientations: Cell Array Tuple Mismatc
 
   auto preflightResult = filter.preflight(dataStructure, args);
   SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+  REQUIRE(preflightResult.outputActions.errors()[0].code == -651);
 }
 
 // =============================================================================
 // SIMPL Backwards Compatibility (kept, unchanged) — validates UUID + parameter
 // conversion of the legacy six-parameter (Rodrigues) filter.
 // =============================================================================
-TEST_CASE("OrientationAnalysis::ComputeAvgOrientationsFilter: Preflight Error - Cell array tuple count mismatch (-651)", "[OrientationAnalysis][ComputeAvgOrientationsFilter][preflight]")
-{
-  UnitTest::LoadPlugins();
-
-  // Build a minimal synthetic DataStructure where the three cell-level arrays that are
-  // validated together (Quats, Phases, FeatureIds) do NOT all share the same tuple count.
-  // This drives the validateNumberOfTuples() guard in preflightImpl that emits error -651.
-  DataStructure dataStructure;
-  auto* imageGeom = ImageGeom::Create(dataStructure, "DataContainer");
-  imageGeom->setDimensions({10, 1, 1});
-
-  auto* cellAM = AttributeMatrix::Create(dataStructure, "CellData", {10}, imageGeom->getId());
-  UnitTest::CreateTestDataArray<float32>(dataStructure, "Quats", {10}, {4}, cellAM->getId());
-  UnitTest::CreateTestDataArray<int32>(dataStructure, "FeatureIds", {10}, {1}, cellAM->getId());
-
-  // CellPhases lives in a separate AttributeMatrix with a deliberately different tuple
-  // count (9 != 10) so the cross-array tuple-count check fails.
-  auto* mismatchAM = AttributeMatrix::Create(dataStructure, "MismatchData", {9}, imageGeom->getId());
-  UnitTest::CreateTestDataArray<int32>(dataStructure, "Phases", {9}, {1}, mismatchAM->getId());
-
-  auto* ensembleAM = AttributeMatrix::Create(dataStructure, "CellEnsembleData", {2}, imageGeom->getId());
-  UnitTest::CreateTestDataArray<uint32>(dataStructure, "CrystalStructures", {2}, {1}, ensembleAM->getId());
-
-  AttributeMatrix::Create(dataStructure, "CellFeatureData", {5}, imageGeom->getId());
-
-  ComputeAvgOrientationsFilter filter;
-  Arguments args;
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(DataPath({"DataContainer", "CellData", "FeatureIds"})));
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_CellPhasesArrayPath_Key, std::make_any<DataPath>(DataPath({"DataContainer", "MismatchData", "Phases"})));
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_CellQuatsArrayPath_Key, std::make_any<DataPath>(DataPath({"DataContainer", "CellData", "Quats"})));
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_CrystalStructuresArrayPath_Key, std::make_any<DataPath>(DataPath({"DataContainer", "CellEnsembleData", "CrystalStructures"})));
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_CellFeatureAttributeMatrixPath_Key, std::make_any<DataPath>(DataPath({"DataContainer", "CellFeatureData"})));
-
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseRodriguesAverage_Key, std::make_any<bool>(true));
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_RodriguesQuatsArrayName_Key, std::make_any<std::string>("AvgQuats"));
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_RodriguesAvgEulerArrayName_Key, std::make_any<std::string>("AvgEulerAngles"));
-
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseVonMisesFisher_Key, std::make_any<bool>(false));
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherAvgQuatsArrayName_Key, std::make_any<std::string>("vMF Avg Quats"));
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherAvgEulerArrayName_Key, std::make_any<std::string>("vMF Avg EulerAngles"));
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_VonMisesFisherKappaArrayName_Key, std::make_any<std::string>("vMF Kappas"));
-
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_UseWatson_Key, std::make_any<bool>(false));
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonAvgQuatsArrayName_Key, std::make_any<std::string>("Watson Avg Quats"));
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonAvgEulerArrayName_Key, std::make_any<std::string>("Watson Avg EulerAngles"));
-  args.insertOrAssign(ComputeAvgOrientationsFilter::k_WatsonKappaArrayName_Key, std::make_any<std::string>("Watson Kappas"));
-
-  auto preflightResult = filter.preflight(dataStructure, args);
-  SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
-  REQUIRE(preflightResult.outputActions.errors()[0].code == -651);
-}
-
 TEST_CASE("OrientationAnalysis::ComputeAvgOrientationsFilter: SIMPL Backwards Compatibility", "[OrientationAnalysis][ComputeAvgOrientationsFilter][BackwardsCompatibility]")
 {
   auto app = Application::GetOrCreateInstance();

--- a/src/Plugins/OrientationAnalysis/vv/ComputeAvgOrientationsFilter.md
+++ b/src/Plugins/OrientationAnalysis/vv/ComputeAvgOrientationsFilter.md
@@ -17,10 +17,10 @@
 | Algorithm Relationship | **Minor changes** (Rodrigues method) **+ New** (vMF/Watson). The Rodrigues average is a faithful port of legacy `FindAvgOrientations::execute()` with 4 deliberate deltas (positive-orientation canonicalization, FeatureId==0 inclusion, divide-by-zero cleanup, EbsdLib library swap). The von Mises-Fisher and Watson methods are **new** (added PR #1577), have **no legacy equivalent**, are off by default, and delegate their EM math to EbsdLib `DirectionalStats`. |
 | Oracle (confirmed)     | **Confirmed.** Rodrigues → **Class 1 (analytical)** + **Class 4 (invariant)**; vMF/Watson → **Class 2 (EbsdLib reference, trusted, not re-tested)** + **Class 4 (invariant)**, scoped to the filter's value-add per the "don't re-test upstream" rule. Encoded as 2 oracle TEST_CASEs (+1 error test) in `test/ComputeAvgOrientationsTest.cpp`; all pass. SIMPLNX matches the oracle on every fixture. |
 | Code paths enumerated  | 10 of 11 paths exercised (see Code path coverage); the one gap is the Watson-only dispatch branch (low-value array-selection path).                                                                                                                                                                       |
-| Tests today            | 5 test cases: Rodrigues analytical (Class 1+4), vMF/Watson EbsdLib-reference (Class 2+4), no-method-enabled error (-54670), cell-array tuple-mismatch error (-651), and SIMPL 6.4/6.5 backwards-compat (DYNAMIC_SECTION). All inline hand-built data — no exemplar archive. Closes the GCOV vMF/Watson coverage gap.       |
+| Tests today            | 9 test cases: Rodrigues analytical (Class 1+4), Rodrigues cubic-symmetry invariant (Class 4, #1660), Rodrigues voxel-ordering independence (Class 4), vMF/Watson EbsdLib-reference (Class 2+4), vMF/Watson phase-0 exclusion regression (#1659), crystal-structure/phase guard warnings (#1661), no-method-enabled error (preflight -54673 + runtime backstop -54670), cell-array tuple-mismatch error (-651, code asserted), and SIMPL 6.4/6.5 backwards-compat (DYNAMIC_SECTION). All inline hand-built data — no exemplar archive. Closes the GCOV vMF/Watson coverage gap.       |
 | Exemplar archive       | **None — retired `7_ComputeAvgOrientation_v2.tar.gz`** (it was a circular oracle regenerated from post-fix SIMPLNX output in PR #1577). Oracle is now inline in the test source. `download_test_data()` entry to be removed in Phase 10.                                                                  |
 | Legacy comparison      | **Run (2026-06-30) vs the official DREAM3D 6.5.171 release.** Two fixtures. On the realistic 480k-cell / 408-feature input the two are **numerically equivalent on all real features** (`AvgQuats` ≤1e-6, zero sign flips; `AvgEulerAngles` max 4.77e-7). Divergences are confined to **feature-0 / unindexed-voxel handling**: **D3** (empty feature 0) and **D2** (FeatureId-0 voxels with phase>0 — demonstrated on a forcing fixture: NX computes the average, legacy writes `(0,0,0,0)`). **D4** sub-epsilon. **D1 downgraded** (no demonstrable divergence). vMF/Watson have no legacy equivalent (N/A). |
-| Bug flags              | One **legacy** bug, empirically confirmed: `ComputeAvgOrientationsFilter-D3` (6.5.171 leaves the zero-voxel feature 0 as `(0,0,0,0)` / divides zero-count features by zero; SIMPLNX writes a clean identity). D2 is a deliberate algorithmic-choice divergence (not a bug). **No SIMPLNX bugs.**                  |
+| Bug flags              | One **legacy** bug, empirically confirmed: `ComputeAvgOrientationsFilter-D3` (6.5.171 leaves the zero-voxel feature 0 as `(0,0,0,0)` / divides zero-count features by zero; SIMPLNX writes a clean identity). D2 is a deliberate algorithmic-choice divergence (not a bug). One **SIMPLNX** bug found by the post-merge adversarial review and fixed 2026-07-08: **issue #1659** — the vMF/Watson gather loop ignored `Phases`, so a phase-0 voxel inside a feature contributed a garbage quaternion to the EM average. Fixed by gating the gather identically to the counting pass; pinned by the `vMF/Watson Ignores Phase-0 Voxels` regression test.                  |
 | V&V phase              | **Phases 1, 3, 4, 5, 6, 7, 8, 9 complete** — oracle confirmed/reconciled, review fixes applied, all 5 tests pass (in-core `NX-Com-Qt69-Vtk95-Rel`, vcpkg EbsdLib 3.0.0), legacy comparison run (numerically equivalent). OOC build skipped (per maintainer). Outstanding: 11 (doc deviation links), 12 (OneDrive archive), 13 (tracking).                  |
 
 ## Summary
@@ -44,7 +44,7 @@
 
 ## Oracle
 
-*Status: in progress (Phase 4). Boundary with EbsdLib confirmed; plan below pending second-engineer review.*
+*Status: confirmed. Boundary with EbsdLib confirmed; second-engineer oracle review pending (see provenance sidecar).*
 
 *Class:* **1 (Analytical) + 4 (Invariant)** for Rodrigues; **2 (Reference — EbsdLib, trusted & not re-tested) + 4 (Invariant)** for vMF/Watson.
 
@@ -68,7 +68,12 @@ EbsdLib owns: EM convergence/multi-restart, symmetry-aware E/M steps, kappa esti
 - `test/ComputeAvgOrientationsTest.cpp::"OrientationAnalysis::ComputeAvgOrientations: vMF/Watson EbsdLib Reference Oracle"` — Class 2 (22-quat feature reproduces EbsdLib's documented VMF/WAT muhat+kappa; quat margin 5e-3, kappa 2% to absorb the float32 input round-trip) + Class 4 (zero-voxel→NaN).
 - `test/ComputeAvgOrientationsTest.cpp::"OrientationAnalysis::ComputeAvgOrientations: No Method Enabled Error"` — error path `-54670`.
 
-All pass in the `NX-Com-Qt69-Vtk95-Rel-EbsdLib` build (4/4). OOC dual-build confirmed in Phase 8.
+- `test/ComputeAvgOrientationsTest.cpp::"OrientationAnalysis::ComputeAvgOrientations: Rodrigues Cubic Symmetry Invariant"` — Class 4 under non-trivial (Cubic_High) symmetry: five representations of the same orientation (Rz(30°+90°k) and −Rz(30°)) must average to Rz(30°) (issue #1660).
+- `test/ComputeAvgOrientationsTest.cpp::"OrientationAnalysis::ComputeAvgOrientations: Rodrigues Voxel Ordering Independence"` — Class 4: F3 fixture in both voxel orderings → identical Rz(45°).
+- `test/ComputeAvgOrientationsTest.cpp::"OrientationAnalysis::ComputeAvgOrientations: vMF/Watson Ignores Phase-0 Voxels"` — regression pin for issue #1659.
+- `test/ComputeAvgOrientationsTest.cpp::"OrientationAnalysis::ComputeAvgOrientations: Unknown Crystal Structure and Out-Of-Range Phase Guards"` — guard/warning coverage for issue #1661 (-54671/-54672).
+
+All 9 test cases pass in the `NX-Com-Qt69-Vtk95-Rel` build. OOC dual-build was skipped per maintainer (this filter's algorithm is feature-indexed with serial execution; no OOC-specific code path).
 
 *Second-engineer review:* *pending — recommend an OA-domain engineer (e.g. Joey) review the Triclinic closed-form derivations and confirm the 22-quaternion Class-2 reuse is a fair value-add check.*
 
@@ -86,7 +91,7 @@ Line-by-line review performed via the `review-algorithm` skill on the already-or
 
 ## Code path coverage
 
-*10 of 11 paths exercised. Source: `src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeAvgOrientations.cpp` (457 lines).* Logical phases: **(a)** `operator()` dispatch + output-array selection/validation, **(b)** Rodrigues two-pass average, **(c)** vMF/Watson per-feature EM (parallel over features).
+*15 of 16 paths exercised. Source: `src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ComputeAvgOrientations.cpp`.* Logical phases: **(a)** `operator()` dispatch + output-array selection/validation, **(b)** Rodrigues two-pass average, **(c)** vMF/Watson per-feature EM (serial over features). Paths 12–16 were added by the #1659/#1661 follow-up work (2026-07-08).
 
 | #  | Phase            | Path                                                                                                                              | Test case            |
 |----|------------------|----|----------------------|
@@ -101,6 +106,11 @@ Line-by-line review performed via the `review-algorithm` skill on the already-or
 | 9  | (c) vMF/Watson   | `featureNumVoxels[fid] == 0` → skip (output stays NaN from fill)                                                                  | both oracle tests — F0/F5 and background feature → NaN |
 | 10 | (c) vMF/Watson   | `fzQuats.size() == 1` → muhat = single FZ quat, kappa = 0 (EM skipped)                                                            | `Rodrigues Analytical Oracle` — F1, F2 (single-voxel) |
 | 11 | (c) vMF/Watson   | `fzQuats.size() > 1` → `DirectionalStats::EMforDS` (VMF or WAT) → muhat, kappa; positiveOrientation; write quat/euler/kappa       | `vMF/Watson EbsdLib Reference Oracle` (22-quat feature) + `Rodrigues Analytical Oracle` F3/F4 |
+| 12 | (a) Preflight    | all three methods disabled → preflight error `-54673` (runtime `-54670` kept as backstop, pinned by direct algorithm invocation)  | `No Method Enabled Error` |
+| 13 | (b)+(c) Guards   | `Phases` value ≥ CrystalStructures tuple count → voxel excluded (no OOB read) + warning `-54672`                                  | `Unknown Crystal Structure and Out-Of-Range Phase Guards` |
+| 14 | (b) Rodrigues    | crystal structure ≥ ops count (e.g. 999/Unknown) → voxel excluded + warning `-54671`; fully-excluded feature → identity           | `Unknown Crystal Structure and Out-Of-Range Phase Guards` |
+| 15 | (c) vMF/Watson   | crystal structure ≥ ops count → feature skipped (outputs stay NaN) + warning `-54671`                                             | `Unknown Crystal Structure and Out-Of-Range Phase Guards` |
+| 16 | (c) vMF/Watson   | gather loop excludes phase-0 / out-of-range-phase voxels (gate identical to counting pass; issue #1659)                           | `vMF/Watson Ignores Phase-0 Voxels` + guards test |
 
 ## Test inventory
 
@@ -108,18 +118,22 @@ Line-by-line review performed via the `review-algorithm` skill on the already-or
 |-----------|--------|-------|
 | `OrientationAnalysis::ComputeAvgOrientations: Rodrigues Analytical Oracle` | new-for-V&V | Class 1 + Class 4. 6 Triclinic Rodrigues fixtures with closed-form averages (exact quats @1e-6) + invariants; also asserts vMF/Watson value-add invariants (single→FZ-quat & kappa 0, zero→NaN) on the same small data. Inline hand-built data. |
 | `OrientationAnalysis::ComputeAvgOrientations: vMF/Watson EbsdLib Reference Oracle` | new-for-V&V | Class 2 + Class 4. One Cubic feature of EbsdLib's 22 reference quaternions reproduces EbsdLib `DirectionalStatsTest`'s documented VMF/WAT muhat+kappa (quat margin 5e-3, kappa 2% to absorb float32 input round-trip). Inline hand-built data. |
-| `OrientationAnalysis::ComputeAvgOrientations: No Method Enabled Error` | new-for-V&V | Error path: no method enabled → algorithm returns `-54670`. |
-| `OrientationAnalysis::ComputeAvgOrientations: Cell Array Tuple Mismatch Error (-651)` | new-for-V&V | Preflight error path: mismatched cell-array tuple counts → `-651`. Overlaps PR #1644's GCOV contribution (same test file) — reconcile the duplicate at merge time. |
+| `OrientationAnalysis::ComputeAvgOrientations: Rodrigues Cubic Symmetry Invariant` | new (issue #1660) | Class 4 under Cubic_High: five representations of one orientation (Rz(30+90k), −Rz(30)) must average to Rz(30). Exercises the symmetry-reduction branch under 24 operators. |
+| `OrientationAnalysis::ComputeAvgOrientations: Rodrigues Voxel Ordering Independence` | new (issue #1661) | Class 4: F3 fixture in both voxel orderings → identical Rz(45). Encodes the invariant the provenance previously claimed without a test. |
+| `OrientationAnalysis::ComputeAvgOrientations: vMF/Watson Ignores Phase-0 Voxels` | new (issue #1659) | Regression pin for the phase-gate fix: a phase-0 voxel inside a feature must not enter the gather (single-voxel shortcut preserved; EM path lands on the valid orientation; cross-checked vs Rodrigues). |
+| `OrientationAnalysis::ComputeAvgOrientations: Unknown Crystal Structure and Out-Of-Range Phase Guards` | new (issue #1661) | Guards: unknown crystal structure (999) and out-of-range `Phases` are excluded from both paths with warnings `-54671`/`-54672` (asserted); dropped features → identity/NaN. |
+| `OrientationAnalysis::ComputeAvgOrientations: No Method Enabled Error` | new-for-V&V (updated for #1661) | No method enabled → preflight error `-54673` (asserted); runtime backstop `-54670` pinned via direct algorithm invocation. |
+| `OrientationAnalysis::ComputeAvgOrientations: Cell Array Tuple Mismatch Error (-651)` | new-for-V&V (updated for #1661) | Preflight error path: mismatched cell-array tuple counts → `-651` (code asserted). The duplicate TEST_CASE that PR #1644 added to this file was removed in favor of this one. |
 | `OrientationAnalysis::ComputeAvgOrientationsFilter: SIMPL Backwards Compatibility` | kept | `DYNAMIC_SECTION` over SIMPL 6.4 + 6.5 conversion fixtures; validates UUID + argument-key conversion only. Unaffected by V&V. |
 
-**Coverage note (GCOV handoff, `.claude/gcov_ComputeAvgOrientations.md`):** the prior capture showed algorithm `.cpp` at 90.7% line / 46.5% branch, with the entire vMF/Watson path, the `-54670` branch, zero/single-voxel handling, and the VMF/Watson feature-array-detection branches **uncovered**. The V&V suite above now exercises all of them (Rodrigues, vMF, Watson, all-three-combined, both error paths, zero- and single-voxel features), closing the gap. The `-651` tuple branch (filter `.cpp`) is covered here and also by PR #1644.
+**Coverage note (GCOV handoff, `.claude/gcov_ComputeAvgOrientations.md`):** the prior capture showed algorithm `.cpp` at 90.7% line / 46.5% branch, with the entire vMF/Watson path, the `-54670` branch, zero/single-voxel handling, and the VMF/Watson feature-array-detection branches **uncovered**. The V&V suite above now exercises all of them (Rodrigues, vMF, Watson, all-three-combined, both error paths, zero- and single-voxel features), closing the gap. The `-651` tuple branch (filter `.cpp`) is covered here; PR #1644's duplicate `-651` TEST_CASE was removed from this file (issue #1661).
 | *(retired)* `OrientationAnalysis::ComputeAvgOrientations` | retired | Exemplar-comparison "valid execution" against `7_ComputeAvgOrientation_v2` (tol 5e-7). **Circular oracle** (exemplar regenerated from SIMPLNX output, PR #1577). Replaced by the Class 1/2/4 oracle tests above. |
 
 ## Exemplar archive
 
 - **Archive:** `7_ComputeAvgOrientation_v2.tar.gz`
 - **SHA512:** `2c2a691f1da301c449c20bafec65512d5134db38384ac7cb4c910880ccd87a260a5f011e905f35b97abff3952309f109c737c63ec3c833708926827a62a92efc`
-- **Provenance:** `src/Plugins/OrientationAnalysis/vv/provenance/7_ComputeAvgOrientation_v2.md` *(to be written, documenting circular-oracle status and replacement)*
+- **Provenance:** `src/Plugins/OrientationAnalysis/vv/provenance/ComputeAvgOrientationsFilter.md` (documents the circular-oracle retirement and the inline replacement oracle)
 - **Circular-oracle flag:** This `_v2` archive was regenerated from post-fix SIMPLNX output during PR #1577 (it bundles the filter's own `AvgQuats`, `Watson Avg Quats`, `vMF Avg Quats`, etc. as the comparison target). It is named explicitly in the audit's cross-cutting circular-oracle list. The V&V replaces this with oracle-derived expected values (Phase 10).
 
 ## Deviations from DREAM3D 6.5.171
@@ -130,3 +144,17 @@ Line-by-line review performed via the `review-algorithm` skill on the already-or
 - `ComputeAvgOrientationsFilter-D2` — **Demonstrated:** FeatureId-0 voxels (phase>0) — SIMPLNX averages them, 6.5.171 writes `(0,0,0,0)`. Algorithmic choice (not a bug). See deviations file.
 - `ComputeAvgOrientationsFilter-D3` — **Confirmed legacy bug:** empty feature 0 is `(0,0,0,0)` in 6.5.171 vs clean identity `(0,0,0,1)` in SIMPLNX. See deviations file.
 - `ComputeAvgOrientationsFilter-D4` — **Confirmed sub-epsilon:** library/precision, `AvgEulerAngles` max diff 4.77e-7. See deviations file.
+
+## Post-merge follow-ups (issues #1659, #1660, #1661 — resolved 2026-07-08)
+
+The adversarial post-merge review of PR #1645 filed three follow-up issues; all are addressed:
+
+1. **#1659 (bug, fixed):** the vMF/Watson gather loop ignored `Phases`, so a phase-0 voxel inside a feature contributed a garbage quaternion to the EM average and defeated the single-voxel shortcut (counting pass said 1, gather collected 2). The gather now gates identically to the counting pass and the Rodrigues path (`phase > 0` and in-range). Regression test: `vMF/Watson Ignores Phase-0 Voxels` (verified failing pre-fix, passing post-fix).
+2. **#1660 (oracle gap, closed):** the Rodrigues symmetry-reduction interaction was only tested under Triclinic (where `getNearestQuat` is a sign-pick no-op). New Class-4 fixture `Rodrigues Cubic Symmetry Invariant` feeds one Cubic_High feature five representations of the same orientation (Rz(30°+90°k) plus −Rz(30°)); the average must be Rz(30°). Cubic correctness no longer rests on the legacy A/B diff.
+3. **#1661 (grab bag, all items):**
+   - Phase index is now range-checked against the CrystalStructures tuple count in both paths (previously an out-of-range read); unknown/unsupported crystal-structure values were already guarded. Both drops now emit warnings (`-54671` unknown crystal structure, `-54672` out-of-range phase) instead of silently dropping, tested by `Unknown Crystal Structure and Out-Of-Range Phase Guards`, and documented in the filter docs.
+   - All-methods-disabled is now a preflight error (`-54673`) instead of a guaranteed runtime failure; the runtime `-54670` backstop is pinned by direct algorithm invocation.
+   - Error tests assert their codes (`-54673`, `-54670`, `-651`); PR #1644's duplicate `-651` test was removed.
+   - The Euler invariant (Φ ≈ 0, finite) checks and the voxel-ordering-independence fixture that the provenance claimed are now actually encoded.
+   - Provenance tolerances reconciled to the shipped values (quat ±5e-3, kappa ±2%) with justification; `featureIdToPhaseMap` last-writer-wins behavior for multi-phase features documented in the algorithm, docs, and provenance.
+   - This report's self-contradictions fixed (test count, OOC status, dangling `7_ComputeAvgOrientation_v2.md` reference).

--- a/src/Plugins/OrientationAnalysis/vv/provenance/ComputeAvgOrientationsFilter.md
+++ b/src/Plugins/OrientationAnalysis/vv/provenance/ComputeAvgOrientationsFilter.md
@@ -34,7 +34,14 @@ Quaternions below are in `(x, y, z, w)` storage order (the order the filter read
 ### Class 4 (Invariant) companions — Rodrigues
 - Output quats unit-norm and northern-hemisphere (`w ≥ 0`).
 - Zero-voxel feature → identity `(0,0,0,1)` + zero Euler.
-- Voxel-ordering independence: F3 with voxels in order [identity, Rz90] vs [Rz90, identity] → identical result (verified: both accumulate to `(0,0,0.7071,1.7071)` pre-normalize).
+- z-rotation fixtures (F2–F4): Euler asserted as the invariant `Φ ≈ 0`, all components finite (encoded in `Rodrigues Analytical Oracle`).
+- Voxel-ordering independence: F3 with voxels in order [identity, Rz90] vs [Rz90, identity] → identical result (both accumulate to `(0,0,0.7071,1.7071)` pre-normalize). Encoded as `Rodrigues Voxel Ordering Independence` (DYNAMIC_SECTION over both orderings).
+
+## Class 4 (Invariant) — Rodrigues under cubic symmetry (issue #1660)
+
+The Triclinic fixtures above make `getNearestQuat` a sign-pick no-op, so they cannot exercise the symmetry-reduction interaction that is the Rodrigues path's value-add. The `Rodrigues Cubic Symmetry Invariant` test closes that gap with an implementation-independent expectation:
+
+One `Cubic_High` feature is fed the **same physical orientation** `Rz(30°)` as five different representations — the cubic-equivalent z-rotations `Rz(30°+90°k)` for k = 1..3 (Rz(90°) is a cubic symmetry operator), the base `Rz(30°)`, and the negated double-cover representative `−Rz(30°)` — in scrambled order so the first-voxel reset operates on `Rz(120°)`. Because rotations about a common axis commute, every representation has an exact distance-0 symmetry-equivalent `Rz(30°)`, so `getNearestQuat` must pick exactly `Rz(30°)` for each voxel and the average must finalize to `Rz(30°) = (0, 0, sin15°, cos15°) = (0, 0, 0.25881905, 0.96592583)` (asserted at ±1e-5). This exercises the 24-operator cubic branch, the reset-to-identity first-voxel branch, the double-cover canonicalization, and the count weighting — independent of the legacy A/B comparison.
 
 ## Class 2 (Reference — EbsdLib, trusted) — vMF / Watson average
 
@@ -47,12 +54,17 @@ The vMF/Watson EM math is owned and tested by EbsdLib (`EbsdLib/Source/Test/Dire
 | **vMF** | `(0.3322000547718371, −0.1964639452260062, 0.2450656693404858, 0.8893749825279105)` | `88.9943042750539774` | `DirectionalStatsTest.cpp:202–206` |
 | **Watson** | `(0.2948298270586034, −0.2106011604618418, 0.2378717152588106, 0.9011878668560466)` | `30.5730272919979669` | `DirectionalStatsTest.cpp:249–253` |
 
-This proves the filter feeds EbsdLib correctly and lands the result in the right output tuple, **without re-deriving any EM math** (per the "test the value-add, not upstream" rule). Tolerance: match EbsdLib's `Approx` margin (quaternion ±1e-6; kappa ±1e-4 relative).
+This proves the filter feeds EbsdLib correctly and lands the result in the right output tuple, **without re-deriving any EM math** (per the "test the value-add, not upstream" rule).
+
+**Tolerances (as shipped in the test):** quaternion components ±5e-3 absolute (`k_QuatMargin`), kappa ±2% relative (`k_KappaRel`). EbsdLib's own test asserts at ±1e-6, but it feeds `EMforDS` double-precision quaternions; the filter round-trips the same inputs through a `float32` DataArray, and the iterative EM estimate — kappa especially, being a concentration (inverse-spread) parameter — amplifies those input perturbations well beyond the raw float32 epsilon. The margins are set an order of magnitude above the observed cross-platform deltas for robustness while remaining far below any physically meaningful divergence (a 5e-3 quaternion delta ≈ 0.6° misorientation; the fixture's kappa values are ~89 and ~31).
 
 ### Class 4 (Invariant) companions — vMF / Watson
-- Single-voxel feature → `muhat` = that voxel's FZ quat, `kappa == 0` (filter shortcut, EM skipped; algorithm lines 103–106 / 139–141).
-- Zero-voxel feature → all vMF/Watson outputs `NaN` (fill at lines 339–355, never overwritten).
+- Single-voxel feature → `muhat` = that voxel's FZ quat, `kappa == 0` (filter shortcut, EM skipped).
+- Zero-voxel feature → all vMF/Watson outputs `NaN` (NaN pre-fill, never overwritten).
 - Output quats unit-norm + northern-hemisphere; results at the feature-index tuple (not voxel index).
+- Phase gating (regression, issue #1659): a phase-0 voxel inside a feature must be excluded from the gather — the counting pass, the gather loop, and the Rodrigues path all gate identically on `phase > 0`. Encoded as `vMF/Watson Ignores Phase-0 Voxels` (single-voxel shortcut preserved + EM path lands on the valid orientation, cross-checked against Rodrigues).
+- Guards (issue #1661): out-of-range `Phases` values and unknown/unsupported crystal-structure values are excluded from both paths and reported as warnings (-54672 / -54671, never silent); fully-excluded features finalize to identity (Rodrigues) / NaN (vMF/Watson). Encoded as `Unknown Crystal Structure and Out-Of-Range Phase Guards`.
+- Multi-phase features: the vMF/Watson `featureIdToPhaseMap` is last-writer-wins — the feature's crystal structure comes from the phase of its highest-index voxel (Rodrigues is per-voxel). Documented in the algorithm and the filter docs; features are normally single-phase.
 
 ## Second-engineer oracle review
 


### PR DESCRIPTION
Addresses the three follow-up issues from the adversarial post-merge review of PR #1645.

Fixes #1659:
* Gate the vMF/Watson voxel-gather loop on phase > 0 to match the counting pass and the Rodrigues path. Previously a phase-0 voxel inside a feature contributed a garbage quaternion to the EM average and defeated the single-voxel shortcut. Pinned by a new regression test with mixed phase-0/phase-1 features.

Closes #1660:
* Add a Class-4 invariant test that exercises the Rodrigues symmetry-reduction branch under Cubic_High: five representations of the same orientation (Rz(30+90k), -Rz(30)) must average to Rz(30). Cubic correctness no longer rests solely on the legacy A/B diff.

Closes #1661:
* Range-check the Phases value against the CrystalStructures tuple count in both averaging paths (previously an out-of-range read).
* Report dropped voxels/features as warnings (-54671 unknown crystal structure, -54672 out-of-range phase) instead of silently skipping; document the behavior in the filter docs.
* Reject the all-methods-disabled configuration in preflight (-54673) instead of deferring to a guaranteed runtime failure; keep the runtime -54670 backstop and pin it via direct algorithm invocation.
* Assert error codes in the error tests and remove the duplicate -651 TEST_CASE introduced by PR #1644.
* Encode the Euler invariant (Phi ~= 0, finite) checks and the voxel-ordering-independence fixture the provenance claimed.
* Reconcile the provenance tolerances to the shipped values (quat 5e-3, kappa 2%) with justification; document the last-writer-wins featureIdToPhaseMap behavior for multi-phase features; fix the V&V report self-contradictions (test count, OOC status, dangling provenance reference).

