### PR TITLE
COMP: Fix clang implicit conversion warnings in parameter conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,7 @@ set(SIMPLNX_HDRS
   ${SIMPLNX_SOURCE_DIR}/Common/Filesystem.hpp
   ${SIMPLNX_SOURCE_DIR}/Common/IteratorUtility.hpp
   ${SIMPLNX_SOURCE_DIR}/Common/Numbers.hpp
+  ${SIMPLNX_SOURCE_DIR}/Common/NumericBounds.hpp
   ${SIMPLNX_SOURCE_DIR}/Common/Range.hpp
   ${SIMPLNX_SOURCE_DIR}/Common/Range2D.hpp
   ${SIMPLNX_SOURCE_DIR}/Common/Range3D.hpp

--- a/src/Plugins/SimplnxCore/test/WriteBinaryDataTest.cpp
+++ b/src/Plugins/SimplnxCore/test/WriteBinaryDataTest.cpp
@@ -120,52 +120,52 @@ private:
 
   void setMemb()
   {
-    if(std::is_same<T, int8>::value)
+    if constexpr(std::is_same_v<T, int8>)
     {
       m_ExemplarsPath = fs::path(fmt::format("{}/export_files_test/write_binary_data_exemplars/{}", unit_test::k_TestFilesDir.view(), "int8"));
       setFillValue(-65, -63, -61);
     }
-    else if(std::is_same<T, int16>::value)
+    else if constexpr(std::is_same_v<T, int16>)
     {
       m_ExemplarsPath = fs::path(fmt::format("{}/export_files_test/write_binary_data_exemplars/{}", unit_test::k_TestFilesDir.view(), "int16"));
       setFillValue(-650, -648, -646);
     }
-    else if(std::is_same<T, int32>::value)
+    else if constexpr(std::is_same_v<T, int32>)
     {
       m_ExemplarsPath = fs::path(fmt::format("{}/export_files_test/write_binary_data_exemplars/{}", unit_test::k_TestFilesDir.view(), "int32"));
       setFillValue(-6500, -6498, -6496);
     }
-    else if(std::is_same<T, int64>::value)
+    else if constexpr(std::is_same_v<T, int64>)
     {
       m_ExemplarsPath = fs::path(fmt::format("{}/export_files_test/write_binary_data_exemplars/{}", unit_test::k_TestFilesDir.view(), "int64"));
       setFillValue(-65000, -64998, -64996);
     }
-    else if(std::is_same<T, uint8>::value)
+    else if constexpr(std::is_same_v<T, uint8>)
     {
       m_ExemplarsPath = fs::path(fmt::format("{}/export_files_test/write_binary_data_exemplars/{}", unit_test::k_TestFilesDir.view(), "uint8"));
       setFillValue(65, 67, 69);
     }
-    else if(std::is_same<T, uint16>::value)
+    else if constexpr(std::is_same_v<T, uint16>)
     {
       m_ExemplarsPath = fs::path(fmt::format("{}/export_files_test/write_binary_data_exemplars/{}", unit_test::k_TestFilesDir.view(), "uint16"));
       setFillValue(650, 652, 654);
     }
-    else if(std::is_same<T, uint32>::value)
+    else if constexpr(std::is_same_v<T, uint32>)
     {
       m_ExemplarsPath = fs::path(fmt::format("{}/export_files_test/write_binary_data_exemplars/{}", unit_test::k_TestFilesDir.view(), "uint32"));
       setFillValue(6500, 6502, 6504);
     }
-    else if(std::is_same<T, uint64>::value)
+    else if constexpr(std::is_same_v<T, uint64>)
     {
       m_ExemplarsPath = fs::path(fmt::format("{}/export_files_test/write_binary_data_exemplars/{}", unit_test::k_TestFilesDir.view(), "uint64"));
       setFillValue(65000, 65002, 65004);
     }
-    else if(std::is_same<T, float32>::value)
+    else if constexpr(std::is_same_v<T, float32>)
     {
       m_ExemplarsPath = fs::path(fmt::format("{}/export_files_test/write_binary_data_exemplars/{}", unit_test::k_TestFilesDir.view(), "float32"));
       setFillValue(65.001, 67.001, 69.001);
     }
-    else if(std::is_same<T, float64>::value)
+    else if constexpr(std::is_same_v<T, float64>)
     {
       m_ExemplarsPath = fs::path(fmt::format("{}/export_files_test/write_binary_data_exemplars/{}", unit_test::k_TestFilesDir.view(), "float64"));
       setFillValue(65.000001, 67.000001, 69.000001);

--- a/src/simplnx/Common/NumericBounds.hpp
+++ b/src/simplnx/Common/NumericBounds.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <limits>
 #include <type_traits>
 
@@ -16,10 +17,9 @@ namespace detail
  * @param exponent The power of two to compute. Must be non-negative and within the exponent range of FloatT.
  * @return 2^exponent
  */
-template <class FloatT>
+template <std::floating_point FloatT>
 constexpr FloatT PowerOfTwo(int exponent)
 {
-  static_assert(std::is_floating_point_v<FloatT>, "PowerOfTwo requires a floating point type");
   FloatT result = 1;
   for(int i = 0; i < exponent; i++)
   {

--- a/src/simplnx/Common/NumericBounds.hpp
+++ b/src/simplnx/Common/NumericBounds.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <limits>
+#include <type_traits>
+
+namespace nx::core
+{
+namespace detail
+{
+/**
+ * @brief Computes 2^exponent as a floating point value at compile time.
+ *
+ * Every power of two within the exponent range of FloatT is exactly representable, so repeated
+ * doubling introduces no rounding error.
+ * @tparam FloatT The floating point type to compute the value in
+ * @param exponent The power of two to compute. Must be non-negative and within the exponent range of FloatT.
+ * @return 2^exponent
+ */
+template <class FloatT>
+constexpr FloatT PowerOfTwo(int exponent)
+{
+  static_assert(std::is_floating_point_v<FloatT>, "PowerOfTwo requires a floating point type");
+  FloatT result = 1;
+  for(int i = 0; i < exponent; i++)
+  {
+    result *= 2;
+  }
+  return result;
+}
+} // namespace detail
+
+/**
+ * @brief Returns true if `value` is larger than the largest value that T can represent.
+ *
+ * Comparing a floating point value directly against std::numeric_limits<T>::max() is incorrect for
+ * the 64 bit integer types. Their maximum is not exactly representable as a float64, so the
+ * implicit conversion rounds the bound *up* to 2^63 / 2^64. That both widens the accepted range by
+ * one ulp and trips clang's -Wimplicit-const-int-float-conversion. Compare against 2^digits
+ * instead: it is exactly representable, and because it is one past the largest integer T can hold,
+ * an inclusive comparison against it is exact. Any float64 strictly below 2^digits truncates to a
+ * value that T can hold.
+ *
+ * @tparam T The destination type whose maximum is the bound
+ * @tparam U The type of the value being checked
+ * @param value The value to test against the maximum of T
+ * @return true if converting `value` to T would overflow
+ */
+template <class T, class U>
+constexpr bool ExceedsMaxOf(U value)
+{
+  if constexpr(std::is_integral_v<T> && std::is_floating_point_v<U>)
+  {
+    return value >= detail::PowerOfTwo<U>(std::numeric_limits<T>::digits);
+  }
+  else
+  {
+    return value > std::numeric_limits<T>::max();
+  }
+}
+
+/**
+ * @brief Returns true if `value` is smaller than the smallest value that T can represent.
+ *
+ * See ExceedsMaxOf() for why the floating point comparison against an integer bound is written as a
+ * power of two. The lowest value of a signed integer type is -2^digits, which is exactly
+ * representable, so that comparison needs no adjustment beyond making the conversion explicit.
+ *
+ * @tparam T The destination type whose lowest value is the bound
+ * @tparam U The type of the value being checked
+ * @param value The value to test against the lowest value of T
+ * @return true if converting `value` to T would underflow
+ */
+template <class T, class U>
+constexpr bool ExceedsLowestOf(U value)
+{
+  if constexpr(std::is_integral_v<T> && std::is_floating_point_v<U>)
+  {
+    if constexpr(std::is_signed_v<T>)
+    {
+      return value < -detail::PowerOfTwo<U>(std::numeric_limits<T>::digits);
+    }
+    else
+    {
+      return value < U{0};
+    }
+  }
+  else
+  {
+    return value < std::numeric_limits<T>::lowest();
+  }
+}
+} // namespace nx::core

--- a/src/simplnx/Parameters/NumberParameter.cpp
+++ b/src/simplnx/Parameters/NumberParameter.cpp
@@ -1,5 +1,6 @@
 #include "NumberParameter.hpp"
 
+#include "simplnx/Common/NumericBounds.hpp"
 #include "simplnx/Common/StringLiteralFormatting.hpp"
 
 #include <fmt/core.h>
@@ -136,18 +137,18 @@ Result<typename IntFilterParameterConverter<T>::ValueType> IntFilterParameterCon
       {
         return {static_cast<T>(0)};
       }
-      if(tmp > std::numeric_limits<T>::max())
+      if(ExceedsMaxOf<T>(tmp))
       {
         return MakeErrorResult<ValueType>(-1, fmt::format("IntFilterParameter: value will overflow when converting to expected type. json '{}'", json.dump()));
       }
     }
     else
     {
-      if(tmp < std::numeric_limits<T>::lowest())
+      if(ExceedsLowestOf<T>(tmp))
       {
         return MakeErrorResult<ValueType>(-1, fmt::format("IntFilterParameter: value will underflow when converting to expected type. json '{}'", json.dump()));
       }
-      if(tmp > std::numeric_limits<T>::max())
+      if(ExceedsMaxOf<T>(tmp))
       {
         return MakeErrorResult<ValueType>(-1, fmt::format("IntFilterParameter: value will overflow when converting to expected type. json '{}'", json.dump()));
       }

--- a/src/simplnx/Parameters/VectorParameter.cpp
+++ b/src/simplnx/Parameters/VectorParameter.cpp
@@ -1,6 +1,7 @@
 #include "VectorParameter.hpp"
 
 #include "simplnx/Common/Any.hpp"
+#include "simplnx/Common/NumericBounds.hpp"
 #include "simplnx/Common/StringLiteralFormatting.hpp"
 #include "simplnx/Common/TypeTraits.hpp"
 
@@ -180,9 +181,6 @@ ConversionState ConversionChecks(TempT temp)
     return Clear;
   }
 
-  constexpr ExpectedT lowerBound = std::numeric_limits<ExpectedT>::lowest();
-  constexpr ExpectedT upperBound = std::numeric_limits<ExpectedT>::max();
-
   // uint8/16/32/64 <- float32/64, int8/16/32/64
   if constexpr(!std::is_floating_point_v<ExpectedT> && std::is_unsigned_v<ExpectedT> && std::is_signed_v<TempT>)
   {
@@ -194,7 +192,7 @@ ConversionState ConversionChecks(TempT temp)
   // int8/16/32/64, float32/64 <- int8/16/32/64, float32/64
   else if constexpr(!std::is_unsigned_v<TempT>)
   {
-    if(temp < lowerBound)
+    if(ExceedsLowestOf<ExpectedT>(temp))
     {
       return Underflow;
     }
@@ -202,7 +200,7 @@ ConversionState ConversionChecks(TempT temp)
   // int8/16/32/64 <- uint8/16/32/64
   // Can't underflow by definition
 
-  if(temp > upperBound)
+  if(ExceedsMaxOf<ExpectedT>(temp))
   {
     return Overflow;
   }

--- a/test/SimplJsonConversionTest.cpp
+++ b/test/SimplJsonConversionTest.cpp
@@ -67,16 +67,18 @@ constexpr float64 k_TwoToThe64 = 18446744073709551616.0;
 
 TEST_CASE("nx::core::SIMPL Json Conversion 64 Bit Integer Bounds", "[simplnx][Parameters]")
 {
-  // The bound helpers themselves
-  static_assert(ExceedsMaxOf<int64>(k_TwoToThe63));
-  static_assert(!ExceedsMaxOf<int64>(k_LargestInt64Double));
-  static_assert(ExceedsMaxOf<uint64>(k_TwoToThe64));
-  static_assert(!ExceedsMaxOf<uint64>(k_LargestUInt64Double));
-  static_assert(ExceedsLowestOf<int64>(-k_TwoToThe63 * 2.0));
-  static_assert(!ExceedsLowestOf<int64>(-k_TwoToThe63));
-  static_assert(ExceedsLowestOf<uint64>(-1.0));
-  static_assert(!ExceedsMaxOf<int32>(static_cast<float64>(std::numeric_limits<int32>::max())));
-  static_assert(ExceedsMaxOf<int32>(static_cast<float64>(std::numeric_limits<int32>::max()) + 1.0));
+  SECTION("The bound helpers themselves")
+  {
+    STATIC_REQUIRE(ExceedsMaxOf<int64>(k_TwoToThe63));
+    STATIC_REQUIRE_FALSE(ExceedsMaxOf<int64>(k_LargestInt64Double));
+    STATIC_REQUIRE(ExceedsMaxOf<uint64>(k_TwoToThe64));
+    STATIC_REQUIRE_FALSE(ExceedsMaxOf<uint64>(k_LargestUInt64Double));
+    STATIC_REQUIRE(ExceedsLowestOf<int64>(-k_TwoToThe63 * 2.0));
+    STATIC_REQUIRE_FALSE(ExceedsLowestOf<int64>(-k_TwoToThe63));
+    STATIC_REQUIRE(ExceedsLowestOf<uint64>(-1.0));
+    STATIC_REQUIRE_FALSE(ExceedsMaxOf<int32>(static_cast<float64>(std::numeric_limits<int32>::max())));
+    STATIC_REQUIRE(ExceedsMaxOf<int32>(static_cast<float64>(std::numeric_limits<int32>::max()) + 1.0));
+  }
 
   SECTION("IntFilterParameterConverter rejects a float64 that overflows the target type")
   {

--- a/test/SimplJsonConversionTest.cpp
+++ b/test/SimplJsonConversionTest.cpp
@@ -1,14 +1,20 @@
 #include <catch2/catch.hpp>
 
+#include "simplnx/Common/NumericBounds.hpp"
 #include "simplnx/Core/Application.hpp"
 #include "simplnx/DataStructure/DataStructure.hpp"
 #include "simplnx/Filter/IFilter.hpp"
+#include "simplnx/Parameters/NumberParameter.hpp"
+#include "simplnx/Parameters/VectorParameter.hpp"
 #include "simplnx/Pipeline/Pipeline.hpp"
 #include "simplnx/Pipeline/PipelineFilter.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 #include "simplnx/unit_test/simplnx_test_dirs.hpp"
 
+#include <nlohmann/json.hpp>
+
 #include <filesystem>
+#include <limits>
 #include <map>
 
 using namespace nx::core;
@@ -42,5 +48,72 @@ TEST_CASE("nx::core::Test SIMPL Json Conversion", "[simplnx][Filter]")
         fmt::print("{}::{}    SIMPL UUID FILE DOES NOT EXIST: {}\n", plugin->getName(), filter->className(), simplJsonFilePath.string());
       }
     }
+  }
+}
+
+namespace
+{
+// The largest float64 that is strictly less than 2^63 and 2^64 respectively. Both round-trip
+// through the corresponding integer type without overflowing.
+constexpr float64 k_LargestInt64Double = 9223372036854774784.0;
+constexpr float64 k_LargestUInt64Double = 18446744073709549568.0;
+
+// 2^63 and 2^64. These are the first float64 values that do *not* fit in int64 / uint64. Because
+// std::numeric_limits<int64>::max() rounds up to exactly 2^63 when converted to a float64, a naive
+// `value > max()` range check accepts these and then invokes undefined behavior in the cast.
+constexpr float64 k_TwoToThe63 = 9223372036854775808.0;
+constexpr float64 k_TwoToThe64 = 18446744073709551616.0;
+} // namespace
+
+TEST_CASE("nx::core::SIMPL Json Conversion 64 Bit Integer Bounds", "[simplnx][Parameters]")
+{
+  // The bound helpers themselves
+  static_assert(ExceedsMaxOf<int64>(k_TwoToThe63));
+  static_assert(!ExceedsMaxOf<int64>(k_LargestInt64Double));
+  static_assert(ExceedsMaxOf<uint64>(k_TwoToThe64));
+  static_assert(!ExceedsMaxOf<uint64>(k_LargestUInt64Double));
+  static_assert(ExceedsLowestOf<int64>(-k_TwoToThe63 * 2.0));
+  static_assert(!ExceedsLowestOf<int64>(-k_TwoToThe63));
+  static_assert(ExceedsLowestOf<uint64>(-1.0));
+  static_assert(!ExceedsMaxOf<int32>(static_cast<float64>(std::numeric_limits<int32>::max())));
+  static_assert(ExceedsMaxOf<int32>(static_cast<float64>(std::numeric_limits<int32>::max()) + 1.0));
+
+  SECTION("IntFilterParameterConverter rejects a float64 that overflows the target type")
+  {
+    Result<int64> int64Result = SIMPLConversion::IntFilterParameterConverter<int64>::convert(nlohmann::json(k_TwoToThe63));
+    SIMPLNX_RESULT_REQUIRE_INVALID(int64Result);
+
+    Result<uint64> uint64Result = SIMPLConversion::IntFilterParameterConverter<uint64>::convert(nlohmann::json(k_TwoToThe64));
+    SIMPLNX_RESULT_REQUIRE_INVALID(uint64Result);
+  }
+
+  SECTION("IntFilterParameterConverter accepts a float64 at the edge of the target type")
+  {
+    Result<int64> int64Result = SIMPLConversion::IntFilterParameterConverter<int64>::convert(nlohmann::json(k_LargestInt64Double));
+    SIMPLNX_RESULT_REQUIRE_VALID(int64Result);
+    REQUIRE(int64Result.value() == static_cast<int64>(k_LargestInt64Double));
+
+    Result<uint64> uint64Result = SIMPLConversion::IntFilterParameterConverter<uint64>::convert(nlohmann::json(k_LargestUInt64Double));
+    SIMPLNX_RESULT_REQUIRE_VALID(uint64Result);
+    REQUIRE(uint64Result.value() == static_cast<uint64>(k_LargestUInt64Double));
+  }
+
+  SECTION("Vec3FilterParameterConverter rejects a float64 that overflows the target type")
+  {
+    nlohmann::json overflowJson = {{"x", 0.0}, {"y", 0.0}, {"z", k_TwoToThe63}};
+    Result<std::vector<int64>> int64Result = SIMPLConversion::Vec3FilterParameterConverter<int64>::convert(overflowJson);
+    SIMPLNX_RESULT_REQUIRE_INVALID(int64Result);
+
+    nlohmann::json unsignedOverflowJson = {{"x", 0.0}, {"y", 0.0}, {"z", k_TwoToThe64}};
+    Result<std::vector<uint64>> uint64Result = SIMPLConversion::Vec3FilterParameterConverter<uint64>::convert(unsignedOverflowJson);
+    SIMPLNX_RESULT_REQUIRE_INVALID(uint64Result);
+  }
+
+  SECTION("Vec3FilterParameterConverter accepts a float64 at the edge of the target type")
+  {
+    nlohmann::json edgeJson = {{"x", 0.0}, {"y", 0.0}, {"z", k_LargestInt64Double}};
+    Result<std::vector<int64>> int64Result = SIMPLConversion::Vec3FilterParameterConverter<int64>::convert(edgeJson);
+    SIMPLNX_RESULT_REQUIRE_VALID(int64Result);
+    REQUIRE(int64Result.value()[2] == static_cast<int64>(k_LargestInt64Double));
   }
 }


### PR DESCRIPTION
## Summary

Newer clang versions emit `-Wimplicit-const-int-float-conversion` in `NumberParameter.cpp` / `VectorParameter.cpp` and `-Wconstant-conversion` in `WriteBinaryDataTest.cpp`. The 64 bit integer cases were real defects, not just diagnostics.

`std::numeric_limits<int64>::max()` (2^63-1) is not representable as a `float64`. Converting it rounds **up** to 2^63, so `if(tmp > std::numeric_limits<T>::max())` was really `if(tmp > 2^63)` — a JSON value of exactly 2^63 passed the range check and then hit undefined behavior in `static_cast<int64>`. Same for `uint64` at 2^64.

* Add `Common/NumericBounds.hpp` with `ExceedsMaxOf<T>()` and `ExceedsLowestOf<T>()`. When the destination is integral and the value is floating point they compare against 2^`digits` — exactly representable, and one past the largest value the type can hold — with an inclusive test. Otherwise they fall back to the plain `numeric_limits` comparison, so behavior for the non-64-bit and floating point destination types is unchanged.
* Use the helpers in `IntFilterParameterConverter<T>::convert()` and `ConversionChecks<ExpectedT, TempT>()`.
* `WriteBinaryDataTest::setMemb()` used a runtime `if(std::is_same<T, ...>::value)` chain, so every branch was compiled for every `T` and the `uint64` fill values were narrowed to `int16` in the `int16` instantiation. Converted to `if constexpr` so the non-matching branches are discarded.

## Test Plan

- [x] New `TEST_CASE "nx::core::SIMPL Json Conversion 64 Bit Integer Bounds"` in `test/SimplJsonConversionTest.cpp` — `static_assert`s on the helpers plus runtime checks that 2^63 / 2^64 are rejected and the largest representable doubles below them still convert, through both `IntFilterParameterConverter` and `Vec3FilterParameterConverter`. Confirmed it fails against the unpatched sources and passes with the fix.
- [x] `cmake --build . --target all` clean, no compiler warnings
- [x] `ctest -R "WriteBinaryData|Test SIMPL Json Conversion|64 Bit Integer Bounds"` — 4/4 pass