### PR TITLE
BUG: Make preflight geometry import metadata-only

### DIFF
--- a/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
@@ -10,6 +10,9 @@
 #include "simplnx/DataStructure/DataGroup.hpp"
 #include "simplnx/DataStructure/DataStore.hpp"
 #include "simplnx/DataStructure/DataStructure.hpp"
+#include "simplnx/DataStructure/IDataArray.hpp"
+#include "simplnx/DataStructure/IDataStore.hpp"
+#include "simplnx/DataStructure/IO/HDF5/DataStructureReader.hpp"
 #include "simplnx/Filter/Arguments.hpp"
 #include "simplnx/Filter/FilterHandle.hpp"
 #include "simplnx/Parameters/Dream3dImportParameter.hpp"
@@ -378,6 +381,77 @@ TEST_CASE("DREAM3DFileTest:Import/Export DREAM3D Filter Test", "[ReadDREAM3DFilt
     REQUIRE(dataArray->template getIDataStoreAs<EmptyDataStore<int8>>() != nullptr);
 
     UnitTest::CheckArraysInheritTupleDims(importDataStructure);
+  }
+}
+
+TEST_CASE("DREAM3DFileTest: Preflight imports geometry connectivity as metadata-only stores", "[ReadDREAM3DFilter][WriteDREAM3DFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  // geoms.dream3d ships a TriangleGeometry whose "required" connectivity arrays are the shared face
+  // list ("Triangles") and the shared vertex list ("Verts"). A metadata-only preflight must import
+  // these exactly like ordinary attribute arrays: as empty stores that carry only shape and type,
+  // never eagerly bulk-read from disk.
+  const fs::path inputFilePath = fs::path(unit_test::k_SimplnxTestDataSourceDir.view()) / "geoms.dream3d";
+
+  const DataPath sharedFaceListPath({"TriangleGeometry", "Triangles"});
+  const DataPath sharedVertexListPath({"TriangleGeometry", "Verts"});
+
+  const auto isEmptyStore = [](const IDataStore* store) {
+    return store != nullptr && (store->getStoreType() == IDataStore::StoreType::Empty || store->getStoreType() == IDataStore::StoreType::EmptyOutOfCore);
+  };
+
+  // Preflight (useEmptyDataStores == true): connectivity must remain an empty, metadata-only store.
+  {
+    auto readResult = DREAM3D::ImportDataStructureFromFile(inputFilePath, /*preflight=*/true);
+    SIMPLNX_RESULT_REQUIRE_VALID(readResult);
+    const DataStructure preflightStructure = std::move(readResult.value());
+
+    const auto* faceList = preflightStructure.getDataAs<IDataArray>(sharedFaceListPath);
+    REQUIRE(faceList != nullptr);
+    REQUIRE(isEmptyStore(faceList->getIDataStore()));
+
+    const auto* vertexList = preflightStructure.getDataAs<IDataArray>(sharedVertexListPath);
+    REQUIRE(vertexList != nullptr);
+    REQUIRE(isEmptyStore(vertexList->getIDataStore()));
+
+    // Shape metadata is still available from the empty store, which is all preflight requires.
+    REQUIRE(faceList->getNumberOfTuples() == 4);
+    REQUIRE(vertexList->getNumberOfTuples() == 10);
+  }
+
+  // Execute (useEmptyDataStores == false): connectivity is fully read from disk into a real store.
+  {
+    auto readResult = DREAM3D::ImportDataStructureFromFile(inputFilePath, /*preflight=*/false);
+    SIMPLNX_RESULT_REQUIRE_VALID(readResult);
+    const DataStructure executedStructure = std::move(readResult.value());
+
+    const auto* faceList = executedStructure.getDataAs<IDataArray>(sharedFaceListPath);
+    REQUIRE(faceList != nullptr);
+    REQUIRE_FALSE(isEmptyStore(faceList->getIDataStore()));
+    REQUIRE(faceList->getNumberOfTuples() == 4);
+
+    const auto* vertexList = executedStructure.getDataAs<IDataArray>(sharedVertexListPath);
+    REQUIRE(vertexList != nullptr);
+    REQUIRE_FALSE(isEmptyStore(vertexList->getIDataStore()));
+    REQUIRE(vertexList->getNumberOfTuples() == 10);
+  }
+
+  // Read directly through the DataStructureReader path overload with useEmptyDataStores == true. This
+  // overload must honor the flag when it delegates to the FileIO overload; connectivity must come back
+  // as an empty, metadata-only store rather than being fully read from disk.
+  {
+    auto readResult = HDF5::DataStructureReader::ReadFile(inputFilePath, /*useEmptyDataStores=*/true);
+    SIMPLNX_RESULT_REQUIRE_VALID(readResult);
+    const DataStructure preflightStructure = std::move(readResult.value());
+
+    const auto* faceList = preflightStructure.getDataAs<IDataArray>(sharedFaceListPath);
+    REQUIRE(faceList != nullptr);
+    REQUIRE(isEmptyStore(faceList->getIDataStore()));
+
+    const auto* vertexList = preflightStructure.getDataAs<IDataArray>(sharedVertexListPath);
+    REQUIRE(vertexList != nullptr);
+    REQUIRE(isEmptyStore(vertexList->getIDataStore()));
   }
 }
 

