### PR TITLE
ENH: Refresh stale filter arguments in example pipelines

### DIFF
--- a/src/Plugins/ITKImageProcessing/pipelines/(02) Image Segmentation.d3dpipeline
+++ b/src/Plugins/ITKImageProcessing/pipelines/(02) Image Segmentation.d3dpipeline
@@ -13,6 +13,14 @@
           "value": false,
           "version": 1
         },
+        "change_origin": {
+          "value": false,
+          "version": 1
+        },
+        "change_spacing": {
+          "value": false,
+          "version": 1
+        },
         "color_weights": {
           "value": [
             0.21250000596046448,
@@ -23,6 +31,40 @@
         },
         "convert_to_gray_scale": {
           "value": false,
+          "version": 1
+        },
+        "cropping_options": {
+          "value": {
+            "bounds_x_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_x_voxels": [
+              0,
+              0
+            ],
+            "bounds_y_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_y_voxels": [
+              0,
+              0
+            ],
+            "bounds_z_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_z_voxels": [
+              0,
+              0
+            ],
+            "crop_x": true,
+            "crop_y": true,
+            "crop_z": true,
+            "is_2d": false,
+            "type": 0
+          },
           "version": 1
         },
         "exact_xy_dimensions": {
@@ -64,6 +106,10 @@
             0.0,
             0.0
           ],
+          "version": 1
+        },
+        "origin_spacing_processing_index": {
+          "value": 1,
           "version": 1
         },
         "output_image_geometry_path": {
@@ -226,7 +272,7 @@
           "value": "NumElements",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "save_element_sizes": {
           "value": false,
           "version": 1
@@ -431,11 +477,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/ImagesStack/Images.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/ITKImageProcessing/pipelines/(03) Porosity Mesh Export.d3dpipeline
+++ b/src/Plugins/ITKImageProcessing/pipelines/(03) Porosity Mesh Export.d3dpipeline
@@ -13,6 +13,14 @@
           "value": false,
           "version": 1
         },
+        "change_origin": {
+          "value": false,
+          "version": 1
+        },
+        "change_spacing": {
+          "value": false,
+          "version": 1
+        },
         "color_weights": {
           "value": [
             0.21250000596046448,
@@ -23,6 +31,40 @@
         },
         "convert_to_gray_scale": {
           "value": false,
+          "version": 1
+        },
+        "cropping_options": {
+          "value": {
+            "bounds_x_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_x_voxels": [
+              0,
+              0
+            ],
+            "bounds_y_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_y_voxels": [
+              0,
+              0
+            ],
+            "bounds_z_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_z_voxels": [
+              0,
+              0
+            ],
+            "crop_x": true,
+            "crop_y": true,
+            "crop_z": true,
+            "is_2d": false,
+            "type": 0
+          },
           "version": 1
         },
         "exact_xy_dimensions": {
@@ -64,6 +106,10 @@
             0.0,
             0.0
           ],
+          "version": 1
+        },
+        "origin_spacing_processing_index": {
+          "value": 1,
           "version": 1
         },
         "output_image_geometry_path": {
@@ -223,6 +269,10 @@
           "version": 1
         },
         "input_data_array_paths": {
+          "value": [],
+          "version": 1
+        },
+        "input_feature_data_array_paths": {
           "value": [],
           "version": 1
         },
@@ -555,11 +605,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Porosity_Analysis.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/ITKImageProcessing/pipelines/(04) Porosity Analysis.d3dpipeline
+++ b/src/Plugins/ITKImageProcessing/pipelines/(04) Porosity Analysis.d3dpipeline
@@ -13,6 +13,14 @@
           "value": false,
           "version": 1
         },
