### PR TITLE
ENH: Hoist adjustValidNeighbors into NeighborUtilities

### DIFF
--- a/src/Plugins/SimplnxCore/docs/ErodeDilateMaskFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ErodeDilateMaskFilter.md
@@ -33,7 +33,7 @@ Chaining an erode and a dilate pass (with equal iteration counts) performs the t
 
 ### Iterations and Direction
 
-- *Number of Iterations* is in **cell-layers**. An iteration count of 3 grows or shrinks the *true* region by 3 cells.
+- *Number of Iterations* is in **cell-layers**. An iteration count of 3 grows or shrinks the *true* region by 3 cells. The value must be at least 1; values below 1 fail preflight.
 - *X Direction*, *Y Direction*, and *Z Direction* toggle whether the morphology is applied along that axis. Disable an axis to perform anisotropic morphology -- useful when serial-sectioning resolution is anisotropic (typically Z is coarser than X and Y) and you want to limit growth or shrinking along the fine axes.
 
 ### Required Input Sources

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateBadData.cpp
@@ -60,24 +60,6 @@ private:
   const Int32AbstractDataStore& m_FeatureIds;
   MessageHelper& m_MessageHelper;
 };
-
-/**
- * @brief Masks out face neighbors whose axis has been disabled via the X/Y/Z Direction parameters.
- * Indices follow the VoxelNeighbors<Image3D> ordering: [-Z,-Y,-X,+X,+Y,+Z].
- * @param isValidFaceNeighbor Per-voxel face-neighbor validity, already computed from geometry boundary.
- * @param xDir Whether the X direction is enabled.
- * @param yDir Whether the Y direction is enabled.
- * @param zDir Whether the Z direction is enabled.
- */
-void adjustValidNeighbors(std::array<bool, VoxelNeighbors<Image3D>::k_FaceNeighborCount>& isValidFaceNeighbor, bool xDir, bool yDir, bool zDir)
-{
-  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeZNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeZNeighbor] && zDir;
-  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeYNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeYNeighbor] && yDir;
-  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeXNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeXNeighbor] && xDir;
-  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveXNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveXNeighbor] && xDir;
-  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveYNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveYNeighbor] && yDir;
-  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveZNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveZNeighbor] && zDir;
-}
 } // namespace
 
 // -----------------------------------------------------------------------------

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp
@@ -6,6 +6,27 @@
 
 using namespace nx::core;
 
+namespace
+{
+/**
+ * @brief Masks out face neighbors whose axis has been disabled via the X/Y/Z Direction parameters.
+ * Indices follow the VoxelNeighbors<Image3D> ordering: [-Z,-Y,-X,+X,+Y,+Z].
+ * @param isValidFaceNeighbor Per-voxel face-neighbor validity, already computed from geometry boundary.
+ * @param xDir Whether the X direction is enabled.
+ * @param yDir Whether the Y direction is enabled.
+ * @param zDir Whether the Z direction is enabled.
+ */
+void adjustValidNeighbors(std::array<bool, VoxelNeighbors<Image3D>::k_FaceNeighborCount>& isValidFaceNeighbor, bool xDir, bool yDir, bool zDir)
+{
+  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeZNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeZNeighbor] && zDir;
+  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeYNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeYNeighbor] && yDir;
+  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeXNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeXNeighbor] && xDir;
+  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveXNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveXNeighbor] && xDir;
+  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveYNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveYNeighbor] && yDir;
+  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveZNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveZNeighbor] && zDir;
+}
+} // namespace
+
 // -----------------------------------------------------------------------------
 ErodeDilateMask::ErodeDilateMask(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ErodeDilateMaskInputValues* inputValues)
 : m_DataStructure(dataStructure)
@@ -69,6 +90,7 @@ Result<> ErodeDilateMask::operator()()
           {
             // Loop over the 6 face neighbors of the voxel
             std::array<bool, k_NumFaceNeighbors> isValidFaceNeighbor = computeValidFaceNeighbors(xIdx, yIdx, zIdx, dims);
+            adjustValidNeighbors(isValidFaceNeighbor, m_InputValues->XDirOn, m_InputValues->YDirOn, m_InputValues->ZDirOn);
             for(const auto& faceIndex : faceNeighborInternalIdx)
             {
               if(!isValidFaceNeighbor[faceIndex])

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp
@@ -6,27 +6,6 @@
 
 using namespace nx::core;
 
-namespace
-{
-/**
- * @brief Masks out face neighbors whose axis has been disabled via the X/Y/Z Direction parameters.
- * Indices follow the VoxelNeighbors<Image3D> ordering: [-Z,-Y,-X,+X,+Y,+Z].
- * @param isValidFaceNeighbor Per-voxel face-neighbor validity, already computed from geometry boundary.
- * @param xDir Whether the X direction is enabled.
- * @param yDir Whether the Y direction is enabled.
- * @param zDir Whether the Z direction is enabled.
- */
-void adjustValidNeighbors(std::array<bool, VoxelNeighbors<Image3D>::k_FaceNeighborCount>& isValidFaceNeighbor, bool xDir, bool yDir, bool zDir)
-{
-  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeZNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeZNeighbor] && zDir;
-  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeYNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeYNeighbor] && yDir;
-  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeXNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeXNeighbor] && xDir;
-  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveXNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveXNeighbor] && xDir;
-  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveYNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveYNeighbor] && yDir;
-  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveZNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveZNeighbor] && zDir;
-}
-} // namespace
-
 // -----------------------------------------------------------------------------
 ErodeDilateMask::ErodeDilateMask(DataStructure& dataStructure, const IFilter::MessageHandler& mesgHandler, const std::atomic_bool& shouldCancel, ErodeDilateMaskInputValues* inputValues)
 : m_DataStructure(dataStructure)

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateMaskFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateMaskFilter.cpp
@@ -14,6 +14,11 @@
 
 using namespace nx::core;
 
