### PR TITLE
ENH: Updated clang-format in ci to 18

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,6 +17,13 @@ AllowShortFunctionsOnASingleLine: false
 # AlwaysBreakAfterReturnType: None
 # AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: true
+# This is necessary for clang-format 19. See https://github.com/llvm/llvm-project/issues/94184
+AttributeMacros:
+  - SIMPLNX_EXPORT
+  - SIMPLNXCORE_EXPORT
+  - ORIENTATIONANALYSIS_EXPORT
+  - ITKIMAGEPROCESSING_EXPORT
+  - SIMPLNX_TEMPLATE_EXPORT
 # BinPackArguments: true
 # BinPackParameters: true
 BraceWrapping:

--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -16,15 +16,20 @@ jobs:
           fetch-depth: 2
       - name: Add Problem Matcher
         uses: ammaraskar/gcc-problem-matcher@a141586609e2a558729b99a8c574c048f7f56204
+      - name: Install clang-format-19
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang-format-19
+          clang-format-19 --version
       - name: Check Formatting
         id: check_format
         continue-on-error: true
         run: |
-          python3 scripts/clang_format.py --format-version 18 --commits HEAD^ HEAD
+          python3 scripts/clang_format.py --format-version 19 --commits HEAD^ HEAD
       - name: Apply Formatting
         if: steps.check_format.outcome != 'success'
         run: |
-          python3 scripts/clang_format.py --format-version 18 --modify --commits HEAD^ HEAD
+          python3 scripts/clang_format.py --format-version 19 --modify --commits HEAD^ HEAD
       - name: Add Suggestions
         if: steps.check_format.outcome != 'success'
         uses: reviewdog/action-suggester@v1

--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   clang_format_pr:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v2
@@ -20,11 +20,11 @@ jobs:
         id: check_format
         continue-on-error: true
         run: |
-          python3 scripts/clang_format.py --format-version 15 --commits HEAD^ HEAD
+          python3 scripts/clang_format.py --format-version 18 --commits HEAD^ HEAD
       - name: Apply Formatting
         if: steps.check_format.outcome != 'success'
         run: |
-          python3 scripts/clang_format.py --format-version 15 --modify --commits HEAD^ HEAD
+          python3 scripts/clang_format.py --format-version 18 --modify --commits HEAD^ HEAD
       - name: Add Suggestions
         if: steps.check_format.outcome != 'success'
         uses: reviewdog/action-suggester@v1

--- a/.github/workflows/format_push.yml
+++ b/.github/workflows/format_push.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   clang_format:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v2
@@ -16,4 +16,4 @@ jobs:
         uses: ammaraskar/gcc-problem-matcher@a141586609e2a558729b99a8c574c048f7f56204
       - name: Check Formatting
         run: |
-          python3 scripts/clang_format.py --format-version 15
+          python3 scripts/clang_format.py --format-version 18

--- a/.github/workflows/format_push.yml
+++ b/.github/workflows/format_push.yml
@@ -14,6 +14,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Add Problem Matcher
         uses: ammaraskar/gcc-problem-matcher@a141586609e2a558729b99a8c574c048f7f56204
+      - name: Install clang-format-19
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang-format-19
+          clang-format-19 --version
       - name: Check Formatting
         run: |
-          python3 scripts/clang_format.py --format-version 18
+          python3 scripts/clang_format.py --format-version 19

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertHexGridToSquareGrid.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/Algorithms/ConvertHexGridToSquareGrid.cpp
@@ -206,8 +206,7 @@ public:
 
           // Write to the output file
           outFile << "  " << phi1[hexGridIndex] << "	" << PHI[hexGridIndex] << "	" << phi2[hexGridIndex] << "	" << xSqr << "	" << ySqr << "	" << iq[hexGridIndex] << "	" << ci[hexGridIndex]
