### PR TITLE
BUG: Harden the binary STL reader against non-conforming files

### DIFF
--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadStlFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadStlFile.cpp
@@ -14,7 +14,6 @@
 #include <array>
 #include <cstdint>
 #include <cstdio>
-#include <utility>
 
 using namespace nx::core;
 
@@ -78,7 +77,14 @@ Result<> ReadStlFile::operator()()
   MessageHelper messageHelper(m_MessageHandler);
   ThrottledMessenger throttledMessenger = messageHelper.createThrottledMessenger();
 
-  fpos_t pos;
+  // Track the read offset arithmetically rather than asking the C library for it every triangle.
+  // fpos_t is an opaque type that is only portably usable with fsetpos(): glibc makes it a struct
+  // whose offset lives in a reserved-identifier member, musl makes it an opaque byte array with no
+  // such member at all, and the 64 bit "tell" functions are spelled differently on every platform
+  // (ftello, ftello64, _ftelli64). Nothing here needs any of that. Every read below advances the
+  // offset by a known amount, so the offset can simply be computed, which is both exact and
+  // portable. It starts just past the header and triangle count that were skipped above.
+  uintmax_t fileOffset = StlConstants::k_StlFixedHeaderBytes;
 
   for(int32_t t = 0; t < triCount; ++t)
   {
@@ -87,22 +93,11 @@ Result<> ReadStlFile::operator()()
     {
       return {};
     }
-    // Get the current File Position
-    fgetpos(f, &pos);
-#if defined(__APPLE__) || defined(_WIN32)
-    if(pos >= stlFileSize)
-#else
-    if(pos.__pos >= stlFileSize)
-#endif
+    if(fileOffset >= stlFileSize)
     {
       std::string msg = fmt::format(
           "Trying to read at file position {} >= file size {}.\n  File Header: '{}'\n  Header Triangle Count: {}  Current Triangle: {}\n  The STL File does not conform to the STL file specification.",
-#if defined(__APPLE__) || defined(_WIN32)
-          pos,
-#else
-          pos.__pos,
-#endif
-          stlFileSize, stlFileCheck.header, triCount, t);
+          fileOffset, stlFileSize, stlFileCheck.header, triCount, t);
       return MakeErrorResult(StlConstants::k_StlFileLengthError, msg);
     }
 
@@ -122,12 +117,20 @@ Result<> ReadStlFile::operator()()
       std::string msg = fmt::format("Error reading Number of attributes for triangle '{}' from STL file '{}'. uint16 count was {} and should have been 1", t, stlFilePathStr, objsRead);
       return MakeErrorResult(StlConstants::k_AttributeParseError, msg);
     }
+    fileOffset += StlConstants::k_StlTriangleBytes;
+
     // The file size told us this file really does carry attribute payload bytes, so the count is
     // an actual length and the payload has to be skipped. When the flag is false the count is
     // vendor garbage (a packed color, for example) and seeking on it would desynchronize the read.
     if(attrByteCount > 0 && stlFileCheck.attributePayloadPresent)
     {
-      std::ignore = std::fseek(f, static_cast<long>(attrByteCount), SEEK_CUR); // Skip past the Triangle Attribute data since we don't know how to read it anyway
+      // Skip past the Triangle Attribute data since we don't know how to read it anyway
+      if(std::fseek(f, static_cast<long>(attrByteCount), SEEK_CUR) != 0)
+      {
+        std::string msg = fmt::format("Error seeking past the {} attribute bytes that follow triangle '{}' in STL file '{}'", attrByteCount, t, stlFilePathStr);
+        return MakeErrorResult(StlConstants::k_AttributeParseError, msg);
+      }
+      fileOffset += attrByteCount;
     }
 
     // Write the data into the actual geometry

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadStlFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadStlFile.cpp
@@ -11,62 +11,14 @@
 #include "simplnx/Utilities/MessageHelper.hpp"
 #include "simplnx/Utilities/StringUtilities.hpp"
 
+#include <array>
+#include <cstdint>
 #include <cstdio>
 #include <utility>
 
 using namespace nx::core;
 
-namespace
-{
-class StlFileSentinel
-{
-public:
-  explicit StlFileSentinel(FILE* file)
-  : m_File(file)
-  {
-  }
-  ~StlFileSentinel()
-  {
-    std::ignore = std::fclose(m_File);
-  }
-  StlFileSentinel(const StlFileSentinel&) = delete;            // Copy Constructor Not Implemented
-  StlFileSentinel(StlFileSentinel&&) = delete;                 // Move Constructor Not Implemented
-  StlFileSentinel& operator=(const StlFileSentinel&) = delete; // Copy Assignment Not Implemented
-  StlFileSentinel& operator=(StlFileSentinel&&) = delete;      // Move Assignment Not Implemented
-
-private:
-  FILE* m_File = nullptr;
-};
-
-bool IsMagicsFile(const std::string& stlHeaderStr)
-{
-  // Look for the tell-tale signs that the file was written from Magics Materialise
-  // If the file was written by Magics as a "Color STL" file then the 2byte int
-  // values between each triangle will be NON-Zero which will screw up the reading.
-  // These NON-Zero value do NOT indicate a length but is some sort of color
-  // value encoded into the file. Instead of being normal like everyone else and
-  // using the STL spec they went off and did their own thing.
-
-  static const std::string k_ColorHeader("COLOR=");
-  static const std::string k_MaterialHeader("MATERIAL=");
-  if(stlHeaderStr.find(k_ColorHeader) != std::string::npos && stlHeaderStr.find(k_MaterialHeader) != std::string::npos)
-  {
-    return true;
-  }
-  return false;
-}
-
-bool IsVxElementsFile(const std::string& stlHeader)
-{
-  // Look for the tell-tale signs that the file was written from VxElements Creaform
-  // STL files do not honor the last 2 bytes of the 50 byte Triangle struct
-  // as specified in the STL Binary File specification. If we detect this, then we
-  // ignore the 2 bytes are anything meaningful.
-  return nx::core::StringUtilities::contains(stlHeader, "VXelements");
-}
-} // End anonymous namespace
-
-ReadStlFile::ReadStlFile(DataStructure& dataStructure, ReadStlFileInputValues& inputValues, const std::atomic_bool& shouldCancel, const IFilter::MessageHandler& mesgHandler)
+ReadStlFile::ReadStlFile(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ReadStlFileInputValues* inputValues)
 : m_DataStructure(dataStructure)
 , m_InputValues(inputValues)
 , m_ShouldCancel(shouldCancel)
@@ -78,42 +30,38 @@ ReadStlFile::~ReadStlFile() noexcept = default;
 
 Result<> ReadStlFile::operator()()
 {
-  std::error_code errorCode;
-  auto stlFileSize = std::filesystem::file_size(m_InputValues.stlFilePath, errorCode);
+  const std::string stlFilePathStr = m_InputValues->stlFilePath.string();
 
-  StlConstants::StlFileCheck stlFileCheck = StlUtilities::SanityCheckFile(m_InputValues.stlFilePath);
+  // Inspect the file before reading it. This parses the header and triangle count and, more
+  // importantly, decides whether the per-triangle "attribute byte count" fields in this file are
+  // real byte lengths or vendor garbage that must be ignored. See StlUtilities::SanityCheckFile().
+  const StlConstants::StlFileCheck stlFileCheck = StlUtilities::SanityCheckFile(m_InputValues->stlFilePath);
   if(stlFileCheck.error != 0)
   {
     return MakeErrorResult(stlFileCheck.error, stlFileCheck.errorMessage);
   }
+  const int32_t triCount = stlFileCheck.numTriangles;
+  const uintmax_t stlFileSize = stlFileCheck.fileSize;
 
   // Open File
-  FILE* f = std::fopen(m_InputValues.stlFilePath.string().c_str(), "rb");
+  FILE* f = std::fopen(stlFilePathStr.c_str(), "rb");
   if(nullptr == f)
   {
-    return MakeErrorResult(nx::core::StlConstants::k_ErrorOpeningFile, "Error opening STL file");
+    return MakeErrorResult(StlConstants::k_ErrorOpeningFile, fmt::format("Error opening STL file '{}'", stlFilePathStr));
   }
-  StlFileSentinel fileSentinel(f); // Will ensure that the file is closed when this method returns
+  StlUtilities::StlFileSentinel fileSentinel(f); // Will ensure that the file is closed when this method returns
 
-  // Read Header
-  std::array<char, nx::core::StlConstants::k_STL_HEADER_LENGTH> stlHeader = {0};
-  int32_t triCount = 0;
-  if(std::fread(stlHeader.data(), nx::core::StlConstants::k_STL_HEADER_LENGTH, 1, f) != 1)
+  // Skip past the 80 byte header and the triangle count. SanityCheckFile() already parsed both,
+  // so there is no reason to read them a second time.
+  if(std::fseek(f, static_cast<long>(StlConstants::k_StlFixedHeaderBytes), SEEK_SET) != 0)
   {
-    return MakeErrorResult(nx::core::StlConstants::k_StlHeaderParseError, "Error reading first 8 bytes of STL header. This can't be good.");
-  }
-  std::string stlHeaderStr(stlHeader.data(), nx::core::StlConstants::k_STL_HEADER_LENGTH);
-
-  // Read the number of triangles in the file.
-  if(std::fread(&triCount, sizeof(int32_t), 1, f) != 1)
-  {
-    return MakeErrorResult(nx::core::StlConstants::k_TriangleCountParseError, "Error reading number of triangles from file. This is bad.");
+    return MakeErrorResult(StlConstants::k_StlHeaderParseError, fmt::format("Error seeking past the {} byte header of STL file '{}'", StlConstants::k_StlFixedHeaderBytes, stlFilePathStr));
   }
 
-  auto& triangleGeom = m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues.geometryPath);
+  auto& triangleGeom = m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues->geometryPath);
 
   triangleGeom.resizeFaceList(triCount);
