### PR TITLE
FILT: Add Keep/Remove Ranked Features filter

### DIFF
--- a/src/Plugins/SimplnxCore/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/CMakeLists.txt
@@ -94,6 +94,7 @@ set(FilterList
   InitializeImageGeomCellDataFilter
   InterpolatePointCloudToRegularGridFilter
   IterativeClosestPointFilter
+  KeepRemoveRankedFeaturesFilter
   LabelTriangleGeometryFilter
   LaplacianSmoothingFilter
   M3CSurfaceMeshingFilter
@@ -263,6 +264,7 @@ set(AlgorithmList
   InterpolatePointCloudToRegularGrid
   IterativeClosestPoint
   InterpolatePointCloudToRegularGrid
+  KeepRemoveRankedFeatures
   LabelTriangleGeometry
   LaplacianSmoothing
   M3CSurfaceMeshing
@@ -395,6 +397,8 @@ set(PLUGIN_EXTRA_SOURCES
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/nifti1.h"
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/NiftiUtilities.hpp"
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/NiftiUtilities.cpp"
+    "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/FeatureRemovalUtilities.hpp"
+    "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/utils/FeatureRemovalUtilities.cpp"
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/SurfaceNets/MMCellFlag.cpp"
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/SurfaceNets/MMCellFlag.h"
     "${${PLUGIN_NAME}_SOURCE_DIR}/src/${PLUGIN_NAME}/SurfaceNets/MMCellMap.cpp"

--- a/src/Plugins/SimplnxCore/docs/KeepRemoveRankedFeaturesFilter.md
+++ b/src/Plugins/SimplnxCore/docs/KeepRemoveRankedFeaturesFilter.md
@@ -1,0 +1,88 @@
+# Keep/Remove Ranked Features
+
+## Description
+
+This **Filter** keeps or removes a count or percentage of **Features** based on their **rank** within
+a chosen scalar **Feature** level array. For example, "keep the 10 largest grains by *NumElements*",
+or "remove the smallest 10% of grains".
+
+This is a **rank** threshold, not a **value** threshold. It answers *"which are the 10 biggest?"*
+rather than *"which are bigger than 100 voxels?"*. The cut therefore depends on the whole population
+rather than on each **Feature** independently. For a value threshold, use **Remove Minimum Size
+Features** or **Multi-Threshold Objects** instead.
+
+Ranking is not limited to size. Any scalar **Feature** array works — *EquivalentDiameters*,
+*AspectRatios*, *NumNeighbors*, *Omega3s*, average misorientation, and so on.
+
+Removed **Features** have their **Cell** level *FeatureIds* set to 0. If *Fill-in Removed Features*
+is enabled, the vacated **Cells** are instead assigned to their surviving neighbors by iterative
+dilation, so no **Cell** is left unassigned. In both cases the **Feature** **Attribute Matrix** is
+then compacted and the surviving **Features** are renumbered contiguously starting at 1.
+
+### Operation and Rank From
+
+*Operation* and *Rank From* are independent. The **selected** set is always the *k* **Features** the
+ranking picked; *Operation* decides only what happens to that set.
+
+| Operation | Rank From | Result |
+|-----------|-----------|--------|
+| Keep | Largest | only the *k* largest survive |
+| Keep | Smallest | only the *k* smallest survive |
+| Remove | Largest | the *k* largest are removed |
+| Remove | Smallest | the *k* smallest are removed |
+
+Note that "Keep the 2 largest" and "Remove the 2 smallest" leave the same **Features** behind only
+when there are exactly 4 **Features**. In general the two are different operations.
+
+### Selection Criterion
+
+- **Feature Count** — an exact number of **Features**. If the requested count exceeds the number of
+  **Features** present it is clamped, and a warning reports the clamp. This lets one pipeline be
+  reused across datasets with differing **Feature** counts.
+- **Percent of Feature Count** — a percentage of the *number* of **Features**. 10% of 500 **Features**
+  selects 50. The result is rounded to the nearest whole **Feature** and never rounds down to zero.
+- **Percent of Summed Value** — **Features** are accumulated in rank order until their running total
+  reaches the given percentage of the *summed* ranking value. The **Feature** that crosses the
+  threshold is included, so the selection always reaches the target and any percentage above zero
+  selects at least one **Feature**.
+
+  This criterion answers "which **Features** make up 70% of the material?" rather than "which are the
+  top 70% of **Features**?". It is only physically meaningful for *extensive* quantities such as
+  *NumElements* or *Volumes*; applying it to *AspectRatios* or a misorientation produces a number
+  with no physical interpretation. All values must be non-negative, since a cumulative fraction is
+  undefined when values can cancel each other out.
+
+### Ties
+
+Exactly *k* **Features** are always selected. When several **Features** share the same ranking value
+at the cutoff, ties are broken by ascending **Feature** id, which makes results reproducible across
+runs and platforms. A warning is emitted whenever a tie straddles the cutoff, because the choice
+among the tied **Features** is arbitrary. Ties are common in integer arrays such as *NumElements*.
+
+## Notes
+
+- **Memory:** ranking requires three temporary buffers sized by the **Feature** count — the ranking
+  values, a sort order, and a removal flag per **Feature**. For 10 million **Features** with a 32-bit
+  ranking array that totals roughly 120 MB. No **Cell** sized buffer is allocated unless *Fill-in
+  Removed Features* is enabled, which additionally needs one 32-bit value per **Cell**.
+- **Feature** 0 is not a real **Feature**. It is excluded from the ranking, from the percentage
+  denominators, and from removal.
+- Any **NeighborList** arrays in the **Feature** **Attribute Matrix** cannot be maintained through the
+  renumbering and will be removed. A warning lists them during preflight.
+- A ranking array containing non-finite values (NaN or infinity) is rejected, because such values
+  have no ordering and cannot be sorted.
+- The filter warns during preflight when the chosen settings would remove nothing, and when they
+  would remove every **Feature**. The latter is an error at execute time, since it would leave
+  nothing behind.
+
+% Auto generated parameter table will be inserted here
+
+## Example Pipelines
+
+## License & Copyright
+
+Please see the description file distributed with this plugin.
+
+## DREAM3D Mailing Lists
+
+If you need help, need to file a bug report or want to request a new feature, please head over to the [DREAM3DNX-Issues](https://github.com/BlueQuartzSoftware/DREAM3DNX-Issues/discussions) GitHub site where the community of DREAM3D-NX users can help answer your questions.

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/KeepRemoveRankedFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/KeepRemoveRankedFeatures.cpp
@@ -1,0 +1,262 @@
+#include "KeepRemoveRankedFeatures.hpp"
+
+#include "SimplnxCore/utils/FeatureRemovalUtilities.hpp"
+
+#include "simplnx/Common/TypeTraits.hpp"
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/Utilities/FilterUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <type_traits>
+#include <vector>
+
+using namespace nx::core;
+
+namespace
+{
+constexpr int32 k_NotEnoughFeatures = -78101;
+constexpr int32 k_NonFiniteValue = -78105;
+constexpr int32 k_NegativeValue = -78106;
+constexpr int32 k_ZeroTotalSum = -78107;
+constexpr int32 k_AllFeaturesFlagged = -78108;
+constexpr int32 k_TieStraddlesCutoff = -78122;
+
+// How often the feature level loops poll for cancellation. Frequent enough to stay responsive on
+// millions of features, rare enough not to slow the loops down.
+constexpr usize k_CancelCheckStride = 65536;
+
+/**
+ * @brief Sorts the feature indices by their ranking value and builds the removal flag vector.
+ *
+ * The comparator orders by value first and then by ascending feature id. That total order makes the
+ * result independent of the sort algorithm's internals, so repeated runs agree across platforms.
+ */
+struct RankAndFlagFunctor
+{
+  template <typename T>
+  Result<> operator()(const IDataArray& rankingArray, const KeepRemoveRankedFeaturesInputValues* inputValues, const std::atomic_bool& shouldCancel, MessageHelper& messageHelper,
+                      std::vector<bool>& flags, std::string& summary, std::vector<Warning>& warnings)
+  {
+    const auto& rankingRef = dynamic_cast<const DataArray<T>&>(rankingArray).getDataStoreRef();
+    const usize numTuples = rankingRef.getNumberOfTuples();
+
+    // The filter's preflight already rejects this, but the algorithm is exported and can be
+    // constructed directly. Without the guard numTuples == 0 underflows below and numTuples == 1
+    // leaves an empty sort order that the selection loop would index into.
+    if(numTuples < 2)
+    {
+      return MakeErrorResult(k_NotEnoughFeatures, fmt::format("The ranking array '{}' holds {} tuple(s), but at least 2 are required. Tuple 0 is the unused dummy feature, so there must be at "
+                                                              "least one real Feature to rank.",
+                                                              rankingArray.getName(), numTuples));
+    }
+    const usize numFeatures = numTuples - 1;
+
+    // Three feature sized buffers are live at once from here on: values (numFeatures * sizeof(T)),
+    // order (numFeatures * sizeof(usize)) and flags (numFeatures bits). For 10 million features with
+    // an int32 ranking array that totals roughly 120 MB. No cell sized buffer is ever allocated.
+    //
+    // Sorting reads the values in random order, which is close to the worst case for a chunked
+    // out-of-core store. Pull them into a contiguous buffer with one sequential pass first, so each
+    // chunk is faulted in once and fully consumed. Tuple 0 is the unused dummy feature and is
+    // excluded, so values[i] belongs to feature id i + 1.
+    messageHelper.sendMessage(fmt::format("Reading {} ranking values...", numFeatures));
+    std::vector<T> values(numFeatures);
+    for(usize i = 0; i < numFeatures; i++)
+    {
+      if(i % k_CancelCheckStride == 0 && shouldCancel)
+      {
+        return {};
+      }
+      values[i] = rankingRef[i + 1];
+    }
+
+    // std::sort with a comparator that sees NaN violates strict weak ordering. That is undefined
+    // behavior and segfaults in practice, so reject non-finite values before sorting, not after.
+    if constexpr(std::is_floating_point_v<T>)
+    {
+      for(usize i = 0; i < numFeatures; i++)
+      {
+        if(i % k_CancelCheckStride == 0 && shouldCancel)
+        {
+          return {};
+        }
+        if(!std::isfinite(static_cast<float64>(values[i])))
+        {
+          return MakeErrorResult(k_NonFiniteValue, fmt::format("Feature {} in the ranking array '{}' holds the non-finite value {}. Features cannot be ranked against a value that has no "
+                                                               "ordering. Remove or replace the non-finite values before running this filter.",
+                                                               i + 1, rankingArray.getName(), values[i]));
+        }
+      }
+    }
+
+    if(shouldCancel)
+    {
+      return {};
+    }
+
+    // std::sort cannot be interrupted, so this is the last cancel opportunity before it runs.
+    messageHelper.sendMessage(fmt::format("Sorting {} Features by rank...", numFeatures));
+    std::vector<usize> order(numFeatures);
+    std::iota(order.begin(), order.end(), 0);
+
+    const bool descending = (inputValues->RankFrom == to_underlying(RankDirection::Largest));
+    std::sort(order.begin(), order.end(), [&values, descending](usize lhs, usize rhs) {
+      if(values[lhs] != values[rhs])
+      {
+        return descending ? values[lhs] > values[rhs] : values[lhs] < values[rhs];
+      }
+      return lhs < rhs;
+    });
+
+    usize selectedCount = 0;
+    if(inputValues->Criterion == to_underlying(RankCriterion::FeatureCount))
+    {
+      selectedCount = std::min(static_cast<usize>(inputValues->NumFeatures), numFeatures);
+    }
+    else if(inputValues->Criterion == to_underlying(RankCriterion::PercentOfCount))
+    {
+      selectedCount = static_cast<usize>(std::llround(inputValues->Percent / 100.0 * static_cast<float64>(numFeatures)));
+      // Never round down to selecting nothing; a small percentage still means "a few".
+      selectedCount = std::max(static_cast<usize>(1), std::min(selectedCount, numFeatures));
+    }
+    else
+    {
+      // Percent of Summed Value. Only meaningful for extensive quantities such as NumElements or
+      // Volumes; a cumulative fraction of an aspect ratio has no physical interpretation.
+      float64 total = 0.0;
+      for(usize i = 0; i < numFeatures; i++)
+      {
+        if(i % k_CancelCheckStride == 0 && shouldCancel)
+        {
+          return {};
+        }
+        if constexpr(std::is_signed_v<T>)
+        {
+          if(values[i] < static_cast<T>(0))
+          {
+            return MakeErrorResult(k_NegativeValue, fmt::format("The 'Percent of Summed Value' criterion requires non-negative values, but Feature {} in the array '{}' holds the value {}. A "
+                                                                "cumulative fraction is undefined when values can cancel each other out.",
+                                                                i + 1, rankingArray.getName(), values[i]));
+          }
+        }
+        total += static_cast<float64>(values[i]);
+      }
+
+      if(total <= 0.0)
+      {
+        return MakeErrorResult(k_ZeroTotalSum, fmt::format("The 'Percent of Summed Value' criterion requires a positive total, but the {} values in the array '{}' sum to {}.", numFeatures,
+                                                           rankingArray.getName(), total));
+      }
+
+      // Accumulate in rank order and include the feature that crosses the target, so any percentage
+      // above zero selects at least one feature and the selection always reaches the target.
+      const float64 target = inputValues->Percent / 100.0 * total;
+      float64 runningSum = 0.0;
+      while(selectedCount < numFeatures && runningSum < target)
+      {
+        runningSum += static_cast<float64>(values[order[selectedCount]]);
+        selectedCount++;
+      }
+    }
+
+    // Ties are broken by ascending feature id, so exactly selectedCount features are always chosen.
+    // That choice is arbitrary among equals, and ties are common in integer arrays like NumElements,
+    // so say so rather than letting the user assume the cut was meaningful.
+    if(selectedCount > 0 && selectedCount < numFeatures && values[order[selectedCount - 1]] == values[order[selectedCount]])
+    {
+      const T tiedValue = values[order[selectedCount - 1]];
+      const auto tiedTotal = static_cast<usize>(std::count(values.cbegin(), values.cend(), tiedValue));
+      warnings.push_back(Warning{k_TieStraddlesCutoff, fmt::format("A tie straddles the cutoff: {} Features share the value {} at the boundary of the {} selected. Ties are broken by ascending "
+                                                                   "feature id, so exactly {} Features were selected and the choice among the tied Features is arbitrary.",
+                                                                   tiedTotal, tiedValue, selectedCount, selectedCount)});
+    }
+
+    // 'true' means flagged for removal. Under Keep, the selected features survive and everything
+    // else is flagged; under Remove it is the other way around. Both fall out of the polarity here,
+    // so there is no per-combination branching.
+    const bool keep = (inputValues->Operation == to_underlying(RankOperation::Keep));
+    flags.assign(numTuples, keep);
+    for(usize i = 0; i < selectedCount; i++)
+    {
+      flags[order[i] + 1] = !keep;
+    }
+    flags[0] = false;
+
+    const auto flaggedCount = static_cast<usize>(std::count(flags.cbegin() + 1, flags.cend(), true));
+    if(flaggedCount == numFeatures)
+    {
+      return MakeErrorResult(k_AllFeaturesFlagged, fmt::format("{} the {} {} of {} features would flag every feature for removal, leaving nothing behind. Adjust the selection so at least one "
+                                                               "feature survives.",
+                                                               keep ? "Keeping" : "Removing", selectedCount, descending ? "largest" : "smallest", numFeatures));
+    }
+
+    summary = fmt::format("{} the {} {} features by '{}'; flagged {} of {} features for removal.", keep ? "Keeping" : "Removing", selectedCount, descending ? "largest" : "smallest",
+                          rankingArray.getName(), flaggedCount, numFeatures);
+    return {};
+  }
+};
+} // namespace
+
+// -----------------------------------------------------------------------------
+KeepRemoveRankedFeatures::KeepRemoveRankedFeatures(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel,
+                                                   KeepRemoveRankedFeaturesInputValues* inputValues)
+: m_DataStructure(dataStructure)
+, m_InputValues(inputValues)
+, m_ShouldCancel(shouldCancel)
+, m_MessageHandler(mesgHandler)
+{
+}
+
+// -----------------------------------------------------------------------------
+KeepRemoveRankedFeatures::~KeepRemoveRankedFeatures() noexcept = default;
+
+// -----------------------------------------------------------------------------
+const std::atomic_bool& KeepRemoveRankedFeatures::getCancel()
+{
+  return m_ShouldCancel;
+}
+
+// -----------------------------------------------------------------------------
+Result<> KeepRemoveRankedFeatures::operator()()
+{
+  const auto& rankingArray = m_DataStructure.getDataRefAs<IDataArray>(m_InputValues->RankingArrayPath);
+
+  std::vector<bool> flags;
+  std::string summary;
+  std::vector<Warning> warnings;
+
+  MessageHelper messageHelper(m_MessageHandler);
+
+  Result<> selectionResult = ExecuteDataFunction(RankAndFlagFunctor{}, rankingArray.getDataType(), rankingArray, m_InputValues, m_ShouldCancel, messageHelper, flags, summary, warnings);
+
+  // Carry any warnings out on the failure path too. A tie warning is raised before the all flagged
+  // check, and dropping it would hide the most useful diagnostic behind the error.
+  selectionResult.warnings().insert(selectionResult.warnings().end(), warnings.cbegin(), warnings.cend());
+  if(selectionResult.invalid())
+  {
+    return selectionResult;
+  }
+
+  if(getCancel())
+  {
+    return {};
+  }
+
+  // Report the user's intent rather than the raw polarity. A message that says only "490 features
+  // flagged true" is the kind that gets confirmed without actually being checked.
+  m_MessageHandler(IFilter::ProgressMessage{IFilter::Message::Type::Info, summary});
+
+  FeatureRemovalUtilities::RemovalArgs removalArgs;
+  removalArgs.ImageGeometryPath = m_InputValues->ImageGeometryPath;
+  removalArgs.FeatureIdsArrayPath = m_InputValues->FeatureIdsArrayPath;
+  removalArgs.FeatureAttributeMatrixPath = m_InputValues->RankingArrayPath.getParent();
+  removalArgs.IgnoredDataArrayPaths = m_InputValues->IgnoredDataArrayPaths;
+  removalArgs.FillRemovedFeatures = m_InputValues->FillRemovedFeatures;
+
+  Result<> result = FeatureRemovalUtilities::removeFlaggedFeatures(m_DataStructure, flags, removalArgs, m_MessageHandler, m_ShouldCancel);
+  result.warnings().insert(result.warnings().end(), warnings.cbegin(), warnings.cend());
+  return result;
+}

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/KeepRemoveRankedFeatures.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/KeepRemoveRankedFeatures.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "SimplnxCore/SimplnxCore_export.hpp"
+
+#include "simplnx/DataStructure/DataPath.hpp"
+#include "simplnx/DataStructure/DataStructure.hpp"
+#include "simplnx/Filter/IFilter.hpp"
+#include "simplnx/Parameters/MultiArraySelectionParameter.hpp"
+
+namespace nx::core
+{
+/**
+ * @brief Whether the ranked features are the ones to keep or the ones to remove.
+ */
+enum class RankOperation : uint64
+{
+  Keep = 0,
+  Remove = 1,
+};
+
+/**
+ * @brief Which end of the sorted population the selection is taken from.
+ */
+enum class RankDirection : uint64
+{
+  Largest = 0,
+  Smallest = 1,
+};
+
+/**
+ * @brief How many features the selection covers.
+ */
+enum class RankCriterion : uint64
+{
+  FeatureCount = 0,
+  PercentOfCount = 1,
+  PercentOfSum = 2,
+};
+
+struct SIMPLNXCORE_EXPORT KeepRemoveRankedFeaturesInputValues
+{
+  uint64 Operation;
+  uint64 RankFrom;
+  uint64 Criterion;
+  uint64 NumFeatures;
+  float64 Percent;
+  bool FillRemovedFeatures;
+  DataPath ImageGeometryPath;
+  DataPath FeatureIdsArrayPath;
+  DataPath RankingArrayPath;
+  MultiArraySelectionParameter::ValueType IgnoredDataArrayPaths;
+};
+
+/**
+ * @class KeepRemoveRankedFeatures
+ * @brief Keeps or removes a count or percentage of features ranked by a scalar feature array.
+ */
+class SIMPLNXCORE_EXPORT KeepRemoveRankedFeatures
+{
+public:
+  KeepRemoveRankedFeatures(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, KeepRemoveRankedFeaturesInputValues* inputValues);
+  ~KeepRemoveRankedFeatures() noexcept;
+
+  KeepRemoveRankedFeatures(const KeepRemoveRankedFeatures&) = delete;
+  KeepRemoveRankedFeatures(KeepRemoveRankedFeatures&&) noexcept = delete;
+  KeepRemoveRankedFeatures& operator=(const KeepRemoveRankedFeatures&) = delete;
+  KeepRemoveRankedFeatures& operator=(KeepRemoveRankedFeatures&&) noexcept = delete;
+
+  Result<> operator()();
+
+  const std::atomic_bool& getCancel();
+
+private:
+  DataStructure& m_DataStructure;
+  const KeepRemoveRankedFeaturesInputValues* m_InputValues = nullptr;
+  const std::atomic_bool& m_ShouldCancel;
+  const IFilter::MessageHandler& m_MessageHandler;
+};
+} // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedFeatures.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/RemoveFlaggedFeatures.cpp
@@ -2,181 +2,16 @@
 
 #include "SimplnxCore/Filters/ComputeFeatureRectFilter.hpp"
 #include "SimplnxCore/Filters/CropImageGeometryFilter.hpp"
+#include "SimplnxCore/utils/FeatureRemovalUtilities.hpp"
 
 #include "simplnx/DataStructure/DataArray.hpp"
-#include "simplnx/DataStructure/DataStore.hpp"
-#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
-#include "simplnx/Utilities/DataGroupUtilities.hpp"
 #include "simplnx/Utilities/MaskCompareUtilities.hpp"
-#include "simplnx/Utilities/MessageHelper.hpp"
-#include "simplnx/Utilities/NeighborUtilities.hpp"
 #include "simplnx/Utilities/ParallelTaskAlgorithm.hpp"
 
 using namespace nx::core;
 
 namespace
 {
-bool IdentifyNeighbors(ImageGeom& imageGeom, Int32AbstractDataStore& featureIds, std::vector<int32>& storageArray, const std::atomic_bool& shouldCancel, MessageHelper& messageHelper)
-{
-  ThrottledMessenger throttledMessenger = messageHelper.createThrottledMessenger();
-
-  SizeVec3 uDims = imageGeom.getDimensions();
-
-  std::array<int64, 3> dims = {
-      static_cast<int64>(uDims[0]),
-      static_cast<int64>(uDims[1]),
-      static_cast<int64>(uDims[2]),
-  };
-
-  constexpr FaceNeighborType k_NumFaceNeighbors = VoxelNeighbors<Image3D>::k_FaceNeighborCount;
-  const std::array<int64, k_NumFaceNeighbors> neighborVoxelIndexOffsets = initializeFaceNeighborOffsets(dims);
-  constexpr std::array<FaceNeighborType, k_NumFaceNeighbors> faceNeighborInternalIdx = initializeFaceNeighborInternalIdx();
-
-  bool shouldLoop = false;
-
-  auto progressIncrement = dims[2] / 100;
-  usize progressCounter = 0;
-  int32 featureName;
-  int64 kStride, jStride;
-  for(int64 zIdx = 0; zIdx < dims[2]; zIdx++)
-  {
-    if(shouldCancel)
-    {
-      return false;
-    }
-
-    if(progressCounter > progressIncrement)
-    {
-      throttledMessenger.sendThrottledMessage([&]() { return fmt::format("Processing Image... {:.2f}%", CalculatePercentComplete(zIdx, dims[2])); });
-      progressCounter = 0;
-    }
-    progressCounter++;
-
-    kStride = dims[0] * dims[1] * zIdx;
-    for(int64 yIdx = 0; yIdx < dims[1]; yIdx++)
-    {
-      jStride = dims[0] * yIdx;
-      for(int64 xIdx = 0; xIdx < dims[0]; xIdx++)
-      {
-        int64 voxelIndex = kStride + jStride + xIdx;
-        featureName = featureIds[voxelIndex];
-        if(featureName > 0)
-        {
-          continue;
-        }
-        shouldLoop = true;
-        int32 current;
-        int32 most = 0;
-        std::vector<int32> numHits(6, 0);
-        std::vector<int32> discoveredFeatures = {};
-        discoveredFeatures.reserve(6);
-        // Loop over the 6 face neighbors of the voxel
-        const std::array<bool, k_NumFaceNeighbors> isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
-        for(const auto& faceIndex : faceNeighborInternalIdx)
-        {
-          if(!isValidFaceNeighbor[faceIndex])
-          {
-            continue;
-          }
-
-          int64 neighborPoint = voxelIndex + neighborVoxelIndexOffsets[faceIndex];
-          int32 feature = featureIds[neighborPoint];
-          if(feature >= 0)
-          {
-            bool found = false;
-            for(usize featIndex = 0; featIndex < discoveredFeatures.size(); featIndex++)
-            {
-              if(discoveredFeatures[featIndex] == feature)
-              {
-                found = true;
-                numHits[featIndex]++;
-                current = numHits[featIndex];
-                if(current > most)
-                {
-                  most = current;
-                  storageArray[voxelIndex] = static_cast<int32>(neighborPoint);
-                }
-                break;
-              }
-            }
-            if(!found)
-            {
-              discoveredFeatures.push_back(feature);
-            }
-          }
-        }
-      }
-    }
-  }
-  return shouldLoop;
-}
-
-std::vector<bool> FlagFeatures(Int32AbstractDataStore& featureIds, std::unique_ptr<MaskCompareUtilities::MaskCompare>& flaggedFeatures, const bool fillRemovedFeatures)
-{
-  bool good = false;
-  usize totalPoints = featureIds.getNumberOfTuples();
-  usize totalFeatures = flaggedFeatures->getNumberOfTuples();
-  std::vector<bool> activeObjects(totalFeatures, true);
-  for(usize i = 1; i < totalFeatures; i++)
-  {
-    if(!flaggedFeatures->isTrue(i))
-    {
-      good = true;
-    }
-    else
-    {
-      activeObjects[i] = false;
-    }
-  }
-  if(!good)
-  {
-    return {};
-  }
-  for(usize i = 0; i < totalPoints; i++)
-  {
-    if(activeObjects[featureIds[i]])
-    {
-      continue;
-    }
-
-    if(fillRemovedFeatures)
-    {
-      featureIds[i] = -1;
-    }
-    else
-    {
-      featureIds[i] = 0;
-    }
-  }
-  return activeObjects;
-}
-
-void FindVoxelArrays(const Int32AbstractDataStore& featureIds, const std::vector<int32>& neighbors, std::vector<std::shared_ptr<IDataArray>>& voxelArrays, const std::atomic_bool& shouldCancel)
-{
-  const usize totalPoints = featureIds.getNumberOfTuples();
-
-  int32 featureName, neighbor;
-  for(usize j = 0; j < totalPoints; j++)
-  {
-    if(shouldCancel)
-    {
-      return;
-    }
-
-    featureName = featureIds[j];
-    neighbor = neighbors[j];
-    if(neighbor >= 0)
-    {
-      if(featureName < 0 && featureIds[neighbor] >= 0)
-      {
-        for(const auto& voxelArray : voxelArrays)
-        {
-          voxelArray->copyTuple(neighbor, j);
-        }
-      }
-    }
-  }
-}
 
 class RunCropImageGeometryImpl
 {
@@ -259,8 +94,6 @@ const std::atomic_bool& RemoveFlaggedFeatures::getCancel()
 // -----------------------------------------------------------------------------
 Result<> RemoveFlaggedFeatures::operator()()
 {
-  auto& featureIds = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureIdsArrayPath)->getDataStoreRef();
-  auto& imageGeom = m_DataStructure.getDataRefAs<ImageGeom>(m_InputValues->ImageGeometryPath);
   auto function = static_cast<Functionality>(m_InputValues->ExtractFeatures);
 
   std::unique_ptr<MaskCompareUtilities::MaskCompare> flaggedFeatures = nullptr;
@@ -279,8 +112,6 @@ Result<> RemoveFlaggedFeatures::operator()()
   {
     return {};
   }
-
-  MessageHelper messageHelper(m_MessageHandler);
 
   // Valid values Functionality::Extract and Functionality::ExtractThenRemove
   if(function != Functionality::Remove)
@@ -360,53 +191,22 @@ Result<> RemoveFlaggedFeatures::operator()()
   // Valid values Functionality::Remove and Functionality::ExtractThenRemove
   if(function != Functionality::Extract)
   {
-    m_MessageHandler(IFilter::ProgressMessage{IFilter::Message::Type::Info, fmt::format("Beginning Feature Removal")});
-
-    std::vector<int32> neighbors((featureIds.getNumberOfTuples() * featureIds.getNumberOfComponents()), -1);
-    std::vector<bool> activeObjects = FlagFeatures(featureIds, flaggedFeatures, m_InputValues->FillRemovedFeatures);
-    if(activeObjects.empty())
+    // Adapt the MaskCompare into a plain flag vector for the shared removal routine.
+    const usize totalFeatures = flaggedFeatures->getNumberOfTuples();
+    std::vector<bool> flagVector(totalFeatures, false);
+    for(usize i = 1; i < totalFeatures; i++)
     {
-      return MakeErrorResult(-45433, "All Features were flagged and would all be removed. The filter has quit.");
+      flagVector[i] = flaggedFeatures->isTrue(i);
     }
 
-    if(getCancel())
-    {
-      return {};
-    }
+    FeatureRemovalUtilities::RemovalArgs removalArgs;
+    removalArgs.ImageGeometryPath = m_InputValues->ImageGeometryPath;
+    removalArgs.FeatureIdsArrayPath = m_InputValues->FeatureIdsArrayPath;
+    removalArgs.FeatureAttributeMatrixPath = m_InputValues->FlaggedFeaturesArrayPath.getParent();
+    removalArgs.IgnoredDataArrayPaths = m_InputValues->IgnoredDataArrayPaths;
+    removalArgs.FillRemovedFeatures = m_InputValues->FillRemovedFeatures;
 
-    if(m_InputValues->FillRemovedFeatures)
-    {
-      bool shouldLoop;
-      usize count = 0;
-      do
-      {
-        count++;
-        m_MessageHandler(IFilter::ProgressMessage{IFilter::Message::Type::Info, fmt::format("Entering iteration number {}...", count)});
-        std::fill(neighbors.begin(), neighbors.end(), -1);
-        shouldLoop = IdentifyNeighbors(imageGeom, featureIds, neighbors, getCancel(), messageHelper);
-
-        if(getCancel())
-        {
-          return {};
-        }
-
-        m_MessageHandler(IFilter::ProgressMessage{IFilter::Message::Type::Info, fmt::format("Filling bad voxels...")});
-        std::vector<std::shared_ptr<IDataArray>> voxelArrays = GenerateDataArrayList(m_DataStructure, m_InputValues->FeatureIdsArrayPath, m_InputValues->IgnoredDataArrayPaths);
-        FindVoxelArrays(featureIds, neighbors, voxelArrays, getCancel());
-      } while(shouldLoop);
-    }
-
-    if(getCancel())
-    {
-      return {};
-    }
-
-    m_MessageHandler(IFilter::ProgressMessage{IFilter::Message::Type::Info, fmt::format("Stripping excess inactive objects from model...")});
-    DataPath featureGroupPath = m_InputValues->FlaggedFeaturesArrayPath.getParent();
-    if(!RemoveInactiveObjects(m_DataStructure, featureGroupPath, activeObjects, featureIds, flaggedFeatures->getNumberOfTuples(), m_MessageHandler, m_ShouldCancel))
-    {
-      return MakeErrorResult(-45434, fmt::format("Failed to remove inactive objects from feature group at path '{}'.", featureGroupPath.toString()));
-    }
+    return FeatureRemovalUtilities::removeFlaggedFeatures(m_DataStructure, flagVector, removalArgs, m_MessageHandler, m_ShouldCancel);
   }
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/KeepRemoveRankedFeaturesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/KeepRemoveRankedFeaturesFilter.cpp
@@ -1,0 +1,256 @@
+#include "KeepRemoveRankedFeaturesFilter.hpp"
+
+#include "SimplnxCore/Filters/Algorithms/KeepRemoveRankedFeatures.hpp"
+
+#include "simplnx/Common/DataTypeUtilities.hpp"
+#include "simplnx/Common/TypeTraits.hpp"
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/DataStructure/DataPath.hpp"
+#include "simplnx/Parameters/ArraySelectionParameter.hpp"
+#include "simplnx/Parameters/BoolParameter.hpp"
+#include "simplnx/Parameters/ChoicesParameter.hpp"
+#include "simplnx/Parameters/GeometrySelectionParameter.hpp"
+#include "simplnx/Parameters/MultiArraySelectionParameter.hpp"
+#include "simplnx/Parameters/NumberParameter.hpp"
+#include "simplnx/Utilities/DataGroupUtilities.hpp"
+#include "simplnx/Utilities/FilterUtilities.hpp"
+
+#include <cmath>
+#include <functional>
+#include <numeric>
+
+using namespace nx::core;
+
+namespace
+{
+constexpr int32 k_ParentNotAttributeMatrix = -78100;
+constexpr int32 k_NotEnoughFeatures = -78101;
+constexpr int32 k_PercentOutOfRange = -78102;
+constexpr int32 k_ZeroNumFeatures = -78103;
+constexpr int32 k_TupleCountMismatch = -78104;
+constexpr int32 k_NumFeaturesClamped = -78120;
+constexpr int32 k_PercentRoundedToZero = -78121;
+constexpr int32 k_NothingFlagged = -78123;
+constexpr int32 k_EverythingFlagged = -78124;
+} // namespace
+
+namespace nx::core
+{
+//------------------------------------------------------------------------------
+std::string KeepRemoveRankedFeaturesFilter::name() const
+{
+  return FilterTraits<KeepRemoveRankedFeaturesFilter>::name.str();
+}
+
+//------------------------------------------------------------------------------
+std::string KeepRemoveRankedFeaturesFilter::className() const
+{
+  return FilterTraits<KeepRemoveRankedFeaturesFilter>::className;
+}
+
+//------------------------------------------------------------------------------
+Uuid KeepRemoveRankedFeaturesFilter::uuid() const
+{
+  return FilterTraits<KeepRemoveRankedFeaturesFilter>::uuid;
+}
+
+//------------------------------------------------------------------------------
+std::string KeepRemoveRankedFeaturesFilter::humanName() const
+{
+  return "Keep/Remove Ranked Features";
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> KeepRemoveRankedFeaturesFilter::defaultTags() const
+{
+  return {className(), "Processing", "Cleanup", "Threshold", "Rank", "Percentile", "Feature Removal"};
+}
+
+//------------------------------------------------------------------------------
+Parameters KeepRemoveRankedFeaturesFilter::parameters() const
+{
+  Parameters params;
+
+  params.insertSeparator(Parameters::Separator{"Input Parameter(s)"});
+  params.insert(std::make_unique<ChoicesParameter>(k_Operation_Key, "Operation", "Whether the ranked Features are the ones to [0] keep or the ones to [1] remove", to_underlying(RankOperation::Keep),
+                                                   ChoicesParameter::Choices{"Keep Selected Features", "Remove Selected Features"}));
+  params.insert(std::make_unique<ChoicesParameter>(k_RankFrom_Key, "Rank From", "Whether to rank from the [0] largest or [1] smallest value of the ranking array",
+                                                   to_underlying(RankDirection::Largest), ChoicesParameter::Choices{"Largest", "Smallest"}));
+  params.insertLinkableParameter(std::make_unique<ChoicesParameter>(
+      k_Criterion_Key, "Selection Criterion", "How many Features to select: [0] an exact count, [1] a percentage of the Feature count, or [2] a percentage of the summed ranking value",
+      to_underlying(RankCriterion::FeatureCount), ChoicesParameter::Choices{"Feature Count", "Percent of Feature Count", "Percent of Summed Value"}));
+  params.insert(std::make_unique<NumberParameter<uint64>>(k_NumFeatures_Key, "Number of Features", "The exact number of Features to select", 10ULL));
+  params.insert(std::make_unique<NumberParameter<float64>>(k_Percent_Key, "Percent", "The percentage to select, in the range (0, 100]", 10.0));
+  params.insert(std::make_unique<BoolParameter>(k_FillRemovedFeatures_Key, "Fill-in Removed Features", "Whether or not to fill in the gaps left by the removed Features", false));
+
+  params.insertSeparator(Parameters::Separator{"Input Geometry"});
+  params.insert(std::make_unique<GeometrySelectionParameter>(k_SelectedImageGeometryPath_Key, "Selected Image Geometry", "The target geometry", DataPath{},
+                                                             GeometrySelectionParameter::AllowedTypes{IGeometry::Type::Image}));
+
+  params.insertSeparator(Parameters::Separator{"Input Cell Data"});
+  params.insert(std::make_unique<ArraySelectionParameter>(k_CellFeatureIdsArrayPath_Key, "Cell Feature Ids", "Specifies to which Feature each Cell belongs.", DataPath({"Cell Data", "FeatureIds"}),
+                                                          ArraySelectionParameter::AllowedTypes{DataType::int32}, ArraySelectionParameter::AllowedComponentShapes{{1}}));
+
+  params.insertSeparator(Parameters::Separator{"Input Feature Data"});
+  params.insert(std::make_unique<ArraySelectionParameter>(k_RankingArrayPath_Key, "Feature Ranking Array", "The scalar Feature level array used to rank the Features", DataPath{},
+                                                          nx::core::GetAllNumericTypes(), ArraySelectionParameter::AllowedComponentShapes{{1}}));
+  params.insert(std::make_unique<MultiArraySelectionParameter>(k_IgnoredDataArrayPaths_Key, "Attribute Arrays to Ignore", "The list of arrays to ignore when removing Features",
+                                                               MultiArraySelectionParameter::ValueType{}, MultiArraySelectionParameter::AllowedTypes{IArray::ArrayType::DataArray},
+                                                               nx::core::GetAllDataTypes()));
+
+  // Associate the Linkable Parameter(s) to the children parameters that they control
+  params.linkParameters(k_Criterion_Key, k_NumFeatures_Key, std::make_any<uint64>(to_underlying(RankCriterion::FeatureCount)));
+  params.linkParameters(k_Criterion_Key, k_Percent_Key, std::make_any<uint64>(to_underlying(RankCriterion::PercentOfCount)));
+  params.linkParameters(k_Criterion_Key, k_Percent_Key, std::make_any<uint64>(to_underlying(RankCriterion::PercentOfSum)));
+
+  return params;
+}
+
+//------------------------------------------------------------------------------
+IFilter::VersionType KeepRemoveRankedFeaturesFilter::parametersVersion() const
+{
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+IFilter::UniquePointer KeepRemoveRankedFeaturesFilter::clone() const
+{
+  return std::make_unique<KeepRemoveRankedFeaturesFilter>();
+}
+
+//------------------------------------------------------------------------------
+IFilter::PreflightResult KeepRemoveRankedFeaturesFilter::preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler,
+                                                                       const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+{
+  auto pFeatureIdsArrayPathValue = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
+  auto pRankingArrayPathValue = filterArgs.value<DataPath>(k_RankingArrayPath_Key);
+  auto pOperationValue = filterArgs.value<ChoicesParameter::ValueType>(k_Operation_Key);
+  auto pCriterionValue = filterArgs.value<ChoicesParameter::ValueType>(k_Criterion_Key);
+  auto pNumFeaturesValue = filterArgs.value<uint64>(k_NumFeatures_Key);
+  auto pPercentValue = filterArgs.value<float64>(k_Percent_Key);
+
+  nx::core::Result<OutputActions> resultOutputActions;
+
+  const DataPath featureAttributeMatrixPath = pRankingArrayPathValue.getParent();
+  const auto* featureAmPtr = dataStructure.getDataAs<AttributeMatrix>(featureAttributeMatrixPath);
+  if(featureAmPtr == nullptr)
+  {
+    return {MakeErrorResult<OutputActions>(k_ParentNotAttributeMatrix,
+                                           fmt::format("The parent of the Feature Ranking Array at path '{}' must be an Attribute Matrix, but no Attribute Matrix was found at '{}'.",
+                                                       pRankingArrayPathValue.toString(), featureAttributeMatrixPath.toString()))};
+  }
+
+  const auto& rankingArray = dataStructure.getDataRefAs<IDataArray>(pRankingArrayPathValue);
+  const usize numTuples = rankingArray.getNumberOfTuples();
+  if(numTuples < 2)
+  {
+    return {MakeErrorResult<OutputActions>(k_NotEnoughFeatures,
+                                           fmt::format("The Feature Attribute Matrix at path '{}' holds {} tuple(s), but at least 2 are required. Tuple 0 is the unused dummy feature, so there "
+                                                       "must be at least one real Feature to rank.",
+                                                       featureAttributeMatrixPath.toString(), numTuples))};
+  }
+  const usize numFeatures = numTuples - 1;
+
+  // validateNumberOfTuples() compares the supplied paths against one another, so passing the single
+  // ranking array path would always succeed. Compare against the parent Attribute Matrix's shape
+  // instead, which is the count the removal step actually relies on.
+  const ShapeType& amShape = featureAmPtr->getShape();
+  const usize amTupleCount = std::accumulate(amShape.cbegin(), amShape.cend(), static_cast<usize>(1), std::multiplies<>());
+  if(numTuples != amTupleCount)
+  {
+    return {MakeErrorResult<OutputActions>(k_TupleCountMismatch, fmt::format("The Feature Ranking Array at path '{}' has {} tuples but its parent Attribute Matrix '{}' has {}. They must match.",
+                                                                             pRankingArrayPathValue.toString(), numTuples, featureAttributeMatrixPath.toString(), amTupleCount))};
+  }
+
+  // Resolve the selected count wherever it is knowable without reading the data, so the user sees
+  // the real cut at preflight rather than discovering it at execute.
+  usize resolvedCount = 0;
+  bool countIsResolvable = true;
+
+  if(pCriterionValue == to_underlying(RankCriterion::FeatureCount))
+  {
+    if(pNumFeaturesValue == 0)
+    {
+      return {MakeErrorResult<OutputActions>(k_ZeroNumFeatures, "'Number of Features' is 0, which would select no Features. Enter a value of 1 or greater.")};
+    }
+    resolvedCount = static_cast<usize>(pNumFeaturesValue);
+    if(resolvedCount > numFeatures)
+    {
+      resultOutputActions.m_Warnings.push_back(
+          Warning{k_NumFeaturesClamped, fmt::format("'Number of Features' is {}, but only {} Features exist. Clamping the selection to {}.", pNumFeaturesValue, numFeatures, numFeatures)});
+      resolvedCount = numFeatures;
+    }
+  }
+  else
+  {
+    if(pPercentValue <= 0.0 || pPercentValue > 100.0)
+    {
+      return {MakeErrorResult<OutputActions>(k_PercentOutOfRange, fmt::format("'Percent' is {}, which is outside the allowed range (0, 100].", pPercentValue))};
+    }
+    if(pCriterionValue == to_underlying(RankCriterion::PercentOfCount))
+    {
+      resolvedCount = static_cast<usize>(std::llround(pPercentValue / 100.0 * static_cast<float64>(numFeatures)));
+      if(resolvedCount == 0)
+      {
+        resultOutputActions.m_Warnings.push_back(Warning{k_PercentRoundedToZero, fmt::format("{}% of {} Features rounds to 0. Selecting 1 Feature instead.", pPercentValue, numFeatures)});
+        resolvedCount = 1;
+      }
+    }
+    else
+    {
+      // Percent of Summed Value depends on the actual values, so it cannot be resolved here.
+      countIsResolvable = false;
+    }
+  }
+
+  if(countIsResolvable)
+  {
+    // One uniform degenerate check covers every bad combination of operation, direction and criterion.
+    const bool keep = (pOperationValue == to_underlying(RankOperation::Keep));
+    const usize flaggedCount = keep ? numFeatures - resolvedCount : resolvedCount;
+    if(flaggedCount == 0)
+    {
+      resultOutputActions.m_Warnings.push_back(
+          Warning{k_NothingFlagged, fmt::format("The current settings leave all {} Features surviving, so no Features will be removed and this filter will do nothing.", numFeatures)});
+    }
+    else if(flaggedCount == numFeatures)
+    {
+      resultOutputActions.m_Warnings.push_back(
+          Warning{k_EverythingFlagged, fmt::format("The current settings flag all {} Features for removal, which would leave nothing behind. This filter will fail during execute.", numFeatures)});
+    }
+  }
+
+  nx::core::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, pFeatureIdsArrayPathValue.getParent(), {});
+  nx::core::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, pRankingArrayPathValue.getParent(), {});
+
+  // This section will warn the user about the removal of NeighborLists
+  auto result = nx::core::NeighborListRemovalPreflightCode(dataStructure, pFeatureIdsArrayPathValue, pRankingArrayPathValue, resultOutputActions);
+  if(result.outputActions.invalid())
+  {
+    return result;
+  }
+
+  return {std::move(resultOutputActions)};
+}
+
+//------------------------------------------------------------------------------
+Result<> KeepRemoveRankedFeaturesFilter::executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler,
+                                                     const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
+{
+  KeepRemoveRankedFeaturesInputValues inputValues;
+
+  inputValues.Operation = filterArgs.value<ChoicesParameter::ValueType>(k_Operation_Key);
+  inputValues.RankFrom = filterArgs.value<ChoicesParameter::ValueType>(k_RankFrom_Key);
+  inputValues.Criterion = filterArgs.value<ChoicesParameter::ValueType>(k_Criterion_Key);
+  inputValues.NumFeatures = filterArgs.value<uint64>(k_NumFeatures_Key);
+  inputValues.Percent = filterArgs.value<float64>(k_Percent_Key);
+  inputValues.FillRemovedFeatures = filterArgs.value<bool>(k_FillRemovedFeatures_Key);
+  inputValues.ImageGeometryPath = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
+  inputValues.FeatureIdsArrayPath = filterArgs.value<DataPath>(k_CellFeatureIdsArrayPath_Key);
+  inputValues.RankingArrayPath = filterArgs.value<DataPath>(k_RankingArrayPath_Key);
+  inputValues.IgnoredDataArrayPaths = filterArgs.value<MultiArraySelectionParameter::ValueType>(k_IgnoredDataArrayPaths_Key);
+
+  return KeepRemoveRankedFeatures(dataStructure, messageHandler, shouldCancel, &inputValues)();
+}
+} // namespace nx::core

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/KeepRemoveRankedFeaturesFilter.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/KeepRemoveRankedFeaturesFilter.hpp
@@ -1,0 +1,123 @@
+#pragma once
+
+#include "SimplnxCore/SimplnxCore_export.hpp"
+
+#include "simplnx/Filter/FilterTraits.hpp"
+#include "simplnx/Filter/IFilter.hpp"
+
+namespace nx::core
+{
+/**
+ * @class KeepRemoveRankedFeaturesFilter
+ * @brief This filter keeps or removes a count or percentage of Features ranked by a scalar Feature level array.
+ *
+ * Unlike the value based thresholds such as Remove Minimum Size Features, the cut here depends on a
+ * Feature's position within the sorted population rather than on its value alone. That makes
+ * requests such as "keep the 10 largest" or "remove the smallest 10%" expressible.
+ */
+class SIMPLNXCORE_EXPORT KeepRemoveRankedFeaturesFilter : public IFilter
+{
+public:
+  KeepRemoveRankedFeaturesFilter() = default;
+  ~KeepRemoveRankedFeaturesFilter() noexcept override = default;
+
+  KeepRemoveRankedFeaturesFilter(const KeepRemoveRankedFeaturesFilter&) = delete;
+  KeepRemoveRankedFeaturesFilter(KeepRemoveRankedFeaturesFilter&&) noexcept = delete;
+
+  KeepRemoveRankedFeaturesFilter& operator=(const KeepRemoveRankedFeaturesFilter&) = delete;
+  KeepRemoveRankedFeaturesFilter& operator=(KeepRemoveRankedFeaturesFilter&&) noexcept = delete;
+
+  // Parameter Keys
+  static inline constexpr StringLiteral k_Operation_Key = "operation_index";
+  static inline constexpr StringLiteral k_RankFrom_Key = "rank_from_index";
+  static inline constexpr StringLiteral k_Criterion_Key = "selection_criterion_index";
+  static inline constexpr StringLiteral k_NumFeatures_Key = "num_features";
+  static inline constexpr StringLiteral k_Percent_Key = "percent";
+  static inline constexpr StringLiteral k_FillRemovedFeatures_Key = "fill_removed_features";
+  static inline constexpr StringLiteral k_SelectedImageGeometryPath_Key = "input_image_geometry_path";
+  static inline constexpr StringLiteral k_CellFeatureIdsArrayPath_Key = "feature_ids_path";
+  static inline constexpr StringLiteral k_RankingArrayPath_Key = "ranking_array_path";
+  static inline constexpr StringLiteral k_IgnoredDataArrayPaths_Key = "ignored_data_array_paths";
+
+  /**
+   * @brief Returns the name of the filter.
+   * @return
+   */
+  std::string name() const override;
+
+  /**
+   * @brief Returns the C++ classname of this filter.
+   * @return
+   */
+  std::string className() const override;
+
+  /**
+   * @brief Returns the uuid of the filter.
+   * @return
+   */
+  Uuid uuid() const override;
+
+  /**
+   * @brief Returns the human-readable name of the filter.
+   * @return
+   */
+  std::string humanName() const override;
+
+  /**
+   * @brief Returns the default tags for this filter.
+   * @return
+   */
+  std::vector<std::string> defaultTags() const override;
+
+  /**
+   * @brief Returns the parameters of the filter (i.e. its inputs)
+   * @return
+   */
+  Parameters parameters() const override;
+
+  /**
+   * @brief Returns parameters version integer.
+   * The Initial version should always be 1.
+   * Should be incremented everytime the parameters change.
+   * @return VersionType
+   */
+  VersionType parametersVersion() const override;
+
+  /**
+   * @brief Returns a copy of the filter.
+   * @return
+   */
+  UniquePointer clone() const override;
+
+protected:
+  /**
+   * @brief Takes in a DataStructure and checks that the filter can be run on it with the given arguments.
+   * Returns any warnings/errors. Also returns the changes that would be applied to the DataStructure.
+   * Some parts of the actions may not be completely filled out if all the required information is not available at preflight time.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @param executionContext The ExecutionContext that can be used to determine the correct absolute path from a relative path
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  PreflightResult preflightImpl(const DataStructure& dataStructure, const Arguments& filterArgs, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                                const ExecutionContext& executionContext) const override;
+
+  /**
+   * @brief Applies the filter's algorithm to the DataStructure with the given arguments. Returns any warnings/errors.
+   * On failure, there is no guarantee that the DataStructure is in a correct state.
+   * @param dataStructure The input DataStructure instance
+   * @param filterArgs These are the input values for each parameter that is required for the filter
+   * @param pipelineNode The node in the pipeline that is being executed
+   * @param messageHandler The MessageHandler object
+   * @param shouldCancel Atomic boolean value that can be checked to cancel the filter
+   * @param executionContext The ExecutionContext that can be used to determine the correct absolute path from a relative path
+   * @return Returns a Result object with error or warning values if any of those occurred during execution of this function
+   */
+  Result<> executeImpl(DataStructure& dataStructure, const Arguments& filterArgs, const PipelineFilter* pipelineNode, const MessageHandler& messageHandler, const std::atomic_bool& shouldCancel,
+                       const ExecutionContext& executionContext) const override;
+};
+} // namespace nx::core
+
+SIMPLNX_DEF_FILTER_TRAITS(nx::core, KeepRemoveRankedFeaturesFilter, "07eb5919-bfd3-4ab7-abdb-5af756a66bce");

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/FeatureRemovalUtilities.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/FeatureRemovalUtilities.cpp
@@ -1,0 +1,253 @@
+#include "SimplnxCore/utils/FeatureRemovalUtilities.hpp"
+
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/DataStructure/DataStore.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/Utilities/DataGroupUtilities.hpp"
+#include "simplnx/Utilities/MessageHelper.hpp"
+#include "simplnx/Utilities/NeighborUtilities.hpp"
+
+#include <algorithm>
+
+using namespace nx::core;
+
+namespace
+{
+bool IdentifyNeighbors(ImageGeom& imageGeom, Int32AbstractDataStore& featureIds, std::vector<int32>& storageArray, const std::atomic_bool& shouldCancel, MessageHelper& messageHelper)
+{
+  ThrottledMessenger throttledMessenger = messageHelper.createThrottledMessenger();
+
+  SizeVec3 uDims = imageGeom.getDimensions();
+
+  std::array<int64, 3> dims = {
+      static_cast<int64>(uDims[0]),
+      static_cast<int64>(uDims[1]),
+      static_cast<int64>(uDims[2]),
+  };
+
+  constexpr FaceNeighborType k_NumFaceNeighbors = VoxelNeighbors<Image3D>::k_FaceNeighborCount;
+  const std::array<int64, k_NumFaceNeighbors> neighborVoxelIndexOffsets = initializeFaceNeighborOffsets(dims);
+  constexpr std::array<FaceNeighborType, k_NumFaceNeighbors> faceNeighborInternalIdx = initializeFaceNeighborInternalIdx();
+
+  bool shouldLoop = false;
+
+  auto progressIncrement = dims[2] / 100;
+  usize progressCounter = 0;
+  int32 featureName;
+  int64 kStride, jStride;
+  for(int64 zIdx = 0; zIdx < dims[2]; zIdx++)
+  {
+    if(shouldCancel)
+    {
+      return false;
+    }
+
+    if(progressCounter > progressIncrement)
+    {
+      throttledMessenger.sendThrottledMessage([&]() { return fmt::format("Processing Image... {:.2f}%", CalculatePercentComplete(zIdx, dims[2])); });
+      progressCounter = 0;
+    }
+    progressCounter++;
+
+    kStride = dims[0] * dims[1] * zIdx;
+    for(int64 yIdx = 0; yIdx < dims[1]; yIdx++)
+    {
+      jStride = dims[0] * yIdx;
+      for(int64 xIdx = 0; xIdx < dims[0]; xIdx++)
+      {
+        int64 voxelIndex = kStride + jStride + xIdx;
+        featureName = featureIds[voxelIndex];
+        if(featureName > 0)
+        {
+          continue;
+        }
+        shouldLoop = true;
+        int32 current;
+        int32 most = 0;
+        std::vector<int32> numHits(6, 0);
+        std::vector<int32> discoveredFeatures = {};
+        discoveredFeatures.reserve(6);
+        // Loop over the 6 face neighbors of the voxel
+        const std::array<bool, k_NumFaceNeighbors> isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
+        for(const auto& faceIndex : faceNeighborInternalIdx)
+        {
+          if(!isValidFaceNeighbor[faceIndex])
+          {
+            continue;
+          }
+
+          int64 neighborPoint = voxelIndex + neighborVoxelIndexOffsets[faceIndex];
+          int32 feature = featureIds[neighborPoint];
+          if(feature >= 0)
+          {
+            bool found = false;
+            for(usize featIndex = 0; featIndex < discoveredFeatures.size(); featIndex++)
+            {
+              if(discoveredFeatures[featIndex] == feature)
+              {
+                found = true;
+                numHits[featIndex]++;
+                current = numHits[featIndex];
+                if(current > most)
+                {
+                  most = current;
+                  storageArray[voxelIndex] = static_cast<int32>(neighborPoint);
+                }
+                break;
+              }
+            }
+            if(!found)
+            {
+              // Count the first sighting as a hit. Without this the tally only records a neighbor on
+              // the SECOND sighting of a feature, so a bad cell whose valid neighbors all belong to
+              // distinct features never gets a fill source. It stays negative, shouldLoop stays true,
+              // and the caller's do/while dilation loop never terminates.
+              discoveredFeatures.push_back(feature);
+              numHits[discoveredFeatures.size() - 1] = 1;
+              if(1 > most)
+              {
+                most = 1;
+                storageArray[voxelIndex] = static_cast<int32>(neighborPoint);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return shouldLoop;
+}
+
+std::vector<bool> FlagFeatures(Int32AbstractDataStore& featureIds, const std::vector<bool>& flaggedFeatures, const bool fillRemovedFeatures)
+{
+  bool good = false;
+  usize totalPoints = featureIds.getNumberOfTuples();
+  usize totalFeatures = flaggedFeatures.size();
+  std::vector<bool> activeObjects(totalFeatures, true);
+  for(usize i = 1; i < totalFeatures; i++)
+  {
+    if(!flaggedFeatures[i])
+    {
+      good = true;
+    }
+    else
+    {
+      activeObjects[i] = false;
+    }
+  }
+  if(!good)
+  {
+    return {};
+  }
+  for(usize i = 0; i < totalPoints; i++)
+  {
+    if(activeObjects[featureIds[i]])
+    {
+      continue;
+    }
+
+    if(fillRemovedFeatures)
+    {
+      featureIds[i] = -1;
+    }
+    else
+    {
+      featureIds[i] = 0;
+    }
+  }
+  return activeObjects;
+}
+
+void FindVoxelArrays(const Int32AbstractDataStore& featureIds, const std::vector<int32>& neighbors, std::vector<std::shared_ptr<IDataArray>>& voxelArrays, const std::atomic_bool& shouldCancel)
+{
+  const usize totalPoints = featureIds.getNumberOfTuples();
+
+  int32 featureName, neighbor;
+  for(usize j = 0; j < totalPoints; j++)
+  {
+    if(shouldCancel)
+    {
+      return;
+    }
+
+    featureName = featureIds[j];
+    neighbor = neighbors[j];
+    if(neighbor >= 0)
+    {
+      if(featureName < 0 && featureIds[neighbor] >= 0)
+      {
+        for(const auto& voxelArray : voxelArrays)
+        {
+          voxelArray->copyTuple(neighbor, j);
+        }
+      }
+    }
+  }
+}
+} // namespace
+
+namespace nx::core::FeatureRemovalUtilities
+{
+// -----------------------------------------------------------------------------
+Result<> removeFlaggedFeatures(DataStructure& dataStructure, const std::vector<bool>& flaggedFeatures, const RemovalArgs& args, const IFilter::MessageHandler& messageHandler,
+                               const std::atomic_bool& shouldCancel)
+{
+  auto& imageGeom = dataStructure.getDataRefAs<ImageGeom>(args.ImageGeometryPath);
+  auto& featureIds = dataStructure.getDataAs<Int32Array>(args.FeatureIdsArrayPath)->getDataStoreRef();
+
+  MessageHelper messageHelper(messageHandler);
+
+  messageHandler(IFilter::ProgressMessage{IFilter::Message::Type::Info, fmt::format("Beginning Feature Removal")});
+
+  std::vector<bool> activeObjects = FlagFeatures(featureIds, flaggedFeatures, args.FillRemovedFeatures);
+  if(activeObjects.empty())
+  {
+    return MakeErrorResult(-45433, "All Features were flagged and would all be removed. The filter has quit.");
+  }
+
+  if(shouldCancel)
+  {
+    return {};
+  }
+
+  if(args.FillRemovedFeatures)
+  {
+    // One int32 per cell. Declared here rather than at function scope because only the fill path
+    // uses it; hoisting it would cost a 4 GB allocation on a 1000^3 volume even with fill disabled,
+    // which is the default.
+    std::vector<int32> neighbors((featureIds.getNumberOfTuples() * featureIds.getNumberOfComponents()), -1);
+
+    bool shouldLoop;
+    usize count = 0;
+    do
+    {
+      count++;
+      messageHandler(IFilter::ProgressMessage{IFilter::Message::Type::Info, fmt::format("Entering iteration number {}...", count)});
+      std::fill(neighbors.begin(), neighbors.end(), -1);
+      shouldLoop = IdentifyNeighbors(imageGeom, featureIds, neighbors, shouldCancel, messageHelper);
+
+      if(shouldCancel)
+      {
+        return {};
+      }
+
+      messageHandler(IFilter::ProgressMessage{IFilter::Message::Type::Info, fmt::format("Filling bad voxels...")});
+      std::vector<std::shared_ptr<IDataArray>> voxelArrays = GenerateDataArrayList(dataStructure, args.FeatureIdsArrayPath, args.IgnoredDataArrayPaths);
+      FindVoxelArrays(featureIds, neighbors, voxelArrays, shouldCancel);
+    } while(shouldLoop);
+  }
+
+  if(shouldCancel)
+  {
+    return {};
+  }
+
+  messageHandler(IFilter::ProgressMessage{IFilter::Message::Type::Info, fmt::format("Stripping excess inactive objects from model...")});
+  if(!RemoveInactiveObjects(dataStructure, args.FeatureAttributeMatrixPath, activeObjects, featureIds, flaggedFeatures.size(), messageHandler, shouldCancel))
+  {
+    return MakeErrorResult(-45434, fmt::format("Failed to remove inactive objects from feature group at path '{}'.", args.FeatureAttributeMatrixPath.toString()));
+  }
+
+  return {};
+}
+} // namespace nx::core::FeatureRemovalUtilities

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/FeatureRemovalUtilities.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/FeatureRemovalUtilities.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "SimplnxCore/SimplnxCore_export.hpp"
+
+#include "simplnx/Common/Result.hpp"
+#include "simplnx/DataStructure/DataPath.hpp"
+#include "simplnx/DataStructure/DataStructure.hpp"
+#include "simplnx/Filter/IFilter.hpp"
+
+#include <atomic>
+#include <vector>
+
+namespace nx::core::FeatureRemovalUtilities
+{
+/**
+ * @brief Inputs describing where the feature data lives and how the removal should behave.
+ */
+struct SIMPLNXCORE_EXPORT RemovalArgs
+{
+  DataPath ImageGeometryPath;
+  DataPath FeatureIdsArrayPath;
+  DataPath FeatureAttributeMatrixPath;
+  std::vector<DataPath> IgnoredDataArrayPaths;
+  bool FillRemovedFeatures = false;
+};
+
+/**
+ * @brief Removes the flagged features from a segmented Image Geometry.
+ *
+ * Zeroes the Cell level FeatureIds for every flagged feature, optionally fills the resulting gaps by
+ * iteratively dilating the surviving neighbors, then compacts the feature Attribute Matrix and
+ * renumbers the surviving features contiguously starting at 1.
+ *
+ * @param dataStructure The DataStructure to modify in place.
+ * @param flaggedFeatures true means flagged for removal. Index 0 is ignored; feature 0 is not a feature.
+ * @param args Paths and options describing the removal.
+ * @param messageHandler Receives progress messages.
+ * @param shouldCancel Polled to abort the long running loops.
+ * @return Invalid if every feature was flagged, or if the feature group could not be compacted.
+ */
+SIMPLNXCORE_EXPORT Result<> removeFlaggedFeatures(DataStructure& dataStructure, const std::vector<bool>& flaggedFeatures, const RemovalArgs& args, const IFilter::MessageHandler& messageHandler,
+                                                  const std::atomic_bool& shouldCancel);
+} // namespace nx::core::FeatureRemovalUtilities

--- a/src/Plugins/SimplnxCore/test/CMakeLists.txt
+++ b/src/Plugins/SimplnxCore/test/CMakeLists.txt
@@ -97,6 +97,7 @@ set(${PLUGIN_NAME}UnitTest_SRCS
   InitializeImageGeomCellDataTest.cpp
   InterpolatePointCloudToRegularGridTest.cpp
   IterativeClosestPointTest.cpp
+  KeepRemoveRankedFeaturesTest.cpp
   LabelTriangleGeometryTest.cpp
   LaplacianSmoothingFilterTest.cpp
   M3CSurfaceMeshingTest.cpp

--- a/src/Plugins/SimplnxCore/test/KeepRemoveRankedFeaturesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/KeepRemoveRankedFeaturesTest.cpp
@@ -1,0 +1,714 @@
+#include "SimplnxCore/Filters/KeepRemoveRankedFeaturesFilter.hpp"
+#include "SimplnxCore/SimplnxCore_test_dirs.hpp"
+
+#include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
+#include "simplnx/DataStructure/NeighborList.hpp"
+#include "simplnx/Parameters/ArraySelectionParameter.hpp"
+#include "simplnx/Parameters/BoolParameter.hpp"
+#include "simplnx/Parameters/ChoicesParameter.hpp"
+#include "simplnx/Parameters/MultiArraySelectionParameter.hpp"
+#include "simplnx/Parameters/NumberParameter.hpp"
+#include "simplnx/UnitTest/UnitTestCommon.hpp"
+
+#include <catch2/catch.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <set>
+#include <tuple>
+#include <vector>
+
+using namespace nx::core;
+using namespace nx::core::Constants;
+using namespace nx::core::UnitTest;
+
+namespace
+{
+const DataPath k_ImageGeomPath({k_DataContainer});
+const DataPath k_FeatureIdsPath({k_DataContainer, k_CellData, k_FeatureIds});
+const std::string k_NumElements("NumElements");
+const DataPath k_FeatureAmPath({k_DataContainer, k_CellFeatureData});
+const DataPath k_RankingArrayPath({k_DataContainer, k_CellFeatureData, k_NumElements});
+
+/**
+ * @brief Builds a 5x2x1 Image Geometry holding 4 features of distinct, deliberately non-monotonic sizes.
+ *
+ * Cell layout (row major, y = 0 then y = 1):
+ *   row 0:  1 1 1 2 3
+ *   row 1:  1 4 4 4 3
+ *
+ * Feature sizes: id 1 -> 4 cells, id 2 -> 1 cell, id 3 -> 2 cells, id 4 -> 3 cells.
+ * Ranked largest first: 1 (4), 4 (3), 3 (2), 2 (1). The sizes are not in id order, so a sort is
+ * genuinely exercised rather than accidentally satisfied by the natural ordering.
+ */
+DataStructure BuildTestData()
+{
+  DataStructure dataStructure;
+
+  auto* imageGeomPtr = ImageGeom::Create(dataStructure, k_DataContainer);
+  const std::vector<usize> dims = {5, 2, 1};
+  imageGeomPtr->setDimensions(dims);
+  imageGeomPtr->setOrigin({0.0f, 0.0f, 0.0f});
+  imageGeomPtr->setSpacing({1.0f, 1.0f, 1.0f});
+
+  const std::vector<usize> cellTupleDims(dims.rbegin(), dims.rend());
+  auto* cellAmPtr = AttributeMatrix::Create(dataStructure, k_CellData, cellTupleDims, imageGeomPtr->getId());
+  imageGeomPtr->setCellData(*cellAmPtr);
+
+  auto* featureIdsPtr = UnitTest::CreateTestDataArray<int32>(dataStructure, k_FeatureIds, cellTupleDims, {1}, cellAmPtr->getId());
+  auto& featureIdsRef = featureIdsPtr->getDataStoreRef();
+  const std::vector<int32> ids = {1, 1, 1, 2, 3, 1, 4, 4, 4, 3};
+  for(usize i = 0; i < ids.size(); i++)
+  {
+    featureIdsRef[i] = ids[i];
+  }
+
+  // Feature Attribute Matrix: 5 tuples, where index 0 is the unused dummy feature.
+  const std::vector<usize> featureTupleDims = {5};
+  auto* featureAmPtr = AttributeMatrix::Create(dataStructure, k_CellFeatureData, featureTupleDims, imageGeomPtr->getId());
+
+  auto* numElementsPtr = UnitTest::CreateTestDataArray<int32>(dataStructure, k_NumElements, featureTupleDims, {1}, featureAmPtr->getId());
+  auto& numElementsRef = numElementsPtr->getDataStoreRef();
+  const std::vector<int32> sizes = {0, 4, 1, 2, 3};
+  for(usize i = 0; i < sizes.size(); i++)
+  {
+    numElementsRef[i] = sizes[i];
+  }
+
+  return dataStructure;
+}
+
+Arguments MakeArgs(uint64 operation, uint64 rankFrom, uint64 numFeatures)
+{
+  Arguments args;
+  args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Operation_Key, std::make_any<ChoicesParameter::ValueType>(operation));
+  args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_RankFrom_Key, std::make_any<ChoicesParameter::ValueType>(rankFrom));
+  args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Criterion_Key, std::make_any<ChoicesParameter::ValueType>(0ULL));
+  args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_NumFeatures_Key, std::make_any<uint64>(numFeatures));
+  args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Percent_Key, std::make_any<float64>(10.0));
+  args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_FillRemovedFeatures_Key, std::make_any<bool>(false));
+  args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_ImageGeomPath));
+  args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(k_FeatureIdsPath));
+  args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_RankingArrayPath_Key, std::make_any<DataPath>(k_RankingArrayPath));
+  args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_IgnoredDataArrayPaths_Key, std::make_any<MultiArraySelectionParameter::ValueType>(MultiArraySelectionParameter::ValueType{}));
+  return args;
+}
+
+/**
+ * @brief Checks for one specific warning code.
+ *
+ * Asserting only that the warning list is non-empty is not enough. Unrelated machinery such as the
+ * NeighborList removal check also contributes warnings, so a bare non-empty assertion passes even
+ * when the warning under test was never emitted.
+ */
+bool HasWarningCode(const std::vector<Warning>& warnings, int32 code)
+{
+  return std::any_of(warnings.cbegin(), warnings.cend(), [code](const Warning& warning) { return warning.code == code; });
+}
+
+std::vector<int32> ReadFeatureIds(const DataStructure& dataStructure)
+{
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<Int32Array>(k_FeatureIdsPath));
+  const auto& featureIdsRef = dataStructure.getDataRefAs<Int32Array>(k_FeatureIdsPath).getDataStoreRef();
+  std::vector<int32> result(featureIdsRef.getNumberOfTuples());
+  for(usize i = 0; i < result.size(); i++)
+  {
+    result[i] = featureIdsRef[i];
+  }
+  return result;
+}
+
+/**
+ * @brief Builds a 6x2x1 Image Geometry holding 5 features, again with sizes out of id order.
+ *
+ * Cell layout (row major, y = 0 then y = 1):
+ *   row 0:  1 1 1 1 1 2
+ *   row 1:  3 3 4 4 4 5
+ *
+ * Feature sizes: id 1 -> 5, id 2 -> 1, id 3 -> 2, id 4 -> 3, id 5 -> 1.
+ * Ranked largest first: 1 (5), 4 (3), 3 (2), then 2 and 5 tied at 1 with 2 winning on id order.
+ *
+ * With 5 features, "keep the 2 largest" and "remove the 3 smallest" select different counts, so the
+ * duality invariant is genuinely exercised rather than satisfied by k == N - k.
+ */
+DataStructure BuildFiveFeatureData()
+{
+  DataStructure dataStructure;
+
+  auto* imageGeomPtr = ImageGeom::Create(dataStructure, k_DataContainer);
+  const std::vector<usize> dims = {6, 2, 1};
+  imageGeomPtr->setDimensions(dims);
+  imageGeomPtr->setOrigin({0.0f, 0.0f, 0.0f});
+  imageGeomPtr->setSpacing({1.0f, 1.0f, 1.0f});
+
+  const std::vector<usize> cellTupleDims(dims.rbegin(), dims.rend());
+  auto* cellAmPtr = AttributeMatrix::Create(dataStructure, k_CellData, cellTupleDims, imageGeomPtr->getId());
+  imageGeomPtr->setCellData(*cellAmPtr);
+
+  auto* featureIdsPtr = UnitTest::CreateTestDataArray<int32>(dataStructure, k_FeatureIds, cellTupleDims, {1}, cellAmPtr->getId());
+  auto& featureIdsRef = featureIdsPtr->getDataStoreRef();
+  const std::vector<int32> ids = {1, 1, 1, 1, 1, 2, 3, 3, 4, 4, 4, 5};
+  for(usize i = 0; i < ids.size(); i++)
+  {
+    featureIdsRef[i] = ids[i];
+  }
+
+  const std::vector<usize> featureTupleDims = {6};
+  auto* featureAmPtr = AttributeMatrix::Create(dataStructure, k_CellFeatureData, featureTupleDims, imageGeomPtr->getId());
+
+  auto* numElementsPtr = UnitTest::CreateTestDataArray<int32>(dataStructure, k_NumElements, featureTupleDims, {1}, featureAmPtr->getId());
+  auto& numElementsRef = numElementsPtr->getDataStoreRef();
+  const std::vector<int32> sizes = {0, 5, 1, 2, 3, 1};
+  for(usize i = 0; i < sizes.size(); i++)
+  {
+    numElementsRef[i] = sizes[i];
+  }
+
+  return dataStructure;
+}
+
+/**
+ * @brief Returns the set of distinct positive FeatureIds present, which identifies the survivors
+ * independently of how they were renumbered.
+ */
+std::set<int32> SurvivingIdSet(const DataStructure& dataStructure)
+{
+  std::set<int32> ids;
+  for(int32 featureId : ReadFeatureIds(dataStructure))
+  {
+    if(featureId > 0)
+    {
+      ids.insert(featureId);
+    }
+  }
+  return ids;
+}
+
+} // namespace
+
+TEST_CASE("SimplnxCore::KeepRemoveRankedFeaturesFilter: Feature Count", "[SimplnxCore][KeepRemoveRankedFeatures]")
+{
+  UnitTest::LoadPlugins();
+
+  // Original ids:            1 1 1 2 3 1 4 4 4 3
+  // Sizes: 1->4, 2->1, 3->2, 4->3.  Ranked largest first: 1, 4, 3, 2.
+  // Surviving features are always renumbered by ascending original id.
+  const std::vector<std::tuple<std::string, uint64, uint64, uint64, std::vector<int32>>> cases = {
+      // Keep the 2 largest: features 1 and 4 survive, renumbered 1 and 2.
+      {"Keep 2 Largest", 0ULL, 0ULL, 2ULL, {1, 1, 1, 0, 0, 1, 2, 2, 2, 0}},
+      // Keep the 2 smallest: features 2 and 3 survive, renumbered 1 and 2.
+      {"Keep 2 Smallest", 0ULL, 1ULL, 2ULL, {0, 0, 0, 1, 2, 0, 0, 0, 0, 2}},
+      // Remove the 2 largest leaves the same survivors as keeping the 2 smallest.
+      {"Remove 2 Largest", 1ULL, 0ULL, 2ULL, {0, 0, 0, 1, 2, 0, 0, 0, 0, 2}},
+      // Remove the 2 smallest leaves the same survivors as keeping the 2 largest.
+      {"Remove 2 Smallest", 1ULL, 1ULL, 2ULL, {1, 1, 1, 0, 0, 1, 2, 2, 2, 0}},
+  };
+
+  for(const auto& [name, operation, rankFrom, numFeatures, expected] : cases)
+  {
+    DYNAMIC_SECTION(name)
+    {
+      DataStructure dataStructure = BuildTestData();
+      KeepRemoveRankedFeaturesFilter filter;
+      Arguments args = MakeArgs(operation, rankFrom, numFeatures);
+
+      auto preflightResult = filter.preflight(dataStructure, args);
+      SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+      auto executeResult = filter.execute(dataStructure, args);
+      SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+      REQUIRE(ReadFeatureIds(dataStructure) == expected);
+
+      // Two features survived, so the compacted Feature Attribute Matrix holds 3 tuples: dummy + 2.
+      REQUIRE_NOTHROW(dataStructure.getDataRefAs<Int32Array>(k_RankingArrayPath));
+      REQUIRE(dataStructure.getDataRefAs<Int32Array>(k_RankingArrayPath).getNumberOfTuples() == 3);
+
+      UnitTest::CheckArraysInheritTupleDims(dataStructure);
+    }
+  }
+}
+
+TEST_CASE("SimplnxCore::KeepRemoveRankedFeaturesFilter: Percent of Feature Count", "[SimplnxCore][KeepRemoveRankedFeatures]")
+{
+  UnitTest::LoadPlugins();
+  KeepRemoveRankedFeaturesFilter filter;
+
+  SECTION("50% of 4 Features keeps the 2 largest")
+  {
+    DataStructure dataStructure = BuildTestData();
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Criterion_Key, std::make_any<ChoicesParameter::ValueType>(1ULL));
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Percent_Key, std::make_any<float64>(50.0));
+
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+    const std::vector<int32> expected = {1, 1, 1, 0, 0, 1, 2, 2, 2, 0};
+    REQUIRE(ReadFeatureIds(dataStructure) == expected);
+
+    UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  }
+
+  SECTION("30% of 4 Features rounds to 1")
+  {
+    // 0.30 * 4 = 1.2, which rounds to 1. Only the single largest Feature (id 1) survives.
+    DataStructure dataStructure = BuildTestData();
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Criterion_Key, std::make_any<ChoicesParameter::ValueType>(1ULL));
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Percent_Key, std::make_any<float64>(30.0));
+
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+    const std::vector<int32> expected = {1, 1, 1, 0, 0, 1, 0, 0, 0, 0};
+    REQUIRE(ReadFeatureIds(dataStructure) == expected);
+
+    UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  }
+
+  SECTION("1% of 4 Features clamps up to 1 and warns")
+  {
+    // 0.01 * 4 = 0.04, which rounds to 0. The clamp keeps the filter doing something.
+    DataStructure dataStructure = BuildTestData();
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Criterion_Key, std::make_any<ChoicesParameter::ValueType>(1ULL));
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Percent_Key, std::make_any<float64>(1.0));
+
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+    REQUIRE(HasWarningCode(preflightResult.outputActions.warnings(), -78121));
+
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+    const std::vector<int32> expected = {1, 1, 1, 0, 0, 1, 0, 0, 0, 0};
+    REQUIRE(ReadFeatureIds(dataStructure) == expected);
+
+    UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  }
+}
+
+TEST_CASE("SimplnxCore::KeepRemoveRankedFeaturesFilter: Percent of Summed Value", "[SimplnxCore][KeepRemoveRankedFeatures]")
+{
+  UnitTest::LoadPlugins();
+  KeepRemoveRankedFeaturesFilter filter;
+
+  // Sizes 4, 1, 2, 3 sum to 10, so a percentage maps onto a cumulative sum without rounding noise.
+  SECTION("70% of the summed size keeps the 2 largest")
+  {
+    // Target = 7.0. Cumulative largest first: 4 (below 7, continue), 7 (reaches 7, stop). k = 2.
+    DataStructure dataStructure = BuildTestData();
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Criterion_Key, std::make_any<ChoicesParameter::ValueType>(2ULL));
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Percent_Key, std::make_any<float64>(70.0));
+
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+    const std::vector<int32> expected = {1, 1, 1, 0, 0, 1, 2, 2, 2, 0};
+    REQUIRE(ReadFeatureIds(dataStructure) == expected);
+
+    UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  }
+
+  SECTION("The Feature straddling the cutoff is included")
+  {
+    // Target = 5.0. Cumulative: 4 (below 5, continue), 7 (passes 5, stop). k = 2, not 1: the
+    // Feature that crosses the threshold counts, so the selection always reaches the target.
+    DataStructure dataStructure = BuildTestData();
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Criterion_Key, std::make_any<ChoicesParameter::ValueType>(2ULL));
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Percent_Key, std::make_any<float64>(50.0));
+
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+    const std::vector<int32> expected = {1, 1, 1, 0, 0, 1, 2, 2, 2, 0};
+    REQUIRE(ReadFeatureIds(dataStructure) == expected);
+
+    UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  }
+
+  SECTION("A small percentage still selects the single largest Feature")
+  {
+    // Target = 0.1. The first Feature accumulated already passes it, so k = 1.
+    DataStructure dataStructure = BuildTestData();
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Criterion_Key, std::make_any<ChoicesParameter::ValueType>(2ULL));
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Percent_Key, std::make_any<float64>(1.0));
+
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+    const std::vector<int32> expected = {1, 1, 1, 0, 0, 1, 0, 0, 0, 0};
+    REQUIRE(ReadFeatureIds(dataStructure) == expected);
+
+    UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  }
+
+  SECTION("Negative values are an error")
+  {
+    DataStructure dataStructure = BuildTestData();
+    REQUIRE_NOTHROW(dataStructure.getDataRefAs<Int32Array>(k_RankingArrayPath));
+    auto& numElementsRef = dataStructure.getDataRefAs<Int32Array>(k_RankingArrayPath).getDataStoreRef();
+    numElementsRef[2] = -5;
+
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Criterion_Key, std::make_any<ChoicesParameter::ValueType>(2ULL));
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Percent_Key, std::make_any<float64>(50.0));
+
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+  }
+
+  SECTION("A zero total sum is an error")
+  {
+    DataStructure dataStructure = BuildTestData();
+    REQUIRE_NOTHROW(dataStructure.getDataRefAs<Int32Array>(k_RankingArrayPath));
+    auto& numElementsRef = dataStructure.getDataRefAs<Int32Array>(k_RankingArrayPath).getDataStoreRef();
+    for(usize i = 0; i < numElementsRef.getNumberOfTuples(); i++)
+    {
+      numElementsRef[i] = 0;
+    }
+
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Criterion_Key, std::make_any<ChoicesParameter::ValueType>(2ULL));
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Percent_Key, std::make_any<float64>(50.0));
+
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+  }
+}
+
+TEST_CASE("SimplnxCore::KeepRemoveRankedFeaturesFilter: Ties and non-finite values and fill", "[SimplnxCore][KeepRemoveRankedFeatures]")
+{
+  UnitTest::LoadPlugins();
+  KeepRemoveRankedFeaturesFilter filter;
+
+  SECTION("A tie straddling the cutoff warns and breaks by ascending feature id")
+  {
+    // Give Features 3 and 4 the same size of 3. Ranked largest first: 1 (4), then the tied pair
+    // 3 and 4, then 2 (1). Keeping 2 must take Feature 1 and, of the tied pair, the lower id.
+    DataStructure dataStructure = BuildTestData();
+    REQUIRE_NOTHROW(dataStructure.getDataRefAs<Int32Array>(k_RankingArrayPath));
+    auto& numElementsRef = dataStructure.getDataRefAs<Int32Array>(k_RankingArrayPath).getDataStoreRef();
+    numElementsRef[3] = 3;
+
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+    REQUIRE(HasWarningCode(executeResult.result.warnings(), -78122));
+
+    // Features 1 and 3 survive and renumber to 1 and 2. Feature 3 occupied cells 4 and 9.
+    const std::vector<int32> expected = {1, 1, 1, 0, 2, 1, 0, 0, 0, 2};
+    REQUIRE(ReadFeatureIds(dataStructure) == expected);
+
+    UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  }
+
+  SECTION("A non-finite ranking value is an error")
+  {
+    DataStructure dataStructure = BuildTestData();
+    REQUIRE_NOTHROW(dataStructure.getDataRefAs<AttributeMatrix>(k_FeatureAmPath));
+    auto& featureAmRef = dataStructure.getDataRefAs<AttributeMatrix>(k_FeatureAmPath);
+    auto* ratiosPtr = UnitTest::CreateTestDataArray<float32>(dataStructure, "AspectRatios", {5}, {1}, featureAmRef.getId());
+    auto& ratiosRef = ratiosPtr->getDataStoreRef();
+    ratiosRef[0] = 0.0f;
+    ratiosRef[1] = 1.0f;
+    ratiosRef[2] = std::numeric_limits<float32>::quiet_NaN();
+    ratiosRef[3] = 3.0f;
+    ratiosRef[4] = 4.0f;
+
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_RankingArrayPath_Key, std::make_any<DataPath>(DataPath({k_DataContainer, k_CellFeatureData, "AspectRatios"})));
+
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+  }
+
+  SECTION("Fill leaves no Cell at zero")
+  {
+    DataStructure dataStructure = BuildTestData();
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_FillRemovedFeatures_Key, std::make_any<bool>(true));
+
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+    for(int32 featureId : ReadFeatureIds(dataStructure))
+    {
+      REQUIRE(featureId > 0);
+    }
+
+    UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  }
+}
+
+TEST_CASE("SimplnxCore::KeepRemoveRankedFeaturesFilter: Invariants", "[SimplnxCore][KeepRemoveRankedFeatures]")
+{
+  UnitTest::LoadPlugins();
+  KeepRemoveRankedFeaturesFilter filter;
+
+  // Sizes on the five feature fixture: 1->5, 2->1, 3->2, 4->3, 5->1.
+  // Ranked largest first: 1, 4, 3, 2, 5 (2 before 5 on the id tie-break).
+
+  SECTION("Keep k largest and Remove (N-k) smallest select the same survivors")
+  {
+    // k = 2 of 5, so the dual is "remove the 3 smallest" — different counts, real duality check.
+    DataStructure keepDs = BuildFiveFeatureData();
+    auto keepResult = filter.execute(keepDs, MakeArgs(0ULL, 0ULL, 2ULL));
+    SIMPLNX_RESULT_REQUIRE_VALID(keepResult.result);
+
+    DataStructure removeDs = BuildFiveFeatureData();
+    auto removeResult = filter.execute(removeDs, MakeArgs(1ULL, 1ULL, 3ULL));
+    SIMPLNX_RESULT_REQUIRE_VALID(removeResult.result);
+
+    REQUIRE(ReadFeatureIds(keepDs) == ReadFeatureIds(removeDs));
+    // Features 1 and 4 survive, renumbered 1 and 2.
+    const std::vector<int32> expected = {1, 1, 1, 1, 1, 0, 0, 0, 2, 2, 2, 0};
+    REQUIRE(ReadFeatureIds(keepDs) == expected);
+  }
+
+  SECTION("Survivors are renumbered contiguously from 1 with no gaps")
+  {
+    DataStructure dataStructure = BuildFiveFeatureData();
+    auto executeResult = filter.execute(dataStructure, MakeArgs(0ULL, 0ULL, 3ULL));
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+    const std::set<int32> survivors = SurvivingIdSet(dataStructure);
+    REQUIRE(survivors.size() == 3);
+    for(int32 expectedId = 1; expectedId <= 3; expectedId++)
+    {
+      REQUIRE(survivors.count(expectedId) == 1);
+    }
+
+    // The compacted Attribute Matrix holds the dummy tuple plus one per survivor.
+    REQUIRE_NOTHROW(dataStructure.getDataRefAs<Int32Array>(k_RankingArrayPath));
+    REQUIRE(dataStructure.getDataRefAs<Int32Array>(k_RankingArrayPath).getNumberOfTuples() == 4);
+  }
+
+  SECTION("Keeping k largest is a superset of keeping k-1 largest")
+  {
+    // Compare against the ORIGINAL ids, since renumbering differs between the two runs.
+    // Keeping 2 gives {1, 4}; keeping 3 gives {1, 4, 3}. Compare cell-wise: every cell surviving
+    // under k=2 must also survive under k=3.
+    DataStructure smallDs = BuildFiveFeatureData();
+    SIMPLNX_RESULT_REQUIRE_VALID(filter.execute(smallDs, MakeArgs(0ULL, 0ULL, 2ULL)).result);
+    DataStructure largeDs = BuildFiveFeatureData();
+    SIMPLNX_RESULT_REQUIRE_VALID(filter.execute(largeDs, MakeArgs(0ULL, 0ULL, 3ULL)).result);
+
+    const std::vector<int32> smallIds = ReadFeatureIds(smallDs);
+    const std::vector<int32> largeIds = ReadFeatureIds(largeDs);
+    REQUIRE(smallIds.size() == largeIds.size());
+    for(usize i = 0; i < smallIds.size(); i++)
+    {
+      if(smallIds[i] > 0)
+      {
+        REQUIRE(largeIds[i] > 0);
+      }
+    }
+  }
+}
+
+TEST_CASE("SimplnxCore::KeepRemoveRankedFeaturesFilter: Remove with percent criteria", "[SimplnxCore][KeepRemoveRankedFeatures]")
+{
+  UnitTest::LoadPlugins();
+  KeepRemoveRankedFeaturesFilter filter;
+
+  SECTION("Remove 40% of the Feature count, ranked smallest first")
+  {
+    // 0.40 * 5 = 2, so features 2 and 5 (both size 1, 2 first on id order) are removed.
+    // Survivors 1, 3, 4 renumber to 1, 2, 3 by ascending original id.
+    DataStructure dataStructure = BuildFiveFeatureData();
+    Arguments args = MakeArgs(1ULL, 1ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Criterion_Key, std::make_any<ChoicesParameter::ValueType>(1ULL));
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Percent_Key, std::make_any<float64>(40.0));
+
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+    const std::vector<int32> expected = {1, 1, 1, 1, 1, 0, 2, 2, 3, 3, 3, 0};
+    REQUIRE(ReadFeatureIds(dataStructure) == expected);
+
+    UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  }
+
+  SECTION("Remove Features making up the smallest 20% of summed size")
+  {
+    // Total = 12, target = 2.4. Smallest first: 2 (1) -> 1.0, 5 (1) -> 2.0, 3 (2) -> 4.0 crosses.
+    // So features 2, 5 and 3 are removed; 1 and 4 survive and renumber to 1 and 2.
+    DataStructure dataStructure = BuildFiveFeatureData();
+    Arguments args = MakeArgs(1ULL, 1ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Criterion_Key, std::make_any<ChoicesParameter::ValueType>(2ULL));
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Percent_Key, std::make_any<float64>(20.0));
+
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+    const std::vector<int32> expected = {1, 1, 1, 1, 1, 0, 0, 0, 2, 2, 2, 0};
+    REQUIRE(ReadFeatureIds(dataStructure) == expected);
+
+    UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  }
+}
+
+TEST_CASE("SimplnxCore::KeepRemoveRankedFeaturesFilter: Unsigned ranking array", "[SimplnxCore][KeepRemoveRankedFeatures]")
+{
+  UnitTest::LoadPlugins();
+  KeepRemoveRankedFeaturesFilter filter;
+
+  // Exercises the is_signed_v == false branch, where the negative value check is compiled out.
+  DataStructure dataStructure = BuildTestData();
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<AttributeMatrix>(k_FeatureAmPath));
+  auto& featureAmRef = dataStructure.getDataRefAs<AttributeMatrix>(k_FeatureAmPath);
+  auto* sizesPtr = UnitTest::CreateTestDataArray<uint16>(dataStructure, "UnsignedSizes", {5}, {1}, featureAmRef.getId());
+  auto& sizesRef = sizesPtr->getDataStoreRef();
+  const std::vector<uint16> sizes = {0, 4, 1, 2, 3};
+  for(usize i = 0; i < sizes.size(); i++)
+  {
+    sizesRef[i] = sizes[i];
+  }
+
+  Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+  args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_RankingArrayPath_Key, std::make_any<DataPath>(DataPath({k_DataContainer, k_CellFeatureData, "UnsignedSizes"})));
+  args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Criterion_Key, std::make_any<ChoicesParameter::ValueType>(2ULL));
+  args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Percent_Key, std::make_any<float64>(70.0));
+
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+  const std::vector<int32> expected = {1, 1, 1, 0, 0, 1, 2, 2, 2, 0};
+  REQUIRE(ReadFeatureIds(dataStructure) == expected);
+
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::KeepRemoveRankedFeaturesFilter: Preflight validation", "[SimplnxCore][KeepRemoveRankedFeatures]")
+{
+  UnitTest::LoadPlugins();
+  KeepRemoveRankedFeaturesFilter filter;
+
+  SECTION("Number of Features of 0 is an error")
+  {
+    DataStructure dataStructure = BuildTestData();
+    Arguments args = MakeArgs(0ULL, 0ULL, 0ULL);
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+  }
+
+  SECTION("Number of Features above the feature count warns and clamps")
+  {
+    // 99 requested but only 4 features exist. Keep-largest so the clamp leaves everything surviving
+    // rather than tripping the all-flagged error.
+    DataStructure dataStructure = BuildTestData();
+    Arguments args = MakeArgs(0ULL, 0ULL, 99ULL);
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+    REQUIRE(HasWarningCode(preflightResult.outputActions.warnings(), -78120));
+  }
+
+  SECTION("Percent at or below 0 is an error")
+  {
+    DataStructure dataStructure = BuildTestData();
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Criterion_Key, std::make_any<ChoicesParameter::ValueType>(1ULL));
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Percent_Key, std::make_any<float64>(0.0));
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+  }
+
+  SECTION("Percent above 100 is an error")
+  {
+    DataStructure dataStructure = BuildTestData();
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Criterion_Key, std::make_any<ChoicesParameter::ValueType>(1ULL));
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_Percent_Key, std::make_any<float64>(100.1));
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+  }
+
+  SECTION("A Feature Attribute Matrix holding only the dummy feature is an error")
+  {
+    DataStructure dataStructure = BuildTestData();
+    REQUIRE_NOTHROW(dataStructure.getDataRefAs<AttributeMatrix>(k_FeatureAmPath));
+    auto& featureAmRef = dataStructure.getDataRefAs<AttributeMatrix>(k_FeatureAmPath);
+    featureAmRef.resizeTuples({1});
+
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+  }
+
+  SECTION("Keeping every feature flags nothing and warns")
+  {
+    DataStructure dataStructure = BuildTestData();
+    Arguments args = MakeArgs(0ULL, 0ULL, 4ULL);
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+    REQUIRE(HasWarningCode(preflightResult.outputActions.warnings(), -78123));
+  }
+
+  SECTION("Removing every feature warns at preflight and fails at execute")
+  {
+    DataStructure dataStructure = BuildTestData();
+    Arguments args = MakeArgs(1ULL, 0ULL, 4ULL);
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+    REQUIRE(HasWarningCode(preflightResult.outputActions.warnings(), -78124));
+
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result);
+  }
+
+  SECTION("A ranking array whose parent is not an Attribute Matrix is an error")
+  {
+    DataStructure dataStructure = BuildTestData();
+    // Put a feature-shaped array under a plain DataGroup rather than an Attribute Matrix.
+    auto* groupPtr = DataGroup::Create(dataStructure, "NotAnAttributeMatrix");
+    UnitTest::CreateTestDataArray<int32>(dataStructure, "Sizes", {5}, {1}, groupPtr->getId());
+
+    Arguments args = MakeArgs(0ULL, 0ULL, 2ULL);
+    args.insertOrAssign(KeepRemoveRankedFeaturesFilter::k_RankingArrayPath_Key, std::make_any<DataPath>(DataPath({"NotAnAttributeMatrix", "Sizes"})));
+
+    auto preflightResult = filter.preflight(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+  }
+
+  SECTION("A NeighborList in the Feature Attribute Matrix produces a warning")
+  {
+    DataStructure dataStructure = BuildTestData();
+    REQUIRE_NOTHROW(dataStructure.getDataRefAs<AttributeMatrix>(k_FeatureAmPath));
+    auto& featureAmRef = dataStructure.getDataRefAs<AttributeMatrix>(k_FeatureAmPath);
+    auto* neighborListPtr = Int32NeighborList::Create(dataStructure, "NeighborList", ShapeType{5}, featureAmRef.getId());
+    REQUIRE(neighborListPtr != nullptr);
+
+    auto preflightResult = filter.preflight(dataStructure, MakeArgs(0ULL, 0ULL, 2ULL));
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions);
+
+    // Assert both the code and that the message names the list that will actually be removed.
+    const auto& warnings = preflightResult.outputActions.warnings();
+    const auto neighborListWarning = std::find_if(warnings.cbegin(), warnings.cend(), [](const Warning& warning) { return warning.code == -5558; });
+    REQUIRE(neighborListWarning != warnings.cend());
+    REQUIRE(neighborListWarning->message.find("NeighborList") != std::string::npos);
+  }
+
+  SECTION("Number of Features above the count clamps at execute as well as preflight")
+  {
+    // Keep-largest with a count of 99 clamps to 4, keeping every Feature and removing nothing.
+    DataStructure dataStructure = BuildTestData();
+    Arguments args = MakeArgs(0ULL, 0ULL, 99ULL);
+
+    auto executeResult = filter.execute(dataStructure, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
+
+    // Nothing removed, so FeatureIds are untouched and the Attribute Matrix keeps all 5 tuples.
+    const std::vector<int32> expected = {1, 1, 1, 2, 3, 1, 4, 4, 4, 3};
+    REQUIRE(ReadFeatureIds(dataStructure) == expected);
+    REQUIRE_NOTHROW(dataStructure.getDataRefAs<Int32Array>(k_RankingArrayPath));
+    REQUIRE(dataStructure.getDataRefAs<Int32Array>(k_RankingArrayPath).getNumberOfTuples() == 5);
+  }
+}