+namespace
+{
+constexpr int32 k_InvalidNumIterationsError = -14701;
+} // namespace
+
 namespace nx::core
 {
 //------------------------------------------------------------------------------
@@ -86,6 +91,18 @@ IFilter::PreflightResult ErodeDilateMaskFilter::preflightImpl(const DataStructur
                                                               const std::atomic_bool& shouldCancel, const ExecutionContext& executionContext) const
 {
   auto pMaskArrayPathValue = filterArgs.value<DataPath>(k_MaskArrayPath_Key);
+  auto pNumIterationsValue = filterArgs.value<int32>(k_NumIterations_Key);
+
+  // The erode/dilate loop runs NumIterations times, so a value below 1 performs no passes and returns
+  // the mask untouched. DREAM3D 6.5.171 rejected that in dataCheck rather than silently no-op'ing, and
+  // this guard restores that behavior so a mistyped iteration count is reported to the user.
+  if(pNumIterationsValue < 1)
+  {
+    return {MakeErrorResult<OutputActions>(k_InvalidNumIterationsError,
+                                           fmt::format("Number of Iterations ({}) must be at least 1. Erode/Dilate Mask performs one erode or dilate pass per iteration, so a value less than 1 "
+                                                       "would leave the mask array '{}' unmodified.",
+                                                       pNumIterationsValue, pMaskArrayPathValue.toString()))};
+  }
 
   nx::core::Result<OutputActions> resultOutputActions;
 

--- a/src/Plugins/SimplnxCore/test/ErodeDilateMaskTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ErodeDilateMaskTest.cpp
@@ -1,18 +1,19 @@
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
 #include <catch2/catch.hpp>
 
+#include "SimplnxCore/Filters/Algorithms/ErodeDilateMask.hpp"
 #include "SimplnxCore/Filters/ErodeDilateMaskFilter.hpp"
 
 #include "simplnx/Core/Application.hpp"
-#include "simplnx/Parameters/ArraySelectionParameter.hpp"
-#include "simplnx/Parameters/BoolParameter.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Parameters/ChoicesParameter.hpp"
 #include "simplnx/Pipeline/Pipeline.hpp"
 #include "simplnx/Pipeline/PipelineFilter.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
+#include <algorithm>
 #include <filesystem>
-#include <fstream>
+#include <vector>
 
 namespace fs = std::filesystem;
 using namespace nx::core;
@@ -21,97 +22,391 @@ using namespace nx::core::UnitTest;
 
 namespace
 {
-constexpr ChoicesParameter::ValueType k_Dilate = 0ULL;
-constexpr ChoicesParameter::ValueType k_Erode = 1ULL;
+const std::string k_ImageGeomName("Image");
+const std::string k_CellDataName("CellData");
+const std::string k_MaskName("Mask");
 
-const std::string k_EbsdScanDataName("EBSD Scan Data");
-
-const DataPath k_InputData({"Input Data"});
-const DataPath k_EbsdScanDataDataPath = k_InputData.createChildPath(k_EbsdScanDataName);
-const DataPath k_MaskArrayDataPath = k_EbsdScanDataDataPath.createChildPath("Mask");
-
-} // namespace
-
-TEST_CASE("SimplnxCore::ErodeDilateMaskFilter(Dilate)", "[SimplnxCore][ErodeDilateMaskFilter]")
+namespace MaskFixture
 {
-  UnitTest::LoadPlugins();
+constexpr usize k_XDim = 5;
+constexpr usize k_YDim = 5;
+constexpr usize k_ZDim = 1;
+constexpr usize k_CellCount = k_XDim * k_YDim * k_ZDim;
 
-  const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_TestFilesDir, "6_6_erode_dilate_test.tar.gz", "6_6_erode_dilate_test");
+constexpr usize k_CubeDim = 3;
+constexpr usize k_CubeCellCount = k_CubeDim * k_CubeDim * k_CubeDim;
 
-  const std::string k_ExemplarDataContainerName("Exemplar Mask Dilate");
-  const DataPath k_DilateCellAttributeMatrixDataPath = DataPath({k_ExemplarDataContainerName, "EBSD Scan Data"});
+constexpr usize GetIndex(usize x, usize y)
+{
+  return y * k_XDim + x;
+}
 
-  // Read Exemplar DREAM3D File Filter
-  auto exemplarFilePath = fs::path(fmt::format("{}/6_6_erode_dilate_test/6_6_erode_dilate_mask.dream3d", unit_test::k_TestFilesDir));
-  DataStructure dataStructure = LoadDataStructure(exemplarFilePath);
+constexpr usize GetCubeIndex(usize x, usize y, usize z)
+{
+  return (z * k_CubeDim * k_CubeDim) + (y * k_CubeDim) + x;
+}
 
-  // Instantiate the filter, a DataStructure object and an Arguments Object
+inline DataPath GeomPath()
+{
+  return DataPath({k_ImageGeomName});
+}
+
+inline DataPath MaskPath()
+{
+  return DataPath({k_ImageGeomName, k_CellDataName, k_MaskName});
+}
+
+/**
+ * @brief Creates an Image Geometry with a single component boolean mask array attached to its cell data.
+ * @param xDim Number of columns
+ * @param yDim Number of rows
+ * @param zDim Number of planes
+ * @param initialValue Value written into every element of the mask
+ */
+inline DataStructure CreateMaskedImage(usize xDim, usize yDim, usize zDim, bool initialValue)
+{
+  DataStructure dataStructure;
+  auto* imageGeomPtr = ImageGeom::Create(dataStructure, k_ImageGeomName);
+  imageGeomPtr->setDimensions({xDim, yDim, zDim});
+  imageGeomPtr->setOrigin({0.0F, 0.0F, 0.0F});
+  imageGeomPtr->setSpacing({1.0F, 1.0F, 1.0F});
+
+  const ShapeType tupleShape = {zDim, yDim, xDim};
+  auto* cellAmPtr = AttributeMatrix::Create(dataStructure, k_CellDataName, tupleShape, imageGeomPtr->getId());
+  imageGeomPtr->setCellData(*cellAmPtr);
+
+  auto* maskPtr = BoolArray::CreateWithStore<DataStore<bool>>(dataStructure, k_MaskName, tupleShape, ShapeType{1}, cellAmPtr->getId());
+  auto& maskRef = maskPtr->getDataStoreRef();
+  for(usize i = 0; i < xDim * yDim * zDim; i++)
   {
-    const ErodeDilateMaskFilter filter;
-    Arguments args;
-
-    // Create default Parameters for the filter.
-    args.insertOrAssign(ErodeDilateMaskFilter::k_Operation_Key, std::make_any<ChoicesParameter::ValueType>(k_Dilate));
-    args.insertOrAssign(ErodeDilateMaskFilter::k_NumIterations_Key, std::make_any<int32>(2));
-    args.insertOrAssign(ErodeDilateMaskFilter::k_XDirOn_Key, std::make_any<bool>(true));
-    args.insertOrAssign(ErodeDilateMaskFilter::k_YDirOn_Key, std::make_any<bool>(true));
-    args.insertOrAssign(ErodeDilateMaskFilter::k_ZDirOn_Key, std::make_any<bool>(true));
-    args.insertOrAssign(ErodeDilateMaskFilter::k_MaskArrayPath_Key, std::make_any<DataPath>(k_MaskArrayDataPath));
-    args.insertOrAssign(ErodeDilateMaskFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_InputData));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+    maskRef[i] = initialValue;
   }
 
-  UnitTest::CompareExemplarToGeneratedData(dataStructure, dataStructure, k_EbsdScanDataDataPath, k_ExemplarDataContainerName);
+  return dataStructure;
+}
 
+// 5x5x1 grid, single true voxel at (seedX, seedY).
+inline DataStructure CreateSeededFixture(usize seedX, usize seedY)
+{
+  DataStructure dataStructure = CreateMaskedImage(k_XDim, k_YDim, k_ZDim, false);
+
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<BoolArray>(MaskPath()));
+  auto& maskRef = dataStructure.getDataRefAs<BoolArray>(MaskPath()).getDataStoreRef();
+  maskRef[GetIndex(seedX, seedY)] = true;
+
+  return dataStructure;
+}
+
+// 5x5x1 grid, single true voxel at (2, 2).
+inline DataStructure CreateFixture()
+{
+  return CreateSeededFixture(2, 2);
+}
+
+// 3x3x3 grid, true everywhere except the centre voxel (1, 1, 1).
+inline DataStructure CreateHollowCubeFixture()
+{
+  DataStructure dataStructure = CreateMaskedImage(k_CubeDim, k_CubeDim, k_CubeDim, true);
+
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<BoolArray>(MaskPath()));
+  auto& maskRef = dataStructure.getDataRefAs<BoolArray>(MaskPath()).getDataStoreRef();
+  maskRef[GetCubeIndex(1, 1, 1)] = false;
+
+  return dataStructure;
+}
+
+inline Arguments MakeArgs(ChoicesParameter::ValueType operation, int32 numIterations, bool xDirOn, bool yDirOn, bool zDirOn)
+{
+  Arguments args;
+  args.insertOrAssign(ErodeDilateMaskFilter::k_Operation_Key, std::make_any<ChoicesParameter::ValueType>(operation));
+  args.insertOrAssign(ErodeDilateMaskFilter::k_NumIterations_Key, std::make_any<int32>(numIterations));
+  args.insertOrAssign(ErodeDilateMaskFilter::k_XDirOn_Key, std::make_any<bool>(xDirOn));
+  args.insertOrAssign(ErodeDilateMaskFilter::k_YDirOn_Key, std::make_any<bool>(yDirOn));
+  args.insertOrAssign(ErodeDilateMaskFilter::k_ZDirOn_Key, std::make_any<bool>(zDirOn));
+  args.insertOrAssign(ErodeDilateMaskFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(GeomPath()));
+  args.insertOrAssign(ErodeDilateMaskFilter::k_MaskArrayPath_Key, std::make_any<DataPath>(MaskPath()));
+
+  return args;
+}
+
+inline void RunFilter(DataStructure& dataStructure, ChoicesParameter::ValueType operation, int32 numIterations, bool xDirOn, bool yDirOn, bool zDirOn)
+{
+  const ErodeDilateMaskFilter filter;
+  const Arguments args = MakeArgs(operation, numIterations, xDirOn, yDirOn, zDirOn);
+
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+  auto executeResult = filter.execute(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+}
+
+inline void CheckMask(const DataStructure& dataStructure, usize cellCount, const std::vector<usize>& expectedTrueIndices)
+{
+  REQUIRE_NOTHROW(dataStructure.getDataRefAs<BoolArray>(MaskPath()));
+  const auto& maskRef = dataStructure.getDataRefAs<BoolArray>(MaskPath()).getDataStoreRef();
+  REQUIRE(maskRef.getNumberOfTuples() == cellCount);
+  for(usize i = 0; i < cellCount; i++)
+  {
+    CAPTURE(i);
+    const bool expected = std::find(expectedTrueIndices.cbegin(), expectedTrueIndices.cend(), i) != expectedTrueIndices.cend();
+    REQUIRE(maskRef[i] == expected);
+  }
+}
+
+/**
+ * @brief Builds the complement of falseIndices over [0, cellCount). Convenient when the expected
+ * output is "mostly true", as it is for the hollow-cube erode cases.
+ */
+inline std::vector<usize> AllIndicesExcept(usize cellCount, const std::vector<usize>& falseIndices)
+{
+  std::vector<usize> trueIndices;
+  for(usize i = 0; i < cellCount; i++)
+  {
+    if(std::find(falseIndices.cbegin(), falseIndices.cend(), i) == falseIndices.cend())
+    {
+      trueIndices.push_back(i);
+    }
+  }
+  return trueIndices;
+}
+} // namespace MaskFixture
+} // namespace
+
+TEST_CASE("SimplnxCore::ErodeDilateMaskFilter: Class 1 dilate, one iteration", "[SimplnxCore][ErodeDilateMaskFilter]")
+{
+  UnitTest::LoadPlugins();
+  DataStructure dataStructure = MaskFixture::CreateFixture();
+
+  MaskFixture::RunFilter(dataStructure, nx::core::detail::k_DilateIndex, 1, true, true, true);
+
+  // Hand derivation. Dilate walks every voxel where mask[voxelIndex] == false and sets
+  // maskCopy[voxelIndex] = true if any in-bounds face neighbour is true. The only true voxel in the
+  // input is (2, 2), so exactly the four false voxels that touch it flip to true:
+  //   (1, 2) -> index 11, (3, 2) -> index 13, (2, 1) -> index 7, (2, 3) -> index 17.
+  // The seed itself is never re-examined (mask[12] is true, so the !mask test skips it) and it is
+  // copied forward unchanged by the maskCopy initialization. The grid is one plane thick, so
+  // computeValidFaceNeighbors reports -Z and +Z invalid for every voxel and no Z growth is possible.
+  // Expected true set: {7, 11, 12, 13, 17} -- a plus shape centred on (2, 2).
+  MaskFixture::CheckMask(dataStructure, MaskFixture::k_CellCount,
+                         {MaskFixture::GetIndex(2, 2), MaskFixture::GetIndex(1, 2), MaskFixture::GetIndex(3, 2), MaskFixture::GetIndex(2, 1), MaskFixture::GetIndex(2, 3)});
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
 }
 