-  triangleGeom.resizeVertexList(triCount * 3);
+  triangleGeom.resizeVertexList(static_cast<usize>(triCount) * 3);
 
   using SharedTriList = AbstractDataStore<IGeometry::MeshIndexArrayType::value_type>;
   using SharedVertList = AbstractDataStore<IGeometry::SharedVertexList::value_type>;
@@ -121,13 +69,11 @@ Result<> ReadStlFile::operator()()
   SharedTriList& triangles = triangleGeom.getFaces()->getDataStoreRef();
   SharedVertList& nodes = triangleGeom.getVertices()->getDataStoreRef();
 
-  auto& faceNormalsStore = m_DataStructure.getDataAs<Float64Array>(m_InputValues.faceNormalsDataPath)->getDataStoreRef();
+  auto& faceNormalsStore = m_DataStructure.getDataAs<Float64Array>(m_InputValues->faceNormalsDataPath)->getDataStoreRef();
 
   // Read the triangles
-  constexpr size_t k_StlElementCount = 12;
-  std::array<float, k_StlElementCount> fileVert = {0.0F};
-  uint16_t attr = 0;
-  std::vector<uint8_t> triangleAttributeBuffer(std::numeric_limits<uint16_t>::max()); // Just allocate a buffer of max UINT16 elements
+  std::array<float, StlConstants::k_StlElementCount> fileVert = {0.0F};
+  uint16_t attrByteCount = 0;
 
   MessageHelper messageHelper(m_MessageHandler);
   ThrottledMessenger throttledMessenger = messageHelper.createThrottledMessenger();
@@ -156,30 +102,32 @@ Result<> ReadStlFile::operator()()
 #else
           pos.__pos,
 #endif
-          stlFileSize, stlHeaderStr, triCount, t);
-      return MakeErrorResult(nx::core::StlConstants::k_StlFileLengthError, msg);
+          stlFileSize, stlFileCheck.header, triCount, t);
+      return MakeErrorResult(StlConstants::k_StlFileLengthError, msg);
     }
 
     // Read the Vertices and Normal (12 total float32 = 48 Bytes)
-    size_t objsRead = std::fread(fileVert.data(), sizeof(float), k_StlElementCount, f); // Read the Triangle
-    if(k_StlElementCount != objsRead)
+    size_t objsRead = std::fread(fileVert.data(), sizeof(float), StlConstants::k_StlElementCount, f); // Read the Triangle
+    if(StlConstants::k_StlElementCount != objsRead)
     {
-      std::string msg = fmt::format("Error reading Triangle '{}'. Object Count was {} and should have been {}", t, objsRead, k_StlElementCount);
-      return MakeErrorResult(nx::core::StlConstants::k_TriangleParseError, msg);
+      std::string msg = fmt::format("Error reading Triangle '{}' from STL file '{}'. Object Count was {} and should have been {}", t, stlFilePathStr, objsRead, StlConstants::k_StlElementCount);
+      return MakeErrorResult(StlConstants::k_TriangleParseError, msg);
     }
     // Read the Uint16 value. This value is supposed to represent the number of bytes following
     // a triangle that are file- or vendor-specific metadata
     // Lots of writers/vendors do NOT set this properly, which can cause problems.
-    objsRead = std::fread(&attr, sizeof(uint16_t), 1, f); // Read the Triangle Attribute Data length
+    objsRead = std::fread(&attrByteCount, sizeof(uint16_t), 1, f); // Read the Triangle Attribute Data length
     if(objsRead != 1)
     {
-      std::string msg = fmt::format("Error reading Number of attributes for triangle '{}'. uint16 count was {} and should have been 1", t, objsRead);
-      return MakeErrorResult(nx::core::StlConstants::k_AttributeParseError, msg);
+      std::string msg = fmt::format("Error reading Number of attributes for triangle '{}' from STL file '{}'. uint16 count was {} and should have been 1", t, stlFilePathStr, objsRead);
+      return MakeErrorResult(StlConstants::k_AttributeParseError, msg);
     }
-    // If we are essentially ignoring the STL binary spec.
-    if(attr > 0 && stlFileCheck.useTriangleAttributeByteCount)
+    // The file size told us this file really does carry attribute payload bytes, so the count is
+    // an actual length and the payload has to be skipped. When the flag is false the count is
+    // vendor garbage (a packed color, for example) and seeking on it would desynchronize the read.
+    if(attrByteCount > 0 && stlFileCheck.attributePayloadPresent)
     {
-      std::ignore = std::fseek(f, static_cast<size_t>(attr), SEEK_CUR); // Skip past the Triangle Attribute data since we don't know how to read it anyway
+      std::ignore = std::fseek(f, static_cast<long>(attrByteCount), SEEK_CUR); // Skip past the Triangle Attribute data since we don't know how to read it anyway
     }
 
     // Write the data into the actual geometry
@@ -200,6 +148,6 @@ Result<> ReadStlFile::operator()()
     triangles[t * 3 + 2] = 3 * t + 2;
   }
 
-  return GeometryUtilities::EliminateDuplicateNodes(triangleGeom, m_InputValues.scaleOutput ? std::optional<float32>(m_InputValues.scaleFactor) : std::nullopt);
+  return GeometryUtilities::EliminateDuplicateNodes(triangleGeom, m_InputValues->scaleOutput ? std::optional<float32>(m_InputValues->scaleFactor) : std::nullopt);
   // The fileSentinel will ensure the FILE* is closed.
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadStlFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadStlFile.cpp
@@ -66,15 +66,9 @@ bool IsVxElementsFile(const std::string& stlHeader)
 }
 } // End anonymous namespace
 
-ReadStlFile::ReadStlFile(DataStructure& dataStructure, fs::path stlFilePath, const DataPath& geometryPath, const DataPath& faceGroupPath, const DataPath& faceNormalsDataPath, bool scaleOutput,
-                         float32 scaleFactor, const std::atomic_bool& shouldCancel, const IFilter::MessageHandler& mesgHandler)
+ReadStlFile::ReadStlFile(DataStructure& dataStructure, ReadStlFileInputValues& inputValues, const std::atomic_bool& shouldCancel, const IFilter::MessageHandler& mesgHandler)
 : m_DataStructure(dataStructure)