--- a/src/simplnx/Utilities/FilterUtilities.cpp
+++ b/src/simplnx/Utilities/FilterUtilities.cpp
@@ -81,7 +81,13 @@ IFilter::PreflightResult NeighborListRemovalPreflightCode(const DataStructure& d
   // Feature Data is going to be modified
   nx::core::AppendDataObjectModifications(dataStructure, resultOutputActions.value().modifiedActions, featureGroupDataPath, {});
 
-  resultOutputActions.warnings().push_back(Warning{k_NeighborListRemoval, ss});
+  // Only warn when there is actually something to remove. Warning unconditionally announced that
+  // NeighborLists would be removed and then listed none, which is noise on every preflight of every
+  // caller, and it silently defeats any test that asserts merely that the warning list is non-empty.
+  if(!featureNeighborListArrays.empty())
+  {
+    resultOutputActions.warnings().push_back(Warning{k_NeighborListRemoval, ss});
+  }
   return {};
 }
 


### PR DESCRIPTION
## Summary

Adds `Keep/Remove Ranked Features`, a rank based threshold for **Features**. The existing thresholds
compare a **Feature's** value against a constant; this one compares its position within the sorted
population, which is what "keep the 10 largest" or "remove the smallest 10%" require. Ranking works
against any scalar **Feature** array, not just size.