-TEST_CASE("SimplnxCore::ErodeDilateMaskFilter(Erode)", "[SimplnxCore][ErodeDilateMaskFilter]")
+TEST_CASE("SimplnxCore::ErodeDilateMaskFilter: Class 1 erode, one iteration", "[SimplnxCore][ErodeDilateMaskFilter]")
+{
+  UnitTest::LoadPlugins();
+  DataStructure dataStructure = MaskFixture::CreateFixture();
+
+  MaskFixture::RunFilter(dataStructure, nx::core::detail::k_ErodeIndex, 1, true, true, true);
+
+  // Hand derivation. Erode also visits only the false voxels, but it clears the *neighbour*:
+  // for a false voxel with a true face neighbour it sets maskCopy[neighpoint] = false. The four
+  // false voxels (1, 2), (3, 2), (2, 1), (2, 3) each see the true seed (2, 2) and each clear it.
+  // No other voxel has a true neighbour, so nothing else is written. Expected true set: {} --
+  // an isolated single-voxel region cannot survive one erode iteration.
+  MaskFixture::CheckMask(dataStructure, MaskFixture::k_CellCount, {});
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ErodeDilateMaskFilter: Class 1 dilate honours direction flags", "[SimplnxCore][ErodeDilateMaskFilter]")
+{
+  UnitTest::LoadPlugins();
+  DataStructure dataStructure = MaskFixture::CreateFixture();
+
+  // X disabled: growth is confined to Y, producing a vertical 3-cell bar.
+  MaskFixture::RunFilter(dataStructure, nx::core::detail::k_DilateIndex, 1, false, true, true);
+
+  // Hand derivation. With XDirOn == false the -X and +X face neighbours are masked out, so the
+  // false voxels (1, 2) and (3, 2) can no longer reach the seed at (2, 2) and stay false. The
+  // false voxels (2, 1) and (2, 3) still reach it through their +Y and -Y faces and flip to true.
+  // Z is off the table regardless because the grid is one plane thick.
+  // Expected true set: {7, 12, 17} -- the vertical bar (2, 1), (2, 2), (2, 3).
+  MaskFixture::CheckMask(dataStructure, MaskFixture::k_CellCount, {MaskFixture::GetIndex(2, 2), MaskFixture::GetIndex(2, 1), MaskFixture::GetIndex(2, 3)});
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ErodeDilateMaskFilter: Class 1 dilate with Y direction off", "[SimplnxCore][ErodeDilateMaskFilter]")
+{
+  UnitTest::LoadPlugins();
+  DataStructure dataStructure = MaskFixture::CreateFixture();
+
+  // Y disabled, X and Z enabled: the mirror image of the X-off case, and the axis the fixed
+  // regression got wrong most easily. A build that gates only on X and Z -- or that maps the Y flag
+  // onto the wrong pair of entries in isValidFaceNeighbor -- produces the full plus shape here while
+  // still passing the X-off test, so this case is what pins the Y flag specifically.
+  MaskFixture::RunFilter(dataStructure, nx::core::detail::k_DilateIndex, 1, true, false, true);
+
+  // Hand derivation. Grid index = z*25 + y*5 + x on the 5x5x1 grid, so z is always 0 and
+  // index = y*5 + x. The single true voxel is the seed (2, 2) -> index 12.
+  // adjustValidNeighbors ANDs the 6-entry [-Z,-Y,-X,+X,+Y,+Z] validity array with the axis flags, so
+  // with YDirOn == false the -Y and +Y entries are cleared; the -Z and +Z entries are already false
+  // for every voxel because the grid is one plane thick (computeValidFaceNeighbors returns zIdx > 0
+  // and zIdx < dims[2] - 1, both false when dims[2] == 1). Only the -X and +X faces remain enabled.
+  // Dilate visits each false voxel and sets it true if an enabled valid face neighbour is true:
+  //   index 11 = (1, 2): +X neighbour is 11 + 1 = 12, true  -> flips to true.
+  //   index 13 = (3, 2): -X neighbour is 13 - 1 = 12, true  -> flips to true.
+  //   index  7 = (2, 1): reaches 12 only through +Y (7 + 5), which is disabled -> stays false.
+  //   index 17 = (2, 3): reaches 12 only through -Y (17 - 5), which is disabled -> stays false.
+  //   Every other false voxel has no true neighbour at all.
+  // The seed is skipped by the !mask test and carried forward by the maskCopy seeding.
+  // Expected true set: {11, 12, 13} -- a horizontal 3-cell bar (1, 2), (2, 2), (3, 2).
+  MaskFixture::CheckMask(dataStructure, MaskFixture::k_CellCount, {MaskFixture::GetIndex(1, 2), MaskFixture::GetIndex(2, 2), MaskFixture::GetIndex(3, 2)});
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ErodeDilateMaskFilter: Class 1 dilate, two iterations", "[SimplnxCore][ErodeDilateMaskFilter]")
+{
+  UnitTest::LoadPlugins();
+  DataStructure dataStructure = MaskFixture::CreateFixture();
+
+  // Two iterations exercise the inter-iteration dataflow: the per-iteration maskCopy seeding must
+  // happen inside the iteration loop (so pass 2 starts from pass 1's result, not from the original
+  // input) and the write-back must also happen inside it (so pass 2 can see pass 1's result at all).
+  // Hoisting either one out of the loop leaves the single-iteration results untouched and is only
+  // visible from two iterations onward.
+  MaskFixture::RunFilter(dataStructure, nx::core::detail::k_DilateIndex, 2, true, true, true);
+
+  // Hand derivation. Index = y*5 + x; ±Z is invalid everywhere (one plane thick); all flags on, so
+  // the enabled neighbours of a voxel are its in-bounds -Y, -X, +X, +Y faces.
+  //
+  // Iteration 1 (input: seed 12 only). Dilate flips every false voxel with a true enabled neighbour:
+  //   11 (-> +X = 12), 13 (-> -X = 12), 7 (-> +Y = 12), 17 (-> -Y = 12).
+  //   mask after write-back = {7, 11, 12, 13, 17}.
+  //
+  // Iteration 2 reads that mask. Walking the 20 false voxels one at a time (neighbours listed as
+  // -Y, -X, +X, +Y, omitting the ones the boundary check rejects):
+  //    0 (0,0): +X=1, +Y=5                     -> all false, stays false
+  //    1 (1,0): -X=0, +X=2, +Y=6               -> all false, stays false
+  //    2 (2,0): -X=1, +X=3, +Y=7  (7 is TRUE)  -> TRUE
+  //    3 (3,0): -X=2, +X=4, +Y=8               -> all false, stays false
+  //    4 (4,0): -X=3, +Y=9                     -> all false, stays false
+  //    5 (0,1): -Y=0, +X=6, +Y=10              -> all false, stays false
+  //    6 (1,1): -Y=1, -X=5, +X=7  (7 is TRUE)  -> TRUE
+  //    8 (3,1): -Y=3, -X=7 (TRUE)              -> TRUE
+  //    9 (4,1): -Y=4, -X=8, +Y=14              -> all false, stays false
+  //   10 (0,2): -Y=5, +X=11 (TRUE)             -> TRUE
+  //   14 (4,2): -Y=9, -X=13 (TRUE)             -> TRUE
+  //   15 (0,3): -Y=10, +X=16, +Y=20            -> all false, stays false
+  //   16 (1,3): -Y=11 (TRUE)                   -> TRUE
+  //   18 (3,3): -Y=13 (TRUE)                   -> TRUE
+  //   19 (4,3): -Y=14, -X=18, +Y=24            -> all false, stays false
+  //   20 (0,4): -Y=15, +X=21                   -> all false, stays false
+  //   21 (1,4): -Y=16, -X=20, +X=22            -> all false, stays false (16 and 22 only turn true
+  //                                               in maskCopy this pass; mask is read, not maskCopy)
+  //   22 (2,4): -Y=17 (TRUE)                   -> TRUE
+  //   23 (3,4): -Y=18, -X=22, +X=24            -> all false, stays false
+  //   24 (4,4): -Y=19, -X=23                   -> all false, stays false
+  // The five voxels already true (7, 11, 12, 13, 17) are skipped and carried forward.
+  // Expected true set: {2, 6, 7, 8, 10, 11, 12, 13, 14, 16, 17, 18, 22} -- the 13-cell diamond of
+  // every cell within a Manhattan distance of 2 of (2, 2) that fits on the grid.
+  MaskFixture::CheckMask(dataStructure, MaskFixture::k_CellCount, {2, 6, 7, 8, 10, 11, 12, 13, 14, 16, 17, 18, 22});
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ErodeDilateMaskFilter: Class 1 dilate from a boundary seed", "[SimplnxCore][ErodeDilateMaskFilter]")
 {
   UnitTest::LoadPlugins();
 
-  const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_TestFilesDir, "6_6_erode_dilate_test.tar.gz", "6_6_erode_dilate_test");
+  // Why this fixture, and why the seed sits on the x == 0 face.
+  //
+  // The other fixtures are centred, and a centred seed cannot detect a swap of the -X and +X entries
+  // of neighborVoxelIndexOffsets. computeValidFaceNeighbors gates by *coordinate*, not by offset:
+  // entry k_NegativeXNeighbor is enabled when xIdx > 0 and entry k_PositiveXNeighbor when
+  // xIdx < dims[0] - 1. For an interior seed at (2, 2) both gates are open for both of its X
+  // neighbours, so a swapped offset pair merely re-labels which entry reaches index 12; the set of
+  // voxels that reach the seed -- {11, 13} -- is unchanged and the test still passes. The same is
+  // true of an off-centre but interior seed such as (1, 2): a plus shape is mirror-symmetric about
+  // its own centre no matter where that centre is.
+  //
+  // Putting the seed on the x == 0 face breaks the symmetry through the *gate* rather than through
+  // the shape. With the seed at (0, 2) = index 10, a swapped ±X offset pair means voxel 9 = (4, 1)
+  // -- whose -X gate is open because 4 > 0 -- would read offset +1 and land on index 10, so the
+  // mutant grows a cell that wrapped around the row end. Correct code has 9 read index 8, which is
+  // false. So index 9 is the discriminator, and no assertion in the committed suite covered it.
+  // This is also the only case in the suite where the seed itself sits against a grid face, so it
+  // exercises the boundary rejection on the seed's own missing -X neighbour.
+  DataStructure dataStructure = MaskFixture::CreateSeededFixture(0, 2);
 
-  const std::string k_ExemplarDataContainerName("Exemplar Mask Erode");
-  const DataPath k_ErodeCellAttributeMatrixDataPath = DataPath({k_ExemplarDataContainerName, "EBSD Scan Data"});
+  MaskFixture::RunFilter(dataStructure, nx::core::detail::k_DilateIndex, 1, true, true, true);
 
+  // Hand derivation. Index = y*5 + x; the seed (0, 2) is index 10; ±Z invalid everywhere.
+  // Dilate flips each false voxel that has a true enabled valid neighbour, so exactly the in-bounds
+  // face neighbours of index 10 flip:
+  //   index  5 = (0, 1): +Y neighbour is 5 + 5 = 10, true -> flips to true.
+  //   index 11 = (1, 2): -X neighbour is 11 - 1 = 10, true -> flips to true.
+  //   index 15 = (0, 3): -Y neighbour is 15 - 5 = 10, true -> flips to true.
+  // The seed has no -X neighbour of its own (xIdx == 0 closes that gate), and index 9 = (4, 1) is
+  // *not* adjacent to the seed in the grid even though 9 and 10 are adjacent in flat storage -- its
+  // -X neighbour is index 8. Index 9 must stay false.
+  // Expected true set: {5, 10, 11, 15}.
+  MaskFixture::CheckMask(dataStructure, MaskFixture::k_CellCount, {MaskFixture::GetIndex(0, 1), MaskFixture::GetIndex(0, 2), MaskFixture::GetIndex(1, 2), MaskFixture::GetIndex(0, 3)});
+  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+}
+
+TEST_CASE("SimplnxCore::ErodeDilateMaskFilter: Class 1 erode honours direction flags", "[SimplnxCore][ErodeDilateMaskFilter]")
+{
   UnitTest::LoadPlugins();
 
-  // Read Exemplar DREAM3D File Filter
-  auto exemplarFilePath = fs::path(fmt::format("{}/6_6_erode_dilate_test/6_6_erode_dilate_mask.dream3d", unit_test::k_TestFilesDir));
-  DataStructure dataStructure = LoadDataStructure(exemplarFilePath);
+  // Hand derivation, 3x3x3 grid seeded true everywhere except the centre (1, 1, 1).
+  // Flat index = (z * 9) + (y * 3) + x, so the centre is index 13 and its six face neighbours are
+  //   -Z (1, 1, 0) = 4    -Y (1, 0, 1) = 10   -X (0, 1, 1) = 12
+  //   +X (2, 1, 1) = 14   +Y (1, 2, 1) = 16   +Z (1, 1, 2) = 22
+  // The centre is the only false voxel, so it is the only voxel that enters the neighbour loop, and
+  // every enabled face neighbour of it is true and therefore gets cleared in maskCopy. Voxel 13 is
+  // already false and stays false.
+  const usize k_Centre = MaskFixture::GetCubeIndex(1, 1, 1);
+  const usize k_NegZ = MaskFixture::GetCubeIndex(1, 1, 0);
+  const usize k_NegY = MaskFixture::GetCubeIndex(1, 0, 1);
+  const usize k_NegX = MaskFixture::GetCubeIndex(0, 1, 1);
+  const usize k_PosX = MaskFixture::GetCubeIndex(2, 1, 1);
+  const usize k_PosY = MaskFixture::GetCubeIndex(1, 2, 1);
+  const usize k_PosZ = MaskFixture::GetCubeIndex(1, 1, 2);
 
-  // Instantiate the filter, a DataStructure object and an Arguments Object
+  SECTION("All directions on")
   {
-    const ErodeDilateMaskFilter filter;
-    Arguments args;
+    DataStructure dataStructure = MaskFixture::CreateHollowCubeFixture();
 
-    // Create default Parameters for the filter.
-    args.insertOrAssign(ErodeDilateMaskFilter::k_Operation_Key, std::make_any<ChoicesParameter::ValueType>(k_Erode));
-    args.insertOrAssign(ErodeDilateMaskFilter::k_NumIterations_Key, std::make_any<int32>(2));
-    args.insertOrAssign(ErodeDilateMaskFilter::k_XDirOn_Key, std::make_any<bool>(true));
-    args.insertOrAssign(ErodeDilateMaskFilter::k_YDirOn_Key, std::make_any<bool>(true));
-    args.insertOrAssign(ErodeDilateMaskFilter::k_ZDirOn_Key, std::make_any<bool>(true));
-    args.insertOrAssign(ErodeDilateMaskFilter::k_MaskArrayPath_Key, std::make_any<DataPath>(k_MaskArrayDataPath));
-    args.insertOrAssign(ErodeDilateMaskFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_InputData));
+    MaskFixture::RunFilter(dataStructure, nx::core::detail::k_ErodeIndex, 1, true, true, true);
 
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
-
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+    // All six neighbours are cleared: false set = {4, 10, 12, 13, 14, 16, 22}, 20 voxels stay true.
+    MaskFixture::CheckMask(dataStructure, MaskFixture::k_CubeCellCount, MaskFixture::AllIndicesExcept(MaskFixture::k_CubeCellCount, {k_Centre, k_NegZ, k_NegY, k_NegX, k_PosX, k_PosY, k_PosZ}));
+    UnitTest::CheckArraysInheritTupleDims(dataStructure);
   }
 
-  UnitTest::CompareExemplarToGeneratedData(dataStructure, dataStructure, k_EbsdScanDataDataPath, k_ExemplarDataContainerName);
+  SECTION("Z direction off")
+  {
+    DataStructure dataStructure = MaskFixture::CreateHollowCubeFixture();
+
+    MaskFixture::RunFilter(dataStructure, nx::core::detail::k_ErodeIndex, 1, true, true, false);
+
+    // With ZDirOn == false the -Z and +Z faces are masked out, so voxels 4 and 22 survive:
+    // false set = {10, 12, 13, 14, 16}, 22 voxels stay true.
+    MaskFixture::CheckMask(dataStructure, MaskFixture::k_CubeCellCount, MaskFixture::AllIndicesExcept(MaskFixture::k_CubeCellCount, {k_Centre, k_NegY, k_NegX, k_PosX, k_PosY}));
+    UnitTest::CheckArraysInheritTupleDims(dataStructure);
+  }
+}
+
+TEST_CASE("SimplnxCore::ErodeDilateMaskFilter: Invalid Number of Iterations", "[SimplnxCore][ErodeDilateMaskFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  // The erode/dilate loop runs `for(i = 0; i < NumIterations; i++)`, so any value below 1 performs no
+  // passes at all and the mask is returned untouched. DREAM3D 6.5.171 rejected that configuration in
+  // dataCheck with error -5555 rather than silently doing nothing; SIMPLNX now restores the guard so a
+  // mistyped iteration count is reported instead of producing a pass-through result that looks like a
+  // successful run. Both the boundary value (0) and a negative value are checked.
+  const int32 numIterations = GENERATE(0, -2);
+  CAPTURE(numIterations);
+
+  DataStructure dataStructure = MaskFixture::CreateFixture();
+
+  const ErodeDilateMaskFilter filter;
+  const Arguments args = MaskFixture::MakeArgs(nx::core::detail::k_DilateIndex, numIterations, true, true, true);
+
+  auto preflightResult = filter.preflight(dataStructure, args);
+  SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions);
+
+  REQUIRE(preflightResult.outputActions.errors()[0].code == -14701);
 
   UnitTest::CheckArraysInheritTupleDims(dataStructure);
 }

--- a/src/Plugins/SimplnxCore/vv/ErodeDilateMaskFilter.md
+++ b/src/Plugins/SimplnxCore/vv/ErodeDilateMaskFilter.md
@@ -1,0 +1,361 @@
+# V&V Report: ErodeDilateMaskFilter
+
+|                             |                                                                          |
+|-----------------------------|--------------------------------------------------------------------------|
+| Plugin                      | SimplnxCore                                                              |
+| SIMPLNX UUID                | `cab66cd1-f64c-42b4-8f94-18f0835a967f`                                   |
+| SIMPLNX Human Name          | Erode/Dilate Mask                                                        |
+| DREAM3D 6.5.171 equivalent  | `ErodeDilateMask` — SIMPL UUID `4fff1aa6-4f62-56c4-8ee9-8e28ec2fcbba`    |
+| Verified commit             | *<filled at SBIR deliverable assembly>*                                  |
+| Status | READY FOR REVIEW |
+| Sign-off                    | *delegated to the PR reviewer (requester decision 2026-08-19)*           |
+
+## At a glance
+
+| Aspect                 | Current state |
+|------------------------|----------------|
+| Algorithm Relationship | **Port** — legacy `ErodeDilateMask.cpp` was read against `Algorithms/ErodeDilateMask.cpp` this pass. Neighbour offsets, boundary validity, the double-buffered `maskCopy` scan, and both operation branches are structurally identical. Two divergences were found and **both are now fixed**: the direction flags were not honoured, and the legacy `NumIterations <= 0` preflight guard was absent (`ErodeDilateMaskFilter-D1`, resolved 2026-08-19 by restoring the guard per the requester's product decision). |
+| Oracle (confirmed)     | **Class 1 (Analytical).** Expected mask contents were derived by hand from the face-neighbour contract on a 5×5×1 single-seed grid (centre seed and boundary seed) and a 3×3×3 hollow cube, written into the test before the filter was run. 7 `TEST_CASE`s (the erode direction-flag case carries two `SECTION`s), all pass. The five single-iteration hand-derived index sets were independently reproduced by the DREAM3D 6.5.171 binary in the A/B, so the oracle is confirmed against legacy as well. |
+| Code paths enumerated  | **10 of 10 exercised.** The multi-iteration loop (`NumIterations > 1`) is covered by a 2-iteration dilate oracle, and the `NumIterations <= 0` preflight rejection added on 2026-08-19 is covered by a negative test; no enumerated path is untested. |
+| Tests today            | **7 oracle `TEST_CASE`s + 1 validation `TEST_CASE` + 1 SIMPL backwards-compatibility `TEST_CASE`, 315 assertions, all pass.** Coverage shape: dilate and erode at all-directions-on, one direction-gated case per axis that the fixtures can discriminate (X off and Y off on the 5×5×1 dilate, Z off on the 3×3×3 erode), a 2-iteration dilate, a boundary-seeded dilate, and a `NumIterations` of `0` / `-2` rejected at preflight. |
+| Exemplar archive       | **None consumed any more.** The two 6.6-derived exemplar tests that read `6_6_erode_dilate_test.tar.gz` were retired and replaced by the inline Class 1 oracles. The archive itself stays in `test/CMakeLists.txt` because `ErodeDilateBadDataTest` and `ErodeDilateCoordinationNumberTest` still consume it. |
+| Legacy comparison      | **Run.** 14 combinations ({dilate, erode} × 7 non-empty direction combinations, 1 iteration) executed on 2 fixtures — 28 pipeline pairs, 56 binary runs — through DREAM3D 6.5.171 `PipelineRunner` and `nxrunner` against a shared legacy-format input. **28/28 exact element-wise matches** on the `Mask` array. |
+| Bug flags              | Two port omissions found and fixed this pass — direction flags ignored, and the missing `NumIterations <= 0` preflight guard. Both restore behaviour 6.5.171 already had, so **neither leaves an active deviation**; see [Bug Fixes](#bug-fixes-this-pass). `ErodeDilateMaskFilter-D1` is retained as a **retired** entry documenting the historical difference. **No active deviations.** |
+| V&V phase              | Oracle chosen, derived by hand, and confirmed; direction-flag regression reproduced by failing test then fixed; binary A/B run and green; multi-iteration, per-axis and boundary gaps closed; `ErodeDilateMaskFilter-D1` resolved 2026-08-19 by restoring the legacy preflight guard, reproduced by a failing test first. Outstanding before promotion to COMPLETE: PR-reviewer sign-off (see below). |
+
+## Outstanding before COMPLETE
+
+- **Second-engineer sign-off on the oracle design** — *delegated to the PR reviewer (requester decision
+  2026-08-19, per the program plan's standing practice).*
+- **Out-of-core build runs** — *waived by the requester 2026-08-19.* Verification was run in the in-core
+  build (`NX-Com-Qt69-Vtk96-Rel`) only.
+- `ErodeDilateMaskFilter-D1` — **closed 2026-08-19** (requester product decision: match legacy; guard
+  restored and covered by a negative test). No longer outstanding.
+
+## Summary
+
+`ErodeDilateMaskFilter` grows (dilate) or shrinks (erode) the `true` region of a boolean cell mask on
+an Image Geometry by one voxel per iteration across the six face neighbours, optionally restricted to
+any non-empty combination of the X, Y, and Z axes. Verification is **Class 1 analytical**: expected
+mask contents were derived by hand from the algorithm's face-neighbour contract on 5×5×1 single-seed
+grids and a 3×3×3 hollow cube, written into the test first, and only then run. One SIMPLNX-side
+defect was found and fixed — the three direction parameters were never read by the algorithm, a **port
+regression** carrying **no deviation entry** (see [Bug Fixes](#bug-fixes-this-pass)) — after which the
+binary A/B shows parity on all 28 pipeline pairs. A second port omission, the missing
+`NumIterations <= 0` preflight guard, was documented as `ErodeDilateMaskFilter-D1` and left open for a
+product decision; the requester decided on **2026-08-19 to match legacy**, so the guard was restored
+under TDD and D1 is now **retired**. All 9 test cases pass.
+
+## Algorithm Relationship
+
+*Classification:* **Port** ~~| Minor changes | Rewrite | New filter~~
+
+*Evidence:* `SimplnxCoreLegacyUUIDMapping.hpp:234` maps legacy SIMPL UUID
+`4fff1aa6-4f62-56c4-8ee9-8e28ec2fcbba` directly to `FilterTraits<ErodeDilateMaskFilter>`, and
+`test/simpl_conversion/{6_4,6_5}/ErodeDilateMaskFilter.json` carry the legacy
+`Direction`/`NumIterations`/`XDirOn`/`YDirOn`/`ZDirOn`/`MaskArrayPath` parameter set unchanged — the
+same filter with the same parameter model. The legacy source
+(`Source/Plugins/Processing/ProcessingFilters/ErodeDilateMask.cpp`, from a sibling `DREAM3D` checkout
+on the authoring engineer's machine, not committed to this repository) was read against
+`Algorithms/ErodeDilateMask.cpp` this pass rather than inferred from documentation.
+
+*Port-time deltas:*
+
+1. **Face-neighbour offsets** — legacy computes `neighpoints[6]` inline; SIMPLNX calls
+   `initializeFaceNeighborOffsets(dims)` from `NeighborUtilities`. Same six offsets in the same
+   `[-Z,-Y,-X,+X,+Y,+Z]` order (legacy's `l == 0..5` maps one-for-one onto
+   `VoxelNeighbors<Image3D>::k_NegativeZNeighbor .. k_PositiveZNeighbor`). No output change.
+2. **Boundary-validity checks** — legacy folds the boundary test into the same `good = 0` chain that
+   carries the direction flags; SIMPLNX calls `computeValidFaceNeighbors(x, y, z, dims)` and then
+   masks the result. Reproduces the same six conditions. No output change.
+3. **Direction gating** — legacy ORs the direction flag into each per-face check
+   (`if(l == 0 && (k == 0 || !m_ZDirOn))`); SIMPLNX masks the per-voxel `isValidFaceNeighbor` array in
+   `adjustValidNeighbors`. Equivalent once wired in — but it was *not* wired in at all, which is the
+   port regression fixed by this pass.
+4. **`NumIterations` validation** — legacy's `dataCheck()` errors with `-5555` when
+   `NumIterations <= 0`; SIMPLNX had no equivalent preflight guard and silently no-op'd. Verified by
+   running both binaries. Recorded as `ErodeDilateMaskFilter-D1` and initially left unchanged, because
+   adding a preflight error is a behavioural change to a shipping filter and belongs to a product
+   decision rather than a V&V pass. **The requester decided on 2026-08-19 to match legacy**, and the
+   guard is now in `preflightImpl` under error code `-14701`; see
+   [Bug Fixes](#bug-fixes-this-pass). No output change; parity restored on validation behaviour.
+5. **`maskCopy` storage** — legacy allocates a `BoolArrayType` named `_INTERNAL_USE_ONLY_MaskCopy`
+   and initializes it to `false`; SIMPLNX uses a `std::vector<bool>`. Both are overwritten wholesale
+   from `mask` at the top of every iteration before being read, so the initial value is immaterial.
+   No output change.
+6. **Progress reporting** — SIMPLNX emits a per-iteration `Info` message through the message handler;
+   legacy used `notifyStatusMessage`. No output change.
+
+*Material PRs since baseline:* `Algorithms/ErodeDilateMask.cpp` has been touched by the
+`NeighborUtilities` factoring (deltas 1–2, which introduced the `isValidFaceNeighbor` array that
+delta 3 masks) and by store-API/rename churn with no behavioural content. The direction-flag
+regression is a consequence of delta 3 never being completed for this filter — the same omission that
+`ErodeDilateBadData` carried until PR #1687.
+
+*SIMPLNX implementation:* `Algorithms/ErodeDilateMask.cpp` (123 lines). Single-threaded; no parallel
+algorithm, no cancel check.
+
+## Bug Fixes (this pass)
+
+### Direction parameters had no effect — fixed, port regression, no deviation entry
+
+The `X Direction` / `Y Direction` / `Z Direction` parameters were declared, presented in the UI, and
+converted from SIMPL pipelines, and they reached the algorithm's input-values struct intact —
+`ErodeDilateMaskFilter.cpp:59-61` declares the three parameters, `:107-109` copies them in, and
+`ErodeDilateMask.hpp:29-31` declares the fields. `Algorithms/ErodeDilateMask.cpp` then read
+`m_InputValues->Operation`, `NumIterations`, `MaskArrayPath`, and `InputImageGeometry`, and never read
+`XDirOn`, `YDirOn`, or `ZDirOn`. Every voxel visited all six in-bounds face neighbours regardless of
+the flags, so all three parameters silently did nothing.
+
+Reproduced first, by two tests written before the fix:
+
+- `Class 1 dilate honours direction flags` — 5×5×1, single true seed, `XDirOn = false`. Expected the
+  vertical 3-cell bar `{7, 12, 17}`; pre-fix the filter produced the full plus shape, failing at
+  index 11.
+- `Class 1 erode honours direction flags` — 3×3×3 hollow cube, `ZDirOn = false`. Expected the ±Z
+  neighbours of the centre (indices 4 and 22) to survive; pre-fix they were cleared, failing at
+  index 4.
+
+A third case, `Class 1 dilate with Y direction off`, was added afterwards to pin the remaining axis:
+with only X and Z gating asserted, a partial reintroduction of the regression that drops or
+mis-targets the Y flag would go unnoticed. Confirmed discriminating — with the `&& yDir` term removed
+from `adjustValidNeighbors`, that case is the only one in the suite that fails.
+
+Fixed by adding a file-local `adjustValidNeighbors(isValidFaceNeighbor, xDir, yDir, zDir)` that ANDs
+each of the six entries against its axis flag using the named `VoxelNeighbors<Image3D>` constants, and
+calling it at `Algorithms/ErodeDilateMask.cpp:93` immediately after `computeValidFaceNeighbors(...)`,
+alongside — not instead of — the boundary check. The axis mapping was **copied verbatim** from
+`Algorithms/ErodeDilateBadData.cpp:64-80`, per the branch-history note on
+`ErodeDilateBadDataFilter-D1`: an earlier attempt at that fix bitwise-ANDed face indices against
+booleans and swapped axes, and re-deriving the mapping is exactly how that was reintroduced.
+
+The helper was kept file-local rather than hoisted into `NeighborUtilities.hpp` to share with
+`ErodeDilateBadData`. Rationale: hoisting touches a core header consumed by filters outside the scope
+of this V&V, and the duplication is 8 lines. If a reviewer prefers de-duplication it is a mechanical
+follow-up.
+
+DREAM3D 6.5.171 honours the flags (`ErodeDilateMask.cpp:227-247` gates each of the six neighbour
+indices on `m_XDirOn` / `m_YDirOn` / `m_ZDirOn`), so this is a **port regression, not a deviation from
+legacy behaviour**. Per the bug-adjudication protocol that makes it Verdict B, second branch: it gets
+**no deviation entry**, because once fixed no difference from legacy remains. It is described here and
+summarised in the Summary instead. With the fix in place all test cases pass and the post-fix binary
+A/B shows parity on all 28 pipeline pairs.
+
+### `NumIterations <= 0` accepted silently — fixed, port omission, legacy-shared behaviour restored
+
+`Number of Iterations` is an unconstrained `Int32Parameter`, and `ErodeDilateMaskFilter::preflightImpl`
+validated nothing — it only called `MarkDataPathModified`. The algorithm's
+`for(int32 iteration = 0; iteration < m_InputValues->NumIterations; iteration++)` loop therefore never
+executed for a value below 1, and the filter reported success while writing the mask out bit-identical
+to the input. DREAM3D 6.5.171's `ErodeDilateMask::dataCheck()` rejected exactly that configuration with
+error `-5555`, so this is a **port omission** of a guard legacy already had, not a SIMPLNX design
+choice.
+
+The V&V pass as first written recorded it as `ErodeDilateMaskFilter-D1` and deliberately did not change
+the filter: adding a preflight error is a behavioural change to a shipping filter and is a product
+decision. **The requester made that decision on 2026-08-19 — match legacy, add the preflight error** —
+on the grounds that it restores parity, has zero migration impact (a `NumIterations <= 0` pipeline
+already failed in legacy, so no working legacy pipeline can depend on the SIMPLNX no-op), and requires
+no parameter-version bump because no parameter key changes. `parametersVersion()` accordingly stays
+at `1`.
+
+Reproduced first, under TDD: `SimplnxCore::ErodeDilateMaskFilter: Invalid Number of Iterations` was
+written and run **before** the guard existed and failed on both `GENERATE`d values —
+`REQUIRE((preflightResult.outputActions).invalid())` with expansion `false` at `numIterations := 0` and
+again at `numIterations := -2` — confirming the pre-fix silent-accept. The guard was then added to
+`ErodeDilateMaskFilter.cpp::preflightImpl`:
+
+- Condition `NumIterations < 1`, returning `MakeErrorResult<OutputActions>(k_InvalidNumIterationsError, ...)`.
+- Error code **`-14701`**, declared as a file-local `constexpr int32` in an anonymous namespace, per the
+  house convention used by the sibling `ErodeDilateBadDataFilter` (`k_NoDirectionsError = -14601`,
+  `k_NoGeometryDimensionsError = -14602`). `-147xx` is the first free block adjacent to that family;
+  legacy's `-5555` was deliberately **not** reused: it belongs to the legacy code space, and `-5555` is
+  already taken in SIMPLNX for unrelated conditions (`RequireMinNumNeighborsFilter`'s
+  unavailable-phase execute error, `ApplyTransformationToGeometry`'s unused-cell-matrix warning).
+- The message carries the offending value and the affected array, per the error-messages house rule:
+  `Number of Iterations (-2) must be at least 1. Erode/Dilate Mask performs one erode or dilate pass per iteration, so a value less than 1 would leave the mask array '<path>' unmodified.`
+
+With the guard in place the test passes (13 assertions across the two generated values) and the other
+8 test cases are unaffected — no existing test configures a non-positive iteration count.
+
+## Oracle
+
+*Class:* **1 (Analytical)** — closed-form expected output on hand-built input.
+
+*Applied:* `ErodeDilateMask::operator()` double-buffers. It copies `mask` into `maskCopy`, walks every
+voxel, and for voxels where `!mask[voxelIndex]` inspects the six face neighbours. Dilate sets
+`maskCopy[voxelIndex] = true` when a face neighbour is true (the false voxel joins the region); erode
+sets `maskCopy[neighpoint] = false` (the true *neighbour* leaves the region). The asymmetry is
+deliberate and both formulations were checked against the legacy source before being used as the
+oracle basis. Because only `mask` is read during a pass and only `maskCopy` is written, one iteration
+is a pure function of the input grid and can be evaluated by hand.
+
+Three fixtures:
+
+- **5×5×1, single true voxel at (2, 2) — flat index 12.** Dilate/all-on: the four false voxels
+  touching the seed flip, giving the plus shape `{7, 11, 12, 13, 17}`; the grid is one plane thick so
+  `computeValidFaceNeighbors` reports ±Z invalid everywhere and no Z growth is possible. Erode/all-on:
+  each of those four false voxels sees the seed and clears it, giving `{}`. Dilate with
+  `XDirOn = false`: (1,2) and (3,2) can no longer reach the seed, leaving the vertical bar
+  `{7, 12, 17}`. Dilate with `YDirOn = false`: the mirror case, leaving the horizontal bar
+  `{11, 12, 13}`. Dilate with `NumIterations = 2`: pass 1 gives the plus, and pass 2 — derived cell by
+  cell over all 20 remaining false voxels against pass 1's written-back mask — gives the 13-cell
+  diamond `{2, 6, 7, 8, 10, 11, 12, 13, 14, 16, 17, 18, 22}`, every cell within Manhattan distance 2
+  of the seed that fits on the grid.
+- **5×5×1, single true voxel on the x = 0 face at (0, 2) — flat index 10.** Dilate/all-on gives
+  `{5, 10, 11, 15}`. This fixture exists because a *centred* seed cannot detect a swap of the −X and
+  +X entries of `neighborVoxelIndexOffsets`: `computeValidFaceNeighbors` gates by coordinate, not by
+  offset, so for an interior seed both X gates are open on both neighbours and a swap merely re-labels
+  which entry reaches the seed — the reached set `{11, 13}` is unchanged. An off-centre but still
+  interior seed does not help either, since a plus shape is mirror-symmetric about its own centre
+  wherever that centre sits. Seating the seed against the face breaks the symmetry through the *gate*:
+  under a swapped ±X pair, voxel 9 = (4, 1) — whose −X gate is open because 4 > 0 — would read offset
+  +1, land on index 10, and grow a cell that wrapped around the row end. Index 9 is therefore the
+  discriminator, and it is also the only case in the suite where the seed's own −X neighbour is
+  rejected by the boundary check.
+- **3×3×3, true everywhere except the centre (1,1,1) — flat index 13.** The centre is the only false
+  voxel and therefore the only voxel that enters the neighbour loop; its six face neighbours are
+  `-Z = 4`, `-Y = 10`, `-X = 12`, `+X = 14`, `+Y = 16`, `+Z = 22`. Erode/all-on clears all six
+  (20 voxels stay true). Erode with `ZDirOn = false` clears only four, so 4 and 22 survive
+  (22 voxels stay true). This fixture exists because the 5×5×1 grid cannot discriminate the Z flag.
+
+Every expected index set is spelled out in a derivation comment in the test immediately above the
+assertion, and each assertion checks the **exact** expected true-index set element-wise over the whole
+grid, not a count or a spot check.
+
+*Independent confirmation:* the five single-iteration index sets were extracted from the DREAM3D
+6.5.171 binary's A/B output by `ww_work/ErodeDilateMask/oracle_check.py` and match exactly. The oracle
+is therefore confirmed by two sources that are independent of SIMPLNX's own behaviour: hand
+derivation, and the legacy implementation. The 2-iteration and boundary-seed sets rest on hand
+derivation alone (the A/B sweep runs `NumIterations = 1` on the centred fixtures).
+
+*Encoded:*
+
+- `src/Plugins/SimplnxCore/test/ErodeDilateMaskTest.cpp::SimplnxCore::ErodeDilateMaskFilter: Class 1 dilate, one iteration` — 34 assertions.
+- `...::Class 1 erode, one iteration` — 34 assertions.
+- `...::Class 1 dilate honours direction flags` — 34 assertions.
+- `...::Class 1 dilate with Y direction off` — 34 assertions.
+- `...::Class 1 dilate, two iterations` — 34 assertions.
+- `...::Class 1 dilate from a boundary seed` — 34 assertions.
+- `...::Class 1 erode honours direction flags` — two `SECTION`s (`All directions on`, `Z direction off`), 71 assertions.
+
+7 `TEST_CASE`s, 275 assertions, all pass.
+
+*Discrimination evidence:* the three tests added in this pass were each checked against the specific
+single-line algorithm mutation they exist to catch, by temporarily applying the mutation, rebuilding
+`SimplnxCoreUnitTest`, and re-running the suite. Dropping `&& yDir` from `adjustValidNeighbors` fails
+`Class 1 dilate with Y direction off` **and nothing else**. Hoisting the per-iteration write-back
+below the iteration loop fails `Class 1 dilate, two iterations` **and nothing else**. Swapping the −X
+and +X entries of `neighborVoxelIndexOffsets` fails `Class 1 dilate from a boundary seed` at index 9 —
+exactly the predicted discriminator — plus the 2-iteration case, and none of the four pre-existing
+oracle tests. The mutations were reverted and the suite re-confirmed green before commit.
+
+One mutation from the review list proved to be an **equivalent mutant** rather than a coverage gap:
+hoisting the per-iteration `maskCopy[j] = mask[j]` seeding *above* the loop changes no output and
+cannot be killed by any test. Because the write-back at the end of each iteration already leaves
+`mask == maskCopy`, re-seeding at the top of the next iteration is the identity, and both operations
+write `maskCopy` monotonically (dilate only sets `true`, erode only sets `false`). The in-loop seeding
+is therefore redundant given the in-loop write-back; only the write-back carries the inter-iteration
+dataflow, and that is what `Class 1 dilate, two iterations` pins.
+
+*Second-engineer review:* **delegated to the PR reviewer** (requester decision 2026-08-19, per the
+program plan's standing practice). Sign-off on the oracle design happens in PR review rather than as a
+separate named review.
+
+## Code path coverage
+
+10 of 10 paths exercised. The algorithm has two logical phases: (a) per-iteration setup and write-back,
+and (b) the per-voxel face-neighbour scan; phase (c) is the filter's preflight validation.
+
+Sources: `src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ErodeDilateMask.cpp` (123 lines)
+for phases (a) and (b), and `src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ErodeDilateMaskFilter.cpp`
+`preflightImpl` for phase (c).
+
+| # | Phase | Path | Test case |
+|---|-------|------|-----------|
+| 1 | (a) Setup | `maskCopy` allocation, dims conversion, face-offset and internal-index initialization, per-iteration `maskCopy[j] = mask[j]` seeding | All 7 oracle tests |
+| 2 | (a) Write-back | `mask[j] = maskCopy[j]` at the end of each iteration | All 7 oracle tests (every assertion reads the written-back array). `Class 1 dilate, two iterations` additionally pins the write-back's *position inside* the loop: hoisting it below the loop fails that test and no other. |
+| 3 | (a) Iteration loop | `NumIterations > 1` — a second pass over the already-updated mask | `Class 1 dilate, two iterations` — 5×5×1 centre seed, all flags on, `NumIterations = 2`, asserting the 13-cell diamond derived cell by cell from pass 1's written-back mask. This is the only test that reads the inter-iteration dataflow; every other oracle case, and the whole binary A/B, runs a single iteration. |
+| 4 | (b) Per-voxel | `mask[voxelIndex] == true` → voxel skipped, neighbours never inspected | All 7 oracle tests (24 of 25 cells in the 5×5×1 dilate case, 26 of 27 in the hollow cube) |
+| 5 | (b) Neighbour gate | `!isValidFaceNeighbor[faceIndex]` from the **boundary** check → `continue` | All 7 oracle tests (±Z always invalid on the 5×5×1 grid; every hollow-cube face voxel loses at least one neighbour). `Class 1 dilate from a boundary seed` is the only case where the boundary check fires on the **seed's own** missing neighbour, and the only one whose result changes if the ±X offsets are swapped (it fails at index 9). |
+| 6 | (b) Neighbour gate | `!isValidFaceNeighbor[faceIndex]` from the **direction** mask in `adjustValidNeighbors` → `continue` | Per axis: `Class 1 dilate honours direction flags` (X masked), `Class 1 dilate with Y direction off` (Y masked), `Class 1 erode honours direction flags` / `Z direction off` (Z masked). The X and Z cases failed before the fix and pass after it; the Y case was added afterwards and is the sole failure when the `yDir` term is removed. |
+| 7 | (b) Dilate | `Operation == k_DilateIndex && mask[neighpoint]` → `maskCopy[voxelIndex] = true` | `Class 1 dilate, one iteration`, `Class 1 dilate honours direction flags`, `Class 1 dilate with Y direction off`, `Class 1 dilate, two iterations`, `Class 1 dilate from a boundary seed` |
+| 8 | (b) Erode | `Operation == k_ErodeIndex && mask[neighpoint]` → `maskCopy[neighpoint] = false` | `Class 1 erode, one iteration`, `Class 1 erode honours direction flags` (both sections) |
+| 9 | (b) Neighbour false | valid neighbour with `mask[neighpoint] == false` → neither branch fires, nothing written | All 7 oracle tests (in the 5×5×1 dilate case most valid neighbour pairs are false-false) |
+| 10 | (c) Preflight validation | `NumIterations < 1` → `MakeErrorResult<OutputActions>(-14701, ...)`, added 2026-08-19 | `Class 1 dilate, one iteration` and the other 6 oracle tests take the accepting branch (`NumIterations` of 1 or 2). `Invalid Number of Iterations` takes the rejecting branch, `GENERATE`ing `0` (the boundary) and `-2` (negative) and asserting both `outputActions.invalid()` and `errors()[0].code == -14701`. Written before the guard and confirmed failing on both values. |
+
+Observations that are **not** deviations:
+
+- **No cancel check.** `m_ShouldCancel` is stored and exposed via `getCancel()` but never polled in
+  the voxel loop. Legacy has no cancel check either, so SIMPLNX is at parity; it is a
+  responsiveness gap on very large volumes, not a correctness one, and is out of scope for this pass.
+- **Preflight error paths.** `preflightImpl` calls `MarkDataPathModified` and, as of 2026-08-19,
+  validates `NumIterations >= 1` (`-14701`). The geometry and mask are selection parameters and are
+  validated by the parameter system, so they need no explicit check. With the `NumIterations` guard
+  restored, SIMPLNX's preflight validation now matches 6.5.171's `dataCheck()`.
+
+## Test inventory
+
+| Test case | Status | Notes |
+|-----------|--------|-------|
+| `SimplnxCore::ErodeDilateMaskFilter(Dilate)` | retired | 6.6-derived exemplar comparison against `Exemplar Mask Dilate` in `6_6_erode_dilate_mask.dream3d`. Retired: the exemplar was generated with all three directions on, so it could not discriminate direction gating — a build with the regression still present passed it. Replaced by the Class 1 oracles. |
+| `SimplnxCore::ErodeDilateMaskFilter(Erode)` | retired | Same, for `Exemplar Mask Erode`. Same reason. |
+| `SimplnxCore::ErodeDilateMaskFilter: Class 1 dilate, one iteration` | new-for-V&V | Class 1 oracle. 5×5×1 single seed, all directions on, 1 iteration. Asserts the exact expected true-index set element-wise over all 25 cells; 34 assertions. |
+| `SimplnxCore::ErodeDilateMaskFilter: Class 1 erode, one iteration` | new-for-V&V | Class 1 oracle. Same fixture, erode. Asserts the mask goes entirely false; 34 assertions. |
+| `SimplnxCore::ErodeDilateMaskFilter: Class 1 dilate honours direction flags` | new-for-V&V | Class 1 oracle, direction-gated. 5×5×1, `XDirOn = false`, dilate. Asserts the vertical bar `{7, 12, 17}`; 34 assertions. Written before the fix and confirmed failing at index 11 with the regression present. |
+| `SimplnxCore::ErodeDilateMaskFilter: Class 1 dilate with Y direction off` | new-for-V&V | Class 1 oracle, direction-gated. 5×5×1 centre seed, `YDirOn = false`, dilate. Asserts the horizontal bar `{11, 12, 13}`; 34 assertions. Pins the Y flag specifically: removing the `&& yDir` term from `adjustValidNeighbors` fails this test and no other. |
+| `SimplnxCore::ErodeDilateMaskFilter: Class 1 dilate, two iterations` | new-for-V&V | Class 1 oracle, multi-iteration. 5×5×1 centre seed, all flags on, `NumIterations = 2`. Asserts the 13-cell diamond `{2, 6, 7, 8, 10, 11, 12, 13, 14, 16, 17, 18, 22}`, derived cell by cell over all 20 false voxels of pass 1's output; 34 assertions. Closes coverage path 3 and pins the write-back's position inside the iteration loop. |
+| `SimplnxCore::ErodeDilateMaskFilter: Class 1 dilate from a boundary seed` | new-for-V&V | Class 1 oracle, boundary. 5×5×1 with the seed on the x = 0 face at (0, 2), dilate, all flags on. Asserts `{5, 10, 11, 15}`; 34 assertions. The only case that discriminates a −X/+X offset swap (fails at index 9, the row-wrap cell) and the only one exercising the boundary rejection on the seed's own neighbour. |
+| `SimplnxCore::ErodeDilateMaskFilter: Class 1 erode honours direction flags` | new-for-V&V | Class 1 oracle, direction-gated. 3×3×3 hollow cube, erode, `SECTION`s for `ZDirOn = true` (20 cells true) and `ZDirOn = false` (22 cells true, ±Z neighbours survive); 71 assertions. Written before the fix and confirmed failing at index 4 with the regression present. |
+| `SimplnxCore::ErodeDilateMaskFilter: Invalid Number of Iterations` | new-for-V&V | Validation test (not an oracle test). `GENERATE`s `NumIterations` of `0` and `-2` on the 5×5×1 centre-seed fixture, preflights, and asserts `SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions)` plus `errors()[0].code == -14701`; 13 assertions. Closes coverage path 10. Written before the guard existed and confirmed failing on both generated values. Pins the resolution of `ErodeDilateMaskFilter-D1`. |
+| `SimplnxCore::ErodeDilateMaskFilter: SIMPL Backwards Compatibility` | kept | Byte-identical to the pre-V&V version. `DYNAMIC_SECTION` over `simpl_conversion/6_5/ErodeDilateMaskFilter.json` (matched by `Filter_Uuid`) and `simpl_conversion/6_4/ErodeDilateMaskFilter.json` (matched by `Filter_Name`). Confirms a single `PipelineFilter` with the right UUID and checks the converted arguments (`Operation == 0`, `NumIterations == 5`, all three direction flags `true`, geometry `DataPath({"DataContainer"})`, mask `DataPath({"DataContainer","CellData","TestArray"})`); 27 assertions. Not an oracle test. |
+
+All 9 remaining test cases pass in the in-core build (`NX-Com-Qt69-Vtk96-Rel`), 315 assertions total
+(275 across the 7 oracle cases, 13 in the validation case, 27 in the backwards-compatibility case).
+Out-of-core build runs were waived by the requester on 2026-08-19.
+
+## Exemplar archive
+
+- **Archive:** none consumed by this filter's tests any more.
+- **SHA512:** n/a
+- **Provenance:** n/a
+
+The retired tests read `6_6_erode_dilate_mask.dream3d` out of `6_6_erode_dilate_test.tar.gz`. That
+archive is **not** removed from `src/Plugins/SimplnxCore/test/CMakeLists.txt:225` by this PR:
+`ErodeDilateBadDataTest.cpp:357` and `ErodeDilateCoordinationNumberTest.cpp:38` still consume it.
+Retirement of the archive completes in whichever PR lands last among the erode/dilate conversions,
+per the plan's grep guard.
+
+The A/B artifacts (legacy-format inputs, 56 pipelines, per-combination outputs, diff scripts, ReadMe)
+live in `/Users/mjackson/Workspace9/ww_work/ErodeDilateMask/` and are uploaded to OneDrive; they are
+never committed.
+
+## Deviations from DREAM3D 6.5.171
+
+The comparison was run as a full binary A/B: 14 combinations ({dilate, erode} × the 7 non-empty
+direction combinations, `NumIterations = 1`) on 2 fixtures — the 5×5×1 single-seed grid and the
+3×3×3 hollow cube the unit tests build — giving 28 pipeline pairs and 56 binary runs through
+`PipelineRunner` (6.5.171) and `nxrunner` against a single shared legacy-format input per fixture.
+
+**28/28 combinations match element-wise on the `Mask` array. No A/B difference was observed.**
+Per-combination results and the re-run recipe are in
+`/Users/mjackson/Workspace9/ww_work/ErodeDilateMask/ReadMe.md` (`results_compare.txt`).
+
+Two of the 28 (`5x5x1_dilate_Z`, `5x5x1_erode_Z`) are no-ops on both sides — a one-plane-thick grid
+has no Z face neighbours — and are reported as such by the diff script rather than being quietly
+counted as evidence. The 3×3×3 fixture carries the Z-direction evidence.
+
+The direction-flag regression fixed by this pass produces **no deviation entry**: 6.5.171 was correct
+(`ErodeDilateMask.cpp:227-247`), SIMPLNX was wrong, and once fixed there is no remaining difference.
+Comparing the legacy outputs against what pre-fix SIMPLNX would have produced (the all-directions
+result for every flag setting) shows the A/B would have failed on 12 of the 28 combinations.
+
+**No deviations remain open.** One was recorded during this pass, found by reading the legacy
+`dataCheck()` and then confirmed by running both binaries, and has since been resolved:
+
+- `ErodeDilateMaskFilter-D1` — `NumIterations <= 0` was a preflight error in 6.5.171 and a silent
+  no-op in SIMPLNX. **Retired 2026-08-19:** on the requester's product decision to match legacy, the
+  preflight guard was restored (error `-14701`, message carrying the offending value) under TDD, so no
+  difference remains. The entry is retained in
+  [`deviations/ErodeDilateMaskFilter.md`](deviations/ErodeDilateMaskFilter.md) with `Status: retired`
+  because it documents a real historical difference between the shipped versions.

--- a/src/Plugins/SimplnxCore/vv/deviations/ErodeDilateMaskFilter.md
+++ b/src/Plugins/SimplnxCore/vv/deviations/ErodeDilateMaskFilter.md
@@ -1,0 +1,89 @@
+# Deviations from DREAM3D 6.5.171: ErodeDilateMaskFilter
+
+This file lists every documented behavioral difference between this SIMPLNX filter and its DREAM3D 6.5.171 equivalent.
+
+Entries are referenced by stable ID (`ErodeDilateMaskFilter-D<N>`) from the V&V report and from public migration guidance. The ID is stable across renames; the Filter UUID field is the permanent cross-reference anchor.
+
+**Output parity:** the binary A/B run for this V&V — 14 combinations ({dilate, erode} × the 7 non-empty
+direction combinations, `NumIterations = 1`) on 2 fixtures, 28 pipeline pairs — produced **28/28
+element-wise matches** on the `Mask` array. **No output-value deviation was observed.** The one entry
+below is a validation-behaviour difference, not an output difference, and it has since been
+**resolved** — as of 2026-08-19 there are **no active deviations** for this filter.
+
+---
+
+## ErodeDilateMaskFilter-D1
+
+| Field | Value |
+|---|---|
+| **Deviation ID** | `ErodeDilateMaskFilter-D1` |
+| **Filter UUID** | `cab66cd1-f64c-42b4-8f94-18f0835a967f` |
+| **Status** | retired 2026-08-19 — difference eliminated in SIMPLNX by restoring the legacy guard (requester product decision, 2026-08-19). Retained for the historical record. |
+
+**Symptom (as observed during this V&V, before the fix):** A pipeline that sets `Number of Iterations`
+to zero or a negative value fails preflight in DREAM3D 6.5.171 with
+`Error (-5555): The number of iterations (0) must be positive`, but ran to completion in SIMPLNX and
+wrote the mask out unchanged. A user migrating such a pipeline got a silently unchanged mask where
+they previously got a hard stop.
+
+**Root cause:** Algorithmic choice — a validation guard that was not carried across in the port.
+Legacy `ErodeDilateMask::dataCheck()` (`Source/Plugins/Processing/ProcessingFilters/ErodeDilateMask.cpp`,
+in the `dataCheck` body) sets error condition `-5555` when `getNumIterations() <= 0`. SIMPLNX's
+`ErodeDilateMaskFilter::preflightImpl` performs no equivalent check — it only calls
+`MarkDataPathModified` — and `k_NumIterations_Key` is an unconstrained `Int32Parameter`. The
+algorithm's `for(int32 iteration = 0; iteration < m_InputValues->NumIterations; iteration++)` loop
+then simply never executes, so the filter succeeds and the mask is untouched. Confirmed by running
+both binaries on the same input with `NumIterations = 0`
+(`ww_work/ErodeDilateMask/extra/`, "Extra probe" section of that folder's `ReadMe.md`).
+
+**Affected users:** Anyone who reaches `NumIterations <= 0`, which in practice means pipelines built
+by scripting or templating where the iteration count is computed rather than typed. Interactively the
+value is rarely zero. The consequence is a silent no-op rather than wrong data: the mask that comes
+out is bit-identical to the mask that went in, so downstream results are those of "filter not run",
+not those of a corrupted run.
+
+**Recommendation:** Trust SIMPLNX — **no remaining difference.** The V&V pass as first written left
+this open, because adding a preflight error is a behavioural change to a shipping filter and therefore
+a product decision rather than a verification finding. The requester made that decision on
+**2026-08-19: match legacy, add the preflight error.** Rationale recorded with the decision — it
+restores 6.5.171 parity, has zero migration impact (a `NumIterations <= 0` pipeline already errored in
+legacy, so no working legacy pipeline can be relying on the SIMPLNX no-op), and needs no
+parameter-version bump because no parameter key changes.
+
+**Resolution (2026-08-19):** `ErodeDilateMaskFilter::preflightImpl` now returns
+`MakeErrorResult<OutputActions>(k_InvalidNumIterationsError /* -14701 */, ...)` when
+`NumIterations < 1`, with the offending value in the message. SIMPLNX's error code is **-14701**, not
+legacy's `-5555`: `-5555` belongs to the legacy code space, and the SIMPLNX house convention is a
+file-local `constexpr int32 k_...Error` in an anonymous namespace drawn from a per-filter block —
+`-147xx` is the first free block adjacent to the sibling `ErodeDilateBadDataFilter`'s `-146xx`
+(`k_NoDirectionsError = -14601`, `k_NoGeometryDimensionsError = -14602`). Covered by
+`SimplnxCore::ErodeDilateMaskFilter: Invalid Number of Iterations`, which preflights `NumIterations`
+of `0` and `-2` and asserts both the invalid result and the code.
+
+---
+
+## Confirmed non-deviations
+
+Recorded so they are not relitigated.
+
+### Direction parameters ignored — SIMPLNX port regression, fixed; not a deviation
+
+Before this V&V pass, `Algorithms/ErodeDilateMask.cpp` never read `XDirOn`, `YDirOn`, or `ZDirOn`, so
+the `X Direction` / `Y Direction` / `Z Direction` parameters had no effect on which face neighbours
+participated. DREAM3D 6.5.171 honours all three (`ErodeDilateMask.cpp:227-247` gates each of the six
+neighbour indices on the corresponding flag), so legacy was correct and SIMPLNX was wrong. Under the
+bug-adjudication protocol that is a **port regression**, not a deviation from legacy behaviour: it was
+fixed in the same change that found it, and once fixed no difference remains, so it gets no deviation
+entry of its own. It is described in the V&V report's Summary and Bug Fixes sections. The
+post-fix binary A/B (28/28 matches) is the confirmation of parity.
+
+Same defect class as `ErodeDilateBadDataFilter-D1` (PR #1687); the fix mirrors that pattern and the
+axis mapping was copied verbatim from `Algorithms/ErodeDilateBadData.cpp:64-80` rather than
+re-derived, per that entry's branch-history note.
+
+### `maskCopy` initial value
+
+Legacy allocates `_INTERNAL_USE_ONLY_MaskCopy` and calls `initializeWithValue(false)`; SIMPLNX uses a
+`std::vector<bool>(totalPoints, false)`. Neither initial value can be observed: the first statement
+of every iteration copies `mask` over the whole of `maskCopy` before anything reads it. Not a
+deviation.

--- a/src/simplnx/Utilities/NeighborUtilities.hpp
+++ b/src/simplnx/Utilities/NeighborUtilities.hpp
@@ -313,6 +313,30 @@ std::array<bool, VoxelNeighbors<ImageDimensionStateT>::k_FaceNeighborCount> comp
 }
 
 /**
+ * @brief Masks out face neighbors whose axis has been disabled via the X/Y/Z Direction parameters.
+ *
+ * Indices follow the VoxelNeighbors<Image3D> ordering: [-Z,-Y,-X,+X,+Y,+Z]. The axis-to-face
+ * mapping is therefore:
+ * - zDir gates k_NegativeZNeighbor (index 0) and k_PositiveZNeighbor (index 5)
+ * - yDir gates k_NegativeYNeighbor (index 1) and k_PositiveYNeighbor (index 4)
+ * - xDir gates k_NegativeXNeighbor (index 2) and k_PositiveXNeighbor (index 3)
+ *
+ * @param isValidFaceNeighbor Per-voxel face-neighbor validity, already computed from geometry boundary.
+ * @param xDir Whether the X direction is enabled.
+ * @param yDir Whether the Y direction is enabled.
+ * @param zDir Whether the Z direction is enabled.
+ */
+inline void adjustValidNeighbors(std::array<bool, VoxelNeighbors<Image3D>::k_FaceNeighborCount>& isValidFaceNeighbor, bool xDir, bool yDir, bool zDir)
+{
+  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeZNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeZNeighbor] && zDir;
+  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeYNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeYNeighbor] && yDir;
+  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeXNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_NegativeXNeighbor] && xDir;
+  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveXNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveXNeighbor] && xDir;
+  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveYNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveYNeighbor] && yDir;
+  isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveZNeighbor] = isValidFaceNeighbor[VoxelNeighbors<Image3D>::k_PositiveZNeighbor] && zDir;
+}
+
+/**
  * @brief Returns the surface area of each face of the voxel corresponding to the
  * initializeFaceNeighborInternalIdx() ordering
  * @param spacing The spacing of each voxel


### PR DESCRIPTION
## Summary
De-duplicates the direction-flag gating helper used by the erode/dilate filter family.

* `adjustValidNeighbors` existed as byte-identical file-local copies in the `ErodeDilateBadData` and `ErodeDilateMask` algorithms. Its axis-to-face mapping has been re-derived incorrectly once before (`ErodeDilateBadDataFilter-D1` branch-history note), so a single canonical copy in `NeighborUtilities.hpp` removes the drift risk before a third family filter needs it.
* No behavior change: the function body is character-identical, both call sites are unchanged, and the Mask direction-flag oracle tests pin the axis mapping empirically.
* Historical line citations in the ErodeDilateBadData V&V documents refer to the pre-hoist file layout.

**Stacked on #1713** — this branch contains the `ErodeDilateMask` V&V commit, so the diff shows both commits until #1713 merges. Merge after #1713; the hoist commit itself touches only three files (`NeighborUtilities.hpp` and the two algorithm `.cpp` files).

## Test Plan
- [x] `ctest -R "SimplnxCore::ErodeDilate"` — 18/18 pass, including the three Mask direction-flag oracles that discriminate axis-mapping errors