--- a/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
@@ -31,6 +31,7 @@
 #include <filesystem>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace nx::core;
@@ -388,14 +389,17 @@ TEST_CASE("DREAM3DFileTest: Preflight imports geometry connectivity as metadata-
 {
   UnitTest::LoadPlugins();
 
-  // geoms.dream3d ships a TriangleGeometry whose "required" connectivity arrays are the shared face
-  // list ("Triangles") and the shared vertex list ("Verts"). A metadata-only preflight must import
-  // these exactly like ordinary attribute arrays: as empty stores that carry only shape and type,
-  // never eagerly bulk-read from disk.
+  // geoms.dream3d ships one geometry of every type whose connectivity was formerly registered as
+  // "required" preflight data: node geometries (vertex/edge/face/polyhedron lists) and a rectilinear
+  // grid (X/Y/Z bounds). A metadata-only preflight must import all of these exactly like ordinary
+  // attribute arrays: as empty stores that carry only shape and type, never eagerly bulk-read from disk.
   const fs::path inputFilePath = fs::path(unit_test::k_SimplnxTestDataSourceDir.view()) / "geoms.dream3d";
 
-  const DataPath sharedFaceListPath({"TriangleGeometry", "Triangles"});
-  const DataPath sharedVertexListPath({"TriangleGeometry", "Verts"});
+  // {connectivity array path, expected tuple count}
+  const std::vector<std::pair<DataPath, usize>> connectivityPaths = {
+      {DataPath({"EdgeGeometry", "Verts"}), 10},       {DataPath({"EdgeGeometry", "Edges"}), 5},       {DataPath({"TriangleGeometry", "Verts"}), 10}, {DataPath({"TriangleGeometry", "Triangles"}), 4},
+      {DataPath({"QuadGeometry", "Quads"}), 2},        {DataPath({"TetrahedralGeometry", "Tets"}), 1}, {DataPath({"HexahedralGeometry", "Hexs"}), 3}, {DataPath({"RectGridGeometry", "XBounds"}), 10},
+      {DataPath({"RectGridGeometry", "YBounds"}), 10}, {DataPath({"RectGridGeometry", "ZBounds"}), 10}};
 
   const auto isEmptyStore = [](const IDataStore* store) {
     return store != nullptr && (store->getStoreType() == IDataStore::StoreType::Empty || store->getStoreType() == IDataStore::StoreType::EmptyOutOfCore);
@@ -407,17 +411,18 @@ TEST_CASE("DREAM3DFileTest: Preflight imports geometry connectivity as metadata-
     SIMPLNX_RESULT_REQUIRE_VALID(readResult);
     const DataStructure preflightStructure = std::move(readResult.value());
 
-    const auto* faceList = preflightStructure.getDataAs<IDataArray>(sharedFaceListPath);
-    REQUIRE(faceList != nullptr);
-    REQUIRE(isEmptyStore(faceList->getIDataStore()));
+    for(const auto& [dataPath, numTuples] : connectivityPaths)
+    {
+      DYNAMIC_SECTION("Preflight: " << dataPath.toString())
+      {
+        const auto* dataArray = preflightStructure.getDataAs<IDataArray>(dataPath);
+        REQUIRE(dataArray != nullptr);
+        REQUIRE(isEmptyStore(dataArray->getIDataStore()));
 
-    const auto* vertexList = preflightStructure.getDataAs<IDataArray>(sharedVertexListPath);
-    REQUIRE(vertexList != nullptr);
-    REQUIRE(isEmptyStore(vertexList->getIDataStore()));
-
-    // Shape metadata is still available from the empty store, which is all preflight requires.
-    REQUIRE(faceList->getNumberOfTuples() == 4);
-    REQUIRE(vertexList->getNumberOfTuples() == 10);
+        // Shape metadata is still available from the empty store, which is all preflight requires.
+        REQUIRE(dataArray->getNumberOfTuples() == numTuples);
+      }
+    }
   }
 
   // Execute (useEmptyDataStores == false): connectivity is fully read from disk into a real store.
@@ -426,15 +431,16 @@ TEST_CASE("DREAM3DFileTest: Preflight imports geometry connectivity as metadata-
     SIMPLNX_RESULT_REQUIRE_VALID(readResult);
     const DataStructure executedStructure = std::move(readResult.value());
 
-    const auto* faceList = executedStructure.getDataAs<IDataArray>(sharedFaceListPath);
-    REQUIRE(faceList != nullptr);
-    REQUIRE_FALSE(isEmptyStore(faceList->getIDataStore()));
-    REQUIRE(faceList->getNumberOfTuples() == 4);
-
-    const auto* vertexList = executedStructure.getDataAs<IDataArray>(sharedVertexListPath);
-    REQUIRE(vertexList != nullptr);
-    REQUIRE_FALSE(isEmptyStore(vertexList->getIDataStore()));
-    REQUIRE(vertexList->getNumberOfTuples() == 10);
+    for(const auto& [dataPath, numTuples] : connectivityPaths)
+    {
+      DYNAMIC_SECTION("Execute: " << dataPath.toString())
+      {
+        const auto* dataArray = executedStructure.getDataAs<IDataArray>(dataPath);
+        REQUIRE(dataArray != nullptr);
+        REQUIRE_FALSE(isEmptyStore(dataArray->getIDataStore()));
+        REQUIRE(dataArray->getNumberOfTuples() == numTuples);
+      }
+    }
   }
 
   // Read directly through the DataStructureReader path overload with useEmptyDataStores == true. This
@@ -445,13 +451,15 @@ TEST_CASE("DREAM3DFileTest: Preflight imports geometry connectivity as metadata-
     SIMPLNX_RESULT_REQUIRE_VALID(readResult);
     const DataStructure preflightStructure = std::move(readResult.value());
 
-    const auto* faceList = preflightStructure.getDataAs<IDataArray>(sharedFaceListPath);
-    REQUIRE(faceList != nullptr);
-    REQUIRE(isEmptyStore(faceList->getIDataStore()));
-
-    const auto* vertexList = preflightStructure.getDataAs<IDataArray>(sharedVertexListPath);
-    REQUIRE(vertexList != nullptr);
-    REQUIRE(isEmptyStore(vertexList->getIDataStore()));
+    for(const auto& [dataPath, numTuples] : connectivityPaths)
+    {
+      DYNAMIC_SECTION("DataStructureReader::ReadFile: " << dataPath.toString())
+      {
+        const auto* dataArray = preflightStructure.getDataAs<IDataArray>(dataPath);
+        REQUIRE(dataArray != nullptr);
+        REQUIRE(isEmptyStore(dataArray->getIDataStore()));
+      }
+    }
   }
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.cpp
@@ -28,20 +28,11 @@ Result<DataStructure> DataStructureReader::ReadFile(const nx::core::HDF5::FileIO
 {
   DataStructureReader dataStructureReader;
   auto groupReader = fileReader.openGroup(Constants::k_DataStructureTag);
-  auto result = dataStructureReader.readGroup(groupReader, useEmptyDataStores);
-
-  // Keep preflight metadata-only. readGroup above already imports every array as an EmptyDataStore
-  // (shape and type only) when useEmptyDataStores is set, and that now includes geometry connectivity
-  // -- vertex/face/edge lists, derived connectivity, and rectilinear-grid bounds -- exactly like
-  // ordinary attribute arrays. Skipping loadRequiredData during preflight guarantees none of those
-  // arrays are eagerly bulk-read from disk, which keeps preflight cheap on high-latency storage. A
-  // full read (useEmptyDataStores == false) imports the real stores directly in readGroup, so nothing
-  // is lost by not running the required-data pass during preflight.
-  if(result.valid() && !useEmptyDataStores)
-  {
-    dataStructureReader.loadRequiredData(fileReader);
-  }
-  return result;
+  // readGroup imports every array -- including geometry connectivity such as vertex/face/edge lists,
+  // derived connectivity, and rectilinear-grid bounds -- as an EmptyDataStore carrying only shape and
+  // type when useEmptyDataStores is set, keeping preflight metadata-only with no eager bulk reads from
+  // disk. A full read (useEmptyDataStores == false) imports the real stores directly in readGroup.
+  return dataStructureReader.readGroup(groupReader, useEmptyDataStores);
 }
 
 Result<std::shared_ptr<DataObject>> DataStructureReader::ReadObject(const nx::core::HDF5::FileIO& fileReader, const DataPath& dataPath)
@@ -273,40 +264,5 @@ std::shared_ptr<DataIOManager> DataStructureReader::getDataReader() const
 std::shared_ptr<IDataIO> DataStructureReader::getDataFactory(typename IDataIOManager::factory_id_type typeName) const
 {
   return getDataReader()->getFactoryAs<IDataIO>(typeName);
-}
-
-void DataStructureReader::addRequiredPath(const DataPath& requiredDataPath)
-{
-  m_RequiredPaths.push_back(requiredDataPath);
-}
-
-void DataStructureReader::addRequiredId(DataObject::IdType requiredDataId)
-{
-  m_RequiredIds.push_back(requiredDataId);
-}
-
-void DataStructureReader::addRequiredId(DataObject::OptionalId requiredDataId)
-{
-  if(requiredDataId.has_value())
-  {
-    m_RequiredIds.push_back(requiredDataId.value());
-  }
-}
-
-void DataStructureReader::loadRequiredData(const nx::core::HDF5::FileIO& fileReader)
-{
-  for(auto& id : m_RequiredIds)
-  {
-    auto* requiredObject = m_CurrentStructure.getData(id);
-    if(requiredObject != nullptr)
-    {
-      addRequiredPath(requiredObject->getDataPaths()[0]);
-    }
-  }
-
-  for(const auto& dataPath : m_RequiredPaths)
-  {
-    FinishImportingObject(m_CurrentStructure, fileReader, dataPath);
-  }
 }
 } // namespace nx::core::HDF5

--- a/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.cpp
@@ -22,7 +22,7 @@ DataStructureReader::~DataStructureReader() noexcept = default;
 Result<DataStructure> DataStructureReader::ReadFile(const std::filesystem::path& path, bool useEmptyDataStores)
 {
   const nx::core::HDF5::FileIO fileReader = HDF5::FileIO::ReadFile(path);
-  return ReadFile(fileReader);
+  return ReadFile(fileReader, useEmptyDataStores);
 }
 Result<DataStructure> DataStructureReader::ReadFile(const nx::core::HDF5::FileIO& fileReader, bool useEmptyDataStores)
 {
@@ -30,7 +30,14 @@ Result<DataStructure> DataStructureReader::ReadFile(const nx::core::HDF5::FileIO
   auto groupReader = fileReader.openGroup(Constants::k_DataStructureTag);
   auto result = dataStructureReader.readGroup(groupReader, useEmptyDataStores);
 
-  if(result.valid())
+  // Keep preflight metadata-only. readGroup above already imports every array as an EmptyDataStore
+  // (shape and type only) when useEmptyDataStores is set, and that now includes geometry connectivity
+  // -- vertex/face/edge lists, derived connectivity, and rectilinear-grid bounds -- exactly like
+  // ordinary attribute arrays. Skipping loadRequiredData during preflight guarantees none of those
+  // arrays are eagerly bulk-read from disk, which keeps preflight cheap on high-latency storage. A
+  // full read (useEmptyDataStores == false) imports the real stores directly in readGroup, so nothing
+  // is lost by not running the required-data pass during preflight.
+  if(result.valid() && !useEmptyDataStores)
   {
     dataStructureReader.loadRequiredData(fileReader);
   }

--- a/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.hpp
+++ b/src/simplnx/DataStructure/IO/HDF5/DataStructureReader.hpp
@@ -91,24 +91,6 @@ public:
    */
   void clearDataStructure();
 
-  /**
-   * @brief Adds a required DataPath that must be loaded during import.
-   * @param requiredDataPath The DataPath to mark as required
-   */
-  void addRequiredPath(const DataPath& requiredDataPath);
-
-  /**
-   * @brief Adds a required DataObject ID that must be loaded during import.
-   * @param requiredDataId The DataObject ID to mark as required
-   */
-  void addRequiredId(DataObject::IdType requiredDataId);
-
-  /**
-   * @brief Adds a required DataObject ID (optional) that must be loaded during import if present.
-   * @param requiredDataId The optional DataObject ID to mark as required
-   */
-  void addRequiredId(DataObject::OptionalId requiredDataId);
-
 protected:
   /**
    * @brief Returns a pointer to the nx::core::HDF5::DataFactoryManager used for finding the
@@ -125,16 +107,8 @@ protected:
    */
   std::shared_ptr<IDataIO> getDataFactory(typename IDataIOManager::factory_id_type typeName) const;
 
-  /**
-   * @brief Loads all data marked as required from the HDF5 file.
-   * @param fileReader The HDF5 file reader to load data from
-   */
-  void loadRequiredData(const nx::core::HDF5::FileIO& fileReader);
-
 private:
   std::shared_ptr<DataIOManager> m_IOManager = nullptr;
   DataStructure m_CurrentStructure;
-  std::vector<DataPath> m_RequiredPaths;
-  std::vector<DataObject::IdType> m_RequiredIds;
 };
 } // namespace nx::core::HDF5

--- a/src/simplnx/DataStructure/IO/HDF5/EdgeGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/EdgeGeomIO.cpp
@@ -39,17 +39,6 @@ Result<> EdgeGeomIO::readData(DataStructureReader& structureReader, const group_
   geometry->setElementCentroidsId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
   geometry->setElementSizesId(ReadDataId(groupReader, IOConstants::k_ElementSizesTag));
 
-  if(useEmptyDataStore)
-  {
-    // Add required data for preflight operations.
-    structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_VertexListTag));
-    structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_EdgeListTag));
-    structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementContainingVertTag));
-    structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementNeighborsTag));
-    structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
-    structureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementSizesTag));
-  }
-
   return {};
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom0dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom0dIO.cpp
@@ -30,13 +30,6 @@ Result<> INodeGeom0dIO::ReadNodeGeom0dData(DataStructureReader& dataStructureRea
   geometry.setVertexListId(ReadDataId(groupReader, IOConstants::k_VertexListTag));
   geometry.setVertexDataId(ReadDataId(groupReader, IOConstants::k_VertexDataTag));
 
-  // Required data
-  if(useEmptyDataStore)
-  {
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_VertexListTag));
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_VertexDataTag));
-  }
-
   return {};
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom1dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom1dIO.cpp
@@ -26,16 +26,6 @@ Result<> INodeGeom1dIO::ReadNodeGeom1dData(DataStructureReader& dataStructureRea
   geometry.setElementNeighborsId(ReadDataId(groupReader, IOConstants::k_ElementNeighborsTag));
   geometry.setElementCentroidsId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
 
-  // Required data
-  if(useEmptyDataStore)
-  {
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_EdgeListTag));
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_EdgeDataTag));
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementContainingVertTag));
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementNeighborsTag));
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ElementCentroidTag));
-  }
-
   return {};
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom2dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom2dIO.cpp
@@ -25,14 +25,6 @@ Result<> INodeGeom2dIO::ReadNodeGeom2dData(DataStructureReader& dataStructureRea
   geometry.setFaceDataId(ReadDataId(groupReader, IOConstants::k_FaceDataTag));
   geometry.setUnsharedEdgesId(ReadDataId(groupReader, IOConstants::k_UnsharedEdgeListTag));
 
-  // Required data
-  if(useEmptyDataStore)
-  {
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_FaceListTag));
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_FaceDataTag));
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_UnsharedEdgeListTag));
-  }
-
   return {};
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/INodeGeom3dIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/INodeGeom3dIO.cpp
@@ -25,14 +25,6 @@ Result<> INodeGeom3dIO::ReadNodeGeom3dData(DataStructureReader& dataStructureRea
   geom.setPolyhedraDataId(ReadDataId(groupReader, IOConstants::k_PolyhedronDataTag));
   geom.setUnsharedFacedId(ReadDataId(groupReader, IOConstants::k_UnsharedFaceListTag));
 
-  // Required data
-  if(useEmptyDataStore)
-  {
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_PolyhedronListTag));
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_PolyhedronDataTag));
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_UnsharedFaceListTag));
-  }
-
   return {};
 }
 