* `Operation` (Keep/Remove) and `Rank From` (Largest/Smallest) are independent, giving all four
  combinations from one polarity flip rather than per-combination branching
* Three selection criteria: an exact **Feature** count, a percent of the **Feature** count, and a
  percent of the summed ranking value
* Percent of Summed Value accumulates in rank order and includes the **Feature** that crosses the
  target, so the selection always reaches it; negative values and a non-positive total are rejected
* Ties break by ascending **Feature** id so runs are reproducible, and a warning fires when a tie
  straddles the cutoff, since that choice is arbitrary
* Non-finite ranking values are rejected before sorting — a comparator that sees `NaN` violates
  strict weak ordering, which is undefined behavior
* The selected count is resolved during preflight for both count based criteria, so the user sees
  the real cut before running, along with warnings when the settings would remove nothing or
  everything

### Shared removal utility

The removal, gap filling and **Attribute Matrix** compaction are lifted out of the
`RemoveFlaggedFeatures` algorithm into a new `FeatureRemovalUtilities` helper taking a plain flag
vector, rather than being duplicated. `RemoveFlaggedFeatures`' Remove branch collapses to a single
call; its Extract path is untouched and its test file is unmodified, which is the proof the refactor
preserved behavior.

### Two fixes to existing behavior

**Infinite loop in the fill-by-dilation path.** `IdentifyNeighbors` only recorded a fill source on
the *second* sighting of a feature among a cell's six face neighbors, so a bad cell whose valid
neighbors all belonged to distinct features never received one. It stayed negative, `shouldLoop`
stayed true, and the caller's `do { } while(shouldLoop)` never terminated. Large volumes almost
always give a bad cell two face neighbors in the same feature, and the fill path had no execution
test coverage, which is why this was never hit. Reachable today from
`Remove/Extract Flagged Features` with *Fill-in Removed Features* checked. See #1698 — that issue
also requests the full V&V suite for that filter, which this PR does not do.