-                  << "	" << phase[hexGridIndex] << "	" << semSig[hexGridIndex] << "	" << fit[hexGridIndex] << "  "
-                  << "\n";
+                  << "	" << phase[hexGridIndex] << "	" << semSig[hexGridIndex] << "	" << fit[hexGridIndex] << "  " << "\n";
         }
       }
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EbsdToH5EbsdFilter.cpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/Filters/EbsdToH5EbsdFilter.cpp
@@ -113,51 +113,27 @@ IFilter::PreflightResult EbsdToH5EbsdFilter::preflightImpl(const DataStructure& 
   switch(referenceFrame)
   {
   case EbsdToH5EbsdInputConstants::k_Edax:
-    description << "Manufacturer: "
-                << "Edax - TSL"
-                << "\n"
-                << "Sample Reference Transformation: "
-                << "180 @ <010>"
-                << "\n"
-                << "Euler Transformation: "
-                << "90 @ <001>"
-                << "\n";
+    description << "Manufacturer: " << "Edax - TSL" << "\n"
+                << "Sample Reference Transformation: " << "180 @ <010>" << "\n"
+                << "Euler Transformation: " << "90 @ <001>" << "\n";
     break;
 
   case EbsdToH5EbsdInputConstants::k_Oxford:
-    description << "Manufacturer: "
-                << "Oxford - HKL"
-                << "\n"
-                << "Sample Reference Transformation: "
-                << "180 @ <010>"
-                << "\n"
-                << "Euler Transformation: "
-                << "0 @ <001>"
-                << "\n";
+    description << "Manufacturer: " << "Oxford - HKL" << "\n"
+                << "Sample Reference Transformation: " << "180 @ <010>" << "\n"
+                << "Euler Transformation: " << "0 @ <001>" << "\n";
     break;
 
   case EbsdToH5EbsdInputConstants::k_Hedm:
-    description << "Manufacturer: "
-                << "HEDM - IceNine"
-                << "\n"
-                << "Sample Reference Transformation: "
-                << "0 @ <001>"
-                << "\n"
-                << "Euler Transformation: "
-                << "0 @ <001>"
-                << "\n";
+    description << "Manufacturer: " << "HEDM - IceNine" << "\n"
+                << "Sample Reference Transformation: " << "0 @ <001>" << "\n"
+                << "Euler Transformation: " << "0 @ <001>" << "\n";
     break;
 
   default:
-    description << "Manufacturer: "
-                << "Unknown"
-                << "\n"
-                << "Sample Reference Transformation: "
-                << "0 @ <001>"
-                << "\n"
-                << "Euler Transformation: "
-                << "0 @ <001>"
-                << "\n";
+    description << "Manufacturer: " << "Unknown" << "\n"
+                << "Sample Reference Transformation: " << "0 @ <001>" << "\n"
+                << "Euler Transformation: " << "0 @ <001>" << "\n";
     break;
   }
 

--- a/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/utilities/EbsdReaderUtilities.hpp
+++ b/src/Plugins/OrientationAnalysis/src/OrientationAnalysis/utilities/EbsdReaderUtilities.hpp
@@ -230,8 +230,7 @@ void GeneratePreflightScanInformation(ReaderType& reader, std::vector<IFilter::P
   }
 
   ss << "Num Rows: " << rowCount << "\n"
-     << "Sample Physical Dimensions: " << (xStep * colCount) << " (W) x " << (yStep * rowCount) << " (H) microns"
-     << "\n";
+     << "Sample Physical Dimensions: " << (xStep * colCount) << " (W) x " << (yStep * rowCount) << " (H) microns" << "\n";
 
   if constexpr(std::is_same_v<ReaderType, ebsdlib::CtfReader>)
   {

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CombineNodeBasedGeometries.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/CombineNodeBasedGeometries.cpp
@@ -140,14 +140,8 @@ Result<> CombineGeometryElements(DataStructure& ds, NodeGeomType* outputGeomPtr,
 Result<> CombineVertexElements(DataStructure& ds, const DataPath& outputGeomPath, const std::vector<DataPath>& inputGeometryPaths, const IFilter::MessageHandler& msgHandler,
                                const std::atomic_bool& shouldCancel)
 {
-  auto getVerticesArrayFunc = [](INodeGeometry0D * ptr) -> auto
-  {
-    return ptr->getVertices();
-  };
-  auto getVertexAttrMatrixFunc = [](INodeGeometry0D * ptr) -> auto
-  {
-    return ptr->getVertexAttributeMatrix();
-  };
+  auto getVerticesArrayFunc = [](INodeGeometry0D* ptr) -> auto { return ptr->getVertices(); };
+  auto getVertexAttrMatrixFunc = [](INodeGeometry0D* ptr) -> auto { return ptr->getVertexAttributeMatrix(); };
 
   auto* outputGeom0d = ds.getDataAs<INodeGeometry0D>(outputGeomPath);
 
@@ -161,14 +155,8 @@ Result<> CombineVertexElements(DataStructure& ds, const DataPath& outputGeomPath
 Result<> CombineEdgeElements(DataStructure& ds, const DataPath& outputGeomPath, const std::vector<DataPath>& inputGeometryPaths, const IFilter::MessageHandler& msgHandler,
                              const std::atomic_bool& shouldCancel)
 {
-  auto getEdgesArrayFunc = [](INodeGeometry1D * ptr) -> auto
-  {
-    return ptr->getEdges();
-  };
-  auto getEdgeAttrMatrixFunc = [](INodeGeometry1D * ptr) -> auto
-  {
-    return ptr->getEdgeAttributeMatrix();
-  };
+  auto getEdgesArrayFunc = [](INodeGeometry1D* ptr) -> auto { return ptr->getEdges(); };
+  auto getEdgeAttrMatrixFunc = [](INodeGeometry1D* ptr) -> auto { return ptr->getEdgeAttributeMatrix(); };
 
   auto* outputGeom1d = ds.getDataAs<INodeGeometry1D>(outputGeomPath);
   if(outputGeom1d == nullptr)
@@ -216,10 +204,7 @@ Result<> CombineEdgeElements(DataStructure& ds, const DataPath& outputGeomPath, 
   // Update the edges array values.  For example, an edge geometry will need its edges
   // array updated since all the vertex indices will be different after concatenation
   msgHandler({IFilter::Message::Type::Info, fmt::format("Updating edge values to use new vertex indices...")});
-  auto getVerticesArrayFunc = [](INodeGeometry1D * ptr) -> auto
-  {
-    return ptr->getVertices();
-  };
+  auto getVerticesArrayFunc = [](INodeGeometry1D* ptr) -> auto { return ptr->getVertices(); };
   UpdateCellArrayIndices(ds, outputGeom1d, inputGeoms, getVerticesArrayFunc, getEdgesArrayFunc, msgHandler, shouldCancel);
   return {};
 }
@@ -227,14 +212,8 @@ Result<> CombineEdgeElements(DataStructure& ds, const DataPath& outputGeomPath, 
 Result<> CombineFaceElements(DataStructure& ds, const DataPath& outputGeomPath, const std::vector<DataPath>& inputGeometryPaths, const IFilter::MessageHandler& msgHandler,
                              const std::atomic_bool& shouldCancel)
 {
-  auto getFacesArrayFunc = [](INodeGeometry2D * ptr) -> auto
-  {
-    return ptr->getFaces();
-  };
-  auto getFaceAttrMatrixFunc = [](INodeGeometry2D * ptr) -> auto
-  {
-    return ptr->getFaceAttributeMatrix();
-  };
+  auto getFacesArrayFunc = [](INodeGeometry2D* ptr) -> auto { return ptr->getFaces(); };
+  auto getFaceAttrMatrixFunc = [](INodeGeometry2D* ptr) -> auto { return ptr->getFaceAttributeMatrix(); };
 
   auto* outputGeom2d = ds.getDataAs<INodeGeometry2D>(outputGeomPath);
   if(outputGeom2d == nullptr)
@@ -281,10 +260,7 @@ Result<> CombineFaceElements(DataStructure& ds, const DataPath& outputGeomPath, 
   // Update the faces array values.  For example, a triangle geometry will need its faces
   // array updated since all the vertex indices will be different after concatenation
   msgHandler({IFilter::Message::Type::Info, fmt::format("Updating face values to use new vertex indices...")});
-  auto getVerticesArrayFunc = [](INodeGeometry2D * ptr) -> auto
-  {
-    return ptr->getVertices();
-  };
+  auto getVerticesArrayFunc = [](INodeGeometry2D* ptr) -> auto { return ptr->getVertices(); };
   UpdateCellArrayIndices(ds, outputGeom2d, inputGeoms, getVerticesArrayFunc, getFacesArrayFunc, msgHandler, shouldCancel);
   return {};
 }
@@ -292,14 +268,8 @@ Result<> CombineFaceElements(DataStructure& ds, const DataPath& outputGeomPath, 
 Result<> CombinePolyElements(DataStructure& ds, const DataPath& outputGeomPath, const std::vector<DataPath>& inputGeometryPaths, const IFilter::MessageHandler& msgHandler,
                              const std::atomic_bool& shouldCancel)
 {
-  auto getPolyArrayFunc = [](INodeGeometry3D * ptr) -> auto
-  {
-    return ptr->getPolyhedra();
-  };
-  auto getPolyAttrMatrixFunc = [](INodeGeometry3D * ptr) -> auto
-  {
-    return ptr->getPolyhedraAttributeMatrix();
-  };
+  auto getPolyArrayFunc = [](INodeGeometry3D* ptr) -> auto { return ptr->getPolyhedra(); };
+  auto getPolyAttrMatrixFunc = [](INodeGeometry3D* ptr) -> auto { return ptr->getPolyhedraAttributeMatrix(); };
 
   auto* outputGeom3d = ds.getDataAs<INodeGeometry3D>(outputGeomPath);
   if(outputGeom3d == nullptr)
@@ -346,10 +316,7 @@ Result<> CombinePolyElements(DataStructure& ds, const DataPath& outputGeomPath, 
   // Update the polyhedra array values.  For example, a tetrahedral geometry will need its
   // polyhedra array updated since all the vertex indices will be different after concatenation
   msgHandler({IFilter::Message::Type::Info, fmt::format("Updating polyhedron values to use new vertex indices...")});
-  auto getVerticesArrayFunc = [](INodeGeometry3D * ptr) -> auto
-  {
-    return ptr->getVertices();
-  };
+  auto getVerticesArrayFunc = [](INodeGeometry3D* ptr) -> auto { return ptr->getVertices(); };
   UpdateCellArrayIndices(ds, outputGeom3d, inputGeoms, getVerticesArrayFunc, getPolyArrayFunc, msgHandler, shouldCancel);
   return {};
 }

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeArrayHistogramByFeature.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeArrayHistogramByFeature.cpp
@@ -158,7 +158,7 @@ public:
               m_Overflow++;
             }
           } // end of numTuples loop
-        }   // end of increment else
+        } // end of increment else
 
         // Bool breaks neighbor lists; if we have made it here we know m_ModalBinRangesList is a nullptr
         if constexpr(!std::is_same_v<Type, bool>)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureNeighbors.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeFeatureNeighbors.cpp
@@ -352,9 +352,8 @@ Result<> ComputeFeatureNeighbors::operator()()
   if(static_cast<usize>(maxFeatureId) >= totalFeatures)
   {
     std::stringstream out;
-    out << "Data Array " << m_InputValues->FeatureIdsPath.getTargetName() << " has a maximum value of " << maxFeatureId << " which is greater than the "
-        << " number of features from array " << m_InputValues->NumberOfNeighborsPath.getTargetName() << " which has " << totalFeatures << ". Did you select the "
-        << " incorrect array for the 'FeatureIds' array?";
+    out << "Data Array " << m_InputValues->FeatureIdsPath.getTargetName() << " has a maximum value of " << maxFeatureId << " which is greater than the " << " number of features from array "
+        << m_InputValues->NumberOfNeighborsPath.getTargetName() << " which has " << totalFeatures << ". Did you select the " << " incorrect array for the 'FeatureIds' array?";
     return MakeErrorResult(-24500, out.str());
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteSPParksSites.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteSPParksSites.cpp
@@ -21,23 +21,15 @@ Result<> WriteHeader(const DataStructure& dataStructure, const WriteSPParksSites
 
   const size_t totalPoints = featureIds.getNumberOfTuples();
 
-  outfile << "-"
-          << "\n";
-  outfile << "3 dimension"
-          << "\n";
-  outfile << totalPoints << " sites"
-          << "\n";
-  outfile << "26 max neighbors"
-          << "\n";
-  outfile << "0 " << dims[0] << " xlo xhi"
-          << "\n";
-  outfile << "0 " << dims[1] << " ylo yhi"
-          << "\n";
-  outfile << "0 " << dims[2] << " zlo zhi"
-          << "\n";
+  outfile << "-" << "\n";
+  outfile << "3 dimension" << "\n";
+  outfile << totalPoints << " sites" << "\n";
+  outfile << "26 max neighbors" << "\n";
+  outfile << "0 " << dims[0] << " xlo xhi" << "\n";
+  outfile << "0 " << dims[1] << " ylo yhi" << "\n";
+  outfile << "0 " << dims[2] << " zlo zhi" << "\n";
   outfile << "\n";
-  outfile << "Values"
-          << "\n";
+  outfile << "Values" << "\n";
   outfile << "\n";
 
   return {};

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineNodeBasedGeometriesFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/CombineNodeBasedGeometriesFilter.cpp
@@ -83,53 +83,29 @@ std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindGeometryElements(cons
 
 std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindVertexElements(const IGeometry* geom)
 {
-  auto getVerticesArrayFunc = [](const INodeGeometry0D* ptr) -> auto
-  {
-    return ptr->getVertices();
-  };
-  auto getVertexAttrMatrixFunc = [](const INodeGeometry0D* ptr) -> auto
-  {
-    return ptr->getVertexAttributeMatrix();
-  };
+  auto getVerticesArrayFunc = [](const INodeGeometry0D* ptr) -> auto { return ptr->getVertices(); };
+  auto getVertexAttrMatrixFunc = [](const INodeGeometry0D* ptr) -> auto { return ptr->getVertexAttributeMatrix(); };
   return FindGeometryElements<INodeGeometry0D>(geom, getVerticesArrayFunc, getVertexAttrMatrixFunc);
 }
 
 std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindEdgeElements(const IGeometry* geom)
 {
-  auto getEdgesArrayFunc = [](const INodeGeometry1D* ptr) -> auto
-  {
-    return ptr->getEdges();
-  };
-  auto getEdgeAttrMatrixFunc = [](const INodeGeometry1D* ptr) -> auto
-  {
-    return ptr->getEdgeAttributeMatrix();
-  };
+  auto getEdgesArrayFunc = [](const INodeGeometry1D* ptr) -> auto { return ptr->getEdges(); };
+  auto getEdgeAttrMatrixFunc = [](const INodeGeometry1D* ptr) -> auto { return ptr->getEdgeAttributeMatrix(); };
   return FindGeometryElements<INodeGeometry1D>(geom, getEdgesArrayFunc, getEdgeAttrMatrixFunc);
 }
 
 std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindFaceElements(const IGeometry* geom)
 {
-  auto getFacesArrayFunc = [](const INodeGeometry2D* ptr) -> auto
-  {
-    return ptr->getFaces();
-  };
-  auto getFaceAttrMatrixFunc = [](const INodeGeometry2D* ptr) -> auto
-  {
-    return ptr->getFaceAttributeMatrix();
-  };
+  auto getFacesArrayFunc = [](const INodeGeometry2D* ptr) -> auto { return ptr->getFaces(); };
+  auto getFaceAttrMatrixFunc = [](const INodeGeometry2D* ptr) -> auto { return ptr->getFaceAttributeMatrix(); };
   return FindGeometryElements<INodeGeometry2D>(geom, getFacesArrayFunc, getFaceAttrMatrixFunc);
 }
 
 std::tuple<bool, bool, std::vector<GeometryArrayInfo>> FindPolyElements(const IGeometry* geom)
 {
-  auto getPolyArrayFunc = [](const INodeGeometry3D* ptr) -> auto
-  {
-    return ptr->getPolyhedra();
-  };
-  auto getPolyAttrMatrixFunc = [](const INodeGeometry3D* ptr) -> auto
-  {
-    return ptr->getPolyhedraAttributeMatrix();
-  };
+  auto getPolyArrayFunc = [](const INodeGeometry3D* ptr) -> auto { return ptr->getPolyhedra(); };
+  auto getPolyAttrMatrixFunc = [](const INodeGeometry3D* ptr) -> auto { return ptr->getPolyhedraAttributeMatrix(); };
   return FindGeometryElements<INodeGeometry3D>(geom, getPolyArrayFunc, getPolyAttrMatrixFunc);
 }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/oless/oless/oless.h
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/oless/oless/oless.h
@@ -23,7 +23,7 @@ private:
   void recurse(POLE::Storage*, const std::string, void (Oless::*)(POLE::Storage*, std::string, std::string));
 
 public:
-  Oless(){};
+  Oless() {};
   Oless(char*);
 
   std::vector<OleSummary*> List();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/oless/txm_reader.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/oless/txm_reader.cpp
@@ -161,8 +161,7 @@ void printStreamInfo(POLE::Storage* storage, const std::string& name, const std:
   }
   else
   {
-    std::cout << fullname << "\t DIRECTORY"
-              << "\n";
+    std::cout << fullname << "\t DIRECTORY" << "\n";
   }
 }
 
@@ -207,8 +206,7 @@ void ReadImages(StoragePtrType storage)
   std::cout << path << "\t" << NoOfImages << "\n";
 
   int numImageGroups = std::ceil(static_cast<float>(NoOfImages) / 100.0f);
-  std::cout << "numImageGroups:"
-            << "\t" << numImageGroups << "\n";
+  std::cout << "numImageGroups:" << "\t" << numImageGroups << "\n";
 
   size_t bitsPerPixel = 0;
   if(DataType == FLOAT_TYPE)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/nanoflann.hpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/nanoflann.hpp
@@ -2205,7 +2205,7 @@ public:
   /** @} */
 
 }; // end of KDTreeEigenMatrixAdaptor
-   /** @} */
+/** @} */
 
 /** @} */ // end of grouping
 } // namespace nanoflann

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/utils/nifti1.h
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/utils/nifti1.h
@@ -992,8 +992,8 @@ typedef struct nifti1_extension nifti1_extension;
 
 #undef XYZT_TO_SPACE
 #undef XYZT_TO_TIME
-#define XYZT_TO_SPACE(xyzt) ((xyzt)&0x07)
-#define XYZT_TO_TIME(xyzt) ((xyzt)&0x38)
+#define XYZT_TO_SPACE(xyzt) ((xyzt) & 0x07)
+#define XYZT_TO_TIME(xyzt) ((xyzt) & 0x38)
 
 #undef SPACE_TIME_TO_XYZT
 #define SPACE_TIME_TO_XYZT(ss, tt) ((((char)(ss)) & 0x07) | (((char)(tt)) & 0x38))

--- a/src/Plugins/SimplnxCore/test/M3CSurfaceMeshingTest.cpp
+++ b/src/Plugins/SimplnxCore/test/M3CSurfaceMeshingTest.cpp
@@ -284,40 +284,35 @@ void RunM3COnToy(usize xDim, usize yDim, usize zDim, LabelFuncT&& labeler, [[may
 // This is the minimal deterministic regression for the null-neighbor crash in treat_anomaly.
 TEST_CASE("SimplnxCore::M3CSurfaceMeshingFilter: Toy Checkerboard Saddle", "[SimplnxCore][M3CSurfaceMeshingFilter]")
 {
-  RunM3COnToy(
-      8, 8, 8, [](usize x, usize y, usize z) -> int32 { return static_cast<int32>(((x + y + z) & 1U) + 1); }, "M3CSurfaceMeshingFilterTest_Checkerboard.dream3d");
+  RunM3COnToy(8, 8, 8, [](usize x, usize y, usize z) -> int32 { return static_cast<int32>(((x + y + z) & 1U) + 1); }, "M3CSurfaceMeshingFilterTest_Checkerboard.dream3d");
 }
 
 // 8-label octant pattern (1 + x%2 + 2*(y%2) + 4*(z%2)): a repeating 2x2x2 of 8 distinct labels, so
 // squares present 4 distinct corners (quad points, get_square_index == 19) plus triple configs.
 TEST_CASE("SimplnxCore::M3CSurfaceMeshingFilter: Toy Octant Quad Points", "[SimplnxCore][M3CSurfaceMeshingFilter]")
 {
-  RunM3COnToy(
-      8, 8, 8, [](usize x, usize y, usize z) -> int32 { return static_cast<int32>(1 + (x & 1U) + 2 * (y & 1U) + 4 * (z & 1U)); }, "M3CSurfaceMeshingFilterTest_Octant.dream3d");
+  RunM3COnToy(8, 8, 8, [](usize x, usize y, usize z) -> int32 { return static_cast<int32>(1 + (x & 1U) + 2 * (y & 1U) + 4 * (z & 1U)); }, "M3CSurfaceMeshingFilterTest_Octant.dream3d");
 }
 
 // Three regions meeting along a vertical line (L-shaped split) => triple lines
 // (get_square_index in {7,11,13,14}) plus ordinary binary interfaces.
 TEST_CASE("SimplnxCore::M3CSurfaceMeshingFilter: Toy Triple Line", "[SimplnxCore][M3CSurfaceMeshingFilter]")
 {
-  RunM3COnToy(
-      8, 8, 8, [](usize x, usize y, usize /*z*/) -> int32 { return (x < 4) ? 1 : ((y < 4) ? 2 : 3); }, "M3CSurfaceMeshingFilterTest_TripleLine.dream3d");
+  RunM3COnToy(8, 8, 8, [](usize x, usize y, usize /*z*/) -> int32 { return (x < 4) ? 1 : ((y < 4) ? 2 : 3); }, "M3CSurfaceMeshingFilterTest_TripleLine.dream3d");
 }
 
 // Single isolated interior voxel in a uniform matrix: the four neighboring squares are [B,A,A,A]
 // rotations, exercising get_square_index in {3,6,9,12} (the single-corner binary configurations).
 TEST_CASE("SimplnxCore::M3CSurfaceMeshingFilter: Toy Single Voxel Inclusion", "[SimplnxCore][M3CSurfaceMeshingFilter]")
 {
-  RunM3COnToy(
-      8, 8, 8, [](usize x, usize y, usize z) -> int32 { return (x == 4 && y == 4 && z == 4) ? 2 : 1; }, "M3CSurfaceMeshingFilterTest_Inclusion.dream3d");
+  RunM3COnToy(8, 8, 8, [](usize x, usize y, usize z) -> int32 { return (x == 4 && y == 4 && z == 4) ? 2 : 1; }, "M3CSurfaceMeshingFilterTest_Inclusion.dream3d");
 }
 
 // Interleaved 3-label tiling (rows "1 2" / "3 1"): squares [1,2,1,3] and [2,1,3,1] have all edges
 // differing with exactly one diagonal equal, exercising get_square_index 17 and 18.
 TEST_CASE("SimplnxCore::M3CSurfaceMeshingFilter: Toy Interleaved Diagonal", "[SimplnxCore][M3CSurfaceMeshingFilter]")
 {
-  RunM3COnToy(
-      8, 8, 8, [](usize x, usize y, usize /*z*/) -> int32 { return (y % 2 == 0) ? ((x % 2 == 0) ? 1 : 2) : ((x % 2 == 0) ? 3 : 1); }, "M3CSurfaceMeshingFilterTest_Interleaved.dream3d");
+  RunM3COnToy(8, 8, 8, [](usize x, usize y, usize /*z*/) -> int32 { return (y % 2 == 0) ? ((x % 2 == 0) ? 1 : 2) : ((x % 2 == 0) ? 3 : 1); }, "M3CSurfaceMeshingFilterTest_Interleaved.dream3d");
 }
 
 TEST_CASE("SimplnxCore::M3CSurfaceMeshingFilter: SIMPL Backwards Compatibility", "[SimplnxCore][M3CSurfaceMeshingFilter][BackwardsCompatibility]")

--- a/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
+++ b/src/Plugins/SimplnxCore/wrapping/python/simplnxpy.cpp
@@ -732,8 +732,7 @@ PYBIND11_MODULE(simplnx, mod)
   parameters.def("insert_linkable_parameter", &PyInsertLinkableParameter<ChoicesParameter>);
   parameters.def("link_parameters", [](Parameters& self, std::string groupKey, std::string childKey, BoolParameter::ValueType value) { self.linkParameters(groupKey, childKey, value); });
   parameters.def("link_parameters", [](Parameters& self, std::string groupKey, std::string childKey, ChoicesParameter::ValueType value) { self.linkParameters(groupKey, childKey, value); });
-  parameters.def(
-      "__getitem__", [](Parameters& self, std::string_view key) { return self.at(key).get(); }, py::return_value_policy::reference_internal);
+  parameters.def("__getitem__", [](Parameters& self, std::string_view key) { return self.at(key).get(); }, py::return_value_policy::reference_internal);
 
   py::class_<IArrayThreshold, std::shared_ptr<IArrayThreshold>> iArrayThreshold(mod, "IArrayThreshold");
 
@@ -1614,12 +1613,10 @@ PYBIND11_MODULE(simplnx, mod)
       "path"_a);
   pipeline.def_property("name", &Pipeline::getName, &Pipeline::setName);
   pipeline.def("execute", &ExecutePipeline);
-  pipeline.def(
-      "__getitem__", [](Pipeline& self, Pipeline::index_type index) { return self.at(index); }, py::return_value_policy::reference_internal);
+  pipeline.def("__getitem__", [](Pipeline& self, Pipeline::index_type index) { return self.at(index); }, py::return_value_policy::reference_internal);
   pipeline.def("__len__", &Pipeline::size);
   pipeline.def("size", &Pipeline::size);
-  pipeline.def(
-      "__iter__", [](Pipeline& self) { return py::make_iterator(self.begin(), self.end()); }, py::keep_alive<0, 1>());
+  pipeline.def("__iter__", [](Pipeline& self) { return py::make_iterator(self.begin(), self.end()); }, py::keep_alive<0, 1>());
   pipeline.def(
       "insert",
       [internals](Pipeline& self, Pipeline::index_type index, const IFilter& filter_, const py::dict& args) {
@@ -1633,10 +1630,8 @@ PYBIND11_MODULE(simplnx, mod)
   pipeline.def("remove", &Pipeline::removeAt, "index"_a);
 
   pipelineFilter.def("get_args", [internals](PipelineFilter& self) { return ConvertArgsToDict(*internals, self.getParameters(), self.getArguments()); });
-  pipelineFilter.def(
-      "set_args", [internals](PipelineFilter& self, py::dict& args) { self.setArguments(ConvertDictToArgs(*internals, self.getParameters(), args)); }, "args"_a);
-  pipelineFilter.def(
-      "get_filter", [](PipelineFilter& self) { return self.getFilter(); }, py::return_value_policy::reference_internal);
+  pipelineFilter.def("set_args", [internals](PipelineFilter& self, py::dict& args) { self.setArguments(ConvertDictToArgs(*internals, self.getParameters(), args)); }, "args"_a);
+  pipelineFilter.def("get_filter", [](PipelineFilter& self) { return self.getFilter(); }, py::return_value_policy::reference_internal);
   pipelineFilter.def(
       "name",
       [](const PipelineFilter& self) {

--- a/src/nxrunner/src/nxrunner.cpp
+++ b/src/nxrunner/src/nxrunner.cpp
@@ -326,8 +326,7 @@ Result<> ExecutePipeline(const Argument& arg)
   }
   if(!loadPipelineResult.m_Warnings.empty())
   {
-    cliOut << "Input Pipeline Warnings"
-           << "\n";
+    cliOut << "Input Pipeline Warnings" << "\n";
     for(const auto& warning : loadPipelineResult.m_Warnings)
     {
       cliOut << fmt::format(" [{}] {}", warning.code, warning.message) << "\n";
@@ -363,8 +362,7 @@ Result<> PreflightPipeline(const Argument& arg)
   }
   if(!loadPipelineResult.m_Warnings.empty())
   {
-    cliOut << "Preflight Pipeline: Input Pipeline Warnings"
-           << "\n";
+    cliOut << "Preflight Pipeline: Input Pipeline Warnings" << "\n";
     for(const auto& warning : loadPipelineResult.m_Warnings)
     {
       cliOut << fmt::format(" [{}] {}", warning.code, warning.message) << "\n";

--- a/src/simplnx/Utilities/GeometryUtilities.cpp
+++ b/src/simplnx/Utilities/GeometryUtilities.cpp
@@ -611,7 +611,7 @@ GeometryUtilities::SliceTriangleReturnType GeometryUtilities::SliceTriangleGeome
         }
       }
     } // END TRIANGLE LOOP
-  }   // END SLICE LOOP
+  } // END SLICE LOOP
 
   return {std::move(slicedVerts), std::move(sliceIds), std::move(regionIds), numberOfSlices};
 }

--- a/src/simplnx/Utilities/NeighborUtilities.hpp
+++ b/src/simplnx/Utilities/NeighborUtilities.hpp
@@ -363,17 +363,13 @@ namespace ImageDimensionalUtilities
 
 template <typename FT>
 concept FrameCellFunction = requires(FT f, int64 x, int64 y, int64 z) {
-                              {
-                                f(x, y, z)
-                                } -> std::same_as<void>;
-                            };
+  { f(x, y, z) } -> std::same_as<void>;
+};
 
 template <typename FT>
 concept FaceCellFunction = requires(FT f, int64 x, int64 y, int64 z, const std::vector<FaceNeighborType>& validNeighbors) {
-                             {
-                               f(x, y, z, validNeighbors)
-                               } -> std::same_as<void>;
-                           };
+  { f(x, y, z, validNeighbors) } -> std::same_as<void>;
+};
 
 /**
  * Process Corners:

--- a/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
+++ b/src/simplnx/Utilities/Parsing/DREAM3D/Dream3dIO.cpp
@@ -139,24 +139,15 @@ void WriteGeomXdmf(std::ostream& out, const ImageGeom& imageGeom, std::string_vi
 
   std::array<int64, 3> volDims = {static_cast<int64>(dims.getX()), static_cast<int64>(dims.getY()), static_cast<int64>(dims.getZ())};
 
-  out << "  <!-- *************** START OF " << name << " *************** -->"
-      << "\n";
-  out << "  <Grid Name=\"" << name << R"(" GridType="Uniform">)"
-      << "\n";
-  out << R"(    <Topology TopologyType="3DCoRectMesh" Dimensions=")" << volDims[2] + 1 << " " << volDims[1] + 1 << " " << volDims[0] + 1 << " \"></Topology>"
-      << "\n";
-  out << "    <Geometry Type=\"ORIGIN_DXDYDZ\">"
-      << "\n";
-  out << "      <!-- Origin  Z, Y, X -->"
-      << "\n";
-  out << R"(      <DataItem Format="XML" Dimensions="3">)" << origin[2] << " " << origin[1] << " " << origin[0] << "</DataItem>"
-      << "\n";
-  out << "      <!-- DxDyDz (Spacing/Spacing) Z, Y, X -->"
-      << "\n";
-  out << R"(      <DataItem Format="XML" Dimensions="3">)" << spacing[2] << " " << spacing[1] << " " << spacing[0] << "</DataItem>"
-      << "\n";
-  out << "    </Geometry>"
-      << "\n";
+  out << "  <!-- *************** START OF " << name << " *************** -->" << "\n";
+  out << "  <Grid Name=\"" << name << R"(" GridType="Uniform">)" << "\n";
+  out << R"(    <Topology TopologyType="3DCoRectMesh" Dimensions=")" << volDims[2] + 1 << " " << volDims[1] + 1 << " " << volDims[0] + 1 << " \"></Topology>" << "\n";
+  out << "    <Geometry Type=\"ORIGIN_DXDYDZ\">" << "\n";
+  out << "      <!-- Origin  Z, Y, X -->" << "\n";
+  out << R"(      <DataItem Format="XML" Dimensions="3">)" << origin[2] << " " << origin[1] << " " << origin[0] << "</DataItem>" << "\n";
+  out << "      <!-- DxDyDz (Spacing/Spacing) Z, Y, X -->" << "\n";
+  out << R"(      <DataItem Format="XML" Dimensions="3">)" << spacing[2] << " " << spacing[1] << " " << spacing[0] << "</DataItem>" << "\n";
+  out << "    </Geometry>" << "\n";
 }
 
 void WriteGeomXdmf(std::ostream& out, const RectGridGeom& rectGridGeom, std::string_view hdf5FilePath)
@@ -177,31 +168,20 @@ void WriteGeomXdmf(std::ostream& out, const RectGridGeom& rectGridGeom, std::str
 
   std::array<int64, 3> volDims = {static_cast<int64>(dims.getX()), static_cast<int64>(dims.getY()), static_cast<int64>(dims.getZ())};
 
-  out << "  <!-- *************** START OF " << name << " *************** -->"
-      << "\n";
-  out << "  <Grid Name=\"" << name << R"(" GridType="Uniform">)"
-      << "\n";
-  out << "    <Topology TopologyType=\"3DRectMesh\" Dimensions=\"" << volDims[2] + 1 << " " << volDims[1] + 1 << " " << volDims[0] + 1 << " \"></Topology>"
-      << "\n";
-  out << "    <Geometry Type=\"VxVyVz\">"
-      << "\n";
-  out << "    <DataItem Format=\"HDF\" Dimensions=\"" << xBounds->getNumberOfTuples() << "\" NumberType=\"Float\" Precision=\"4\">"
-      << "\n";
+  out << "  <!-- *************** START OF " << name << " *************** -->" << "\n";
+  out << "  <Grid Name=\"" << name << R"(" GridType="Uniform">)" << "\n";
+  out << "    <Topology TopologyType=\"3DRectMesh\" Dimensions=\"" << volDims[2] + 1 << " " << volDims[1] + 1 << " " << volDims[0] + 1 << " \"></Topology>" << "\n";
+  out << "    <Geometry Type=\"VxVyVz\">" << "\n";
+  out << "    <DataItem Format=\"HDF\" Dimensions=\"" << xBounds->getNumberOfTuples() << "\" NumberType=\"Float\" Precision=\"4\">" << "\n";
   out << "      " << hdf5FilePath << ":/DataStructure/" << xBoundsPath.toString() << "\n";
-  out << "    </DataItem>"
-      << "\n";
-  out << "    <DataItem Format=\"HDF\" Dimensions=\"" << yBounds->getNumberOfTuples() << "\" NumberType=\"Float\" Precision=\"4\">"
-      << "\n";
+  out << "    </DataItem>" << "\n";
+  out << "    <DataItem Format=\"HDF\" Dimensions=\"" << yBounds->getNumberOfTuples() << "\" NumberType=\"Float\" Precision=\"4\">" << "\n";
   out << "      " << hdf5FilePath << ":/DataStructure/" << yBoundsPath.toString() << "\n";
-  out << "    </DataItem>"
-      << "\n";
-  out << "    <DataItem Format=\"HDF\" Dimensions=\"" << zBounds->getNumberOfTuples() << "\" NumberType=\"Float\" Precision=\"4\">"
-      << "\n";
+  out << "    </DataItem>" << "\n";
+  out << "    <DataItem Format=\"HDF\" Dimensions=\"" << zBounds->getNumberOfTuples() << "\" NumberType=\"Float\" Precision=\"4\">" << "\n";
   out << "      " << hdf5FilePath << ":/DataStructure/" << zBoundsPath.toString() << "\n";
-  out << "    </DataItem>"
-      << "\n";
-  out << "    </Geometry>"
-      << "\n";
+  out << "    </DataItem>" << "\n";
+  out << "    </Geometry>" << "\n";
 }
 
 void WriteGeomXdmf(std::ostream& out, const VertexGeom& vertexGeom, std::string_view hdf5FilePath)
@@ -216,33 +196,21 @@ void WriteGeomXdmf(std::ostream& out, const VertexGeom& vertexGeom, std::string_
 
   DataPath geomPath = vertexGeom.getDataPaths().at(0);
 
-  out << "  <!-- *************** START OF " << name << " *************** -->"
-      << "\n";
-  out << "  <Grid Name=\"" << name << R"(" GridType="Uniform">)"
-      << "\n";
+  out << "  <!-- *************** START OF " << name << " *************** -->" << "\n";
+  out << "  <Grid Name=\"" << name << R"(" GridType="Uniform">)" << "\n";
 
-  out << R"(    <Topology TopologyType="Polyvertex" NumberOfElements=")" << numVerts << "\">"
-      << "\n";
-  out << R"(      <DataItem Format="HDF" NumberType="Int" Dimensions=")" << numVerts << "\">"
-      << "\n";
-  out << "        " << hdf5FilePath << ":/DataStructure/" << geomPath.toString() << "/_VertexIndices"
-      << "\n";
-  out << "      </DataItem>"
-      << "\n";
-  out << "    </Topology>"
-      << "\n";
+  out << R"(    <Topology TopologyType="Polyvertex" NumberOfElements=")" << numVerts << "\">" << "\n";
+  out << R"(      <DataItem Format="HDF" NumberType="Int" Dimensions=")" << numVerts << "\">" << "\n";
+  out << "        " << hdf5FilePath << ":/DataStructure/" << geomPath.toString() << "/_VertexIndices" << "\n";
+  out << "      </DataItem>" << "\n";
+  out << "    </Topology>" << "\n";
 
-  out << "    <Geometry Type=\"XYZ\">"
-      << "\n";
-  out << R"(      <DataItem Format="HDF"  Dimensions=")" << numVerts << R"( 3" NumberType="Float" Precision="4">)"
-      << "\n";
+  out << "    <Geometry Type=\"XYZ\">" << "\n";
+  out << R"(      <DataItem Format="HDF"  Dimensions=")" << numVerts << R"( 3" NumberType="Float" Precision="4">)" << "\n";
   out << "        " << hdf5FilePath << ":/DataStructure/" << verticesPath.toString() << "\n";
-  out << "      </DataItem>"
-      << "\n";
-  out << "    </Geometry>"
-      << "\n";
-  out << ""
-      << "\n";
+  out << "      </DataItem>" << "\n";
+  out << "    </Geometry>" << "\n";
+  out << "" << "\n";
 }
 
 void WriteGeomXdmf(std::ostream& out, const EdgeGeom& edgeGeom, std::string_view hdf5FilePath)
@@ -258,30 +226,19 @@ void WriteGeomXdmf(std::ostream& out, const EdgeGeom& edgeGeom, std::string_view
   DataPath edgesPath = edgeGeom.getEdgesRef().getDataPaths().at(0);
   DataPath verticesPath = edgeGeom.getVerticesRef().getDataPaths().at(0);
 
-  out << "  <!-- *************** START OF " << name << " *************** -->"
-      << "\n";
-  out << "  <Grid Name=\"" << name << "\" GridType=\"Uniform\">"
-      << "\n";
-  out << "    <Topology TopologyType=\"Polyline\" NodesPerElement=\"2\" NumberOfElements=\"" << numEdges << "\">"
-      << "\n";
-  out << "      <DataItem Format=\"HDF\" NumberType=\"Int\" Dimensions=\"" << numEdges << " 2\">"
-      << "\n";
+  out << "  <!-- *************** START OF " << name << " *************** -->" << "\n";
+  out << "  <Grid Name=\"" << name << "\" GridType=\"Uniform\">" << "\n";
+  out << "    <Topology TopologyType=\"Polyline\" NodesPerElement=\"2\" NumberOfElements=\"" << numEdges << "\">" << "\n";
+  out << "      <DataItem Format=\"HDF\" NumberType=\"Int\" Dimensions=\"" << numEdges << " 2\">" << "\n";
   out << "        " << hdf5FilePath << ":/DataStructure/" << edgesPath.toString() << "\n";
-  out << "      </DataItem>"
-      << "\n";
-  out << "    </Topology>"
-      << "\n";
-  out << "    <Geometry Type=\"XYZ\">"
-      << "\n";
-  out << "      <DataItem Format=\"HDF\"  Dimensions=\"" << numVerts << " 3\" NumberType=\"Float\" Precision=\"4\">"
-      << "\n";
+  out << "      </DataItem>" << "\n";
+  out << "    </Topology>" << "\n";
+  out << "    <Geometry Type=\"XYZ\">" << "\n";
+  out << "      <DataItem Format=\"HDF\"  Dimensions=\"" << numVerts << " 3\" NumberType=\"Float\" Precision=\"4\">" << "\n";
   out << "        " << hdf5FilePath << ":/DataStructure/" << verticesPath.toString() << "\n";
-  out << "      </DataItem>"
-      << "\n";
-  out << "    </Geometry>"
-      << "\n";
-  out << ""
-      << "\n";
+  out << "      </DataItem>" << "\n";
+  out << "    </Geometry>" << "\n";
+  out << "" << "\n";
 }
 
 void WriteGeomXdmf(std::ostream& out, const TriangleGeom& triangleGeom, std::string_view hdf5FilePath)
@@ -297,30 +254,19 @@ void WriteGeomXdmf(std::ostream& out, const TriangleGeom& triangleGeom, std::str
   DataPath facesPath = triangleGeom.getFacesRef().getDataPaths().at(0);
   DataPath verticesPath = triangleGeom.getVerticesRef().getDataPaths().at(0);
 
-  out << "  <!-- *************** START OF " << name << " *************** -->"
-      << "\n";
-  out << "  <Grid Name=\"" << name << "\" GridType=\"Uniform\">"
-      << "\n";
-  out << "    <Topology TopologyType=\"Triangle\" NumberOfElements=\"" << numFaces << "\">"
-      << "\n";
-  out << "      <DataItem Format=\"HDF\" NumberType=\"Int\" Dimensions=\"" << numFaces << " 3\">"
-      << "\n";
+  out << "  <!-- *************** START OF " << name << " *************** -->" << "\n";
+  out << "  <Grid Name=\"" << name << "\" GridType=\"Uniform\">" << "\n";
+  out << "    <Topology TopologyType=\"Triangle\" NumberOfElements=\"" << numFaces << "\">" << "\n";
+  out << "      <DataItem Format=\"HDF\" NumberType=\"Int\" Dimensions=\"" << numFaces << " 3\">" << "\n";
   out << "        " << hdf5FilePath << ":/DataStructure/" << facesPath.toString() << "\n";
-  out << "      </DataItem>"
-      << "\n";
-  out << "    </Topology>"
-      << "\n";
-  out << "    <Geometry Type=\"XYZ\">"
-      << "\n";
-  out << "      <DataItem Format=\"HDF\"  Dimensions=\"" << numVerts << " 3\" NumberType=\"Float\" Precision=\"4\">"
-      << "\n";
+  out << "      </DataItem>" << "\n";
+  out << "    </Topology>" << "\n";
+  out << "    <Geometry Type=\"XYZ\">" << "\n";
+  out << "      <DataItem Format=\"HDF\"  Dimensions=\"" << numVerts << " 3\" NumberType=\"Float\" Precision=\"4\">" << "\n";
   out << "        " << hdf5FilePath << ":/DataStructure/" << verticesPath.toString() << "\n";
-  out << "      </DataItem>"
-      << "\n";
-  out << "    </Geometry>"
-      << "\n";
-  out << ""
-      << "\n";
+  out << "      </DataItem>" << "\n";
+  out << "    </Geometry>" << "\n";
+  out << "" << "\n";
 }
 
 void WriteGeomXdmf(std::ostream& out, const QuadGeom& quadGeom, std::string_view hdf5FilePath)
@@ -335,30 +281,19 @@ void WriteGeomXdmf(std::ostream& out, const QuadGeom& quadGeom, std::string_view
   DataPath facesPath = quadGeom.getFacesRef().getDataPaths().at(0);
   DataPath verticesPath = quadGeom.getVerticesRef().getDataPaths().at(0);
 
-  out << "  <!-- *************** START OF " << name << " *************** -->"
-      << "\n";
-  out << "  <Grid Name=\"" << name << "\" GridType=\"Uniform\">"
-      << "\n";
-  out << "    <Topology TopologyType=\"Quadrilateral\" NumberOfElements=\"" << numFaces << "\">"
-      << "\n";
-  out << "      <DataItem Format=\"HDF\" NumberType=\"Int\" Dimensions=\"" << numFaces << " 4\">"
-      << "\n";
+  out << "  <!-- *************** START OF " << name << " *************** -->" << "\n";
+  out << "  <Grid Name=\"" << name << "\" GridType=\"Uniform\">" << "\n";
+  out << "    <Topology TopologyType=\"Quadrilateral\" NumberOfElements=\"" << numFaces << "\">" << "\n";
+  out << "      <DataItem Format=\"HDF\" NumberType=\"Int\" Dimensions=\"" << numFaces << " 4\">" << "\n";
   out << "        " << hdf5FilePath << ":/DataStructure/" << facesPath.toString() << "\n";
-  out << "      </DataItem>"
-      << "\n";
-  out << "    </Topology>"
-      << "\n";
-  out << "    <Geometry Type=\"XYZ\">"
-      << "\n";
-  out << "      <DataItem Format=\"HDF\"  Dimensions=\"" << numVerts << " 3\" NumberType=\"Float\" Precision=\"4\">"
-      << "\n";
+  out << "      </DataItem>" << "\n";
+  out << "    </Topology>" << "\n";
+  out << "    <Geometry Type=\"XYZ\">" << "\n";
+  out << "      <DataItem Format=\"HDF\"  Dimensions=\"" << numVerts << " 3\" NumberType=\"Float\" Precision=\"4\">" << "\n";
   out << "        " << hdf5FilePath << ":/DataStructure/" << verticesPath.toString() << "\n";
-  out << "      </DataItem>"
-      << "\n";
-  out << "    </Geometry>"
-      << "\n";
-  out << ""
-      << "\n";
+  out << "      </DataItem>" << "\n";
+  out << "    </Geometry>" << "\n";
+  out << "" << "\n";
 }
 
 void WriteGeomXdmf(std::ostream& out, const TetrahedralGeom& tetrahedralGeom, std::string_view hdf5FilePath)
@@ -373,30 +308,19 @@ void WriteGeomXdmf(std::ostream& out, const TetrahedralGeom& tetrahedralGeom, st
   DataPath polyhedraPath = tetrahedralGeom.getPolyhedraRef().getDataPaths().at(0);
   DataPath verticesPath = tetrahedralGeom.getVerticesRef().getDataPaths().at(0);
 
-  out << "  <!-- *************** START OF " << name << " *************** -->"
-      << "\n";
-  out << "  <Grid Name=\"" << name << "\" GridType=\"Uniform\">"
-      << "\n";
-  out << "    <Topology TopologyType=\"Tetrahedron\" NumberOfElements=\"" << numPolyhedra << "\">"
-      << "\n";
-  out << "      <DataItem Format=\"HDF\" NumberType=\"Int\" Dimensions=\"" << numPolyhedra << " 4\">"
-      << "\n";
+  out << "  <!-- *************** START OF " << name << " *************** -->" << "\n";
+  out << "  <Grid Name=\"" << name << "\" GridType=\"Uniform\">" << "\n";
+  out << "    <Topology TopologyType=\"Tetrahedron\" NumberOfElements=\"" << numPolyhedra << "\">" << "\n";
+  out << "      <DataItem Format=\"HDF\" NumberType=\"Int\" Dimensions=\"" << numPolyhedra << " 4\">" << "\n";
   out << "        " << hdf5FilePath << ":/DataStructure/" << polyhedraPath.toString() << "\n";
-  out << "      </DataItem>"
-      << "\n";
-  out << "    </Topology>"
-      << "\n";
-  out << "    <Geometry Type=\"XYZ\">"
-      << "\n";
-  out << "      <DataItem Format=\"HDF\"  Dimensions=\"" << numVerts << " 3\" NumberType=\"Float\" Precision=\"4\">"
-      << "\n";
+  out << "      </DataItem>" << "\n";
+  out << "    </Topology>" << "\n";
+  out << "    <Geometry Type=\"XYZ\">" << "\n";
+  out << "      <DataItem Format=\"HDF\"  Dimensions=\"" << numVerts << " 3\" NumberType=\"Float\" Precision=\"4\">" << "\n";
   out << "        " << hdf5FilePath << ":/DataStructure/" << verticesPath.toString() << "\n";
-  out << "      </DataItem>"
-      << "\n";
-  out << "    </Geometry>"
-      << "\n";
-  out << ""
-      << "\n";
+  out << "      </DataItem>" << "\n";
+  out << "    </Geometry>" << "\n";
+  out << "" << "\n";
 }
 
 void WriteGeomXdmf(std::ostream& out, const HexahedralGeom& hexhedralGeom, std::string_view hdf5FilePath)
@@ -411,50 +335,33 @@ void WriteGeomXdmf(std::ostream& out, const HexahedralGeom& hexhedralGeom, std::
   DataPath polyhedraPath = hexhedralGeom.getPolyhedraRef().getDataPaths().at(0);
   DataPath verticesPath = hexhedralGeom.getVerticesRef().getDataPaths().at(0);
 
-  out << "  <!-- *************** START OF " << name << " *************** -->"
-      << "\n";
-  out << "  <Grid Name=\"" << name << "\" GridType=\"Uniform\">"
-      << "\n";
-  out << "    <Topology TopologyType=\"Hexahedron\" NumberOfElements=\"" << numPolyhedra << "\">"
-      << "\n";
-  out << "      <DataItem Format=\"HDF\" NumberType=\"Int\" Dimensions=\"" << numPolyhedra << " 8\">"
-      << "\n";
+  out << "  <!-- *************** START OF " << name << " *************** -->" << "\n";
+  out << "  <Grid Name=\"" << name << "\" GridType=\"Uniform\">" << "\n";
+  out << "    <Topology TopologyType=\"Hexahedron\" NumberOfElements=\"" << numPolyhedra << "\">" << "\n";
+  out << "      <DataItem Format=\"HDF\" NumberType=\"Int\" Dimensions=\"" << numPolyhedra << " 8\">" << "\n";
   out << "        " << hdf5FilePath << ":/DataStructure/" << polyhedraPath.toString() << "\n";
-  out << "      </DataItem>"
-      << "\n";
-  out << "    </Topology>"
-      << "\n";
-  out << "    <Geometry Type=\"XYZ\">"
-      << "\n";
-  out << "      <DataItem Format=\"HDF\"  Dimensions=\"" << numVerts << " 3\" NumberType=\"Float\" Precision=\"4\">"
-      << "\n";
+  out << "      </DataItem>" << "\n";
+  out << "    </Topology>" << "\n";
+  out << "    <Geometry Type=\"XYZ\">" << "\n";
+  out << "      <DataItem Format=\"HDF\"  Dimensions=\"" << numVerts << " 3\" NumberType=\"Float\" Precision=\"4\">" << "\n";
   out << "        " << hdf5FilePath << ":/DataStructure/" << verticesPath.toString() << "\n";
-  out << "      </DataItem>"
-      << "\n";
-  out << "    </Geometry>"
-      << "\n";
-  out << ""
-      << "\n";
+  out << "      </DataItem>" << "\n";
+  out << "    </Geometry>" << "\n";
+  out << "" << "\n";
 }
 
 void WriteXdmfHeader(std::ostream& out)
 {
-  out << "<?xml version=\"1.0\"?>"
-      << "\n";
-  out << "<!DOCTYPE Xdmf SYSTEM \"Xdmf.dtd\"[]>"
-      << "\n";
-  out << "<Xdmf xmlns:xi=\"http://www.w3.org/2003/XInclude\" Version=\"2.2\">"
-      << "\n";
-  out << " <Domain>"
-      << "\n";
+  out << "<?xml version=\"1.0\"?>" << "\n";
+  out << "<!DOCTYPE Xdmf SYSTEM \"Xdmf.dtd\"[]>" << "\n";
+  out << "<Xdmf xmlns:xi=\"http://www.w3.org/2003/XInclude\" Version=\"2.2\">" << "\n";
+  out << " <Domain>" << "\n";
 }
 
 void WriteXdmfFooter(std::ostream& xdmf)
 {
-  xdmf << " </Domain>"
-       << "\n";
-  xdmf << "</Xdmf>"
-       << "\n";
+  xdmf << " </Domain>" << "\n";
+  xdmf << "</Xdmf>" << "\n";
 }
 
 std::string GetXdmfArrayType(usize numComp)
@@ -502,18 +409,13 @@ void WriteXdmfAttributeDataHelper(std::ostream& out, usize numComp, std::string_
   {
     out << "    <Attribute Name=\"" << arrayName << "\" ";
     out << "AttributeType=\"" << attrType << "\" ";
-    out << "Center=\"" << centering << "\">"
-        << "\n";
+    out << "Center=\"" << centering << "\">" << "\n";
     // Open the <DataItem> Tag
     out << R"(      <DataItem Format="HDF" Dimensions=")" << dimStr << "\" ";
-    out << "NumberType=\"" << xdmfTypeName << "\" "
-        << "Precision=\"" << precision << "\" >"
-        << "\n";
+    out << "NumberType=\"" << xdmfTypeName << "\" " << "Precision=\"" << precision << "\" >" << "\n";
     out << "        " << hdf5DatasetPath << "\n";
-    out << "      </DataItem>"
-        << "\n";
-    out << "    </Attribute>"
-        << "\n";
+    out << "      </DataItem>" << "\n";
+    out << "    </Attribute>" << "\n";
   }
   else if(numComp == 2 || numComp == 6)
   {
@@ -521,77 +423,48 @@ void WriteXdmfAttributeDataHelper(std::ostream& out, usize numComp, std::string_
     out << "    <Attribute Name=\"" << arrayName << " (Feature 0)\" ";
     out << "AttributeType=\"" << attrType << "\" ";
 
-    out << "Center=\"" << centering << "\">"
-        << "\n";
+    out << "Center=\"" << centering << "\">" << "\n";
     // Open the <DataItem> Tag
     out << R"(      <DataItem ItemType="HyperSlab" Dimensions=")" << dimStrHalf << "\" ";
-    out << "Type=\"HyperSlab\" "
-        << "Name=\"" << arrayName << " (Feature 0)\" >"
-        << "\n";
-    out << "        <DataItem Dimensions=\"3 2\" "
-        << "Format=\"XML\" >"
-        << "\n";
-    out << "          0        0"
-        << "\n";
-    out << "          1        1"
-        << "\n";
-    out << "          " << dimStrHalf << " </DataItem>"
-        << "\n";
+    out << "Type=\"HyperSlab\" " << "Name=\"" << arrayName << " (Feature 0)\" >" << "\n";
+    out << "        <DataItem Dimensions=\"3 2\" " << "Format=\"XML\" >" << "\n";
+    out << "          0        0" << "\n";
+    out << "          1        1" << "\n";
+    out << "          " << dimStrHalf << " </DataItem>" << "\n";
     out << "\n";
-    out << R"(        <DataItem Format="HDF" Dimensions=")" << dimStr << "\" "
-        << "NumberType=\"" << xdmfTypeName << "\" "
-        << "Precision=\"" << precision << "\" >"
-        << "\n";
+    out << R"(        <DataItem Format="HDF" Dimensions=")" << dimStr << "\" " << "NumberType=\"" << xdmfTypeName << "\" " << "Precision=\"" << precision << "\" >" << "\n";
 
     out << "        " << hdf5DatasetPath << "\n";
-    out << "        </DataItem>"
-        << "\n";
-    out << "      </DataItem>"
-        << "\n";
-    out << "    </Attribute>"
-        << "\n"
+    out << "        </DataItem>" << "\n";
+    out << "      </DataItem>" << "\n";
+    out << "    </Attribute>" << "\n"
         << "\n";
 
     // Second Slab
     out << "    <Attribute Name=\"" << arrayName << " (Feature 1)\" ";
     out << "AttributeType=\"" << attrType << "\" ";
 
-    out << "Center=\"" << centering << "\">"
-        << "\n";
+    out << "Center=\"" << centering << "\">" << "\n";
     // Open the <DataItem> Tag
     out << R"(      <DataItem ItemType="HyperSlab" Dimensions=")" << dimStrHalf << "\" ";
-    out << "Type=\"HyperSlab\" "
-        << "Name=\"" << arrayName << " (Feature 1)\" >"
-        << "\n";
-    out << "        <DataItem Dimensions=\"3 2\" "
-        << "Format=\"XML\" >"
-        << "\n";
+    out << "Type=\"HyperSlab\" " << "Name=\"" << arrayName << " (Feature 1)\" >" << "\n";
+    out << "        <DataItem Dimensions=\"3 2\" " << "Format=\"XML\" >" << "\n";
     out << "          0        " << (numComp / 2) << "\n";
-    out << "          1        1"
-        << "\n";
-    out << "          " << dimStrHalf << " </DataItem>"
-        << "\n";
+    out << "          1        1" << "\n";
+    out << "          " << dimStrHalf << " </DataItem>" << "\n";
     out << "\n";
-    out << R"(        <DataItem Format="HDF" Dimensions=")" << dimStr << "\" "
-        << "NumberType=\"" << xdmfTypeName << "\" "
-        << "Precision=\"" << precision << "\" >"
-        << "\n";
+    out << R"(        <DataItem Format="HDF" Dimensions=")" << dimStr << "\" " << "NumberType=\"" << xdmfTypeName << "\" " << "Precision=\"" << precision << "\" >" << "\n";
     out << "        " << hdf5DatasetPath << "\n";
-    out << "        </DataItem>"
-        << "\n";
-    out << "      </DataItem>"
-        << "\n";
-    out << "    </Attribute>"
-        << "\n";
+    out << "        </DataItem>" << "\n";
+    out << "      </DataItem>" << "\n";
+    out << "    </Attribute>" << "\n";
   }
 }
 
 void WriteXdmfGeomFooter(std::ostream& xdmf, std::string_view geomName)
 {
-  xdmf << "  </Grid>"
-       << "\n";
-  xdmf << "  <!-- *************** END OF " << geomName << " *************** -->"
-       << "\n";
+  xdmf << "  </Grid>" << "\n";
+  xdmf << "  <!-- *************** END OF " << geomName << " *************** -->" << "\n";
 }
 
 void WriteXdmfAttributeMatrix(std::ostream& out, const AttributeMatrix& attributeMatrix, std::string_view geomName, std::string_view hdf5FilePath, std::string_view centering)

--- a/src/simplnx/Utilities/Parsing/HDF5/H5Support.hpp
+++ b/src/simplnx/Utilities/Parsing/HDF5/H5Support.hpp
@@ -39,8 +39,7 @@
   error = H5Aclose(attributeId);                                                                                                                                                                       \
   if(error < 0)                                                                                                                                                                                        \
   {                                                                                                                                                                                                    \
-    std::cout << "File: " << __FILE__ << "(" << __LINE__ << "): "                                                                                                                                      \
-              << "Error Closing Attribute." << std::endl;                                                                                                                                              \
+    std::cout << "File: " << __FILE__ << "(" << __LINE__ << "): " << "Error Closing Attribute." << std::endl;                                                                                          \
     returnError = MakeErrorResult(error, "Error Closing Attribute");                                                                                                                                   \
   }
 
@@ -48,8 +47,7 @@
   error = H5Sclose(dataspaceId);                                                                                                                                                                       \
   if(error < 0)                                                                                                                                                                                        \
   {                                                                                                                                                                                                    \
-    std::cout << "File: " << __FILE__ << "(" << __LINE__ << "): "                                                                                                                                      \
-              << "Error closing Dataspace." << std::endl;                                                                                                                                              \
+    std::cout << "File: " << __FILE__ << "(" << __LINE__ << "): " << "Error closing Dataspace." << std::endl;                                                                                          \
     returnError = MakeErrorResult(error, "Error Closing Dataspace");                                                                                                                                   \
   }
 
@@ -57,8 +55,7 @@
   error = H5Tclose(typeId);                                                                                                                                                                            \
   if(error < 0)                                                                                                                                                                                        \
   {                                                                                                                                                                                                    \
-    std::cout << "File: " << __FILE__ << "(" << __LINE__ << "): "                                                                                                                                      \
-              << "Error closing DataType" << std::endl;                                                                                                                                                \
+    std::cout << "File: " << __FILE__ << "(" << __LINE__ << "): " << "Error closing DataType" << std::endl;                                                                                            \
     returnError = MakeErrorResult(error, "Error closing DataType");                                                                                                                                    \
   }
 
@@ -66,8 +63,7 @@
   error = H5Dclose(datasetId);                                                                                                                                                                         \
   if(error < 0)                                                                                                                                                                                        \
   {                                                                                                                                                                                                    \
-    std::cout << "File: " << __FILE__ << "(" << __LINE__ << "): "                                                                                                                                      \
-              << "Error Closing Dataset: " << datasetName << " datasetId=" << datasetId << " retError=" << returnError << std::endl;                                                                   \
+    std::cout << "File: " << __FILE__ << "(" << __LINE__ << "): " << "Error Closing Dataset: " << datasetName << " datasetId=" << datasetId << " retError=" << returnError << std::endl;               \
     returnError = error;                                                                                                                                                                               \
   }
 

--- a/wrapping/python/docs/generate_sphinx_docs.cpp
+++ b/wrapping/python/docs/generate_sphinx_docs.cpp
@@ -664,10 +664,8 @@ void GeneratePythonRstFiles()
       return;
     }
 
-    rstStream << plugName << " Filter API"
-              << "\n";
-    rstStream << GenerateUnderline(plugName.size(), '=') << "============="
-              << "\n\n";
+    rstStream << plugName << " Filter API" << "\n";
+    rstStream << GenerateUnderline(plugName.size(), '=') << "=============" << "\n\n";
 
     rstStream << "   This is the documentation for all filters included in the " << plugName << " module. These filters can"
               << " be used by importing the appropriate module. Each filter is contained in the module:\n\n"


### PR DESCRIPTION
Updated clang-format to `18.1.3` on the GitHub actions runner using Ubuntu 24.04. Local clang-format should also be updated to be *exactly* `18.1.3`.