--- a/src/simplnx/DataStructure/IO/HDF5/RectGridGeomIO.cpp
+++ b/src/simplnx/DataStructure/IO/HDF5/RectGridGeomIO.cpp
@@ -58,14 +58,6 @@ Result<> RectGridGeomIO::readData(DataStructureReader& dataStructureReader, cons
   geometry->setYBoundsId(ReadDataId(groupReader, IOConstants::k_YBoundsTag));
   geometry->setZBoundsId(ReadDataId(groupReader, IOConstants::k_ZBoundsTag));
 
-  // Required data
-  if(useEmptyDataStore)
-  {
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_XBoundsTag));
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_YBoundsTag));
-    dataStructureReader.addRequiredId(ReadDataId(groupReader, IOConstants::k_ZBoundsTag));
-  }
-
   return {};
 }
 


### PR DESCRIPTION
## Summary

During a metadata-only preflight, `DataStructureReader` now leaves geometry connectivity — vertex/face/edge lists, derived connectivity, and rectilinear-grid bounds — as an `EmptyDataStore` carrying only shape and type (exactly like ordinary attribute arrays), instead of eagerly bulk-reading it from disk. This removes a wasted per-geometry disk read from every preflight, which is costly on high-latency storage such as network mounts. Execute is unchanged — it imports the real connectivity stores directly in `readGroup`.

* `readGroup` already imports every array as an `EmptyDataStore` when `useEmptyDataStores` is set, so `loadRequiredData` is now skipped during preflight.
* Geometry IO readers (`EdgeGeomIO`, `INodeGeom0d/1d/2d/3dIO`, `RectGridGeomIO`) no longer register connectivity as required data — those ids were only ever consumed by the eager preflight read.
* Forward `useEmptyDataStores` from the `std::filesystem::path` overload of `DataStructureReader::ReadFile` to the `FileIO` overload; it was previously dropped and always defaulted to `false`.

## Test Plan

- [ ] `DREAM3DFileTest` passes (adds preflight metadata-only coverage asserting geometry connectivity stores are empty after preflight and populated after execute)
- [ ] Existing DREAM3D read/write and geometry tests pass
