### PR TITLE
BUG: Fixed stack-use-after-return asan issue with ReadStlFileTest

### DIFF
--- a/src/Plugins/SimplnxCore/test/ReadStlFileTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ReadStlFileTest.cpp
@@ -283,7 +283,7 @@ TEST_CASE("SimplnxCore::ReadStlFileFilter:NonConformingAttributeByteCount", "[Si
   const std::string k_VxElementsHeader = "Exported by VXelements";
   const std::string k_AnonymousHeader = "Written by some CAD package that nobody has heard of";
 
-  auto headerText = GENERATE_COPY(k_MagicsHeader, k_VxElementsHeader, k_AnonymousHeader);
+  auto headerText = GENERATE_COPY(as<std::string>{}, k_MagicsHeader, k_VxElementsHeader, k_AnonymousHeader);
 
   DYNAMIC_SECTION("Header: '" << headerText << "'")
   {


### PR DESCRIPTION
* `GENERATE_COPY` deduced the variables as `const std::string&` instead of `std::string` which caused a lifetime issue
* For future reference other solutions that would also work here:
  * Making the constants `static`
  * Avoiding variables entirely and using string literals directly