### PR TITLE
ENH: Cache preflight metadata for .dream3d imports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -606,6 +606,7 @@ set(SIMPLNX_HDRS
   ${SIMPLNX_SOURCE_DIR}/Utilities/Meshing/TriangleUtilities.hpp
 
   ${SIMPLNX_SOURCE_DIR}/Utilities/Parsing/DREAM3D/Dream3dIO.hpp
+  ${SIMPLNX_SOURCE_DIR}/Utilities/Parsing/DREAM3D/Dream3dPreflightCache.hpp
 
   ${SIMPLNX_SOURCE_DIR}/Utilities/Parsing/HDF5/H5.hpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/Parsing/HDF5/H5Support.hpp
@@ -803,6 +804,7 @@ set(SIMPLNX_SRCS
   ${SIMPLNX_SOURCE_DIR}/Utilities/Meshing/TriangleUtilities.cpp
 
   ${SIMPLNX_SOURCE_DIR}/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+  ${SIMPLNX_SOURCE_DIR}/Utilities/Parsing/DREAM3D/Dream3dPreflightCache.cpp
 
   ${SIMPLNX_SOURCE_DIR}/Utilities/Parsing/HDF5/H5.cpp
   ${SIMPLNX_SOURCE_DIR}/Utilities/Parsing/HDF5/H5Support.cpp

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadDREAM3DFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadDREAM3DFilter.cpp
@@ -6,7 +6,7 @@
 #include "simplnx/Parameters/StringParameter.hpp"
 #include "simplnx/Pipeline/Pipeline.hpp"
 #include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
-#include "simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp"
+#include "simplnx/Utilities/Parsing/DREAM3D/Dream3dPreflightCache.hpp"
 
 #include "simplnx/Utilities/SIMPLConversion.hpp"
 
@@ -16,7 +16,6 @@
 namespace
 {
 constexpr nx::core::int32 k_NoImportPathError = -1;
-constexpr nx::core::int32 k_FailedOpenFileIOError = -25;
 constexpr nx::core::int32 k_UnsupportedPathImportPolicyError = -51;
 } // namespace
 
@@ -82,16 +81,17 @@ IFilter::PreflightResult ReadDREAM3DFilter::preflightImpl(const DataStructure& d
   {
     return {MakeErrorResult<OutputActions>(k_NoImportPathError, "Import file path not provided.")};
   }
-  auto fileReader = nx::core::HDF5::FileIO::ReadFile(importData.FilePath);
-  if(!fileReader.isValid())
-  {
-    return {MakeErrorResult<OutputActions>(k_FailedOpenFileIOError, fmt::format("Failed to open the HDF5 file at the specified path: '{}'", importData.FilePath.string()))};
-  }
+
+  // Preflight metadata is served from Dream3dPreflightCache instead of being
+  // read from the file on every pass: pipelines re-preflight on every
+  // parameter edit, and a full HDF5 metadata traversal per edit freezes the
+  // UI for seconds on high-latency storage (network mounts). After the first
+  // import, each preflight costs a single stat() (see Dream3dPreflightCache).
+  Result<DataStructure> dataStructureResult = DREAM3D::Dream3dPreflightCache::Instance().fetch(importData.FilePath);
 
   Result<OutputActions> result;
   OutputActions& actions = result.value();
 
-  Result<DataStructure> dataStructureResult = DREAM3D::ImportDataStructureFromFile(fileReader, true);
   if(dataStructureResult.invalid())
   {
     return {ConvertResultTo<OutputActions>(ConvertResult(std::move(dataStructureResult)), {})};

--- a/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/DREAM3DFileTest.cpp
@@ -24,10 +24,12 @@
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 #include "simplnx/Utilities/ArrayCreationUtilities.hpp"
 #include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
+#include "simplnx/Utilities/Parsing/DREAM3D/Dream3dPreflightCache.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp"
 
 #include <catch2/catch.hpp>
 
+#include <chrono>
 #include <filesystem>
 #include <mutex>
 #include <string>
@@ -967,4 +969,71 @@ TEST_CASE("WriteDREAM3DFilter: Compression_Preflight_RejectsOutOfRangeLevel", "[
     args.insertOrAssign(WriteDREAM3DFilter::k_CompressionLevel, static_cast<int32>(0));
     REQUIRE(filter.preflight(ds, args).outputActions.valid());
   }
+}
+
+TEST_CASE("DREAM3DFileTest: PreflightCache avoids re-reading unchanged files", "[ReadDREAM3DFilter][PreflightCache]")
+{
+  Application::GetOrCreateInstance()->loadPlugins(unit_test::k_BuildDir.view(), true);
+
+  // Build and write a small file, then backdate its mtime past the cache's
+  // trust window so hit/miss behavior is deterministic.
+  DataStructure writtenData;
+  auto* group = DataGroup::Create(writtenData, "CacheGroup");
+  auto floatStore = std::make_shared<DataStore<float32>>(ShapeType{16}, ShapeType{1}, 2.5f);
+  Float32Array::Create(writtenData, "CacheFloats", floatStore, group->getId());
+  fs::path filePath = GetDataDir(*Application::Instance()) / "preflight_cache_integration.dream3d";
+  fs::remove(filePath);
+  REQUIRE(DREAM3D::WriteFile(filePath, writtenData, Pipeline{}, false).valid());
+  fs::last_write_time(filePath, fs::last_write_time(filePath) - std::chrono::seconds(10));
+
+  auto& cache = DREAM3D::Dream3dPreflightCache::Instance();
+  cache.clear();
+  cache.resetStats();
+  HDF5::FileIO::ResetReadOpenCount();
+
+  // Pipeline with a single ReadDREAM3DFilter, exactly as the GUI/nxrunner run it.
+  Pipeline pipeline;
+  Arguments args;
+  Dream3dImportParameter::ImportData importData(filePath);
+  args.insertOrAssign(ReadDREAM3DFilter::k_ImportFileData, importData);
+  auto filterNode = PipelineFilter::Create(k_ImportD3DHandle);
+  filterNode->setArguments(args);
+  pipeline.push_back(std::move(filterNode));
+
+  // Preflight #1 populates the cache: exactly one miss (the filter's fetch reads
+  // the file's metadata once). The import action's fetch on the same file is a
+  // hit, so it performs no second metadata traversal.
+  REQUIRE(pipeline.preflight());
+  REQUIRE(cache.missCount() == 1);
+
+  // Preflight #2 is the per-edit path. The cache serves the metadata, so there
+  // is no new miss and no metadata re-traversal -- the property that keeps
+  // re-preflight cheap on high-latency storage.
+  HDF5::FileIO::ResetReadOpenCount();
+  REQUIRE(pipeline.preflight());
+  REQUIRE(cache.missCount() == 1);
+  // A fully-cached preflight opens the file zero times: Dream3dImportParameter's
+  // validate() only stats the path (no HDF5 open), and the cache serves the
+  // filter's metadata fetch from memory instead of re-reading the file.
+  REQUIRE(HDF5::FileIO::GetReadOpenCount() == 0);
+
+  // Execute: bulk data must still be read correctly from disk.
+  REQUIRE(pipeline.execute());
+  const DataStructure executed = pipeline[0]->getDataStructure();
+  const auto* readFloats = executed.getDataAs<Float32Array>(DataPath({"CacheGroup", "CacheFloats"}));
+  REQUIRE(readFloats != nullptr);
+  REQUIRE((*readFloats)[0] == 2.5f);
+
+  // Rewriting the file must invalidate: preflight sees the new content.
+  DataStructure newData;
+  auto* group2 = DataGroup::Create(newData, "CacheGroup");
+  auto intStore = std::make_shared<DataStore<int32>>(ShapeType{4}, ShapeType{1}, 9);
+  Int32Array::Create(newData, "CacheInts", intStore, group2->getId());
+  fs::remove(filePath);
+  REQUIRE(DREAM3D::WriteFile(filePath, newData, Pipeline{}, false).valid());
+  fs::last_write_time(filePath, fs::last_write_time(filePath) - std::chrono::seconds(10));
+
+  const uint64 missesBeforeRewritePreflight = cache.missCount();
+  REQUIRE(pipeline.preflight());
+  REQUIRE(cache.missCount() == missesBeforeRewritePreflight + 1);
 }

--- a/src/simplnx/Filter/Actions/ImportH5ObjectPathsAction.cpp
+++ b/src/simplnx/Filter/Actions/ImportH5ObjectPathsAction.cpp
@@ -4,6 +4,7 @@
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataStore.hpp"
 #include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
+#include "simplnx/Utilities/Parsing/DREAM3D/Dream3dPreflightCache.hpp"
 #include "simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp"
 
 #include <fmt/core.h>
@@ -37,9 +38,12 @@ Result<> ImportH5ObjectPathsAction::apply(DataStructure& dataStructure, Mode mod
 {
   static constexpr StringLiteral prefix = "ImportH5ObjectPathsAction: ";
 
-  auto fileReader = nx::core::HDF5::FileIO::ReadFile(m_H5FilePath);
-  // Import as a preflight data structure to start to conserve memory and only allocate the data you want later
-  Result<DataStructure> dataStructureResult = DREAM3D::ImportDataStructureFromFile(fileReader, true);
+  // Metadata comes from Dream3dPreflightCache in BOTH modes: this action runs
+  // on every pipeline preflight, and re-traversing the file's HDF5 metadata
+  // each time freezes the UI on high-latency storage. The cache stat-validates
+  // the file on every fetch, so a file modified between preflight and execute
+  // is re-read rather than served stale.
+  Result<DataStructure> dataStructureResult = DREAM3D::Dream3dPreflightCache::Instance().fetch(m_H5FilePath);
   if(dataStructureResult.invalid())
   {
     return ConvertResult(std::move(dataStructureResult));
@@ -50,6 +54,20 @@ Result<> ImportH5ObjectPathsAction::apply(DataStructure& dataStructure, Mode mod
   importStructure.resetIds(dataStructure.getNextId());
 
   const bool preflighting = mode == Mode::Preflight;
+
+  // Execute mode needs an open file for the bulk-array reads performed by
+  // FinishImportingObject; preflight never touches file contents, so the open
+  // (a round-trip on network storage) is skipped entirely.
+  nx::core::HDF5::FileIO fileReader;
+  if(!preflighting)
+  {
+    fileReader = nx::core::HDF5::FileIO::ReadFile(m_H5FilePath);
+    if(!fileReader.isValid())
+    {
+      return MakeErrorResult(-6204, fmt::format("{}Failed to open the HDF5 file at the specified path: '{}'", prefix, m_H5FilePath.string()));
+    }
+  }
+
   std::stringstream errorMessages;
   for(const auto& targetPath : m_Paths)
   {
@@ -58,7 +76,8 @@ Result<> ImportH5ObjectPathsAction::apply(DataStructure& dataStructure, Mode mod
       return MakeErrorResult(-6203, fmt::format("{}Unable to import DataObject at '{}' because an object already exists there. Consider a rename of existing object.", prefix, targetPath.toString()));
     }
 
-    auto result = DREAM3D::FinishImportingObject(importStructure, dataStructure, targetPath, fileReader, preflighting);
+    auto result = preflighting ? DREAM3D::FinishImportingObjectPreflight(importStructure, dataStructure, targetPath) :
+                                 DREAM3D::FinishImportingObject(importStructure, dataStructure, targetPath, fileReader, preflighting);
     if(result.invalid())
     {
       for(const auto& errorResult : result.errors())
@@ -72,7 +91,7 @@ Result<> ImportH5ObjectPathsAction::apply(DataStructure& dataStructure, Mode mod
     return MakeErrorResult(-6201, errorMessages.str());
   }
 
-  return ConvertResult(std::move(dataStructureResult));
+  return {};
 }
 
 IDataAction::UniquePointer ImportH5ObjectPathsAction::clone() const

--- a/src/simplnx/Parameters/Dream3dImportParameter.cpp
+++ b/src/simplnx/Parameters/Dream3dImportParameter.cpp
@@ -3,7 +3,6 @@
 #include "simplnx/Common/Any.hpp"
 #include "simplnx/Common/StringLiteral.hpp"
 #include "simplnx/Common/StringLiteralFormatting.hpp"
-#include "simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp"
 
 #include <fmt/core.h>
 #include <nlohmann/json.hpp>
@@ -183,11 +182,13 @@ Result<> Dream3dImportParameter::validatePath(const ValueType& importData) const
       return MakeErrorResult(-3, fmt::format("Path '{}' is not a file", path.string()));
     }
 
-    auto fileReader = HDF5::FileIO::ReadFile(path);
-    if(!fileReader.isValid())
-    {
-      return MakeErrorResult(-4, fmt::format("HDF5 file at path '{}' could not be read", path.string()));
-    }
+    // Opening the file to confirm it is readable HDF5 is left to the consuming
+    // filter's preflight (e.g. ReadDREAM3DFilter via Dream3dPreflightCache),
+    // which already performs that open to read the file's metadata. Doing it
+    // again here would be a second HDF5 open per parameter validation, and
+    // validation runs on every pipeline edit, so on high-latency storage that
+    // is a repeated, redundant round-trip for a check the preflight already
+    // makes authoritatively.
   } catch(const fs::filesystem_error& exception)
   {
     return MakeErrorResult(-5, fmt::format("Filesystem exception: {}", exception.what()));

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -2309,7 +2309,7 @@ Result<std::vector<std::shared_ptr<DataObject>>> DREAM3D::ImportSelectDataObject
   return {dataObjects};
 }
 
-Result<> DREAM3D::FinishImportingObject(DataStructure& importStructure, DataStructure& dataStructure, const DataPath& dataPath, const nx::core::HDF5::FileIO& fileReader, bool preflight)
+Result<> DREAM3D::FinishImportingObjectPreflight(DataStructure& importStructure, DataStructure& dataStructure, const DataPath& dataPath)
 {
   if(!importStructure.containsData(dataPath))
   {
@@ -2327,24 +2327,35 @@ Result<> DREAM3D::FinishImportingObject(DataStructure& importStructure, DataStru
   {
     return MakeErrorResult(-6202, fmt::format("Unable to insert DataObject at DatPath '{}' into the DataStructure", dataPath.toString()));
   }
-  if(!preflight)
-  {
-    const auto dataPtr = dataStructure.getSharedData(dataPath);
-    if(dataPtr == nullptr)
-    {
-      return MakeErrorResult(-1502234, fmt::format("Cannot finish importing HDF5 data at DataPath '{}'. DataObject does not exist to copy data into.", dataPath.toString()));
-    }
+  return {};
+}
 
-    const auto fileVersion = GetFileVersion(fileReader);
-    if(fileVersion == k_CurrentFileVersion)
-    {
-      return HDF5::DataStructureReader::FinishImportingObject(dataStructure, fileReader, dataPath);
-    }
-    else if(fileVersion == k_LegacyFileVersion)
-    {
-      const auto dataStructureReader = fileReader.openGroup(k_LegacyDataStructureGroupTag);
-      return FinishImportingLegacyDataObject(dataStructure, dataStructureReader, dataPath);
-    }
+Result<> DREAM3D::FinishImportingObject(DataStructure& importStructure, DataStructure& dataStructure, const DataPath& dataPath, const nx::core::HDF5::FileIO& fileReader, bool preflight)
+{
+  // Insert the (metadata-only) object first; in preflight mode this is all the
+  // work there is. The bulk-array read below is skipped for preflight because
+  // preflight never populates array contents.
+  Result<> insertResult = FinishImportingObjectPreflight(importStructure, dataStructure, dataPath);
+  if(insertResult.invalid() || preflight)
+  {
+    return insertResult;
+  }
+
+  const auto dataPtr = dataStructure.getSharedData(dataPath);
+  if(dataPtr == nullptr)
+  {
+    return MakeErrorResult(-1502234, fmt::format("Cannot finish importing HDF5 data at DataPath '{}'. DataObject does not exist to copy data into.", dataPath.toString()));
+  }
+
+  const auto fileVersion = GetFileVersion(fileReader);
+  if(fileVersion == k_CurrentFileVersion)
+  {
+    return HDF5::DataStructureReader::FinishImportingObject(dataStructure, fileReader, dataPath);
+  }
+  else if(fileVersion == k_LegacyFileVersion)
+  {
+    const auto dataStructureReader = fileReader.openGroup(k_LegacyDataStructureGroupTag);
+    return FinishImportingLegacyDataObject(dataStructure, dataStructureReader, dataPath);
   }
   return {};
 }

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp
@@ -147,6 +147,19 @@ SIMPLNX_EXPORT Result<std::shared_ptr<DataObject>> ImportDataObjectFromFile(cons
 
 SIMPLNX_EXPORT Result<std::vector<std::shared_ptr<DataObject>>> ImportSelectDataObjectsFromFile(const nx::core::HDF5::FileIO& fileReader, const std::vector<DataPath>& dataPaths);
 
+/**
+ * @brief Inserts a shallow copy of the object at dataPath from importStructure
+ * into dataStructure, without opening or reading the source file. Opening a
+ * file is itself a round-trip on network storage, and preflight never reads
+ * file contents, so this preflight-mode half of FinishImportingObject needs no
+ * open file handle at all.
+ * @param importStructure The (metadata-only) structure imported from the file.
+ * @param dataStructure The pipeline structure receiving the object.
+ * @param dataPath The object to transfer.
+ * @return Result<> Errors if the path is missing or insertion fails.
+ */
+SIMPLNX_EXPORT Result<> FinishImportingObjectPreflight(DataStructure& importStructure, DataStructure& dataStructure, const DataPath& dataPath);
+
 SIMPLNX_EXPORT Result<> FinishImportingObject(DataStructure& importStructure, DataStructure& dataStructure, const DataPath& dataPath, const nx::core::HDF5::FileIO& fileReader, bool preflight);
 
 /**

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dPreflightCache.cpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dPreflightCache.cpp
@@ -1,0 +1,257 @@
+#include "Dream3dPreflightCache.hpp"
+
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/DataStructure/IDataArray.hpp"
+#include "simplnx/DataStructure/INeighborList.hpp"
+#include "simplnx/DataStructure/NeighborList.hpp"
+#include "simplnx/DataStructure/StringArray.hpp"
+#include "simplnx/DataStructure/StringStore.hpp"
+#include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
+#include "simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp"
+
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <optional>
+
+namespace fs = std::filesystem;
+
+namespace nx::core::DREAM3D
+{
+namespace
+{
+// Matches ReadDREAM3DFilter's open-failure code and message so cache fetches
+// surface the same user-visible error for a missing or unreadable file.
+constexpr int32 k_FailedOpenFileIOError = -25;
+
+/**
+ * @brief Canonicalizes a path for use as a cache key so the same file reached
+ * via different spellings (relative vs absolute, redundant separators) maps to
+ * one entry. Falls back to fs::absolute when canonicalization fails (e.g. the
+ * file does not exist yet).
+ */
+std::string MakeKey(const fs::path& filePath)
+{
+  std::error_code errorCode;
+  fs::path canonical = fs::weakly_canonical(filePath, errorCode);
+  if(errorCode)
+  {
+    canonical = fs::absolute(filePath, errorCode);
+  }
+  return canonical.string();
+}
+
+/**
+ * @brief Reads the preflight (metadata-only) DataStructure from disk. This is
+ * the cache's miss path: open the file and import metadata-only (empty) data
+ * stores.
+ */
+Result<DataStructure> ReadFromDisk(const fs::path& filePath)
+{
+  auto fileReader = nx::core::HDF5::FileIO::ReadFile(filePath);
+  if(!fileReader.isValid())
+  {
+    return MakeErrorResult<DataStructure>(k_FailedOpenFileIOError, fmt::format("Failed to open the HDF5 file at the specified path: '{}'", filePath.string()));
+  }
+  return ImportDataStructureFromFile(fileReader, true);
+}
+
+/**
+ * @brief Rebinds a DataArray<T> to a deep copy of its current store. Deep
+ * copying an EmptyDataStore allocates nothing; it only duplicates the shape
+ * metadata, which is exactly what preflight handouts need.
+ */
+struct RefreshDataArrayStoreFunctor
+{
+  template <typename T>
+  void operator()(DataStructure& dataStructure, const DataPath& path) const
+  {
+    auto& dataArray = dataStructure.getDataRefAs<DataArray<T>>(path);
+    std::shared_ptr<IDataStore> freshBase(dataArray.getIDataStore()->deepCopy());
+    auto freshStore = std::dynamic_pointer_cast<AbstractDataStore<T>>(freshBase);
+    dataArray.setDataStore(std::move(freshStore));
+  }
+};
+
+/**
+ * @brief Rebinds a NeighborList<T> to a deep copy of its list store, for the
+ * same isolation reason as RefreshDataArrayStoreFunctor.
+ */
+struct RefreshNeighborListStoreFunctor
+{
+  template <typename T>
+  void operator()(DataStructure& dataStructure, const DataPath& path) const
+  {
+    auto& neighborList = dataStructure.getDataRefAs<NeighborList<T>>(path);
+    neighborList.setStore(std::shared_ptr<AbstractListStore<T>>(neighborList.getStore()->deepCopy()));
+  }
+};
+} // namespace
+
+Dream3dPreflightCache& Dream3dPreflightCache::Instance()
+{
+  static Dream3dPreflightCache instance;
+  return instance;
+}
+
+void Dream3dPreflightCache::RefreshStores(DataStructure& dataStructure)
+{
+  for(const auto& path : dataStructure.getAllDataPaths())
+  {
+    if(auto* dataArray = dataStructure.getDataAs<IDataArray>(path); dataArray != nullptr)
+    {
+      ExecuteDataFunction(RefreshDataArrayStoreFunctor{}, dataArray->getDataType(), dataStructure, path);
+    }
+    else if(auto* stringArray = dataStructure.getDataAs<StringArray>(path); stringArray != nullptr)
+    {
+      // StringArray exposes no store getter; rebuilding from its values gives
+      // an equivalent, independent store. Preflight string stores hold only
+      // placeholder strings, so this copies almost nothing.
+      stringArray->setStore(std::make_shared<StringStore>(stringArray->values(), stringArray->getTupleShape()));
+    }
+    else if(auto* neighborList = dataStructure.getDataAs<INeighborList>(path); neighborList != nullptr)
+    {
+      ExecuteDataFunctionNoBool(RefreshNeighborListStoreFunctor{}, neighborList->getDataType(), dataStructure, path);
+    }
+  }
+}
+
+std::optional<DataStructure> Dream3dPreflightCache::tryServeFromCache(const std::string& key, uint64 fileSize, const fs::file_time_type& mtime)
+{
+  std::optional<DataStructure> handout;
+  {
+    const std::lock_guard<std::mutex> lock(m_Mutex);
+    auto iter = m_Entries.find(key);
+    if(iter != m_Entries.end() && iter->second.fileSize == fileSize && iter->second.mtime == mtime)
+    {
+      m_Hits++;
+      iter->second.lastUsedTick = ++m_Tick;
+      // Copy under the lock (the entry could be evicted after release); the
+      // copy is cheap because preflight stores hold no bulk data.
+      handout = iter->second.master;
+    }
+  }
+  if(handout.has_value())
+  {
+    // Refresh outside the lock: the handout's shared_ptrs keep the source
+    // stores alive on their own, and masters are never mutated in place, so
+    // isolating the copy needs no synchronization with other fetches.
+    RefreshStores(*handout);
+  }
+  return handout;
+}
+
+Result<DataStructure> Dream3dPreflightCache::fetch(const fs::path& filePath)
+{
+  std::error_code errorCode;
+  const uint64 fileSize = static_cast<uint64>(fs::file_size(filePath, errorCode));
+  const auto mtime = fs::last_write_time(filePath, errorCode);
+  if(errorCode)
+  {
+    // Stat failed (file missing/unreachable): fall through to a direct read so
+    // the caller receives the normal open-failure error for a missing or
+    // unreadable file.
+    // Freshly read from disk and never cached, so no refresh is needed: this
+    // handout already owns stores no other handout can reach. The read is still
+    // serialized because the HDF5 C library is not safe to call concurrently.
+    m_Misses++;
+    const std::lock_guard<std::mutex> readLock(m_ReadMutex);
+    return ReadFromDisk(filePath);
+  }
+
+  // Never trust entries for a file modified within the mtime rounding window
+  // of network filesystems: a same-size rewrite inside that window would be
+  // indistinguishable from the cached state. Serve a fresh read instead.
+  if(fs::file_time_type::clock::now() - mtime < k_MtimeTrustWindow)
+  {
+    // Freshly read from disk and never cached, so no refresh is needed: this
+    // handout already owns stores no other handout can reach. The read is still
+    // serialized because the HDF5 C library is not safe to call concurrently.
+    m_Misses++;
+    const std::lock_guard<std::mutex> readLock(m_ReadMutex);
+    return ReadFromDisk(filePath);
+  }
+
+  const std::string key = MakeKey(filePath);
+
+  // Fast path: a valid cached entry needs only m_Mutex and never blocks on a
+  // disk read in flight for some other file, keeping the per-edit path light.
+  if(std::optional<DataStructure> hit = tryServeFromCache(key, fileSize, mtime); hit.has_value())
+  {
+    return {std::move(*hit)};
+  }
+
+  // Miss: serialize the disk read with m_ReadMutex because the HDF5 C library
+  // is not safe to call concurrently in this build. Per the lock ordering,
+  // m_ReadMutex is acquired here BEFORE any m_Mutex acquisition below.
+  const std::lock_guard<std::mutex> readLock(m_ReadMutex);
+
+  // Re-check under m_Mutex: another thread may have populated this entry while
+  // we waited for m_ReadMutex. If so, serve it and skip the redundant (and, on
+  // high-latency storage, expensive) read.
+  if(std::optional<DataStructure> hit = tryServeFromCache(key, fileSize, mtime); hit.has_value())
+  {
+    return {std::move(*hit)};
+  }
+
+  m_Misses++;
+  Result<DataStructure> diskResult = ReadFromDisk(filePath);
+  if(diskResult.invalid())
+  {
+    // Failures are never cached: the next fetch must retry the file.
+    return diskResult;
+  }
+
+  DataStructure handout;
+  {
+    const std::lock_guard<std::mutex> lock(m_Mutex);
+    Entry& entry = m_Entries[key];
+    entry.master = std::move(diskResult.value());
+    entry.fileSize = fileSize;
+    entry.mtime = mtime;
+    entry.lastUsedTick = ++m_Tick;
+
+    // Bound the table: evict the least-recently-used entry. The cap exists to
+    // bound bookkeeping in long GUI sessions that touch many files; preflight
+    // masters themselves are only kilobytes.
+    while(m_Entries.size() > k_Capacity)
+    {
+      auto victim = std::min_element(m_Entries.begin(), m_Entries.end(), [](const auto& a, const auto& b) { return a.second.lastUsedTick < b.second.lastUsedTick; });
+      m_Entries.erase(victim);
+    }
+
+    handout = entry.master;
+  }
+  RefreshStores(handout);
+  return {std::move(handout)};
+}
+
+void Dream3dPreflightCache::invalidate(const fs::path& filePath)
+{
+  const std::lock_guard<std::mutex> lock(m_Mutex);
+  m_Entries.erase(MakeKey(filePath));
+}
+
+void Dream3dPreflightCache::clear()
+{
+  const std::lock_guard<std::mutex> lock(m_Mutex);
+  m_Entries.clear();
+}
+
+uint64 Dream3dPreflightCache::hitCount() const
+{
+  return m_Hits.load();
+}
+
+uint64 Dream3dPreflightCache::missCount() const
+{
+  return m_Misses.load();
+}
+
+void Dream3dPreflightCache::resetStats()
+{
+  m_Hits.store(0);
+  m_Misses.store(0);
+}
+} // namespace nx::core::DREAM3D

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dPreflightCache.hpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dPreflightCache.hpp
@@ -1,0 +1,185 @@
+#pragma once
+
+#include "simplnx/Common/Result.hpp"
+#include "simplnx/DataStructure/DataStructure.hpp"
+#include "simplnx/simplnx_export.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+
+namespace nx::core::DREAM3D
+{
+/**
+ * @class Dream3dPreflightCache
+ * @brief Process-wide cache of preflight (metadata-only) DataStructures imported
+ * from .dream3d files, keyed by canonical file path and validated by file size
+ * and modification time on every fetch.
+ *
+ * Why this exists: a pipeline re-preflights whenever any filter parameter
+ * changes, and every preflight of a ReadDREAM3DFilter re-imports the HDF5
+ * metadata tree of its input file. That traversal is hundreds of small,
+ * latency-bound reads (object headers, B-tree nodes, attributes). On local
+ * disks it is milliseconds; on high-latency storage such as NAS/SMB mounts it
+ * can take many seconds — repeated on every edit, for metadata that has not
+ * changed. Caching the imported preflight structure reduces every fetch after
+ * the first to a single filesystem stat.
+ *
+ * fetch() never hands out the cached master DataStructure itself; it returns
+ * a copy whose arrays own freshly created store instances, so mutations made
+ * by one preflight pass can never bleed into another pass or into the master.
+ * Preflight stores are metadata-only, so allocating fresh copies costs no
+ * bulk data.
+ *
+ * Staleness guarantee: every fetch stats the file and compares (size, mtime)
+ * against the values captured when the entry was populated; any mismatch
+ * evicts the entry and re-reads from disk. Files whose mtime is younger than
+ * k_MtimeTrustWindow are never served from the cache because network
+ * filesystems round mtimes coarsely enough that a very recent rewrite could
+ * otherwise go undetected.
+ */
+class SIMPLNX_EXPORT Dream3dPreflightCache
+{
+public:
+  /**
+   * @brief The maximum number of entries the cache holds. Once a fetch would
+   * grow the table past this size, the least-recently-used entry (by fetch
+   * recency, tracked per-entry and updated on every hit or insert) is evicted
+   * first. Preflight structures store only shapes and names (kilobytes), so
+   * this bounds bookkeeping, not memory pressure.
+   */
+  static constexpr usize k_Capacity = 8;
+
+  /**
+   * @brief Files modified more recently than this are never served from the
+   * cache. Guards against coarse mtime granularity on network filesystems
+   * (SMB/NFS commonly round to 1-2 s), where a same-size rewrite inside the
+   * rounding window would otherwise be indistinguishable from the cached state.
+   */
+  static constexpr std::chrono::seconds k_MtimeTrustWindow{2};
+
+  /**
+   * @brief Returns the process-wide cache instance. A singleton because the
+   * cache must be shared across every filter instance and pipeline that reads
+   * the same file, and because preflight runs on worker threads that have no
+   * shared context other than process globals.
+   */
+  static Dream3dPreflightCache& Instance();
+
+  /**
+   * @brief Returns a preflight DataStructure for the given file.
+   *
+   * Stats the file first: on a (size, mtime) match with a cached entry this
+   * is a pure in-memory operation; otherwise the file is opened and its
+   * metadata imported exactly as ImportDataStructureFromFile(reader, true)
+   * would, and the result cached. Errors (missing/unreadable file, malformed
+   * content) are returned unchanged from the underlying reader so callers keep
+   * their existing error contracts; failures are never cached.
+   * @param filePath Path to the .dream3d file.
+   * @return Result<DataStructure> An isolated handout: every array's store is
+   * a fresh instance, never shared with the cached master or any other
+   * handout, or import errors.
+   */
+  Result<DataStructure> fetch(const std::filesystem::path& filePath);
+
+  /**
+   * @brief Removes the entry for the given file, if present. Exists so tests
+   * and callers that know a file changed can force the next fetch to re-read
+   * without waiting for stat-based detection.
+   * @param filePath Path whose entry should be dropped.
+   */
+  void invalidate(const std::filesystem::path& filePath);
+
+  /**
+   * @brief Removes all entries. Primarily for test isolation.
+   */
+  void clear();
+
+  /**
+   * @brief Number of fetches served from the cache since the last resetStats().
+   * Tests assert on these counters instead of wall-clock time so the I/O
+   * behavior is verified deterministically on any machine.
+   */
+  uint64 hitCount() const;
+
+  /**
+   * @brief Number of fetches that read the file since the last resetStats().
+   */
+  uint64 missCount() const;
+
+  /**
+   * @brief Resets hit/miss counters to zero. For test isolation.
+   */
+  void resetStats();
+
+private:
+  Dream3dPreflightCache() = default;
+
+  /**
+   * @brief Replaces every array store in the given structure with a freshly
+   * allocated copy.
+   *
+   * Why: DataStructure copy-construction shallow-copies each DataObject, so a
+   * copied array still points at the SAME store instance as its source. A
+   * handout built by plain copy would therefore share mutable state with the
+   * cached master and with every other handout — mutating one preflight pass
+   * could corrupt another. Replacing the stores severs that link. Preflight
+   * stores are metadata-only (empty stores holding shapes), so the copies
+   * allocate no bulk data.
+   * @param dataStructure The handout to isolate, modified in place.
+   */
+  static void RefreshStores(DataStructure& dataStructure);
+
+  /**
+   * @brief Looks up a cached entry for the given key and, if it is still valid
+   * for the supplied (size, mtime) token, records a hit, refreshes its recency,
+   * and returns an isolated handout copy; returns nullopt on a miss.
+   *
+   * Acquires m_Mutex internally (the caller must not already hold it) and, on a
+   * hit, releases it before isolating the copy via RefreshStores so that work
+   * never runs under the table lock. Shared by the fast path and the miss
+   * path's post-read-lock re-check so both consult the cache identically.
+   * @param key Canonical cache key for the file.
+   * @param fileSize Current on-disk size, compared against the cached token.
+   * @param mtime Current on-disk modification time, compared against the token.
+   * @return An isolated handout on a hit, or nullopt on a miss.
+   */
+  std::optional<DataStructure> tryServeFromCache(const std::string& key, uint64 fileSize, const std::filesystem::file_time_type& mtime);
+
+  /**
+   * @brief One cached file: the immutable master structure plus the (size,
+   * mtime) token captured when it was read, used to detect on-disk changes.
+   */
+  struct Entry
+  {
+    DataStructure master;
+    uint64 fileSize = 0;
+    std::filesystem::file_time_type mtime;
+    uint64 lastUsedTick = 0;
+  };
+
+  /**
+   * @brief Serializes the cache's own metadata reads from disk so no two HDF5
+   * imports run concurrently. The bundled HDF5 C library is built without its
+   * thread-safe option, so its API cannot be called from multiple threads at
+   * once; every cache miss reads the file through this mutex to honor that
+   * constraint. It is deliberately distinct from m_Mutex, which guards only the
+   * in-memory entry table: a cache hit takes m_Mutex alone and never blocks on
+   * an in-flight read, keeping the common per-edit fetch path lock-light.
+   *
+   * Lock ordering: whenever both are held, m_ReadMutex is acquired before
+   * m_Mutex, never the reverse. Hits take only m_Mutex; the miss path takes
+   * m_ReadMutex first and then briefly m_Mutex to consult and update the table.
+   */
+  std::mutex m_ReadMutex;
+  mutable std::mutex m_Mutex;
+  std::map<std::string, Entry> m_Entries;
+  uint64 m_Tick = 0;
+  std::atomic<uint64> m_Hits{0};
+  std::atomic<uint64> m_Misses{0};
+};
+} // namespace nx::core::DREAM3D

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/FileIO.cpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/FileIO.cpp
@@ -4,12 +4,72 @@
 
 #include <fmt/format.h>
 
+#include <H5Ppublic.h>
+
+#include <atomic>
+#include <functional>
+
+namespace
+{
+// Counts every ReadFile() open so tests can assert that cached preflight paths
+// perform zero file opens. Process-wide and atomic because ReadFile() is called
+// from preflight worker threads.
+std::atomic<nx::core::uint64> s_ReadOpenCount{0};
+
+// Optional test-only hook applied to the file-access property list just before
+// a file is opened. Unset in production, so opens use H5P_DEFAULT unchanged.
+std::function<void(hid_t)> s_FaplConfigurator;
+
+// Builds the file-access property list for a file open. Returns H5P_DEFAULT
+// when no configurator is installed (the production path); otherwise creates a
+// fapl, hands it to the configurator, and returns it. The caller must close a
+// non-default result with CloseFaplId().
+hid_t MakeFaplId()
+{
+  if(!s_FaplConfigurator)
+  {
+    return H5P_DEFAULT;
+  }
+  hid_t faplId = H5Pcreate(H5P_FILE_ACCESS);
+  s_FaplConfigurator(faplId);
+  return faplId;
+}
+
+// Releases a fapl produced by MakeFaplId(). H5P_DEFAULT is a constant, not an
+// allocated id, so it is left alone.
+void CloseFaplId(hid_t faplId)
+{
+  if(faplId != H5P_DEFAULT)
+  {
+    H5Pclose(faplId);
+  }
+}
+} // namespace
+
 namespace nx::core::HDF5
 {
 FileIO FileIO::ReadFile(const std::filesystem::path& filepath)
 {
-  hid_t fileId = H5Fopen(filepath.string().c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+  s_ReadOpenCount++;
+  hid_t faplId = MakeFaplId();
+  hid_t fileId = H5Fopen(filepath.string().c_str(), H5F_ACC_RDONLY, faplId);
+  CloseFaplId(faplId);
   return FileIO(filepath, fileId);
+}
+
+uint64 FileIO::GetReadOpenCount()
+{
+  return s_ReadOpenCount.load();
+}
+
+void FileIO::ResetReadOpenCount()
+{
+  s_ReadOpenCount.store(0);
+}
+
+void FileIO::SetFaplConfigurator(std::function<void(hid_t)> configurator)
+{
+  s_FaplConfigurator = std::move(configurator);
 }
 
 FileIO FileIO::WriteFile(const std::filesystem::path& filepath)
@@ -26,7 +86,9 @@ FileIO FileIO::WriteFile(const std::filesystem::path& filepath)
     }
   }
 
-  hid_t fileId = H5Fcreate(filepath.string().c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  hid_t faplId = MakeFaplId();
+  hid_t fileId = H5Fcreate(filepath.string().c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, faplId);
+  CloseFaplId(faplId);
   if(fileId > 0)
   {
     return FileIO(filepath, fileId);

--- a/src/simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp
@@ -9,6 +9,7 @@
 #include <H5Fpublic.h>
 
 #include <filesystem>
+#include <functional>
 #include <string>
 
 namespace nx::core::HDF5
@@ -19,6 +20,40 @@ public:
   static FileIO ReadFile(const std::filesystem::path& filepath);
   static FileIO WriteFile(const std::filesystem::path& filepath);
   static FileIO AppendFile(const std::filesystem::path& filepath);
+
+  /**
+   * @brief Returns the number of times ReadFile() has opened a file since the
+   * last ResetReadOpenCount(). Diagnostic used by tests to prove that cached
+   * preflight paths perform zero file opens; asserting on operation counts is
+   * deterministic where wall-clock timing is not.
+   * @return uint64
+   */
+  static uint64 GetReadOpenCount();
+
+  /**
+   * @brief Resets the ReadFile() open counter. For test isolation.
+   */
+  static void ResetReadOpenCount();
+
+  /**
+   * @brief Installs a callback invoked with the file-access property list used
+   * by ReadFile()/WriteFile() just before the file is opened.
+   *
+   * Why: benchmarks inject a latency-simulating HDF5 virtual file driver
+   * through this hook to reproduce network-storage behavior deterministically
+   * on local disks. Production code never sets it; when unset, files open with
+   * the default property list when no configurator is installed.
+   *
+   * Threading contract: this is a test-only diagnostic hook. It stores the
+   * callback without synchronization, so it must NOT be called while any
+   * ReadFile()/WriteFile() may be running on another thread (ReadFile() is
+   * invoked from preflight worker threads). Install the configurator before,
+   * and clear it after, any concurrent I/O.
+   * @param configurator Callback that receives the HDF5 file-access property
+   * list id to configure (e.g. to select a virtual file driver). Passing an
+   * empty function removes any previously installed configurator.
+   */
+  static void SetFaplConfigurator(std::function<void(hid_t faplId)> configurator);
 
   FileIO() = default;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,9 @@ add_executable(simplnx_test
   DataStructObserver.hpp
   DataStructObserver.cpp
   DataStructTest.cpp
+  DelayVfd.hpp
+  DelayVfd.cpp
+  Dream3dPreflightCacheTest.cpp
   DynamicFilterInstantiationTest.cpp
   FilePathGeneratorTest.cpp
   GeometryTest.cpp

--- a/test/DelayVfd.cpp
+++ b/test/DelayVfd.cpp
@@ -1,0 +1,168 @@
+#include "DelayVfd.hpp"
+
+#include <H5FDdevelop.h>
+#include <H5Fpublic.h>
+#include <H5Ppublic.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <thread>
+
+using namespace nx::core;
+
+namespace
+{
+// Per-operation sleep, in microseconds, applied on every open and read. Atomic
+// so the benchmark can arm and disarm the driver without touching HDF5 state.
+std::atomic<uint64> s_DelayMicroseconds{0};
+
+// The registered driver id, cached so Register() is idempotent across calls.
+hid_t s_DriverId = H5I_INVALID_HID;
+
+// Sleeps for the currently configured per-operation delay. A zero delay is a
+// no-op, so the registered driver behaves as a plain pass-through when disarmed.
+void Sleep()
+{
+  const uint64 usec = s_DelayMicroseconds.load();
+  if(usec > 0)
+  {
+    std::this_thread::sleep_for(std::chrono::microseconds(usec));
+  }
+}
+
+// The driver's per-file state. Its first member is the public H5FD_t part that
+// HDF5 fills in and hands back to every callback; keeping it first lets the
+// callbacks reinterpret_cast the H5FD_t* they receive back to a DelayFile*.
+struct DelayFile
+{
+  H5FD_t pub{};
+  std::FILE* fp = nullptr;
+  haddr_t eoa = 0;
+  haddr_t eof = 0;
+};
+
+int64 FileSize(std::FILE* fp)
+{
+#ifdef _WIN32
+  _fseeki64(fp, 0, SEEK_END);
+  return _ftelli64(fp);
+#else
+  fseeko(fp, 0, SEEK_END);
+  return ftello(fp);
+#endif
+}
+
+void SeekTo(std::FILE* fp, haddr_t addr)
+{
+#ifdef _WIN32
+  _fseeki64(fp, static_cast<int64_t>(addr), SEEK_SET);
+#else
+  fseeko(fp, static_cast<off_t>(addr), SEEK_SET);
+#endif
+}
+
+H5FD_t* DelayOpen(const char* name, unsigned flags, hid_t /*fapl*/, haddr_t /*maxaddr*/)
+{
+  if((flags & H5F_ACC_RDWR) != 0)
+  {
+    return nullptr; // read-only driver: benchmarks only ever read
+  }
+  Sleep();
+  std::FILE* fp = std::fopen(name, "rb");
+  if(fp == nullptr)
+  {
+    return nullptr;
+  }
+  auto* file = new DelayFile();
+  file->fp = fp;
+  file->eof = static_cast<haddr_t>(FileSize(fp));
+  return reinterpret_cast<H5FD_t*>(file);
+}
+
+herr_t DelayClose(H5FD_t* fdt)
+{
+  auto* file = reinterpret_cast<DelayFile*>(fdt);
+  std::fclose(file->fp);
+  delete file;
+  return 0;
+}
+
+haddr_t DelayGetEoa(const H5FD_t* fdt, H5FD_mem_t /*type*/)
+{
+  return reinterpret_cast<const DelayFile*>(fdt)->eoa;
+}
+
+herr_t DelaySetEoa(H5FD_t* fdt, H5FD_mem_t /*type*/, haddr_t addr)
+{
+  reinterpret_cast<DelayFile*>(fdt)->eoa = addr;
+  return 0;
+}
+
+haddr_t DelayGetEof(const H5FD_t* fdt, H5FD_mem_t /*type*/)
+{
+  return reinterpret_cast<const DelayFile*>(fdt)->eof;
+}
+
+herr_t DelayRead(H5FD_t* fdt, H5FD_mem_t /*type*/, hid_t /*dxpl*/, haddr_t addr, size_t size, void* buf)
+{
+  Sleep();
+  auto* file = reinterpret_cast<DelayFile*>(fdt);
+  SeekTo(file->fp, addr);
+  const size_t got = std::fread(buf, 1, size, file->fp);
+  if(got < size)
+  {
+    std::memset(static_cast<char*>(buf) + got, 0, size - got);
+  }
+  return 0;
+}
+
+herr_t DelayWrite(H5FD_t* /*fdt*/, H5FD_mem_t /*type*/, hid_t /*dxpl*/, haddr_t /*addr*/, size_t /*size*/, const void* /*buf*/)
+{
+  return -1; // read-only
+}
+
+// Builds the driver class descriptor. The struct is zero-initialized so every
+// optional callback stays null; only the members H5FDregister requires (open,
+// close, get_eoa, set_eoa, get_eof, read, write) plus identity fields are set.
+// This driver's unique H5FD class value, identifying it among registered drivers.
+constexpr int k_DriverClassValue = 4242;
+
+H5FD_class_t MakeDriverClass()
+{
+  H5FD_class_t cls{};
+  cls.version = H5FD_CLASS_VERSION;
+  cls.value = static_cast<H5FD_class_value_t>(k_DriverClassValue);
+  cls.name = "simplnx_delay";
+  cls.maxaddr = HADDR_MAX - 1;
+  cls.fc_degree = H5F_CLOSE_WEAK;
+  cls.fapl_size = 0;
+  cls.open = DelayOpen;
+  cls.close = DelayClose;
+  cls.get_eoa = DelayGetEoa;
+  cls.set_eoa = DelaySetEoa;
+  cls.get_eof = DelayGetEof;
+  cls.read = DelayRead;
+  cls.write = DelayWrite;
+  return cls;
+}
+} // namespace
+
+namespace DelayVfd
+{
+hid_t Register()
+{
+  if(s_DriverId == H5I_INVALID_HID)
+  {
+    static H5FD_class_t cls = MakeDriverClass();
+    s_DriverId = H5FDregister(&cls);
+  }
+  return s_DriverId;
+}
+
+void SetDelayMicroseconds(uint64 microseconds)
+{
+  s_DelayMicroseconds.store(microseconds);
+}
+} // namespace DelayVfd

--- a/test/DelayVfd.hpp
+++ b/test/DelayVfd.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "simplnx/Common/Types.hpp"
+
+#include <H5Ipublic.h>
+
+/**
+ * @brief A read-only HDF5 Virtual File Driver that adds a configurable sleep to
+ * every file open and read.
+ *
+ * Why: the cost of preflighting a .dream3d file on network storage is
+ * per-operation latency multiplied by the hundreds of small metadata reads an
+ * HDF5 tree traversal performs. Injecting that latency at the VFD layer
+ * reproduces the pathology deterministically on a local disk -- no root
+ * privileges, no network, identical on every platform -- so benchmarks can
+ * demonstrate the before/after effect of the preflight metadata cache.
+ */
+namespace DelayVfd
+{
+/**
+ * @brief Registers the driver with HDF5 (idempotent) and returns its id for use
+ * with H5Pset_driver. Returns H5I_INVALID_HID if registration fails.
+ * @return The registered HDF5 driver id, or H5I_INVALID_HID on failure.
+ */
+hid_t Register();
+
+/**
+ * @brief Sets the sleep applied to each open and read call.
+ * @param microseconds Per-operation delay in microseconds; 0 disarms the driver
+ * so it behaves as a plain pass-through.
+ */
+void SetDelayMicroseconds(nx::core::uint64 microseconds);
+} // namespace DelayVfd

--- a/test/Dream3dPreflightCacheTest.cpp
+++ b/test/Dream3dPreflightCacheTest.cpp
@@ -1,0 +1,334 @@
+#include "DelayVfd.hpp"
+
+#include "simplnx/Common/Types.hpp"
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/DataStructure/DataStore.hpp"
+#include "simplnx/DataStructure/DataStructure.hpp"
+#include "simplnx/DataStructure/StringArray.hpp"
+#include "simplnx/Pipeline/Pipeline.hpp"
+#include "simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.hpp"
+#include "simplnx/Utilities/Parsing/DREAM3D/Dream3dPreflightCache.hpp"
+#include "simplnx/Utilities/Parsing/HDF5/IO/FileIO.hpp"
+
+#include "simplnx/unit_test/simplnx_test_dirs.hpp"
+
+#include <catch2/catch.hpp>
+
+#include <fmt/core.h>
+
+#include <H5Ppublic.h>
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <thread>
+#include <vector>
+
+using namespace nx::core;
+namespace fs = std::filesystem;
+
+namespace
+{
+/**
+ * @brief Writes a small .dream3d file containing a group, an attribute matrix,
+ * two DataArrays, and a StringArray, then backdates its mtime so the cache's
+ * young-mtime guard (files newer than k_MtimeTrustWindow are never trusted)
+ * does not interfere with hit/miss assertions.
+ */
+fs::path WriteTestFile(const std::string& fileName, usize numTuples = 10)
+{
+  DataStructure dataStructure;
+  auto* group = DataGroup::Create(dataStructure, "TestGroup");
+  auto* attrMat = AttributeMatrix::Create(dataStructure, "CellData", ShapeType{numTuples}, group->getId());
+  using FloatStore = DataStore<float32>;
+  auto floatStore = std::make_shared<FloatStore>(ShapeType{numTuples}, ShapeType{3}, 1.5f);
+  DataArray<float32>::Create(dataStructure, "Floats", floatStore, attrMat->getId());
+  auto intStore = std::make_shared<DataStore<int32>>(ShapeType{numTuples}, ShapeType{1}, 7);
+  DataArray<int32>::Create(dataStructure, "Ints", intStore, attrMat->getId());
+  StringArray::CreateWithValues(dataStructure, "Strings", ShapeType{2}, {"alpha", "beta"}, group->getId());
+
+  fs::path filePath = fs::path(unit_test::k_BinaryTestOutputDir.view()) / fileName;
+  fs::remove(filePath);
+  Result<> writeResult = DREAM3D::WriteFile(filePath, dataStructure, Pipeline{}, false);
+  REQUIRE(writeResult.valid());
+  // Backdate mtime past the trust window so validation relies on the (size, mtime) token.
+  fs::last_write_time(filePath, fs::last_write_time(filePath) - std::chrono::seconds(10));
+  return filePath;
+}
+} // namespace
+
+TEST_CASE("Dream3dPreflightCache: miss then hit with equivalent structure", "[Dream3dPreflightCache]")
+{
+  auto& cache = DREAM3D::Dream3dPreflightCache::Instance();
+  cache.clear();
+  cache.resetStats();
+
+  const fs::path filePath = WriteTestFile("preflight_cache_basic.dream3d");
+
+  // First fetch: miss (reads the file).
+  Result<DataStructure> first = cache.fetch(filePath);
+  REQUIRE(first.valid());
+  REQUIRE(cache.missCount() == 1);
+  REQUIRE(cache.hitCount() == 0);
+
+  // Second fetch: hit (no file read).
+  Result<DataStructure> second = cache.fetch(filePath);
+  REQUIRE(second.valid());
+  REQUIRE(cache.missCount() == 1);
+  REQUIRE(cache.hitCount() == 1);
+
+  // Hit handout is structurally equivalent to a direct preflight import.
+  auto fileReader = HDF5::FileIO::ReadFile(filePath);
+  Result<DataStructure> direct = DREAM3D::ImportDataStructureFromFile(fileReader, true);
+  REQUIRE(direct.valid());
+  auto expectedPaths = direct.value().getAllDataPaths();
+  auto actualPaths = second.value().getAllDataPaths();
+  REQUIRE(actualPaths.size() == expectedPaths.size());
+  for(const auto& path : expectedPaths)
+  {
+    INFO(path.toString());
+    REQUIRE(second.value().containsData(path));
+  }
+  const auto* floats = second.value().getDataAs<Float32Array>(DataPath({"TestGroup", "CellData", "Floats"}));
+  REQUIRE(floats != nullptr);
+  REQUIRE(floats->getTupleShape() == ShapeType{10});
+  REQUIRE(floats->getComponentShape() == ShapeType{3});
+}
+
+TEST_CASE("Dream3dPreflightCache: missing file returns open error", "[Dream3dPreflightCache]")
+{
+  auto& cache = DREAM3D::Dream3dPreflightCache::Instance();
+  cache.clear();
+  cache.resetStats();
+
+  Result<DataStructure> result = cache.fetch(fs::path(unit_test::k_BinaryTestOutputDir.view()) / "does_not_exist.dream3d");
+  REQUIRE(result.invalid());
+  REQUIRE(result.errors()[0].code == -25);
+}
+
+TEST_CASE("Dream3dPreflightCache: handouts are isolated from master and each other", "[Dream3dPreflightCache]")
+{
+  auto& cache = DREAM3D::Dream3dPreflightCache::Instance();
+  cache.clear();
+  cache.resetStats();
+
+  const fs::path filePath = WriteTestFile("preflight_cache_isolation.dream3d");
+  const DataPath floatsPath({"TestGroup", "CellData", "Floats"});
+  const DataPath stringsPath({"TestGroup", "Strings"});
+
+  Result<DataStructure> resultA = cache.fetch(filePath);
+  Result<DataStructure> resultB = cache.fetch(filePath);
+  REQUIRE(resultA.valid());
+  REQUIRE(resultB.valid());
+  DataStructure handoutA = std::move(resultA.value());
+  DataStructure handoutB = std::move(resultB.value());
+
+  auto* arrayA = handoutA.getDataAs<Float32Array>(floatsPath);
+  auto* arrayB = handoutB.getDataAs<Float32Array>(floatsPath);
+  REQUIRE(arrayA != nullptr);
+  REQUIRE(arrayB != nullptr);
+
+  // Every handout's DataArray owns a distinct store instance. Preflight arrays
+  // are backed by EmptyDataStore, whose mutators throw (it holds no data to
+  // mutate in place), so pointer inequality is the correct proxy for
+  // "mutating one handout cannot reach another". A third fetch must likewise
+  // get a store distinct from both prior handouts.
+  Result<DataStructure> resultC = cache.fetch(filePath);
+  REQUIRE(resultC.valid());
+  DataStructure handoutC = std::move(resultC.value());
+  auto* arrayC = handoutC.getDataAs<Float32Array>(floatsPath);
+  REQUIRE(arrayC != nullptr);
+  REQUIRE(arrayA->getIDataStore() != arrayB->getIDataStore());
+  REQUIRE(arrayA->getIDataStore() != arrayC->getIDataStore());
+  REQUIRE(arrayB->getIDataStore() != arrayC->getIDataStore());
+
+  // StringArrays are backed by a real, mutable StringStore (of placeholder
+  // empty strings under preflight), so isolation is proven behaviorally: an
+  // in-place edit to one handout's StringArray must not reach another handout
+  // or a later fetch. This exercises the StringStore deep copy directly —
+  // without it, stringsB would observe "mutated".
+  auto* stringsA = handoutA.getDataAs<StringArray>(stringsPath);
+  auto* stringsB = handoutB.getDataAs<StringArray>(stringsPath);
+  auto* stringsC = handoutC.getDataAs<StringArray>(stringsPath);
+  REQUIRE(stringsA != nullptr);
+  REQUIRE(stringsB != nullptr);
+  REQUIRE(stringsC != nullptr);
+  const std::vector<std::string> stringsBBefore = stringsB->values();
+  const std::vector<std::string> stringsCBefore = stringsC->values();
+  stringsA->setValue(0, "mutated");
+  REQUIRE(stringsB->values() == stringsBBefore);
+  REQUIRE(stringsC->values() == stringsCBefore);
+}
+
+TEST_CASE("Dream3dPreflightCache: modified file is detected and re-read", "[Dream3dPreflightCache]")
+{
+  auto& cache = DREAM3D::Dream3dPreflightCache::Instance();
+  cache.clear();
+  cache.resetStats();
+
+  const fs::path filePath = WriteTestFile("preflight_cache_stale.dream3d");
+  REQUIRE(cache.fetch(filePath).valid());
+  REQUIRE(cache.missCount() == 1);
+
+  // Rewrite with different content (more tuples -> different size), backdated.
+  WriteTestFile("preflight_cache_stale.dream3d", 20);
+
+  Result<DataStructure> refreshed = cache.fetch(filePath);
+  REQUIRE(refreshed.valid());
+  REQUIRE(cache.missCount() == 2);
+  REQUIRE(refreshed.value().getDataAs<Float32Array>(DataPath({"TestGroup", "CellData", "Floats"}))->getTupleShape() == ShapeType{20});
+}
+
+TEST_CASE("Dream3dPreflightCache: files younger than the trust window are never served from cache", "[Dream3dPreflightCache]")
+{
+  auto& cache = DREAM3D::Dream3dPreflightCache::Instance();
+  cache.clear();
+  cache.resetStats();
+
+  const fs::path filePath = WriteTestFile("preflight_cache_young.dream3d");
+  // Make the file look just-written.
+  fs::last_write_time(filePath, fs::file_time_type::clock::now());
+
+  REQUIRE(cache.fetch(filePath).valid());
+  REQUIRE(cache.fetch(filePath).valid());
+  REQUIRE(cache.missCount() == 2);
+  REQUIRE(cache.hitCount() == 0);
+
+  // Once the mtime ages past the window, caching resumes.
+  fs::last_write_time(filePath, fs::last_write_time(filePath) - std::chrono::seconds(10));
+  REQUIRE(cache.fetch(filePath).valid());
+  REQUIRE(cache.fetch(filePath).valid());
+  REQUIRE(cache.hitCount() == 1);
+}
+
+TEST_CASE("Dream3dPreflightCache: invalidate() forces a re-read", "[Dream3dPreflightCache]")
+{
+  auto& cache = DREAM3D::Dream3dPreflightCache::Instance();
+  cache.clear();
+  cache.resetStats();
+
+  const fs::path filePath = WriteTestFile("preflight_cache_invalidate.dream3d");
+  REQUIRE(cache.fetch(filePath).valid());
+  cache.invalidate(filePath);
+  REQUIRE(cache.fetch(filePath).valid());
+  REQUIRE(cache.missCount() == 2);
+  REQUIRE(cache.hitCount() == 0);
+}
+
+TEST_CASE("Dream3dPreflightCache: least-recently-used entry is evicted past capacity", "[Dream3dPreflightCache]")
+{
+  auto& cache = DREAM3D::Dream3dPreflightCache::Instance();
+  cache.clear();
+  cache.resetStats();
+
+  std::vector<fs::path> files;
+  for(usize i = 0; i < DREAM3D::Dream3dPreflightCache::k_Capacity + 1; i++)
+  {
+    files.push_back(WriteTestFile(fmt::format("preflight_cache_lru_{}.dream3d", i)));
+  }
+  // Fill to capacity, then touch file 0 so file 1 is the LRU victim.
+  for(usize i = 0; i < DREAM3D::Dream3dPreflightCache::k_Capacity; i++)
+  {
+    REQUIRE(cache.fetch(files[i]).valid());
+  }
+  REQUIRE(cache.fetch(files[0]).valid());                                          // hit; refreshes recency
+  REQUIRE(cache.fetch(files[DREAM3D::Dream3dPreflightCache::k_Capacity]).valid()); // miss; evicts files[1]
+
+  cache.resetStats();
+  REQUIRE(cache.fetch(files[0]).valid());
+  REQUIRE(cache.hitCount() == 1); // still cached
+  REQUIRE(cache.fetch(files[1]).valid());
+  REQUIRE(cache.missCount() == 1); // was evicted
+}
+
+TEST_CASE("Dream3dPreflightCache: concurrent fetches are safe and consistent", "[Dream3dPreflightCache]")
+{
+  auto& cache = DREAM3D::Dream3dPreflightCache::Instance();
+  cache.clear();
+  cache.resetStats();
+
+  const fs::path fileA = WriteTestFile("preflight_cache_conc_a.dream3d");
+  const fs::path fileB = WriteTestFile("preflight_cache_conc_b.dream3d", 20);
+  const DataPath floatsPath({"TestGroup", "CellData", "Floats"});
+
+  constexpr usize k_NumThreads = 8;
+  constexpr usize k_FetchesPerThread = 25;
+  std::atomic<usize> failures{0};
+  std::vector<std::thread> threads;
+  for(usize t = 0; t < k_NumThreads; t++)
+  {
+    threads.emplace_back([&, t]() {
+      for(usize i = 0; i < k_FetchesPerThread; i++)
+      {
+        const fs::path& target = (t + i) % 2 == 0 ? fileA : fileB;
+        const usize expectedTuples = (t + i) % 2 == 0 ? 10 : 20;
+        Result<DataStructure> result = cache.fetch(target);
+        if(result.invalid() || result.value().getDataAs<Float32Array>(floatsPath) == nullptr || result.value().getDataAs<Float32Array>(floatsPath)->getTupleShape() != ShapeType{expectedTuples})
+        {
+          failures++;
+        }
+      }
+    });
+  }
+  for(auto& thread : threads)
+  {
+    thread.join();
+  }
+  REQUIRE(failures.load() == 0);
+  REQUIRE(cache.hitCount() + cache.missCount() == k_NumThreads * k_FetchesPerThread);
+}
+
+// Hidden benchmark ([.benchmark]): demonstrates the cache's effect under
+// simulated network-storage latency. Excluded from default runs because it
+// asserts on wall-clock behavior, which is only meaningful with the delay
+// driver installed. Run manually:
+//   ./simplnx_test "[.benchmark]"
+TEST_CASE("Dream3dPreflightCache: benchmark under simulated storage latency", "[.benchmark]")
+{
+  auto& cache = DREAM3D::Dream3dPreflightCache::Instance();
+  cache.clear();
+
+  // Metadata-heavy file: many small arrays make traversal cost dominate.
+  DataStructure dataStructure;
+  auto* group = DataGroup::Create(dataStructure, "BenchGroup");
+  for(usize i = 0; i < 150; i++)
+  {
+    auto store = std::make_shared<DataStore<float32>>(ShapeType{8}, ShapeType{1}, 0.0f);
+    Float32Array::Create(dataStructure, fmt::format("Array_{}", i), store, group->getId());
+  }
+  const fs::path filePath = fs::path(unit_test::k_BinaryTestOutputDir.view()) / "preflight_cache_benchmark.dream3d";
+  fs::remove(filePath);
+  REQUIRE(DREAM3D::WriteFile(filePath, dataStructure, Pipeline{}, false).valid());
+  fs::last_write_time(filePath, fs::last_write_time(filePath) - std::chrono::seconds(10));
+
+  // Install the delay driver: every HDF5 open/read now costs 2 ms, like a
+  // high-latency network mount.
+  const hid_t driverId = DelayVfd::Register();
+  REQUIRE(driverId != H5I_INVALID_HID);
+  DelayVfd::SetDelayMicroseconds(2000);
+  HDF5::FileIO::SetFaplConfigurator([driverId](hid_t faplId) { H5Pset_driver(faplId, driverId, nullptr); });
+
+  using Clock = std::chrono::steady_clock;
+
+  // Microsecond resolution: a warm cache hit is sub-millisecond, so timing in
+  // milliseconds would round it to 0 and let a several-ms regression slip past
+  // the ratio assertion below.
+  // BEFORE (per-edit behavior without a cache): clear + fetch = full traversal.
+  cache.clear();
+  const auto coldStart = Clock::now();
+  REQUIRE(cache.fetch(filePath).valid());
+  const auto coldUs = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - coldStart).count();
+
+  // AFTER: warm fetch = stat only.
+  const auto warmStart = Clock::now();
+  REQUIRE(cache.fetch(filePath).valid());
+  const auto warmUs = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - warmStart).count();
+
+  HDF5::FileIO::SetFaplConfigurator({});
+  DelayVfd::SetDelayMicroseconds(0);
+
+  WARN(fmt::format("PreflightCache benchmark @2ms/op: cold (uncached, = old per-edit cost) {} us | warm (cached) {} us", coldUs, warmUs));
+  REQUIRE(warmUs * 10 < coldUs); // the cache must be at least 10x faster under latency
+}

--- a/test/Dream3dPreflightCacheTest.cpp
+++ b/test/Dream3dPreflightCacheTest.cpp
@@ -169,11 +169,20 @@ TEST_CASE("Dream3dPreflightCache: modified file is detected and re-read", "[Drea
   cache.resetStats();
 
   const fs::path filePath = WriteTestFile("preflight_cache_stale.dream3d");
+  const auto cachedMtime = fs::last_write_time(filePath);
   REQUIRE(cache.fetch(filePath).valid());
   REQUIRE(cache.missCount() == 1);
 
-  // Rewrite with different content (more tuples -> different size), backdated.
+  // Rewrite with different content, then stamp the file with a modification time
+  // that is unambiguously different from the cached entry's while remaining
+  // older than the trust window. The rewrite's natural (size, mtime) token is
+  // not a reliable change signal: HDF5 aggregates small allocations into fixed
+  // blocks, so the 10- and 20-tuple files can be byte-identical in size, and
+  // filesystem timestamp granularity (notably ~15 ms on Windows) can give two
+  // writes milliseconds apart the same mtime. An explicit distinct mtime makes
+  // the staleness check deterministic on every platform.
   WriteTestFile("preflight_cache_stale.dream3d", 20);
+  fs::last_write_time(filePath, cachedMtime - std::chrono::seconds(20));
 
   Result<DataStructure> refreshed = cache.fetch(filePath);
   REQUIRE(refreshed.valid());


### PR DESCRIPTION
## Summary

Adds `Dream3dPreflightCache`, a process-wide cache of preflight (metadata-only) `DataStructure`s imported from `.dream3d` files, and routes the two preflight consumers (`ReadDREAM3DFilter` and `ImportH5ObjectPathsAction`) through it. A pipeline re-preflights on every parameter edit, and each pass previously re-traversed the input file's full HDF5 metadata tree — hundreds of small, latency-bound reads that freeze the UI for seconds on high-latency storage such as network mounts. After the first import, every subsequent fetch of an unchanged file becomes a single filesystem `stat`.

**The cache.** Keyed by canonical file path and validated on every fetch by comparing the file's `(size, mtime)` against the values captured when the entry was populated; any mismatch evicts and re-reads. Files modified more recently than a 2-second trust window are never served, guarding against coarse mtime granularity on SMB/NFS. `fetch()` never hands out the cached master — it returns a copy whose array stores are freshly allocated, so a mutation in one preflight pass can never bleed into another; metadata-only stores keep these copies free of bulk data. The table is bounded (capacity 8, LRU by fetch recency). Two mutexes with a fixed lock order keep hits lock-light while serializing the HDF5 metadata reads (the bundled HDF5 C library is built without its thread-safe option).

**Consumers.** `ReadDREAM3DFilter::preflightImpl` and `ImportH5ObjectPathsAction::apply` now fetch from the cache instead of opening the file every pass. `ImportH5ObjectPathsAction` opens the file only in execute mode, where the bulk-array reads actually need a handle.

**Fewer redundant opens.** `Dream3dImportParameter::validatePath` no longer re-opens the file as HDF5 to prove readability (a redundant round-trip on every edit for a check the consuming filter's preflight already makes) — it now only stats the path. `FinishImportingObject` is split so its metadata-only insert (`FinishImportingObjectPreflight`) needs no open file handle.

**Test instrumentation.** `FileIO` gains a process-wide `ReadFile` open counter and a test-only fapl-configurator hook (unset in production, so opens use `H5P_DEFAULT`), letting tests assert I/O behavior deterministically instead of against wall-clock time.

## Test Plan

- [ ] `Dream3dPreflightCache` unit tests pass: miss-then-hit, missing-file error passthrough, handout isolation, mtime/size invalidation, trust window, `invalidate()`, LRU eviction, concurrency hammer
- [ ] `DREAM3DFileTest` integration test passes: a real `ReadDREAM3DFilter` pipeline performs zero file opens on the second preflight, execute still reads bulk data, and a rewrite invalidates the entry
- [ ] `DelayVfd` `[.benchmark]` demonstrates the before/after under simulated storage latency