-, m_FilePath(std::move(stlFilePath))
-, m_GeometryDataPath(geometryPath)
-, m_FaceGroupPath(faceGroupPath)
-, m_FaceNormalsDataPath(faceNormalsDataPath)
-, m_ScaleOutput(scaleOutput)
-, m_ScaleFactor(scaleFactor)
+, m_InputValues(inputValues)
 , m_ShouldCancel(shouldCancel)
 , m_MessageHandler(mesgHandler)
 {
@@ -85,10 +79,16 @@ ReadStlFile::~ReadStlFile() noexcept = default;
 Result<> ReadStlFile::operator()()
 {
   std::error_code errorCode;
-  auto stlFileSize = std::filesystem::file_size(m_FilePath, errorCode);
+  auto stlFileSize = std::filesystem::file_size(m_InputValues.stlFilePath, errorCode);
+
+  StlConstants::StlFileCheck stlFileCheck = StlUtilities::SanityCheckFile(m_InputValues.stlFilePath);
+  if(stlFileCheck.error != 0)
+  {
+    return MakeErrorResult(stlFileCheck.error, stlFileCheck.errorMessage);
+  }
 
   // Open File
-  FILE* f = std::fopen(m_FilePath.string().c_str(), "rb");
+  FILE* f = std::fopen(m_InputValues.stlFilePath.string().c_str(), "rb");
   if(nullptr == f)
   {
     return MakeErrorResult(nx::core::StlConstants::k_ErrorOpeningFile, "Error opening STL file");
@@ -102,16 +102,7 @@ Result<> ReadStlFile::operator()()
   {
     return MakeErrorResult(nx::core::StlConstants::k_StlHeaderParseError, "Error reading first 8 bytes of STL header. This can't be good.");
   }
-
-  // Look for the tell-tale signs that the file was written from Magics Materialise
-  // If the file was written by Magics as a "Color STL" file then the 2byte int
-  // values between each triangle will be NON-Zero which will screw up the reading.
-  // This NON-Zero value does NOT indicate a length but is some sort of color
-  // value encoded into the file. Instead of being normal like everyone else and
-  // using the STL spec they went off and did their own thing.
   std::string stlHeaderStr(stlHeader.data(), nx::core::StlConstants::k_STL_HEADER_LENGTH);
-
-  bool ignoreMetaSizeValue = (IsMagicsFile(stlHeaderStr) || IsVxElementsFile(stlHeaderStr) ? true : false);
 
   // Read the number of triangles in the file.
   if(std::fread(&triCount, sizeof(int32_t), 1, f) != 1)
@@ -119,7 +110,7 @@ Result<> ReadStlFile::operator()()
     return MakeErrorResult(nx::core::StlConstants::k_TriangleCountParseError, "Error reading number of triangles from file. This is bad.");
   }
 
-  auto& triangleGeom = m_DataStructure.getDataRefAs<TriangleGeom>(m_GeometryDataPath);
+  auto& triangleGeom = m_DataStructure.getDataRefAs<TriangleGeom>(m_InputValues.geometryPath);
 
   triangleGeom.resizeFaceList(triCount);
   triangleGeom.resizeVertexList(triCount * 3);
@@ -130,7 +121,7 @@ Result<> ReadStlFile::operator()()
   SharedTriList& triangles = triangleGeom.getFaces()->getDataStoreRef();
   SharedVertList& nodes = triangleGeom.getVertices()->getDataStoreRef();
 
-  auto& faceNormalsStore = m_DataStructure.getDataAs<Float64Array>(m_FaceNormalsDataPath)->getDataStoreRef();
+  auto& faceNormalsStore = m_DataStructure.getDataAs<Float64Array>(m_InputValues.faceNormalsDataPath)->getDataStoreRef();
 
   // Read the triangles
   constexpr size_t k_StlElementCount = 12;
@@ -176,17 +167,17 @@ Result<> ReadStlFile::operator()()
       std::string msg = fmt::format("Error reading Triangle '{}'. Object Count was {} and should have been {}", t, objsRead, k_StlElementCount);
       return MakeErrorResult(nx::core::StlConstants::k_TriangleParseError, msg);
     }
-    // Read the Uint16 value that is supposed to represent the number of bytes following that are file/vendor specific metadata
-    // Lots of writers/vendors do NOT set this properly which can cause problems.
+    // Read the Uint16 value. This value is supposed to represent the number of bytes following
+    // a triangle that are file- or vendor-specific metadata
+    // Lots of writers/vendors do NOT set this properly, which can cause problems.
     objsRead = std::fread(&attr, sizeof(uint16_t), 1, f); // Read the Triangle Attribute Data length
     if(objsRead != 1)
     {
       std::string msg = fmt::format("Error reading Number of attributes for triangle '{}'. uint16 count was {} and should have been 1", t, objsRead);
       return MakeErrorResult(nx::core::StlConstants::k_AttributeParseError, msg);
     }
-    // If we are trying to follow along the STL Spec, skip the stated bytes unless
-    // we detected known Vendors that do not write proper STL Files.
-    if(attr > 0 && !ignoreMetaSizeValue)
+    // If we are essentially ignoring the STL binary spec.
+    if(attr > 0 && stlFileCheck.useTriangleAttributeByteCount)
     {
       std::ignore = std::fseek(f, static_cast<size_t>(attr), SEEK_CUR); // Skip past the Triangle Attribute data since we don't know how to read it anyway
     }
@@ -209,6 +200,6 @@ Result<> ReadStlFile::operator()()
     triangles[t * 3 + 2] = 3 * t + 2;
   }
 
-  return GeometryUtilities::EliminateDuplicateNodes(triangleGeom, m_ScaleOutput ? std::optional<float32>(m_ScaleFactor) : std::nullopt);
+  return GeometryUtilities::EliminateDuplicateNodes(triangleGeom, m_InputValues.scaleOutput ? std::optional<float32>(m_InputValues.scaleFactor) : std::nullopt);
   // The fileSentinel will ensure the FILE* is closed.
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadStlFile.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadStlFile.hpp
@@ -7,7 +7,6 @@
 #include "simplnx/Filter/Arguments.hpp"
 #include "simplnx/Filter/IFilter.hpp"
 
-#include <array>
 #include <filesystem>
 
 namespace fs = std::filesystem;
@@ -21,8 +20,8 @@ struct SIMPLNXCORE_EXPORT ReadStlFileInputValues
   DataPath geometryPath;
   DataPath faceGroupPath;
   DataPath faceNormalsDataPath;
-  bool scaleOutput;
-  float32 scaleFactor;
+  bool scaleOutput = false;
+  float32 scaleFactor = 1.0F;
 };
 
 /**
@@ -31,7 +30,7 @@ struct SIMPLNXCORE_EXPORT ReadStlFileInputValues
 class SIMPLNXCORE_EXPORT ReadStlFile
 {
 public:
-  ReadStlFile(DataStructure& dataStructure, ReadStlFileInputValues& inputValues, const std::atomic_bool& shouldCancel, const IFilter::MessageHandler& mesgHandler);
+  ReadStlFile(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ReadStlFileInputValues* inputValues);
   ~ReadStlFile() noexcept;
 
   ReadStlFile(const ReadStlFile&) = delete;
@@ -41,14 +40,9 @@ public:
 
   Result<> operator()();
 
-  /**
-   * @brief readFile Reads the .stl file
-   */
-  Result<> readFile();
-
 private:
   DataStructure& m_DataStructure;