**Cell sized allocation with fill disabled.** The same path allocated one `int32` per cell
unconditionally while only using it when fill was enabled — 4 GB on a 1000³ volume in the default
configuration. Now scoped to the branch that uses it.

**Spurious NeighborList warning.** `NeighborListRemovalPreflightCode` emitted its `-5558` warning
unconditionally and then listed no arrays, which is noise on every preflight of all four callers and
silently defeats any test asserting only that the warning list is non-empty. It now warns only when
the **Attribute Matrix** actually holds NeighborLists — matching the behavior the
`RequireMinNumNeighbors` V&V report already documents for that code path.

## Test Plan

- [x] Full suite passes: **1744/1744**, run sequentially
- [x] `RemoveFlaggedFeaturesTest.cpp` passes **unmodified**, proving the extraction preserved behavior
- [x] All four affected callers of the shared preflight helper pass (25 tests)
- [x] clang-format verified against the repository-root `.clang-format`

8 test cases for the new filter. Expected values are hand derived from small in-memory fixtures
rather than regenerated from filter output, so the oracle is not circular; no test data archive is
required. Value assertions are paired with invariants — Keep/Remove duality on a five **Feature**
fixture where *k* and *N−k* differ, contiguous renumbering, and monotonicity of the kept set.

Coverage includes all four Operation × Rank From combinations, each criterion including its rounding
and clamping edges, ties, non-finite values, an unsigned ranking array, fill on and off, and every
preflight error and warning code. Cancel paths are not covered.

## Notes for the reviewer

* The `Extract` / `Extract then Remove` modes are deliberately out of scope. The utility boundary is
  drawn so adding them later is additive.
* The two `Remove/Extract Flagged Features` fixes can be split into a separate PR if you would rather
  review them independently — say the word and I will pull them out.