+        "change_origin": {
+          "value": false,
+          "version": 1
+        },
+        "change_spacing": {
+          "value": false,
+          "version": 1
+        },
         "color_weights": {
           "value": [
             0.21250000596046448,
@@ -23,6 +31,40 @@
         },
         "convert_to_gray_scale": {
           "value": false,
+          "version": 1
+        },
+        "cropping_options": {
+          "value": {
+            "bounds_x_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_x_voxels": [
+              0,
+              0
+            ],
+            "bounds_y_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_y_voxels": [
+              0,
+              0
+            ],
+            "bounds_z_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_z_voxels": [
+              0,
+              0
+            ],
+            "crop_x": true,
+            "crop_y": true,
+            "crop_z": true,
+            "is_2d": false,
+            "type": 0
+          },
           "version": 1
         },
         "exact_xy_dimensions": {
@@ -64,6 +106,10 @@
             0.0,
             0.0
           ],
+          "version": 1
+        },
+        "origin_spacing_processing_index": {
+          "value": 1,
           "version": 1
         },
         "output_image_geometry_path": {
@@ -226,7 +272,7 @@
           "value": "NumElements",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "save_element_sizes": {
           "value": false,
           "version": 1
@@ -496,11 +542,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/ImagesStack/Images.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/AlignSectionsMutualInformation.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/AlignSectionsMutualInformation.d3dpipeline
@@ -197,11 +197,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/OrientationAnalysis/SmallIN100_AlignSectionsMutualInformation.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/EBSD_Hexagonal_Data_Analysis.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/EBSD_Hexagonal_Data_Analysis.d3dpipeline
@@ -195,6 +195,10 @@
           "value": "DataContainer/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "DataContainer/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -203,7 +207,7 @@
           "value": "DataContainer/Cell Data/Mask",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,
@@ -711,7 +715,43 @@
           "value": "DataContainer/Cell Ensemble Data/CrystalStructures",
           "version": 1
         },
-        "parameters_version": 1
+        "parameters_version": 2,
+        "use_rodrigues_average": {
+          "value": true,
+          "version": 1
+        },
+        "use_vmf_average": {
+          "value": false,
+          "version": 1
+        },
+        "use_watson_average": {
+          "value": false,
+          "version": 1
+        },
+        "vmf_euler_array_name": {
+          "value": "vMF Avg EulerAngles",
+          "version": 1
+        },
+        "vmf_kappa_array_name": {
+          "value": "vMF Kappas",
+          "version": 1
+        },
+        "vmf_quat_array_name": {
+          "value": "vMF Avg Quats",
+          "version": 1
+        },
+        "watson_euler_array_name": {
+          "value": "Watson Avg EulerAngles",
+          "version": 1
+        },
+        "watson_kappa_array_name": {
+          "value": "Watson Kappas",
+          "version": 1
+        },
+        "watson_quat_array_name": {
+          "value": "Watson Avg Quats",
+          "version": 1
+        }
       },
       "comments": "",
       "filter": {
@@ -812,11 +852,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Examples/Combo-EBSD-osc_r0c0_CAxis.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/Edax_IPF_Colors.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/Edax_IPF_Colors.d3dpipeline
@@ -186,6 +186,10 @@
           "value": "DataContainer/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "DataContainer/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -194,7 +198,7 @@
           "value": "DataContainer/Cell Data/Mask",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/EnsembleInfoReader.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/EnsembleInfoReader.d3dpipeline
@@ -48,6 +48,18 @@
     },
     {
       "args": {
+        "allow_partial_filling": {
+          "value": false,
+          "version": 1
+        },
+        "component_dimensions": {
+          "value": [
+            [
+              4.0
+            ]
+          ],
+          "version": 1
+        },
         "created_attribute_array_path": {
           "value": "[Image Geometry]/Cell Data/Quats",
           "version": 1
@@ -60,17 +72,13 @@
           "value": "Data/OrientationAnalysis/quats.raw",
           "version": 1
         },
-        "component_dimensions": {
-          "value": [
-            [
-              4.0
-            ]
-          ],
-          "version": 1
-        },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "scalar_type_index": {
           "value": 8,
+          "version": 1
+        },
+        "set_tuple_dimensions": {
+          "value": true,
           "version": 1
         },
         "skip_header_bytes": {
@@ -212,6 +220,10 @@
           "value": "[Image Geometry]/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "[Image Geometry]/Cell Ensemble/CrystalStructures",
           "version": 1
@@ -220,7 +232,7 @@
           "value": "",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,
@@ -243,11 +255,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Examples/EnsembleInfoReaderExample.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/ImportBrukerNanoEspritData.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/ImportBrukerNanoEspritData.d3dpipeline
@@ -58,11 +58,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Examples/H5EspritData.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/ImportEdaxOIMData.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/ImportEdaxOIMData.d3dpipeline
@@ -159,11 +159,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Examples/EdaxOIMData.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/Read_EDAX_Ang_File.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/Read_EDAX_Ang_File.d3dpipeline
@@ -186,6 +186,10 @@
           "value": "DataContainer/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "DataContainer/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -194,7 +198,7 @@
           "value": "",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/Read_Oxford_Ctf_File.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/Read_Oxford_Ctf_File.d3dpipeline
@@ -178,6 +178,10 @@
           "value": "DataContainer/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "DataContainer/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -186,7 +190,7 @@
           "value": "DataContainer/Cell Data/Mask",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/TxCopper_Exposed.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/TxCopper_Exposed.d3dpipeline
@@ -253,6 +253,10 @@
           "value": "Cugrid_after 2nd_15kv_2kx_2/EBSD Scan Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "Cugrid_after 2nd_15kv_2kx_2/Phase Data/CrystalStructures",
           "version": 1
@@ -261,7 +265,7 @@
           "value": "Cugrid_after 2nd_15kv_2kx_2/EBSD Scan Data/Mask",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/TxCopper_Unexposed.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/TxCopper_Unexposed.d3dpipeline
@@ -253,6 +253,10 @@
           "value": "Cugrid_after 2nd_15kv_2kx_2/EBSD Scan Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "Cugrid_after 2nd_15kv_2kx_2/Phase Data/CrystalStructures",
           "version": 1
@@ -261,7 +265,7 @@
           "value": "Cugrid_after 2nd_15kv_2kx_2/EBSD Scan Data/Mask",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/aptr12_Analysis.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/aptr12_Analysis.d3dpipeline
@@ -237,6 +237,10 @@
           "value": "fw-ar-IF1-aptr12-corr/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "fw-ar-IF1-aptr12-corr/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -245,7 +249,7 @@
           "value": "",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,
@@ -351,6 +355,10 @@
           "value": "fw-ar-IF1-aptr12-corr/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "fw-ar-IF1-aptr12-corr/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -359,7 +367,7 @@
           "value": "",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,
@@ -465,6 +473,10 @@
           "value": "fw-ar-IF1-aptr12-corr/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "fw-ar-IF1-aptr12-corr/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -473,7 +485,7 @@
           "value": "",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             1.0,
@@ -685,7 +697,7 @@
           "value": "NumElements",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "save_element_sizes": {
           "value": false,
           "version": 1
@@ -783,7 +795,7 @@
           "value": "NumElements",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "save_element_sizes": {
           "value": false,
           "version": 1
@@ -830,7 +842,43 @@
           "value": "fw-ar-IF1-aptr12-corr/Cell Ensemble Data/CrystalStructures",
           "version": 1
         },
-        "parameters_version": 1
+        "parameters_version": 2,
+        "use_rodrigues_average": {
+          "value": true,
+          "version": 1
+        },
+        "use_vmf_average": {
+          "value": false,
+          "version": 1
+        },
+        "use_watson_average": {
+          "value": false,
+          "version": 1
+        },
+        "vmf_euler_array_name": {
+          "value": "vMF Avg EulerAngles",
+          "version": 1
+        },
+        "vmf_kappa_array_name": {
+          "value": "vMF Kappas",
+          "version": 1
+        },
+        "vmf_quat_array_name": {
+          "value": "vMF Avg Quats",
+          "version": 1
+        },
+        "watson_euler_array_name": {
+          "value": "Watson Avg EulerAngles",
+          "version": 1
+        },
+        "watson_kappa_array_name": {
+          "value": "Watson Kappas",
+          "version": 1
+        },
+        "watson_quat_array_name": {
+          "value": "Watson Avg Quats",
+          "version": 1
+        }
       },
       "comments": "",
       "filter": {
@@ -986,6 +1034,10 @@
           "value": "FeatureAvgMisorientations",
           "version": 1
         },
+        "feature_euclidean_center_array_name": {
+          "value": "Euclidean Centers",
+          "version": 1
+        },
         "feature_ids_path": {
           "value": "fw-ar-IF1-aptr12-corr/Cell Data/FeatureIds",
           "version": 1
@@ -998,7 +1050,7 @@
           "value": "Cell Data/GBEuclideanDistances",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "quats_array_path": {
           "value": "fw-ar-IF1-aptr12-corr/Cell Data/Quats",
           "version": 1
@@ -1167,11 +1219,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/fw-ar-IF1-aptr12-corr/fw-ar-IF1-aptr12-corr.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/avtr12_Analysis.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/EBSD_File_Processing/avtr12_Analysis.d3dpipeline
@@ -237,6 +237,10 @@
           "value": "fw-ar-IF1-avtr12-corr/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "fw-ar-IF1-avtr12-corr/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -245,7 +249,7 @@
           "value": "",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,
@@ -351,6 +355,10 @@
           "value": "fw-ar-IF1-avtr12-corr/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "fw-ar-IF1-avtr12-corr/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -359,7 +367,7 @@
           "value": "",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,
@@ -465,6 +473,10 @@
           "value": "fw-ar-IF1-avtr12-corr/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "fw-ar-IF1-avtr12-corr/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -473,7 +485,7 @@
           "value": "",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             1.0,
@@ -685,7 +697,7 @@
           "value": "NumElements",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "save_element_sizes": {
           "value": false,
           "version": 1
@@ -783,7 +795,7 @@
           "value": "NumElements",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "save_element_sizes": {
           "value": false,
           "version": 1
@@ -830,7 +842,43 @@
           "value": "fw-ar-IF1-avtr12-corr/Cell Ensemble Data/CrystalStructures",
           "version": 1
         },
-        "parameters_version": 1
+        "parameters_version": 2,
+        "use_rodrigues_average": {
+          "value": true,
+          "version": 1
+        },
+        "use_vmf_average": {
+          "value": false,
+          "version": 1
+        },
+        "use_watson_average": {
+          "value": false,
+          "version": 1
+        },
+        "vmf_euler_array_name": {
+          "value": "vMF Avg EulerAngles",
+          "version": 1
+        },
+        "vmf_kappa_array_name": {
+          "value": "vMF Kappas",
+          "version": 1
+        },
+        "vmf_quat_array_name": {
+          "value": "vMF Avg Quats",
+          "version": 1
+        },
+        "watson_euler_array_name": {
+          "value": "Watson Avg EulerAngles",
+          "version": 1
+        },
+        "watson_kappa_array_name": {
+          "value": "Watson Kappas",
+          "version": 1
+        },
+        "watson_quat_array_name": {
+          "value": "Watson Avg Quats",
+          "version": 1
+        }
       },
       "comments": "",
       "filter": {
@@ -986,6 +1034,10 @@
           "value": "FeatureAvgMisorientations",
           "version": 1
         },
+        "feature_euclidean_center_array_name": {
+          "value": "Euclidean Centers",
+          "version": 1
+        },
         "feature_ids_path": {
           "value": "fw-ar-IF1-avtr12-corr/Cell Data/FeatureIds",
           "version": 1
@@ -998,7 +1050,7 @@
           "value": "Cell Data/GBEuclideanDistances",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "quats_array_path": {
           "value": "fw-ar-IF1-avtr12-corr/Cell Data/Quats",
           "version": 1
@@ -1167,11 +1219,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/fw-ar-IF1-avtr12-corr/fw-ar-IF1-avtr12-corr.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(02) Small IN100 Full Reconstruction.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(02) Small IN100 Full Reconstruction.d3dpipeline
@@ -483,7 +483,43 @@
           "value": "DataContainer/Cell Ensemble Data/CrystalStructures",
           "version": 1
         },
-        "parameters_version": 1
+        "parameters_version": 2,
+        "use_rodrigues_average": {
+          "value": true,
+          "version": 1
+        },
+        "use_vmf_average": {
+          "value": false,
+          "version": 1
+        },
+        "use_watson_average": {
+          "value": false,
+          "version": 1
+        },
+        "vmf_euler_array_name": {
+          "value": "vMF Avg EulerAngles",
+          "version": 1
+        },
+        "vmf_kappa_array_name": {
+          "value": "vMF Kappas",
+          "version": 1
+        },
+        "vmf_quat_array_name": {
+          "value": "vMF Avg Quats",
+          "version": 1
+        },
+        "watson_euler_array_name": {
+          "value": "Watson Avg EulerAngles",
+          "version": 1
+        },
+        "watson_kappa_array_name": {
+          "value": "Watson Kappas",
+          "version": 1
+        },
+        "watson_quat_array_name": {
+          "value": "Watson Avg Quats",
+          "version": 1
+        }
       },
       "comments": "",
       "filter": {
@@ -590,6 +626,10 @@
           "version": 1
         },
         "parameters_version": 1,
+        "randomize_parent_ids": {
+          "value": false,
+          "version": 1
+        },
         "seed_array_name": {
           "value": "MergeTwins SeedValue",
           "version": 1
@@ -632,7 +672,7 @@
           "value": "NumElements",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "save_element_sizes": {
           "value": false,
           "version": 1
@@ -959,6 +999,10 @@
           "value": "DataContainer/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "DataContainer/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -967,7 +1011,7 @@
           "value": "DataContainer/Cell Data/Mask",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,
@@ -990,11 +1034,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Reconstruction/SmallIN100_Final.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(03) Small IN100 Morphological Statistics.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(03) Small IN100 Morphological Statistics.d3dpipeline
@@ -7,8 +7,7 @@
       "args": {
         "import_data_object": {
           "value": {
-            "data_paths": [
-            ],
+            "data_paths": [],
             "file_path": "Data/Output/Reconstruction/SmallIN100_Final.dream3d",
             "path_import_policy": 0
           },
@@ -103,7 +102,7 @@
           "value": "NumElements",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "save_element_sizes": {
           "value": false,
           "version": 1
@@ -240,6 +239,7 @@
           "value": "Neighborhoods",
           "version": 1
         },
+        "parameters_version": 2,
         "search_radius": {
           "value": 1.0,
           "version": 1
@@ -247,8 +247,7 @@
         "search_radius_type_index": {
           "value": 0,
           "version": 1
-        },
-        "parameters_version": 2
+        }
       },
       "comments": "",
       "filter": {
@@ -341,11 +340,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Statistics/SmallIN100_Morph.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(04) Small IN100 Crystallographic Statistics.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(04) Small IN100 Crystallographic Statistics.d3dpipeline
@@ -7,8 +7,7 @@
       "args": {
         "import_data_object": {
           "value": {
-            "data_paths": [
-            ],
+            "data_paths": [],
             "file_path": "Data/Output/Statistics/SmallIN100_Morph.dream3d",
             "path_import_policy": 0
           },
@@ -53,7 +52,43 @@
           "value": "DataContainer/Cell Ensemble Data/CrystalStructures",
           "version": 1
         },
-        "parameters_version": 1
+        "parameters_version": 2,
+        "use_rodrigues_average": {
+          "value": true,
+          "version": 1
+        },
+        "use_vmf_average": {
+          "value": false,
+          "version": 1
+        },
+        "use_watson_average": {
+          "value": false,
+          "version": 1
+        },
+        "vmf_euler_array_name": {
+          "value": "vMF Avg EulerAngles",
+          "version": 1
+        },
+        "vmf_kappa_array_name": {
+          "value": "vMF Kappas",
+          "version": 1
+        },
+        "vmf_quat_array_name": {
+          "value": "vMF Avg Quats",
+          "version": 1
+        },
+        "watson_euler_array_name": {
+          "value": "Watson Avg EulerAngles",
+          "version": 1
+        },
+        "watson_kappa_array_name": {
+          "value": "Watson Kappas",
+          "version": 1
+        },
+        "watson_quat_array_name": {
+          "value": "Watson Avg Quats",
+          "version": 1
+        }
       },
       "comments": "",
       "filter": {
@@ -198,6 +233,10 @@
           "value": "FeatureAvgMisorientations",
           "version": 1
         },
+        "feature_euclidean_center_array_name": {
+          "value": "Euclidean Centers",
+          "version": 1
+        },
         "feature_ids_path": {
           "value": "DataContainer/Cell Data/FeatureIds",
           "version": 1
@@ -210,7 +249,7 @@
           "value": "Cell Data/GBEuclideanDistances",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "quats_array_path": {
           "value": "DataContainer/Cell Data/Quats",
           "version": 1
@@ -276,11 +315,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Statistics/SmallIN100_CrystalStats.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(05) Small IN100 Quick Mesh.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(05) Small IN100 Quick Mesh.d3dpipeline
@@ -7,8 +7,7 @@
       "args": {
         "import_data_object": {
           "value": {
-            "data_paths": [
-            ],
+            "data_paths": [],
             "file_path": "Data/Output/Statistics/SmallIN100_CrystalStats.dream3d",
             "path_import_policy": 0
           },
@@ -149,6 +148,10 @@
           "value": [],
           "version": 1
         },
+        "input_feature_data_array_paths": {
+          "value": [],
+          "version": 1
+        },
         "input_grid_geometry_path": {
           "value": "DataContainer",
           "version": 1
@@ -180,11 +183,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/SurfaceMesh/SmallIN100_Mesh.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(06) Small IN100 Smooth Mesh.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(06) Small IN100 Smooth Mesh.d3dpipeline
@@ -7,8 +7,7 @@
       "args": {
         "import_data_object": {
           "value": {
-            "data_paths": [
-            ],
+            "data_paths": [],
             "file_path": "Data/Output/SurfaceMesh/SmallIN100_Mesh.dream3d",
             "path_import_policy": 0
           },
@@ -80,11 +79,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/SurfaceMesh/SmallIN100_Smoothed.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(07) Small IN100 Mesh Statistics.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(07) Small IN100 Mesh Statistics.d3dpipeline
@@ -7,8 +7,7 @@
       "args": {
         "import_data_object": {
           "value": {
-            "data_paths": [
-            ],
+            "data_paths": [],
             "file_path": "Data/Output/SurfaceMesh/SmallIN100_Smoothed.dream3d",
             "path_import_policy": 0
           },
@@ -82,6 +81,10 @@
     },
     {
       "args": {
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "DataContainer/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -94,9 +97,13 @@
           "value": "DataContainer/Cell Feature Data/Phases",
           "version": 1
         },
-        "parameters_version": 1,
-        "surface_mesh_face_ipf_colors_array_name": {
+        "first_face_ipf_colors_array_name": {
           "value": "FaceIPFColors",
+          "version": 1
+        },
+        "parameters_version": 2,
+        "second_face_ipf_colors_array_name": {
+          "value": "Face IPF Colors (1)",
           "version": 1
         },
         "surface_mesh_face_labels_array_path": {
@@ -129,13 +136,13 @@
           "value": "DataContainer/Cell Feature Data/Phases",
           "version": 1
         },
-        "parameters_version": 1,
-        "surface_mesh_face_labels_array_path": {
-          "value": "TriangleDataContainer/Face Data/FaceLabels",
+        "misorientation_array_name": {
+          "value": "FaceMisorientationColors",
           "version": 1
         },
-        "surface_mesh_face_misorientation_colors_array_name": {
-          "value": "FaceMisorientationColors",
+        "parameters_version": 2,
+        "surface_mesh_face_labels_array_path": {
+          "value": "TriangleDataContainer/Face Data/FaceLabels",
           "version": 1
         }
       },
@@ -148,11 +155,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/SurfaceMesh/SmallIN100_MeshStats.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(08) Small IN100 GBCD.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(08) Small IN100 GBCD.d3dpipeline
@@ -7,8 +7,7 @@
       "args": {
         "import_data_object": {
           "value": {
-            "data_paths": [
-            ],
+            "data_paths": [],
             "file_path": "Data/Output/SurfaceMesh/SmallIN100_MeshStats.dream3d",
             "path_import_policy": 0
           },
@@ -287,11 +286,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/SurfaceMesh/SmallIN100_GBCD.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(09) Small IN100 GBCD Metric.d3dpipeline
+++ b/src/Plugins/OrientationAnalysis/pipelines/Small_IN100_Processing/(09) Small IN100 GBCD Metric.d3dpipeline
@@ -7,8 +7,7 @@
       "args": {
         "import_data_object": {
           "value": {
-            "data_paths": [
-            ],
+            "data_paths": [],
             "file_path": "Data/Output/SurfaceMesh/SmallIN100_MeshStats.dream3d",
             "path_import_policy": 0
           },
@@ -148,11 +147,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/SurfaceMesh/SmallIN100_GBCD_Metric.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/AppendImageGeometry.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/AppendImageGeometry.d3dpipeline
@@ -525,11 +525,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Examples/AppendImageGeometry.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/ApplyTransformation_Image.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/ApplyTransformation_Image.d3dpipeline
@@ -652,11 +652,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Transformation/ApplyTransformation_Image.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/ApplyTransformation_Node.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/ApplyTransformation_Node.d3dpipeline
@@ -484,11 +484,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/ApplyTransformation_Node.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/ArrayCalculatorExample.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/ArrayCalculatorExample.d3dpipeline
@@ -145,7 +145,7 @@
           },
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "scalar_type_index": {
           "value": 8,
           "version": 1
@@ -172,7 +172,7 @@
           },
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "scalar_type_index": {
           "value": 8,
           "version": 1
@@ -199,7 +199,7 @@
           },
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "scalar_type_index": {
           "value": 8,
           "version": 1
@@ -226,7 +226,7 @@
           },
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "scalar_type_index": {
           "value": 9,
           "version": 1
@@ -253,7 +253,7 @@
           },
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "scalar_type_index": {
           "value": 8,
           "version": 1
@@ -280,7 +280,7 @@
           },
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "scalar_type_index": {
           "value": 8,
           "version": 1
@@ -295,11 +295,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/ArrayCalculatorExampleResults.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/ComputeBiasedFeatures.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/ComputeBiasedFeatures.d3dpipeline
@@ -205,11 +205,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Examples/ComputeBiasedFeatures.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/ComputeBoundaryCells.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/ComputeBoundaryCells.d3dpipeline
@@ -86,11 +86,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Examples/SmallIN100_BoundaryCells.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/ComputeLargestCrossSections.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/ComputeLargestCrossSections.d3dpipeline
@@ -232,11 +232,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Examples/SmallIN100_LargestCrossSections.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/Compute_Feature_Face_Curvature_Goldfeather.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/Compute_Feature_Face_Curvature_Goldfeather.d3dpipeline
@@ -501,11 +501,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/6_5_Goldfeather/6_5_Goldfeather.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/Compute_Feature_Face_Curvature_Small_IN100.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/Compute_Feature_Face_Curvature_Small_IN100.d3dpipeline
@@ -170,6 +170,14 @@
           "value": "DataContainer/Cell Data/FeatureIds",
           "version": 1
         },
+        "input_data_array_paths": {
+          "value": [],
+          "version": 1
+        },
+        "input_feature_data_array_paths": {
+          "value": [],
+          "version": 1
+        },
         "input_grid_geometry_path": {
           "value": "DataContainer",
           "version": 1
@@ -377,11 +385,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Small IN100 Face Curvature.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/CreateScanVectors.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/CreateScanVectors.d3dpipeline
@@ -185,11 +185,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/ScanVectors/ExampleAMScanVectors.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/DBSDScan_2d_Example.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/DBSDScan_2d_Example.d3dpipeline
@@ -1374,11 +1374,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/dbscan_2d/dbscan_2d_example.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/ExtractFeatureBoundaries2D.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/ExtractFeatureBoundaries2D.d3dpipeline
@@ -237,6 +237,10 @@
           "value": "fw-ar-IF1-avtr12-corr/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "fw-ar-IF1-avtr12-corr/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -245,7 +249,7 @@
           "value": "",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,
@@ -386,7 +390,7 @@
           "value": "NumElements",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "save_element_sizes": {
           "value": false,
           "version": 1
@@ -485,7 +489,7 @@
           "version": 1
         },
         "parameters_version": 1,
-        "z_value_choice": {
+        "z_value_choice_index": {
           "value": 1,
           "version": 1
         }

--- a/src/Plugins/SimplnxCore/pipelines/ExtractVertexGeometry.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/ExtractVertexGeometry.d3dpipeline
@@ -186,6 +186,10 @@
           "value": "DataContainer/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "DataContainer/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -194,7 +198,7 @@
           "value": "",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,

--- a/src/Plugins/SimplnxCore/pipelines/Image_Processing/ResamplePorosityImage.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/Image_Processing/ResamplePorosityImage.d3dpipeline
@@ -13,6 +13,14 @@
           "value": false,
           "version": 1
         },
+        "change_origin": {
+          "value": false,
+          "version": 1
+        },
+        "change_spacing": {
+          "value": false,
+          "version": 1
+        },
         "color_weights": {
           "value": [
             0.21250000596046448,
@@ -23,6 +31,40 @@
         },
         "convert_to_gray_scale": {
           "value": false,
+          "version": 1
+        },
+        "cropping_options": {
+          "value": {
+            "bounds_x_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_x_voxels": [
+              0,
+              0
+            ],
+            "bounds_y_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_y_voxels": [
+              0,
+              0
+            ],
+            "bounds_z_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_z_voxels": [
+              0,
+              0
+            ],
+            "crop_x": true,
+            "crop_y": true,
+            "crop_z": true,
+            "is_2d": false,
+            "type": 0
+          },
           "version": 1
         },
         "exact_xy_dimensions": {
@@ -64,6 +106,10 @@
             0.0,
             0.0
           ],
+          "version": 1
+        },
+        "origin_spacing_processing_index": {
+          "value": 1,
           "version": 1
         },
         "output_image_geometry_path": {
@@ -286,11 +332,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/ResamplePorosityImage.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/Pad_Image_Geometry.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/Pad_Image_Geometry.d3dpipeline
@@ -184,6 +184,10 @@
           "value": "ImageGeom/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "ImageGeom/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -192,7 +196,7 @@
           "value": "",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,

--- a/src/Plugins/SimplnxCore/pipelines/Read_Data_Files/Import_CSV_File.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/Read_Data_Files/Import_CSV_File.d3dpipeline
@@ -5,11 +5,19 @@
   "pipeline": [
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Import_ASCII_IPF.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1
@@ -244,6 +252,10 @@
           "value": "[Image Geometry]/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "[Image Geometry]/EnsembleAttributeMatrix/CrystalStructures",
           "version": 1
@@ -252,7 +264,7 @@
           "value": "",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,

--- a/src/Plugins/SimplnxCore/pipelines/Remove_Flagged_Triangles.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/Remove_Flagged_Triangles.d3dpipeline
@@ -184,11 +184,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/remove_flagged_elements_data/remove_flagged_triangles_data.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/ReplaceElementAttributesWithNeighbor.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/ReplaceElementAttributesWithNeighbor.d3dpipeline
@@ -321,6 +321,10 @@
           "value": "DataContainer/Cell Data/Phases",
           "version": 1
         },
+        "color_key_index": {
+          "value": 0,
+          "version": 1
+        },
         "crystal_structures_array_path": {
           "value": "DataContainer/Cell Ensemble Data/CrystalStructures",
           "version": 1
@@ -329,7 +333,7 @@
           "value": "DataContainer/Cell Data/Mask",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
         "reference_dir": {
           "value": [
             0.0,
@@ -383,11 +387,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/Examples/ReplaceElementAttributesWithNeighbor.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/ResampleRectGridToImageGeom.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/ResampleRectGridToImageGeom.d3dpipeline
@@ -531,11 +531,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Examples/ResampleRectGridToImageGeom.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/SurfaceNets_Demo.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/SurfaceNets_Demo.d3dpipeline
@@ -13,6 +13,14 @@
           "value": false,
           "version": 1
         },
+        "change_origin": {
+          "value": false,
+          "version": 1
+        },
+        "change_spacing": {
+          "value": false,
+          "version": 1
+        },
         "color_weights": {
           "value": [
             0.21250000596046448,
@@ -23,6 +31,40 @@
         },
         "convert_to_gray_scale": {
           "value": false,
+          "version": 1
+        },
+        "cropping_options": {
+          "value": {
+            "bounds_x_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_x_voxels": [
+              0,
+              0
+            ],
+            "bounds_y_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_y_voxels": [
+              0,
+              0
+            ],
+            "bounds_z_physical": [
+              0.0,
+              0.0
+            ],
+            "bounds_z_voxels": [
+              0,
+              0
+            ],
+            "crop_x": true,
+            "crop_y": true,
+            "crop_z": true,
+            "is_2d": false,
+            "type": 0
+          },
           "version": 1
         },
         "exact_xy_dimensions": {
@@ -64,6 +106,10 @@
             0.0,
             0.0
           ],
+          "version": 1
+        },
+        "origin_spacing_processing_index": {
+          "value": 1,
           "version": 1
         },
         "output_image_geometry_path": {
@@ -222,6 +268,14 @@
           "value": "RoboMet.3D Image Stack/Optical Data/FeatureIds",
           "version": 1
         },
+        "input_data_array_paths": {
+          "value": [],
+          "version": 1
+        },
+        "input_feature_data_array_paths": {
+          "value": [],
+          "version": 1
+        },
         "input_grid_geometry_path": {
           "value": "RoboMet.3D Image Stack",
           "version": 1
@@ -265,11 +319,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/SurfaceMesh/SurfaceNets_Demo.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1

--- a/src/Plugins/SimplnxCore/pipelines/Write_Data_Files/CombineStlFiles.d3dpipeline
+++ b/src/Plugins/SimplnxCore/pipelines/Write_Data_Files/CombineStlFiles.d3dpipeline
@@ -72,11 +72,19 @@
     },
     {
       "args": {
+        "compression_level": {
+          "value": 5,
+          "version": 1
+        },
         "export_file_path": {
           "value": "Data/Output/CombinedStlFiles.dream3d",
           "version": 1
         },
-        "parameters_version": 1,
+        "parameters_version": 2,
+        "use_compression": {
+          "value": true,
+          "version": 1
+        },
         "write_xdmf_file": {
           "value": true,
           "version": 1


### PR DESCRIPTION
## Summary

Refreshes 44 example `.d3dpipeline` files whose filter arguments had gone stale as filters gained or renamed parameters, eliminating the `-5432`/`-5433` "Parameter key not found" warnings DREAM3D-NX shows when loading them.

* Each stale pipeline was round-tripped through `Pipeline::FromFile` → `toJson` (via the python bindings) so every filter now serializes its current full parameter key set, defaults, and `parameters_version` — identical to what DREAM3D-NX would save today.
* Three renamed keys were migrated value-preserving instead of falling back to defaults:
  * `surface_mesh_face_ipf_colors_array_name` → `first_face_ipf_colors_array_name` (following the filter's own SIMPL-converter precedent; the second color array keeps its default name)
  * `surface_mesh_face_misorientation_colors_array_name` → `misorientation_array_name`
  * `z_value_choice` → `z_value_choice_index`
* GUI-level top-level fields (`pipeline_uuid`, `workflowParams`, `pinnedParams`) and all filter comments are preserved; core `Pipeline::toJson` does not emit the GUI fields, so they were re-applied from the original files.
* V&V comparison pipelines under `vv/` are deliberately untouched (provenance artifacts).

## Test Plan

- [x] Preflight sweep of all 68 example pipelines with nxrunner shows zero missing/obsolete parameter-key warnings (only the intentionally excluded `vv/` pipeline still warns).
- [x] Line-level diff audit confirms no argument values were lost — only added keys with defaults, version bumps, and the three value-preserving renames.
- [x] `Import_CSV_File.d3dpipeline` executes end-to-end cleanly via nxrunner.

Note: `ExtractFeatureBoundaries2D.d3dpipeline` contains a pre-existing hard-coded absolute input path from another machine and cannot execute portably; left for a separate fix.