-  const ReadStlFileInputValues& m_InputValues;
+  const ReadStlFileInputValues* m_InputValues = nullptr;
   const std::atomic_bool& m_ShouldCancel;
   const IFilter::MessageHandler& m_MessageHandler;
 };

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadStlFile.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ReadStlFile.hpp
@@ -14,15 +14,24 @@ namespace fs = std::filesystem;
 
 namespace nx::core
 {
-/**
- * @class ConditionalSetValueFilter
 
+struct SIMPLNXCORE_EXPORT ReadStlFileInputValues
+{
+  fs::path stlFilePath;
+  DataPath geometryPath;
+  DataPath faceGroupPath;
+  DataPath faceNormalsDataPath;
+  bool scaleOutput;
+  float32 scaleFactor;
+};
+
+/**
+ * @class ReadStlFile
  */
 class SIMPLNXCORE_EXPORT ReadStlFile
 {
 public:
-  ReadStlFile(DataStructure& dataStructure, fs::path stlFilePath, const DataPath& geometryPath, const DataPath& faceGroupPath, const DataPath& faceNormalsDataPath, bool scaleOutput,
-              float32 scaleFactor, const std::atomic_bool& shouldCancel, const IFilter::MessageHandler& mesgHandler);
+  ReadStlFile(DataStructure& dataStructure, ReadStlFileInputValues& inputValues, const std::atomic_bool& shouldCancel, const IFilter::MessageHandler& mesgHandler);
   ~ReadStlFile() noexcept;
 
   ReadStlFile(const ReadStlFile&) = delete;
@@ -39,12 +48,7 @@ public:
 
 private:
   DataStructure& m_DataStructure;
-  const fs::path m_FilePath;
-  const DataPath& m_GeometryDataPath;
-  const DataPath& m_FaceGroupPath;
-  const DataPath m_FaceNormalsDataPath;
-  const bool m_ScaleOutput = false;
-  const float m_ScaleFactor = 1.0F;
+  const ReadStlFileInputValues& m_InputValues;
   const std::atomic_bool& m_ShouldCancel;
   const IFilter::MessageHandler& m_MessageHandler;
 };

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStlFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStlFileFilter.cpp
@@ -179,29 +179,25 @@ IFilter::PreflightResult ReadStlFileFilter::preflightImpl(const DataStructure& d
 Result<> ReadStlFileFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
                                         const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
-  auto pStlFilePathValue = filterArgs.value<FileSystemPathParameter::ValueType>(k_StlFilePath_Key);
-  auto pTriangleGeometryPath = filterArgs.value<DataPath>(k_CreatedTriangleGeometryPath_Key);
-  auto vertexMatrixName = filterArgs.value<std::string>(k_VertexAttributeMatrixName_Key);
+  ReadStlFileInputValues inputValues;
+
+  inputValues.stlFilePath = filterArgs.value<FileSystemPathParameter::ValueType>(k_StlFilePath_Key);
+  inputValues.geometryPath = filterArgs.value<DataPath>(k_CreatedTriangleGeometryPath_Key);
   auto faceMatrixName = filterArgs.value<std::string>(k_FaceAttributeMatrixName_Key);
-  auto faceNormalsName = filterArgs.value<std::string>(k_FaceNormalsName_Key);
-
-  auto pFaceDataGroupPath = pTriangleGeometryPath.createChildPath(faceMatrixName);
-
-  auto pFaceNormalsPath = pFaceDataGroupPath.createChildPath(faceNormalsName);
-
-  auto createFaceLabels = filterArgs.value<BoolParameter::ValueType>(k_CreateFaceLabels_Key);
-  auto faceLabelsName = filterArgs.value<std::string>(k_FaceLabelsName_Key);
-
-  auto scaleOutput = filterArgs.value<bool>(k_ScaleOutput);
-  auto scaleFactor = filterArgs.value<float32>(k_ScaleFactor);
+  inputValues.faceGroupPath = inputValues.geometryPath.createChildPath(faceMatrixName);
+  inputValues.faceNormalsDataPath = inputValues.faceGroupPath.createChildPath(filterArgs.value<std::string>(k_FaceNormalsName_Key));
+  inputValues.scaleOutput = filterArgs.value<bool>(k_ScaleOutput);
+  inputValues.scaleFactor = filterArgs.value<float32>(k_ScaleFactor);
 
   // The actual STL File Reading is placed in a separate class `ReadStlFile`
-  Result<> result = ReadStlFile(dataStructure, pStlFilePathValue, pTriangleGeometryPath, pFaceDataGroupPath, pFaceNormalsPath, scaleOutput, scaleFactor, shouldCancel, messageHandler)();
+  Result<> result = ReadStlFile(dataStructure, inputValues, shouldCancel, messageHandler)();
 
   // Create the Face Labels Array if the user asked for it.
+  auto createFaceLabels = filterArgs.value<BoolParameter::ValueType>(k_CreateFaceLabels_Key);
   if(createFaceLabels)
   {
-    auto* faceLabelDataStorePtr = dataStructure.getDataRefAs<Int32Array>(pTriangleGeometryPath.createChildPath(faceMatrixName).createChildPath(faceLabelsName)).getDataStore();
+    auto faceLabelsName = filterArgs.value<std::string>(k_FaceLabelsName_Key);
+    auto* faceLabelDataStorePtr = dataStructure.getDataRefAs<Int32Array>(inputValues.geometryPath.createChildPath(faceMatrixName).createChildPath(faceLabelsName)).getDataStore();
     usize numTuples = faceLabelDataStorePtr->getNumberOfTuples();
 
     for(usize idx = 0; idx < numTuples; idx++)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStlFileFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ReadStlFileFilter.cpp
@@ -119,22 +119,22 @@ IFilter::PreflightResult ReadStlFileFilter::preflightImpl(const DataStructure& d
   {
     return MakePreflightErrorResult(
         StlConstants::k_UnsupportedFileType,
-        fmt::format("The Input STL File is ASCII which is not currently supported. Please convert it to a binary STL file using another program.", pStlFilePathValue.string()));
+        fmt::format("The Input STL File '{}' is ASCII which is not currently supported. Please convert it to a binary STL file using another program.", pStlFilePathValue.string()));
   }
   if(stlFileType == StlConstants::StlFileType::FileOpenError)
   {
-    return MakePreflightErrorResult(StlConstants::k_ErrorOpeningFile, fmt::format("Error opening the STL file.", pStlFilePathValue.string()));
+    return MakePreflightErrorResult(StlConstants::k_ErrorOpeningFile, fmt::format("Error opening the STL file '{}'.", pStlFilePathValue.string()));
   }
   if(stlFileType == StlConstants::StlFileType::HeaderParseError)
   {
-    return MakePreflightErrorResult(StlConstants::k_ErrorOpeningFile, fmt::format("Error reading the header from STL file.", pStlFilePathValue.string()));
+    return MakePreflightErrorResult(StlConstants::k_ErrorOpeningFile, fmt::format("Error reading the header from STL file '{}'.", pStlFilePathValue.string()));
   }
 
   // Now get the number of Triangles according to the STL Header
   int32_t numTriangles = StlUtilities::NumFacesFromHeader(pStlFilePathValue);
   if(numTriangles < 0)
   {
-    return MakePreflightErrorResult(numTriangles, fmt::format("Error extracting the number of triangles from the STL file.", pStlFilePathValue.string()));
+    return MakePreflightErrorResult(numTriangles, fmt::format("Error extracting the number of triangles from the STL file '{}'. Returned error code {}.", pStlFilePathValue.string(), numTriangles));
   }
 
   // This can happen in a LOT of STL files. Just means the writer didn't go back and update the header.
@@ -190,14 +190,19 @@ Result<> ReadStlFileFilter::executeImpl(DataStructure& dataStructure, const Argu
   inputValues.scaleFactor = filterArgs.value<float32>(k_ScaleFactor);
 
   // The actual STL File Reading is placed in a separate class `ReadStlFile`
-  Result<> result = ReadStlFile(dataStructure, inputValues, shouldCancel, messageHandler)();
+  Result<> result = ReadStlFile(dataStructure, messageHandler, shouldCancel, &inputValues)();
+  if(result.invalid())
+  {
+    // The geometry is only partially populated, so do not go on to label its faces.
+    return result;
+  }
 
   // Create the Face Labels Array if the user asked for it.
   auto createFaceLabels = filterArgs.value<BoolParameter::ValueType>(k_CreateFaceLabels_Key);
   if(createFaceLabels)
   {
     auto faceLabelsName = filterArgs.value<std::string>(k_FaceLabelsName_Key);
-    auto* faceLabelDataStorePtr = dataStructure.getDataRefAs<Int32Array>(inputValues.geometryPath.createChildPath(faceMatrixName).createChildPath(faceLabelsName)).getDataStore();
+    auto* faceLabelDataStorePtr = dataStructure.getDataRefAs<Int32Array>(inputValues.faceGroupPath.createChildPath(faceLabelsName)).getDataStore();
     usize numTuples = faceLabelDataStorePtr->getNumberOfTuples();
 
     for(usize idx = 0; idx < numTuples; idx++)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/StlUtilities.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/StlUtilities.cpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include <fmt/format.h>
+
 using namespace nx::core;
 
 StlConstants::StlFileType StlUtilities::DetermineStlFileType(const fs::path& path)
@@ -77,6 +79,66 @@ int32_t StlUtilities::NumFacesFromHeader(const fs::path& path)
 
   std::ignore = std::fclose(f);
   return triCount;
+}
+
+StlConstants::StlFileCheck StlUtilities::SanityCheckFile(const fs::path& path)
+{
+  StlConstants::StlFileCheck stlFileCheck = {0, "", "", 0, 0, false};
+
+  uintmax_t fileSize = std::filesystem::file_size(path);
+
+  // Open File
+  FILE* f = std::fopen(path.string().c_str(), "rb");
+  if(nullptr == f)
+  {
+    return {StlConstants::k_ErrorOpeningFile, "Error opening file", "", 0, 0, false};
+  }
+
+  // Read the first 256 bytes of data, that should be enough, but I'm sure someone will write
+  // an ASCII STL File that contains a really long name which messes this up.
+  std::string header(StlConstants::k_STL_HEADER_LENGTH, 0x00);
+  if(std::fread(header.data(), 1, StlConstants::k_STL_HEADER_LENGTH, f) != StlConstants::k_STL_HEADER_LENGTH)
+  {
+    std::ignore = std::fclose(f);
+    return {StlConstants::k_StlHeaderParseError, "STL File header parse error.", "", 0, 0, false};
+  }
+
+  int32_t triCount = 0;
+  // Read the number of triangles in the file.
+  if(std::fread(&triCount, sizeof(int32_t), 1, f) != 1)
+  {
+    std::ignore = std::fclose(f);
+    return {StlConstants::k_StlHeaderParseError, "Error reading the Triangle Count value from the file", "", 0, 0, false};
+  }
+
+  // Read a single Triangle and its attribute byte count.
+  constexpr size_t k_StlElementCount = 12;
+  std::array<float, k_StlElementCount> fileVert = {0.0f};
+  uint16_t attrByteCount = 0;
+  size_t t = 0;
+
+  size_t objsRead = std::fread(fileVert.data(), sizeof(float), k_StlElementCount, f); // Read the Triangle
+  if(k_StlElementCount != objsRead)
+  {
+    std::string msg = fmt::format("Error reading Triangle '{}'. Object Count was {} and should have been {}", t, objsRead, k_StlElementCount);
+    return {nx::core::StlConstants::k_TriangleParseError, msg, "", 0, 0, false};
+  }
+  // Read the Uint16 value. This value is supposed to represent the number of bytes following
+  // a triangle that are file- or vendor-specific metadata
+  // Lots of writers/vendors do NOT set this properly, which can cause problems.
+  objsRead = std::fread(&attrByteCount, sizeof(uint16_t), 1, f); // Read the Triangle Attribute Data length
+  if(objsRead != 1)
+  {
+    std::string msg = fmt::format("Error reading Number of attributes for triangle '{}'. uint16 count was {} and should have been 1", t, objsRead);
+    return {nx::core::StlConstants::k_AttributeParseError, msg, "", 0, 0, false};
+  }
+
+  std::ignore = std::fclose(f);
+
+  // Now calculate the file size IF we were to honor that attribute byte count
+  size_t estimatedFileSize = 84 + (triCount * 50) + (triCount * attrByteCount);
+
+  return {0, "", header, triCount, fileSize, fileSize == estimatedFileSize};
 }
 
 struct Triangle

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/StlUtilities.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/StlUtilities.cpp
@@ -1,15 +1,50 @@
 #include "StlUtilities.hpp"
 
+#include "simplnx/Utilities/StringUtilities.hpp"
+
+#include <fmt/format.h>
+
+#include <cstdint>
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <system_error>
+#include <tuple>
 #include <vector>
 
-#include <fmt/format.h>
-
 using namespace nx::core;
+
+namespace
+{
+/**
+ * @brief Looks for the tell-tale signs that the file was written by Magics Materialise.
+ *
+ * If the file was written by Magics as a "Color STL" file then the 2 byte int value that
+ * follows each triangle will be NON-Zero. That value does NOT indicate a length, it is a
+ * color packed into the field. Instead of being normal like everyone else and using the
+ * STL spec they went off and did their own thing.
+ */
+bool IsMagicsFile(const std::string& stlHeaderStr)
+{
+  static const std::string k_ColorHeader("COLOR=");
+  static const std::string k_MaterialHeader("MATERIAL=");
+  return stlHeaderStr.find(k_ColorHeader) != std::string::npos && stlHeaderStr.find(k_MaterialHeader) != std::string::npos;
+}
+
+/**
+ * @brief Looks for the tell-tale signs that the file was written by VxElements Creaform.
+ *
+ * These files do not honor the last 2 bytes of the 50 byte Triangle struct as specified in
+ * the STL Binary File specification, so those 2 bytes are not treated as meaningful.
+ */
+bool IsVxElementsFile(const std::string& stlHeaderStr)
+{
+  return nx::core::StringUtilities::contains(stlHeaderStr, "VXelements");
+}
+} // namespace
 
 StlConstants::StlFileType StlUtilities::DetermineStlFileType(const fs::path& path)
 {
@@ -83,62 +118,75 @@ int32_t StlUtilities::NumFacesFromHeader(const fs::path& path)
 
 StlConstants::StlFileCheck StlUtilities::SanityCheckFile(const fs::path& path)
 {
-  StlConstants::StlFileCheck stlFileCheck = {0, "", "", 0, 0, false};
+  StlConstants::StlFileCheck stlFileCheck;
 
-  uintmax_t fileSize = std::filesystem::file_size(path);
+  std::error_code errorCode;
+  const uintmax_t fileSize = std::filesystem::file_size(path, errorCode);
+  if(errorCode)
+  {
+    stlFileCheck.error = StlConstants::k_ErrorOpeningFile;
+    stlFileCheck.errorMessage = fmt::format("Could not determine the size of STL file '{}': {}", path.string(), errorCode.message());
+    return stlFileCheck;
+  }
 
   // Open File
   FILE* f = std::fopen(path.string().c_str(), "rb");
   if(nullptr == f)
   {
-    return {StlConstants::k_ErrorOpeningFile, "Error opening file", "", 0, 0, false};
+    stlFileCheck.error = StlConstants::k_ErrorOpeningFile;
+    stlFileCheck.errorMessage = fmt::format("Error opening STL file '{}'", path.string());
+    return stlFileCheck;
   }
+  StlFileSentinel fileSentinel(f); // Ensures the file is closed on every return path below
 
-  // Read the first 256 bytes of data, that should be enough, but I'm sure someone will write
-  // an ASCII STL File that contains a really long name which messes this up.
+  // Read the 80 byte header.
   std::string header(StlConstants::k_STL_HEADER_LENGTH, 0x00);
   if(std::fread(header.data(), 1, StlConstants::k_STL_HEADER_LENGTH, f) != StlConstants::k_STL_HEADER_LENGTH)
   {
-    std::ignore = std::fclose(f);
-    return {StlConstants::k_StlHeaderParseError, "STL File header parse error.", "", 0, 0, false};
+    stlFileCheck.error = StlConstants::k_StlHeaderParseError;
+    stlFileCheck.errorMessage = fmt::format("Error reading the {} byte header from STL file '{}'. The file is only {} bytes long.", StlConstants::k_STL_HEADER_LENGTH, path.string(), fileSize);
+    return stlFileCheck;
   }
 
   int32_t triCount = 0;
   // Read the number of triangles in the file.
   if(std::fread(&triCount, sizeof(int32_t), 1, f) != 1)
   {
-    std::ignore = std::fclose(f);
-    return {StlConstants::k_StlHeaderParseError, "Error reading the Triangle Count value from the file", "", 0, 0, false};
+    stlFileCheck.error = StlConstants::k_TriangleCountParseError;
+    stlFileCheck.errorMessage = fmt::format("Error reading the triangle count from STL file '{}'. The file is only {} bytes long.", path.string(), fileSize);
+    return stlFileCheck;
   }
 
-  // Read a single Triangle and its attribute byte count.
-  constexpr size_t k_StlElementCount = 12;
-  std::array<float, k_StlElementCount> fileVert = {0.0f};
-  uint16_t attrByteCount = 0;
-  size_t t = 0;
-
-  size_t objsRead = std::fread(fileVert.data(), sizeof(float), k_StlElementCount, f); // Read the Triangle
-  if(k_StlElementCount != objsRead)
+  // The spec stores the count as an unsigned 32 bit value but it is read into a signed type.
+  // A value with the high bit set is nonsense and would become an enormous allocation
+  // downstream, so reject it here rather than letting it reach resizeFaceList().
+  if(triCount < 0)
   {
-    std::string msg = fmt::format("Error reading Triangle '{}'. Object Count was {} and should have been {}", t, objsRead, k_StlElementCount);
-    return {nx::core::StlConstants::k_TriangleParseError, msg, "", 0, 0, false};
-  }
-  // Read the Uint16 value. This value is supposed to represent the number of bytes following
-  // a triangle that are file- or vendor-specific metadata
-  // Lots of writers/vendors do NOT set this properly, which can cause problems.
-  objsRead = std::fread(&attrByteCount, sizeof(uint16_t), 1, f); // Read the Triangle Attribute Data length
-  if(objsRead != 1)
-  {
-    std::string msg = fmt::format("Error reading Number of attributes for triangle '{}'. uint16 count was {} and should have been 1", t, objsRead);
-    return {nx::core::StlConstants::k_AttributeParseError, msg, "", 0, 0, false};
+    stlFileCheck.error = StlConstants::k_TriangleCountParseError;
+    stlFileCheck.errorMessage =
+        fmt::format("STL file '{}' declares an out of range triangle count of {} in its header. The file is not a valid binary STL file.", path.string(), static_cast<uint32_t>(triCount));
+    return stlFileCheck;
   }
 
-  std::ignore = std::fclose(f);
+  stlFileCheck.header = header;
+  stlFileCheck.numTriangles = triCount;
+  stlFileCheck.fileSize = fileSize;
 
-  // Now calculate the file size IF we were to honor that attribute byte count
-  size_t estimatedFileSize = 84 + (triCount * 50) + (triCount * attrByteCount);
+  // The size this file would be if none of its triangles carry any attribute payload. The
+  // arithmetic is done in uintmax_t because triCount * k_StlTriangleBytes overflows int32
+  // for meshes beyond roughly 42.9 million triangles.
+  const uintmax_t sizeWithoutPayload = StlConstants::k_StlFixedHeaderBytes + (static_cast<uintmax_t>(triCount) * StlConstants::k_StlTriangleBytes);
 
-  return {0, "", header, triCount, fileSize, fileSize == estimatedFileSize};
+  // Only a file with bytes left over beyond the fixed size records has anywhere to put
+  // attribute payload. If the size matches exactly then every attribute byte count in the file
+  // is something other than a length and must be ignored, no matter what any individual
+  // triangle happens to contain. A file that is *smaller* than this is truncated; report no
+  // payload so the reader does not seek, and let the read loop report the truncation precisely.
+  // Vendors known to misuse the field are excluded even when there are spare bytes, since those
+  // bytes may just be trailing junk.
+  stlFileCheck.attributePayloadPresent = (fileSize > sizeWithoutPayload) && !IsMagicsFile(header) && !IsVxElementsFile(header);
+
+  return stlFileCheck;
 }
 
 struct Triangle

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/StlUtilities.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/StlUtilities.cpp
@@ -178,7 +178,7 @@ StlConstants::StlFileCheck StlUtilities::SanityCheckFile(const fs::path& path)
   const uintmax_t sizeWithoutPayload = StlConstants::k_StlFixedHeaderBytes + (static_cast<uintmax_t>(triCount) * StlConstants::k_StlTriangleBytes);
 
   // Only a file with bytes left over beyond the fixed size records has anywhere to put
-  // attribute payload. If the size matches exactly then every attribute byte count in the file
+  // attribute payload. If the size matches exactly, then every attribute byte count in the file
   // is something other than a length and must be ignored, no matter what any individual
   // triangle happens to contain. A file that is *smaller* than this is truncated; report no
   // payload so the reader does not seek, and let the read loop report the truncation precisely.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/StlUtilities.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/StlUtilities.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <cstdio>
 #include <filesystem>
 #include <string>
+#include <tuple>
 
 namespace fs = std::filesystem;
 
@@ -10,6 +13,24 @@ namespace nx::core
 namespace StlConstants
 {
 inline constexpr size_t k_STL_HEADER_LENGTH = 80;
+
+/**
+ * @brief The number of float32 values that make up a single binary STL triangle record:
+ * 3 for the facet normal plus 3 each for the 3 vertices.
+ */
+inline constexpr size_t k_StlElementCount = 12;
+
+/**
+ * @brief The size, in bytes, of the fixed portion at the front of a binary STL file: the
+ * 80 byte header followed by the uint32 triangle count. (80 + 4 = 84)
+ */
+inline constexpr uintmax_t k_StlFixedHeaderBytes = k_STL_HEADER_LENGTH + sizeof(uint32_t);
+
+/**
+ * @brief The size, in bytes, of a single binary STL triangle record: 12 float32 values
+ * followed by the uint16 "attribute byte count". (48 + 2 = 50)
+ */
+inline constexpr uintmax_t k_StlTriangleBytes = (k_StlElementCount * sizeof(float)) + sizeof(uint16_t);
 
 inline constexpr int32_t k_InputFileNotSet = -1100;
 inline constexpr int32_t k_InputFileDoesNotExist = -1101;
@@ -29,19 +50,62 @@ enum class StlFileType : int
   HeaderParseError = 3
 };
 
+/**
+ * @brief The result of StlUtilities::SanityCheckFile().
+ *
+ * If @c error is non-zero the file could not be inspected and every other member is left
+ * at its default value; @c errorMessage describes the failure. If @c error is zero then
+ * the remaining members describe the file.
+ */
 struct StlFileCheck
 {
+  /** @brief Zero on success, otherwise one of the StlConstants error codes. */
   int32_t error = 0;
+  /** @brief Human readable description of the failure. Empty on success. */
   std::string errorMessage;
+  /** @brief The raw 80 byte file header. */
   std::string header;
-  int32_t numTriangles;
-  size_t fileSize;
-  bool useTriangleAttributeByteCount;
+  /** @brief The triangle count declared by the file header. Always >= 0 on success. */
+  int32_t numTriangles = 0;
+  /** @brief The size of the file on disk, in bytes. */
+  uintmax_t fileSize = 0;
+  /**
+   * @brief True when the file actually carries per-triangle attribute payload bytes and the
+   * reader should therefore honor each triangle's "attribute byte count" field. When false
+   * the reader must ignore that field entirely.
+   */
+  bool attributePayloadPresent = false;
 };
 } // namespace StlConstants
 
 namespace StlUtilities
 {
+/**
+ * @brief RAII guard that closes a C @c FILE* when it leaves scope.
+ */
+class StlFileSentinel
+{
+public:
+  explicit StlFileSentinel(FILE* file)
+  : m_File(file)
+  {
+  }
+  ~StlFileSentinel() noexcept
+  {
+    if(m_File != nullptr)
+    {
+      std::ignore = std::fclose(m_File);
+    }
+  }
+  StlFileSentinel(const StlFileSentinel&) = delete;            // Copy Constructor Not Implemented
+  StlFileSentinel(StlFileSentinel&&) = delete;                 // Move Constructor Not Implemented
+  StlFileSentinel& operator=(const StlFileSentinel&) = delete; // Copy Assignment Not Implemented
+  StlFileSentinel& operator=(StlFileSentinel&&) = delete;      // Move Assignment Not Implemented
+
+private:
+  FILE* m_File = nullptr;
+};
+
 // -----------------------------------------------------------------------------
 /**
  * @brief This function will determine if the given STL file is ASCII or BINARY.
@@ -64,8 +128,24 @@ int32_t NumFacesFromHeader(const fs::path& path);
 /**
  * @brief This function will return whether or not the 2 byte Triangle attribute byte count
  * value should be honored or not.
+ *
+ * The binary STL specification places a uint16 "attribute byte count" after each triangle that
+ * states how many vendor specific bytes follow it. Many writers instead abuse that field to
+ * store something else entirely: Magics Materialise packs a per-facet RGB color into it and
+ * VxElements leaves garbage in it, while neither writes any payload bytes at all. Seeking
+ * forward by those values would desynchronize the read stream and produce garbage geometry, so
+ * the reader has to determine up front whether payload bytes are really present.
+ *
+ * That decision is made from the file size, which cannot be fooled by the contents of any
+ * individual triangle:
+ * - A file of exactly @c k_StlFixedHeaderBytes + numTriangles * @c k_StlTriangleBytes has no
+ *   room for payload, so the attribute fields are ignored no matter what they contain.
+ * - A file smaller than that is truncated and is reported as @c k_StlFileLengthError.
+ * - A larger file does carry extra bytes, so the attribute fields are honored, unless the
+ *   header identifies a vendor known to misuse them.
+ *
  * @param path The path to the input STL file
- * @return StlFileCheck struct
+ * @return StlFileCheck struct. Check @c error before using any other member.
  */
 StlConstants::StlFileCheck SanityCheckFile(const fs::path& path);
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/StlUtilities.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/StlUtilities.hpp
@@ -28,6 +28,16 @@ enum class StlFileType : int
   FileOpenError = 2,
   HeaderParseError = 3
 };
+
+struct StlFileCheck
+{
+  int32_t error = 0;
+  std::string errorMessage;
+  std::string header;
+  int32_t numTriangles;
+  size_t fileSize;
+  bool useTriangleAttributeByteCount;
+};
 } // namespace StlConstants
 
 namespace StlUtilities
@@ -50,6 +60,14 @@ StlConstants::StlFileType DetermineStlFileType(const fs::path& path);
  * @return Number of triangle faces
  */
 int32_t NumFacesFromHeader(const fs::path& path);
+
+/**
+ * @brief This function will return whether or not the 2 byte Triangle attribute byte count
+ * value should be honored or not.
+ * @param path The path to the input STL file
+ * @return StlFileCheck struct
+ */
+StlConstants::StlFileCheck SanityCheckFile(const fs::path& path);
 
 /**
  * @brief A very basic function to convert a well behaved ASCII STL File into a binary STL file

--- a/src/Plugins/SimplnxCore/test/ReadStlFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReadStlFileTest.cpp
@@ -1,5 +1,6 @@
 #include "SimplnxCore/Filters/ReadStlFileFilter.hpp"
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
+#include "SimplnxCore/utils/StlUtilities.hpp"
 
 #include "simplnx/Core/Application.hpp"
 #include "simplnx/DataStructure/Geometry/TriangleGeom.hpp"
@@ -12,13 +13,118 @@
 
 #include <catch2/catch.hpp>
 
+#include <algorithm>
+#include <array>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <vector>
 
 namespace fs = std::filesystem;
 using namespace nx::core;
 using namespace nx::core::Constants;
+
+namespace
+{
+/**
+ * @brief Describes one triangle record to write into a synthetic binary STL file.
+ */
+struct StlTriangleSpec
+{
+  /** @brief The value written into the 2 byte "attribute byte count" field. */
+  uint16_t attributeByteCount = 0;
+  /** @brief How many real payload bytes to write after that field. Often 0 in the wild. */
+  uint16_t payloadBytes = 0;
+};
+
+/**
+ * @brief Writes a synthetic binary STL file so the reader can be exercised against files that do
+ * not obey the STL specification without shipping binary fixtures in the data archive.
+ *
+ * Triangle @c t is given vertices (10t, 0, 0), (10t + 1, 0, 0) and (10t, 1, 0) so that every vertex
+ * in the file is unique and the exact coordinates can be asserted afterwards. A misaligned read
+ * produces garbage coordinates, which is what makes the attribute-byte-count tests meaningful.
+ */
+void WriteBinaryStlFile(const fs::path& path, const std::string& headerText, int32_t declaredTriangleCount, const std::vector<StlTriangleSpec>& triangleSpecs)
+{
+  fs::create_directories(path.parent_path());
+  std::ofstream outputFile(path, std::ios::binary | std::ios::trunc);
+  REQUIRE(outputFile.is_open());
+
+  std::string header(StlConstants::k_STL_HEADER_LENGTH, '\0');
+  const size_t copyLength = std::min(headerText.size(), StlConstants::k_STL_HEADER_LENGTH);
+  std::copy_n(headerText.begin(), copyLength, header.begin());
+  outputFile.write(header.data(), static_cast<std::streamsize>(StlConstants::k_STL_HEADER_LENGTH));
+  outputFile.write(reinterpret_cast<const char*>(&declaredTriangleCount), sizeof(int32_t));
+
+  for(size_t t = 0; t < triangleSpecs.size(); t++)
+  {
+    const float base = static_cast<float>(t) * 10.0F;
+    const std::array<float, StlConstants::k_StlElementCount> values = {
+        0.0F,        0.0F, 1.0F, // facet normal
+        base,        0.0F, 0.0F, // vertex 0
+        base + 1.0F, 0.0F, 0.0F, // vertex 1
+        base,        1.0F, 0.0F  // vertex 2
+    };
+    outputFile.write(reinterpret_cast<const char*>(values.data()), static_cast<std::streamsize>(values.size() * sizeof(float)));
+    outputFile.write(reinterpret_cast<const char*>(&triangleSpecs[t].attributeByteCount), sizeof(uint16_t));
+
+    const std::vector<char> payload(triangleSpecs[t].payloadBytes, 0x5A);
+    if(!payload.empty())
+    {
+      outputFile.write(payload.data(), static_cast<std::streamsize>(payload.size()));
+    }
+  }
+  outputFile.close();
+}
+
+/**
+ * @brief Runs ReadStlFileFilter over @p inputFile and returns the execute result.
+ */
+IFilter::ExecuteResult RunReadStlFileFilter(DataStructure& dataStructure, const fs::path& inputFile, const DataPath& triangleGeomDataPath)
+{
+  Arguments args;
+  ReadStlFileFilter filter;
+  args.insertOrAssign(ReadStlFileFilter::k_StlFilePath_Key, std::make_any<FileSystemPathParameter::ValueType>(inputFile));
+  args.insertOrAssign(ReadStlFileFilter::k_CreatedTriangleGeometryPath_Key, std::make_any<DataPath>(triangleGeomDataPath));
+
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+  return filter.execute(dataStructure, args);
+}
+
+/**
+ * @brief Asserts that every triangle written by WriteBinaryStlFile() came back with the exact
+ * coordinates it was written with. Reads the coordinates through the face connectivity so the test
+ * is insensitive to any vertex reordering done by EliminateDuplicateNodes().
+ */
+void CheckSyntheticTriangleGeometry(const TriangleGeom& triangleGeom, size_t expectedTriangleCount)
+{
+  REQUIRE(triangleGeom.getNumberOfFaces() == expectedTriangleCount);
+  REQUIRE(triangleGeom.getNumberOfVertices() == expectedTriangleCount * 3);
+
+  const auto& facesRef = triangleGeom.getFaces()->getDataStoreRef();
+  const auto& verticesRef = triangleGeom.getVertices()->getDataStoreRef();
+
+  for(size_t t = 0; t < expectedTriangleCount; t++)
+  {
+    const float base = static_cast<float>(t) * 10.0F;
+    const usize vertex0 = facesRef[t * 3 + 0];
+    const usize vertex1 = facesRef[t * 3 + 1];
+    const usize vertex2 = facesRef[t * 3 + 2];
+
+    REQUIRE(verticesRef[vertex0 * 3 + 0] == Approx(base));
+    REQUIRE(verticesRef[vertex0 * 3 + 1] == Approx(0.0F));
+    REQUIRE(verticesRef[vertex0 * 3 + 2] == Approx(0.0F));
+    REQUIRE(verticesRef[vertex1 * 3 + 0] == Approx(base + 1.0F));
+    REQUIRE(verticesRef[vertex1 * 3 + 1] == Approx(0.0F));
+    REQUIRE(verticesRef[vertex2 * 3 + 0] == Approx(base));
+    REQUIRE(verticesRef[vertex2 * 3 + 1] == Approx(1.0F));
+  }
+}
+} // namespace
 
 TEST_CASE("SimplnxCore::ReadStlFileFilter:Valid_File", "[SimplnxCore][ReadStlFileFilter]")
 {
@@ -153,6 +259,159 @@ TEST_CASE("SimplnxCore::ReadStlFileFilter:AttributeParseError", "[SimplnxCore][R
   REQUIRE(executeResult.result.errors().front().code == -1107);
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ReadStlFileFilter:NonConformingAttributeByteCount", "[SimplnxCore][ReadStlFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const size_t k_TriangleCount = 8;
+  const DataPath triangleGeomDataPath({"[Triangle Geometry]"});
+
+  // Every case below writes a file whose size is exactly 84 + 50 * numTriangles, meaning there is
+  // no room for attribute payload at all. The reader must therefore ignore the attribute byte count
+  // of every triangle no matter what value it holds. Note that in each case triangle 0 carries a
+  // count of 0, so any heuristic that samples only the first triangle concludes the file is
+  // well behaved and then desynchronizes on the very first non-zero triangle.
+  std::vector<StlTriangleSpec> triangleSpecs(k_TriangleCount);
+  for(size_t t = 1; t < k_TriangleCount; t++)
+  {
+    triangleSpecs[t].attributeByteCount = static_cast<uint16_t>(0x3C1F + t); // A packed color, not a length
+  }
+
+  const std::string k_MagicsHeader = "COLOR=\xFF\xFF\xFF\xFF,MATERIAL=\xFF\xFF\xFF";
+  const std::string k_VxElementsHeader = "Exported by VXelements";
+  const std::string k_AnonymousHeader = "Written by some CAD package that nobody has heard of";
+
+  auto headerText = GENERATE_COPY(k_MagicsHeader, k_VxElementsHeader, k_AnonymousHeader);
+
+  DYNAMIC_SECTION("Header: '" << headerText << "'")
+  {
+    const fs::path inputFile = fs::path(unit_test::k_BinaryTestOutputDir.view()) / "ReadStlFileTest" / "non_conforming_attribute_byte_count.stl";
+    WriteBinaryStlFile(inputFile, headerText, static_cast<int32_t>(k_TriangleCount), triangleSpecs);
+    REQUIRE(fs::file_size(inputFile) == StlConstants::k_StlFixedHeaderBytes + (k_TriangleCount * StlConstants::k_StlTriangleBytes));
+
+    // The file size proves there is no payload, so no seeking may happen regardless of vendor.
+    const StlConstants::StlFileCheck stlFileCheck = StlUtilities::SanityCheckFile(inputFile);
+    REQUIRE(stlFileCheck.error == 0);
+    REQUIRE(stlFileCheck.numTriangles == static_cast<int32_t>(k_TriangleCount));
+    REQUIRE(stlFileCheck.attributePayloadPresent == false);
+
+    DataStructure dataStructure;
+    auto executeResult = RunReadStlFileFilter(dataStructure, inputFile, triangleGeomDataPath);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+    REQUIRE_NOTHROW(dataStructure.getDataRefAs<TriangleGeom>(triangleGeomDataPath));
+    const auto& triangleGeom = dataStructure.getDataRefAs<TriangleGeom>(triangleGeomDataPath);
+    CheckSyntheticTriangleGeometry(triangleGeom, k_TriangleCount);
+
+    UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  }
+}
+
+TEST_CASE("SimplnxCore::ReadStlFileFilter:ConformingAttributePayload", "[SimplnxCore][ReadStlFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const size_t k_TriangleCount = 8;
+  const uint16_t k_PayloadBytes = 6;
+  const DataPath triangleGeomDataPath({"[Triangle Geometry]"});
+
+  // A spec-conforming file that really does carry attribute payload after every triangle. Here the
+  // byte counts are genuine lengths and MUST be honored, otherwise the read desynchronizes.
+  std::vector<StlTriangleSpec> triangleSpecs(k_TriangleCount);
+  for(StlTriangleSpec& spec : triangleSpecs)
+  {
+    spec.attributeByteCount = k_PayloadBytes;
+    spec.payloadBytes = k_PayloadBytes;
+  }
+
+  const fs::path inputFile = fs::path(unit_test::k_BinaryTestOutputDir.view()) / "ReadStlFileTest" / "conforming_attribute_payload.stl";
+  WriteBinaryStlFile(inputFile, "A well behaved binary STL writer", static_cast<int32_t>(k_TriangleCount), triangleSpecs);
+  REQUIRE(fs::file_size(inputFile) == StlConstants::k_StlFixedHeaderBytes + (k_TriangleCount * (StlConstants::k_StlTriangleBytes + k_PayloadBytes)));
+
+  const StlConstants::StlFileCheck stlFileCheck = StlUtilities::SanityCheckFile(inputFile);
+  REQUIRE(stlFileCheck.error == 0);
+  REQUIRE(stlFileCheck.numTriangles == static_cast<int32_t>(k_TriangleCount));
+  REQUIRE(stlFileCheck.attributePayloadPresent == true);
+
+  DataStructure dataStructure;
+  auto executeResult = RunReadStlFileFilter(dataStructure, inputFile, triangleGeomDataPath);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<TriangleGeom>(triangleGeomDataPath));
+  const auto& triangleGeom = dataStructure.getDataRefAs<TriangleGeom>(triangleGeomDataPath);
+  CheckSyntheticTriangleGeometry(triangleGeom, k_TriangleCount);
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::StlUtilities:SanityCheckFile", "[SimplnxCore][ReadStlFileFilter]")
+{
+  const fs::path testDir = fs::path(unit_test::k_BinaryTestOutputDir.view()) / "ReadStlFileTest";
+  fs::create_directories(testDir);
+
+  SECTION("Missing file returns an error instead of throwing")
+  {
+    const fs::path inputFile = testDir / "this_file_does_not_exist.stl";
+    fs::remove(inputFile);
+
+    StlConstants::StlFileCheck stlFileCheck;
+    REQUIRE_NOTHROW(stlFileCheck = StlUtilities::SanityCheckFile(inputFile));
+    REQUIRE(stlFileCheck.error == StlConstants::k_ErrorOpeningFile);
+    // The message has to name the file the user actually chose.
+    REQUIRE(stlFileCheck.errorMessage.find(inputFile.string()) != std::string::npos);
+  }
+
+  SECTION("File too short to hold an 80 byte header")
+  {
+    const fs::path inputFile = testDir / "truncated_header.stl";
+    std::ofstream outputFile(inputFile, std::ios::binary | std::ios::trunc);
+    const std::vector<char> shortHeader(20, 'x');
+    outputFile.write(shortHeader.data(), static_cast<std::streamsize>(shortHeader.size()));
+    outputFile.close();
+
+    const StlConstants::StlFileCheck stlFileCheck = StlUtilities::SanityCheckFile(inputFile);
+    REQUIRE(stlFileCheck.error == StlConstants::k_StlHeaderParseError);
+    REQUIRE(stlFileCheck.errorMessage.find(inputFile.string()) != std::string::npos);
+  }
+
+  SECTION("File with a header but no triangle count")
+  {
+    const fs::path inputFile = testDir / "missing_triangle_count.stl";
+    std::ofstream outputFile(inputFile, std::ios::binary | std::ios::trunc);
+    const std::vector<char> header(StlConstants::k_STL_HEADER_LENGTH, 'x');
+    outputFile.write(header.data(), static_cast<std::streamsize>(header.size()));
+    outputFile.close();
+
+    const StlConstants::StlFileCheck stlFileCheck = StlUtilities::SanityCheckFile(inputFile);
+    REQUIRE(stlFileCheck.error == StlConstants::k_TriangleCountParseError);
+  }
+
+  SECTION("Header declaring a triangle count with the high bit set is rejected")
+  {
+    // 0xFFFFFFFF reads back as -1 in the signed field. Left unchecked this reaches
+    // resizeFaceList() as an enormous unsigned value.
+    const fs::path inputFile = testDir / "negative_triangle_count.stl";
+    WriteBinaryStlFile(inputFile, "Corrupt triangle count", -1, std::vector<StlTriangleSpec>(1));
+
+    const StlConstants::StlFileCheck stlFileCheck = StlUtilities::SanityCheckFile(inputFile);
+    REQUIRE(stlFileCheck.error == StlConstants::k_TriangleCountParseError);
+    REQUIRE(stlFileCheck.numTriangles == 0);
+  }
+
+  SECTION("Truncated triangle data reports no payload so the reader does not seek")
+  {
+    // The header claims more triangles than the file can hold. The read loop is responsible for
+    // reporting exactly where it ran out, so SanityCheckFile must not seek past anything.
+    const fs::path inputFile = testDir / "truncated_triangle_data.stl";
+    WriteBinaryStlFile(inputFile, "Header count is too large", 100, std::vector<StlTriangleSpec>(4));
+
+    const StlConstants::StlFileCheck stlFileCheck = StlUtilities::SanityCheckFile(inputFile);
+    REQUIRE(stlFileCheck.error == 0);
+    REQUIRE(stlFileCheck.numTriangles == 100);
+    REQUIRE(stlFileCheck.attributePayloadPresent == false);
+  }
 }
 
 TEST_CASE("SimplnxCore::ReadStlFileFilter: SIMPL Backwards Compatibility", "[SimplnxCore][ReadStlFileFilter][BackwardsCompatibility]")

--- a/src/Plugins/SimplnxCore/test/ReadStlFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReadStlFileTest.cpp
@@ -346,6 +346,48 @@ TEST_CASE("SimplnxCore::ReadStlFileFilter:ConformingAttributePayload", "[Simplnx
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
 }
 
+TEST_CASE("SimplnxCore::ReadStlFileFilter:ShortFileWithAttributePayload", "[SimplnxCore][ReadStlFileFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  const int32_t k_DeclaredTriangleCount = 10;
+  const size_t k_ActualTriangleCount = 5;
+  const uint16_t k_PayloadBytes = 100;
+  const DataPath triangleGeomDataPath({"[Triangle Geometry]"});
+
+  // A file that carries real attribute payload but whose header over-declares the triangle count.
+  // The reader tracks its own read offset, and that offset only stays correct if the skipped
+  // payload bytes are counted too. If they are not, the running offset lags far behind the real
+  // file position and the overrun is misreported as a triangle parse error instead of a file
+  // length error.
+  std::vector<StlTriangleSpec> triangleSpecs(k_ActualTriangleCount);
+  for(StlTriangleSpec& spec : triangleSpecs)
+  {
+    spec.attributeByteCount = k_PayloadBytes;
+    spec.payloadBytes = k_PayloadBytes;
+  }
+
+  const fs::path inputFile = fs::path(unit_test::k_BinaryTestOutputDir.view()) / "ReadStlFileTest" / "short_file_with_attribute_payload.stl";
+  WriteBinaryStlFile(inputFile, "Header over-declares the triangle count", k_DeclaredTriangleCount, triangleSpecs);
+
+  const uintmax_t expectedFileSize = StlConstants::k_StlFixedHeaderBytes + (k_ActualTriangleCount * (StlConstants::k_StlTriangleBytes + k_PayloadBytes));
+  REQUIRE(fs::file_size(inputFile) == expectedFileSize);
+
+  // There are spare bytes beyond the declared records, so the attribute counts are honored.
+  const StlConstants::StlFileCheck stlFileCheck = StlUtilities::SanityCheckFile(inputFile);
+  REQUIRE(stlFileCheck.error == 0);
+  REQUIRE(stlFileCheck.attributePayloadPresent == true);
+
+  DataStructure dataStructure;
+  auto executeResult = RunReadStlFileFilter(dataStructure, inputFile, triangleGeomDataPath);
+  SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+  REQUIRE(executeResult.result.errors().front().code == StlConstants::k_StlFileLengthError);
+
+  // The reported position must be the real end of the data, which is only reachable when the
+  // payload bytes are included in the running offset.
+  REQUIRE(executeResult.result.errors().front().message.find(std::to_string(expectedFileSize)) != std::string::npos);
+}
+
 TEST_CASE("SimplnxCore::StlUtilities:SanityCheckFile", "[SimplnxCore][ReadStlFileFilter]")
 {
   const fs::path testDir = fs::path(unit_test::k_BinaryTestOutputDir.view()) / "ReadStlFileTest";


### PR DESCRIPTION
## Summary

Makes the binary STL reader robust against files that do not obey the STL specification, and fixes several defects found while reviewing that work.

The core problem is the per-triangle uint16 "attribute byte count". The spec says it is the number of vendor bytes that follow the triangle, but many writers abuse it: Magics Materialise packs a per-facet RGB color into it, VxElements leaves garbage in it, and neither writes any payload bytes. Seeking forward on those values desynchronizes the read and produces garbage geometry.

An earlier attempt replaced the old vendor header sniffing with a file-size heuristic that sampled the attribute byte count of **triangle 0 only**. Magics color files commonly leave facet 0 uncolored, so the heuristic concluded the file was well behaved and the reader then seeked on every colored facet. A Magics file the old code read correctly failed at triangle 2 with a seek to position 15576 in a 484 byte file.

* Decide from the file size alone. A file of exactly `84 + 50 * numTriangles` bytes has no room for payload, so the attribute fields are ignored regardless of what any individual triangle contains. Only a file with spare bytes honors them
* Restore the Magics and VxElements header detection as an override for files that do have spare bytes, moved into `StlUtilities`
* Remove the non-portable `fpos_t` / `pos.__pos` position check from the read loop. `fpos_t` is opaque and `__pos` is a glibc detail that does not exist on musl. The offset is now tracked arithmetically in a `uintmax_t`, which deletes both platform `#if` blocks and one library call per triangle
* Close the file on the two `SanityCheckFile` error paths that leaked it, via a shared `StlUtilities::StlFileSentinel`
* Compute the expected file size in `uintmax_t`; the previous expression overflowed `int32` on large meshes and on garbage attribute values
* Use the `error_code` overload of `file_size` so a missing file returns an error instead of throwing out of an error-returning function
* Reject a triangle count with the high bit set before it reaches `resizeFaceList()` as an enormous unsigned value
* Stop populating face labels when the read failed and the geometry is only partially filled
* Consume the sanity check results instead of reopening the file and re-parsing the header a second time
* Name the offending file in every STL error message, and add four missing format placeholders that silently dropped the path
* Adopt the house `InputValues` pointer pattern; remove an unused 64KB buffer, an undefined `readFile()` declaration, and dead local constants

## Test Plan

New tests generate synthetic STL files in-process, so no data archive upload is required.

- [x] Magics / VxElements / anonymous headers, no payload, facet 0 zero and later facets non-zero — the shape that reproduces the regression
- [x] Spec-conforming file with real attribute payload, which must still be honored
- [x] Short file carrying real payload, covering the payload-inclusive offset accounting
- [x] `SanityCheckFile` error paths: missing file, truncated header, missing triangle count, high-bit triangle count, truncated triangle data
- [x] Each new test was confirmed to fail against the pre-fix code, not just pass against the new code
- [x] Existing `-1106` / `-1107` / `-1108` error-code tests still pass unchanged
- [x] All 19 STL-related tests pass, including `CombineStlFiles`, `WriteStlFile`, and the import pipeline
- [x] Full `SimplnxCore` suite: 949/949 pass
- [x] clang-format verified against the repository-root `.clang-format`; builds clean with no warnings

Verified on macOS only. The read loop no longer contains any platform-conditional code, so CI covers the Windows and Linux paths.