### PR TITLE
VV: Compute Surface Area to Volume Fully V&V'ed

### DIFF
--- a/src/Plugins/SimplnxCore/docs/ComputeSurfaceAreaToVolumeFilter.md
+++ b/src/Plugins/SimplnxCore/docs/ComputeSurfaceAreaToVolumeFilter.md
@@ -6,40 +6,60 @@ Statistics (Morphological)
 
 ## Description
 
-This **Filter** calculates the ratio of surface area to volume for each **Feature** in an **Image Geometry**.
-
-This filter also optionally calculate the [Sphericity](https://en.wikipedia.org/wiki/Sphericity) of each feature.
+This **Filter** calculates the ratio of surface area to volume for each **Feature** in an **Image Geometry**, and optionally the [Sphericity](https://en.wikipedia.org/wiki/Sphericity) of each **Feature**.
 
 ![Equation for Sphericity used in the filter](Images/Sphericity_Equation.png)
 
-This **Filter** determines whether a **Feature** touches an outer *Surface* of the sample volume. A **Feature** is considered touching the *Surface* of the sample if either of the following conditions are met:
+The **Feature** surface area is accumulated one **Cell** face at a time. Walking every **Cell** of the geometry, each of the **Cell**'s six face neighbors is examined and the area of the shared face is added to the owning **Feature**'s total when **both** of the following hold:
 
-+ Any cell location is x<sub>min</sub>, x<sub>max</sub>, y<sub>min</sub>, y<sub>max</sub>, z<sub>min</sub> or z<sub>max</sub>
-+ Any cell has **Feature ID = 0** as a neighbor.
++ the neighboring **Cell** lies **inside** the geometry, and
++ the neighboring **Cell**'s *Feature Id* is **different** from the current **Cell**'s.
+
+The area added is the product of the two spacings that span the shared face: a face shared with the ±Z neighbor contributes `dx·dy`, a face shared with the ±Y neighbor contributes `dx·dz`, and a face shared with the ±X neighbor contributes `dy·dz`. On anisotropic spacing these are three different numbers, so the orientation of a **Feature** changes its surface area.
+
+The **Feature** volume is the *Number of Cells* value the user selects, multiplied by the volume of one **Cell** (`dx·dy·dz`). The filter does **not** recount the **Cells** of each **Feature** from the *Feature Ids* array — whatever the selected *Number of Cells* array says is what is used.
+
+Feature Id 0 is normally used to mark "bad data" or unindexed **Cells**. This filter does not compute a value for **Feature** 0: the first tuple of both output arrays is left at 0.
 
 ## Algorithm Details
 
-- First, all the boundary **Cells** are found for each **Feature**. 
-- Next, the surface area for each face that is in contact with a different **Feature** is totalled as long as that neighboring *featureId* is > 0.
-- This number is divided by the volume of each **Feature**, calculated by taking the number of **Cells** of each **Feature** and multiplying by the volume of a **Cell**.
+1. Every **Cell** with a *Feature Id* of 1 or greater is visited.
+2. For each of that **Cell**'s six face neighbors, the shared face area is added to the **Feature**'s running total when the neighbor is inside the geometry and carries a different *Feature Id*.
+3. For each **Feature**, `SurfaceAreaVolumeRatio = A / V`, where `A` is the accumulated area and `V = NumCells · dx·dy·dz`. The units are inverse length.
+4. If *Calculate Sphericity* is on, `Sphericity = π^(1/3) · (6V)^(2/3) / A`, which is 1 for a perfect sphere and less than 1 for every other real solid.
+
+### Feature Id 0 counts as surface
+
+A face shared with a **Cell** whose *Feature Id* is 0 **is** counted — id 0 is treated as an ordinary differing **Feature**. A **Feature** completely surrounded by "bad data" therefore reports the same surface area it would report if it were surrounded by a neighboring **Feature**.
+
+### Faces on the outer boundary of the volume are NOT counted
+
+A face that would look out of the sample is skipped, because there is no neighboring **Cell** on the far side of it. Any **Feature** that touches x<sub>min</sub>, x<sub>max</sub>, y<sub>min</sub>, y<sub>max</sub>, z<sub>min</sub> or z<sub>max</sub> therefore has its surface area **under-estimated** by the total area of the faces it presents to the outside world, and its surface-area-to-volume ratio is correspondingly too low.
+
+Two visible consequences:
+
++ Because *Sphericity* divides by that under-estimated area, a boundary-touching **Feature** can report a **sphericity greater than 1**, which is geometrically impossible for a real solid. A single **Cell** in the corner of a volume, for example, reports a sphericity of about 1.61.
++ A **Feature** that fills the entire volume presents no interior faces at all, so its area is 0, its ratio is 0, and its sphericity is `+infinity`.
+
+If either matters for your analysis, exclude boundary-touching **Features** first — the *Compute Surface Features* filter identifies them.
 
 ### WARNING - Aliasing
 
-The surface area will be the surface area of the **Cells** in contact with the neighboring **Feature** and will be influenced by the aliasing of the structure.  As a result, the surface area to volume will likely be over-estimated with respect to the *real* **Feature**.
-
-### WARNING - Skewed Results for features touching the surface
-
-Because the filter does not include any surface that is touching/connected to a "FeatureId = 0", those features that are in contact with the edge of the virtual volume or in contact with internal features that are labeled as "FeatureId = 0" will have their values skewed.
+The surface area is the area of the **Cell** faces in contact with a neighboring **Feature** and is influenced by the aliasing (voxelization) of the structure. As a result the surface area to volume ratio will generally be over-estimated with respect to the *real* **Feature**, and the sphericity under-estimated. A perfect digital cube, for example, reports a sphericity of `(π/6)^(1/3) ≈ 0.806` at every size rather than the 1.0 of the sphere of equal volume.
 
 ### Warning - 2D Image Geometry Results
 
-Because even a single slice has *volume* according to DREAM3D-NX, results will still be computed. These results should **NOT** be interpreted as "Boundary Length to Area" values.
+An **Image Geometry** one **Cell** thick still has *volume* according to DREAM3D-NX, so results are computed. In that case both z-neighbors of every **Cell** are outside the geometry, so no `dx·dy` face is ever counted and the reported "surface area" is really the perimeter of the **Feature** multiplied by the slice thickness. These results should **NOT** be interpreted as "Boundary Length to Area" values.
 
 % Auto generated parameter table will be inserted here
 
 ## Example Pipelines
 
 + (03) Small IN100 Morphological Statistics
+
+## References
+
+Wadell, H. (1935). *Volume, Shape, and Roundness of Quartz Particles*. The Journal of Geology, 43(3), 250-280.
 
 ## License & Copyright
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeSurfaceAreaToVolume.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeSurfaceAreaToVolume.cpp
@@ -123,19 +123,25 @@ Result<> ComputeSurfaceAreaToVolume::operator()()
           //
           int64 neighborIndex = zStride + yStride + xIdx + neighborOffset[neighborOffsetIndex];
 
+          // Note that a FeatureId of 0 is an ordinary *differing* id here: a face shared with a
+          // "bad data" voxel counts toward the surface area exactly like a face shared with a
+          // different Feature. Faces on the outer boundary of the geometry were skipped above and
+          // never contribute, so a Feature touching the sample edge under-reports its area.
           if(featureIdsStoreRef[neighborIndex] != currentFeatureId)
           {
-            if(neighborOffsetIndex == 0 || neighborOffsetIndex == 5) // XY face shared
+            // The area of the shared face is the product of the two spacings that span the face's
+            // plane. The +/-Z neighbor shares the XY face, +/-Y shares the XZ face, +/-X the YZ face.
+            if(neighborOffsetIndex == 0 || neighborOffsetIndex == 5) // -Z / +Z neighbor: XY face shared
             {
               onSurface = onSurface + spacing[0] * spacing[1];
             }
-            if(neighborOffsetIndex == 1 || neighborOffsetIndex == 4) // YZ face shared
+            if(neighborOffsetIndex == 1 || neighborOffsetIndex == 4) // -Y / +Y neighbor: XZ face shared
+            {
+              onSurface = onSurface + spacing[0] * spacing[2];
+            }
+            if(neighborOffsetIndex == 2 || neighborOffsetIndex == 3) // -X / +X neighbor: YZ face shared
             {
               onSurface = onSurface + spacing[1] * spacing[2];
-            }
-            if(neighborOffsetIndex == 2 || neighborOffsetIndex == 3) // XZ face shared
-            {
-              onSurface = onSurface + spacing[2] * spacing[0];
             }
           }
         }
@@ -145,8 +151,11 @@ Result<> ComputeSurfaceAreaToVolume::operator()()
     }
   }
 
-  const float32 thirdRootPi = std::pow(nx::core::Constants::k_PiF, 0.333333f);
-  for(usize i = 1; i < numFeatures; i++)
+  // Sphericity (Wadell 1935) is pi^(1/3) * (6 V)^(2/3) / A. The exponents must be the exact
+  // rational values: the truncated decimals 0.333333f / 0.66666f that this filter shipped with
+  // biased the result by up to ~4e-5 relative.
+  const float32 thirdRootPi = std::pow(nx::core::Constants::k_PiF, 1.0f / 3.0f);
+  for(usize i = 1; i < static_cast<usize>(numFeatures); i++)
   {
     float featureVolume = voxelVol * numCells[i];
     surfaceAreaVolumeRatio[i] = featureSurfaceArea[i] / featureVolume;
@@ -160,7 +169,7 @@ Result<> ComputeSurfaceAreaToVolume::operator()()
     for(usize i = 1; i < static_cast<usize>(numFeatures); i++)
     {
       float featureVolume = voxelVol * numCells[i];
-      sphericity[i] = (thirdRootPi * std::pow((6.0f * featureVolume), 0.66666f)) / featureSurfaceArea[i];
+      sphericity[i] = (thirdRootPi * std::pow((6.0f * featureVolume), 2.0f / 3.0f)) / featureSurfaceArea[i];
     }
   }
 

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceAreaToVolumeFilter.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/ComputeSurfaceAreaToVolumeFilter.cpp
@@ -5,6 +5,7 @@
 #include "simplnx/DataStructure/AttributeMatrix.hpp"
 #include "simplnx/DataStructure/DataArray.hpp"
 #include "simplnx/DataStructure/DataPath.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Filter/Actions/CreateArrayAction.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
@@ -113,6 +114,22 @@ IFilter::PreflightResult ComputeSurfaceAreaToVolumeFilter::preflightImpl(const D
                                                         "located in the cell feature attribute matrix of the selected geometry",
                                                         pNumCellsArrayPathValue.toString()));
   }
+  // The algorithm walks the ImageGeom's cell extents and indexes FeatureIds with the resulting flat
+  // index, so a FeatureIds selection whose tuple count does not cover the geometry is read out of
+  // bounds. Nothing forces the selection to come from the geometry's own cell AttributeMatrix, so
+  // this cross-check has to be made explicitly.
+  auto pInputImageGeometryPathValue = filterArgs.value<DataPath>(k_SelectedImageGeometryPath_Key);
+  const auto& imageGeom = dataStructure.getDataRefAs<ImageGeom>(pInputImageGeometryPathValue);
+  const auto& featureIdsArray = dataStructure.getDataRefAs<Int32Array>(pFeatureIdsArrayPathValue);
+  const usize numGeometryCells = imageGeom.getNumberOfCells();
+  const usize numFeatureIdsTuples = featureIdsArray.getNumberOfTuples();
+  if(numFeatureIdsTuples != numGeometryCells)
+  {
+    return MakePreflightErrorResult(-12803, fmt::format("The selected Feature Ids array '{}' has {} tuples, but the selected Image Geometry '{}' has {} cells. The Feature Ids array must have exactly "
+                                                        "one tuple per cell of the selected geometry.",
+                                                        pFeatureIdsArrayPathValue.toString(), numFeatureIdsTuples, pInputImageGeometryPathValue.toString(), numGeometryCells));
+  }
+
   ShapeType tupleShape = cellFeatureData->getShape();
   // Create the SurfaceAreaVolumeRatio
   {

--- a/src/Plugins/SimplnxCore/test/ComputeSurfaceAreaToVolumeTest.cpp
+++ b/src/Plugins/SimplnxCore/test/ComputeSurfaceAreaToVolumeTest.cpp
@@ -2,6 +2,10 @@
 #include "SimplnxCore/SimplnxCore_test_dirs.hpp"
 
 #include "simplnx/Core/Application.hpp"
+#include "simplnx/DataStructure/AttributeMatrix.hpp"
+#include "simplnx/DataStructure/DataArray.hpp"
+#include "simplnx/DataStructure/DataGroup.hpp"
+#include "simplnx/DataStructure/Geometry/ImageGeom.hpp"
 #include "simplnx/Parameters/ArrayCreationParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Pipeline/Pipeline.hpp"
@@ -10,76 +14,567 @@
 
 #include <catch2/catch.hpp>
 
+#include <array>
+#include <cmath>
 #include <filesystem>
-#include <fstream>
+#include <vector>
 
 namespace fs = std::filesystem;
 
 using namespace nx::core;
-using namespace nx::core::Constants;
 using namespace nx::core::UnitTest;
 
-namespace
-{
-const std::string k_SurfaceAreaVolumeRationArrayName("SurfaceAreaVolumeRatio");
-const std::string k_SphericityArrayName("Sphericity");
-const std::string k_SurfaceAreaVolumeRationArrayNameNX("SurfaceAreaVolumeRatioNX");
-const std::string k_SphericityArrayNameNX("SphericityNX");
-} // namespace
+// =============================================================================
+// V&V Class 1 (Analytical) oracle support — added 2026-08-20.
+//
+// ORACLE, derived by hand from the definition of the quantities and NOT from any
+// DREAM3D/SIMPLNX source or output:
+//
+//   Surface area A(f) = sum over every cell c of feature f, and every one of c's
+//   six face neighbours n, of the area of the shared face — counted if and only if
+//     (a) n lies INSIDE the grid, and
+//     (b) FeatureIds[n] != FeatureIds[c].
+//   The face shared with the +/-Z neighbour lies in the XY plane -> area dx*dy.
+//   The face shared with the +/-Y neighbour lies in the XZ plane -> area dx*dz.
+//   The face shared with the +/-X neighbour lies in the YZ plane -> area dy*dz.
+//   Two consequences that the fixtures below pin down deliberately:
+//     * A face on the OUTER BOUNDARY of the grid is never counted (rule (a)) —
+//       so a feature touching the sample edge under-reports its area, and its
+//       sphericity can exceed 1 (see the "Corner voxel" section).
+//     * FeatureId 0 is an ordinary differing id (rule (b)) — a feature embedded in
+//       id-0 "bad data" gets exactly the same area as one embedded in a positive
+//       neighbour (see the "Id 0 counts as surface" section).
+//
+//   Volume V(f) = NumCells[f] * dx*dy*dz — the USER-SUPPLIED NumCells value, never
+//   a recount of the FeatureIds array.
+//   SurfaceAreaVolumeRatio(f) = A(f) / V(f).
+//   Sphericity(f) = pi^(1/3) * (6 V(f))^(2/3) / A(f)     [Wadell 1935]
+//
+// Every expected number in this file was derived from the rules above by an
+// independent brute-force face enumeration written before the filter was ever run
+// (see the V&V report's Oracle section and ww_work/ComputeSurfaceAreaToVolume/derive.py).
+//
+// Spacings are dyadic (0.5) or small integers (1, 2, 4) so that every expected area,
+// volume and ratio is exactly representable in float32; the ratio assertions are
+// therefore exact equalities. Sphericity involves cube roots, so those assertions
+// use a 1e-6 relative tolerance (the fixed float32 expression lands within 1.3e-7).
+//
+// These inline fixtures replace the retired 6_6_stats_test_v2 exemplar test, which
+// compared SIMPLNX against a sibling array in the same archive that had been produced
+// by the very code under test — a circular oracle that additionally baked in the two
+// bugs fixed on this branch.
+//
+// Reference: src/Plugins/SimplnxCore/vv/ComputeSurfaceAreaToVolumeFilter.md
+// =============================================================================
 
-TEST_CASE("SimplnxCore::ComputeSurfaceAreaToVolume", "[SimplnxCore][ComputeSurfaceAreaToVolume]")
+namespace SavToy
+{
+const std::string k_GeomName = "Image";
+const std::string k_CellAMName = "Cell Data";
+const std::string k_FeatureAMName = "Cell Feature Data";
+const std::string k_FeatureIdsName = "FeatureIds";
+const std::string k_NumCellsName = "NumElements";
+const std::string k_SavrName = "SurfaceAreaVolumeRatio";
+// Legacy SIMPL pins the sphericity array name to "Sphericity" (it never reads the name from
+// the pipeline file), so the A/B fixtures use that name here too.
+const std::string k_SphericityName = "Sphericity";
+
+struct Scaffold
+{
+  DataStructure ds;
+  DataPath geomPath;
+  DataPath featureIdsPath;
+  DataPath featureAMPath;
+  DataPath numCellsPath;
+  DataPath savrPath;
+  DataPath sphericityPath;
+};
+
+/**
+ * @brief Builds an ImageGeom + Cell Data AM (FeatureIds) + Cell Feature Data AM (NumElements).
+ * @param dims (x, y, z) cell counts
+ * @param spacing (dx, dy, dz)
+ * @param featureIdValues flat FeatureIds in (z, y, x) row-major order, length dims[0]*dims[1]*dims[2]
+ * @param numCellsValues NumElements, one per feature tuple (index 0 included)
+ */
+inline Scaffold Build(std::array<usize, 3> dims, std::array<float32, 3> spacing, const std::vector<int32>& featureIdValues, const std::vector<int32>& numCellsValues)
+{
+  Scaffold s;
+  auto* imageGeomPtr = ImageGeom::Create(s.ds, k_GeomName);
+  imageGeomPtr->setDimensions({dims[0], dims[1], dims[2]});
+  imageGeomPtr->setSpacing({spacing[0], spacing[1], spacing[2]});
+  imageGeomPtr->setOrigin({0.0F, 0.0F, 0.0F});
+
+  const ShapeType cellTupleShape{dims[2], dims[1], dims[0]};
+  auto* cellAMPtr = AttributeMatrix::Create(s.ds, k_CellAMName, cellTupleShape, imageGeomPtr->getId());
+  imageGeomPtr->setCellData(*cellAMPtr);
+
+  REQUIRE(featureIdValues.size() == dims[0] * dims[1] * dims[2]);
+  auto* featureIdsPtr = CreateTestDataArray<int32>(s.ds, k_FeatureIdsName, cellTupleShape, {1}, cellAMPtr->getId());
+  for(usize i = 0; i < featureIdValues.size(); ++i)
+  {
+    (*featureIdsPtr)[i] = featureIdValues[i];
+  }
+
+  auto* featureAMPtr = AttributeMatrix::Create(s.ds, k_FeatureAMName, ShapeType{numCellsValues.size()}, imageGeomPtr->getId());
+  auto* numCellsPtr = CreateTestDataArray<int32>(s.ds, k_NumCellsName, ShapeType{numCellsValues.size()}, {1}, featureAMPtr->getId());
+  for(usize i = 0; i < numCellsValues.size(); ++i)
+  {
+    (*numCellsPtr)[i] = numCellsValues[i];
+  }
+
+  s.geomPath = DataPath({k_GeomName});
+  s.featureIdsPath = s.geomPath.createChildPath(k_CellAMName).createChildPath(k_FeatureIdsName);
+  s.featureAMPath = s.geomPath.createChildPath(k_FeatureAMName);
+  s.numCellsPath = s.featureAMPath.createChildPath(k_NumCellsName);
+  s.savrPath = s.featureAMPath.createChildPath(k_SavrName);
+  s.sphericityPath = s.featureAMPath.createChildPath(k_SphericityName);
+  return s;
+}
+
+inline Arguments MakeArgs(const Scaffold& s, bool calculateSphericity)
+{
+  Arguments args;
+  args.insertOrAssign(ComputeSurfaceAreaToVolumeFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(s.geomPath));
+  args.insertOrAssign(ComputeSurfaceAreaToVolumeFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(s.featureIdsPath));
+  args.insertOrAssign(ComputeSurfaceAreaToVolumeFilter::k_NumCellsArrayPath_Key, std::make_any<DataPath>(s.numCellsPath));
+  args.insertOrAssign(ComputeSurfaceAreaToVolumeFilter::k_CalculateSphericity_Key, std::make_any<bool>(calculateSphericity));
+  args.insertOrAssign(ComputeSurfaceAreaToVolumeFilter::k_SurfaceAreaVolumeRatioArrayName_Key, std::make_any<std::string>(k_SavrName));
+  args.insertOrAssign(ComputeSurfaceAreaToVolumeFilter::k_SphericityArrayName_Key, std::make_any<std::string>(k_SphericityName));
+  return args;
+}
+
+struct Output
+{
+  std::vector<float32> savr;
+  std::vector<float32> sphericity; // empty when CalculateSphericity was off
+};
+
+inline Output Run(Scaffold& s, bool calculateSphericity = true)
+{
+  ComputeSurfaceAreaToVolumeFilter filter;
+  const Arguments args = MakeArgs(s, calculateSphericity);
+
+  auto preflightResult = filter.preflight(s.ds, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+
+  auto executeResult = filter.execute(s.ds, args);
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+
+  Output out;
+  REQUIRE_NOTHROW(s.ds.getDataRefAs<Float32Array>(s.savrPath));
+  const auto& savrRef = s.ds.getDataRefAs<Float32Array>(s.savrPath).getDataStoreRef();
+  out.savr.resize(savrRef.getNumberOfTuples());
+  for(usize i = 0; i < savrRef.getNumberOfTuples(); ++i)
+  {
+    out.savr[i] = savrRef[i];
+  }
+
+  if(calculateSphericity)
+  {
+    REQUIRE_NOTHROW(s.ds.getDataRefAs<Float32Array>(s.sphericityPath));
+    const auto& sphericityRef = s.ds.getDataRefAs<Float32Array>(s.sphericityPath).getDataStoreRef();
+    out.sphericity.resize(sphericityRef.getNumberOfTuples());
+    for(usize i = 0; i < sphericityRef.getNumberOfTuples(); ++i)
+    {
+      out.sphericity[i] = sphericityRef[i];
+    }
+  }
+  return out;
+}
+
+// Relative tolerance for sphericity. The fixed float32 expression
+// pow(pi, 1/3) * pow(6V, 2/3) / A reproduces the double-precision oracle to
+// within 1.3e-7 relative on every fixture in this file, so 1e-6 is a real
+// constraint and not a rubber stamp: the pre-fix truncated exponents
+// (0.333333 / 0.66666) miss by 1.4e-6 .. 3.6e-5 and fail it.
+constexpr float64 k_SphericityEpsilon = 1.0e-6;
+
+inline void RequireSphericity(const std::vector<float32>& sphericity, usize featureId, float64 expected)
+{
+  CAPTURE(featureId, sphericity[featureId], expected);
+  REQUIRE(static_cast<float64>(sphericity[featureId]) == Approx(expected).epsilon(k_SphericityEpsilon));
+}
+
+// (pi/6)^(1/3) — the sphericity of any perfect cube whose faces are all counted.
+constexpr float64 k_CubeSphericity = 0.8059959770082348;
+} // namespace SavToy
+
+TEST_CASE("SimplnxCore::ComputeSurfaceAreaToVolumeFilter: Class 1 - Analytical Surface Area & Sphericity", "[SimplnxCore][ComputeSurfaceAreaToVolumeFilter]")
 {
   UnitTest::LoadPlugins();
 
-  const nx::core::UnitTest::TestFileSentinel testDataSentinel(nx::core::unit_test::k_TestFilesDir, "6_6_stats_test_v2.tar.gz", "6_6_stats_test_v2.dream3d");
-
-  // Read the Small IN100 Data set
-  auto baseDataFilePath = fs::path(fmt::format("{}/6_6_stats_test_v2.dream3d", unit_test::k_TestFilesDir));
-  DataStructure dataStructure = UnitTest::LoadDataStructure(baseDataFilePath);
-
-  // Instantiate the filter, a DataStructure object and an Arguments Object
+  SECTION("F1 single interior voxel")
   {
+    // 3x3x3, spacing a = 0.5. One voxel of feature 1 at (1,1,1); everything else id 0.
+    // All six neighbours exist and differ  ->  A = 6a^2 = 1.5
+    // V = NumCells[1] * a^3 = 1 * 0.125     ->  SAVR = 6/a = 12
+    // Psi = pi^(1/3)(6V)^(2/3)/A = (pi/6)^(1/3), independent of a.
+    //
+    // NumCells[0] is deliberately set to a non-zero sentinel (5). Both output loops start at
+    // feature 1, so index 0 must remain at its preflight-created 0.0F. Had the sphericity loop
+    // started at 0 it would have written pi^(1/3)(6*5*a^3)^(2/3)/0 = +inf there, so this
+    // assertion actually discriminates the loop start.
+    std::vector<int32> ids(27, 0);
+    ids[1 * 9 + 1 * 3 + 1] = 1;
+    auto s = SavToy::Build({3, 3, 3}, {0.5F, 0.5F, 0.5F}, ids, {5, 1});
+    auto out = SavToy::Run(s);
+
+    REQUIRE(out.savr.size() == 2);
+    REQUIRE(out.savr[1] == 12.0F);
+    SavToy::RequireSphericity(out.sphericity, 1, SavToy::k_CubeSphericity);
+
+    // Index 0 is never written by either loop.
+    REQUIRE(out.savr[0] == 0.0F);
+    REQUIRE(out.sphericity[0] == 0.0F);
+
+    UnitTest::CheckArraysInheritTupleDims(s.ds);
+  }
+
+  SECTION("F1b over-provisioned Feature AM is accepted")
+  {
+    // Same geometry as F1, but the Feature AttributeMatrix has 4 tuples while the largest
+    // FeatureId present is 1. SIMPLNX accepts this -- the execute-time guard only rejects ids
+    // that would index PAST the feature arrays -- and simply never writes the unused tuples'
+    // area, so they finish with A = 0:
+    //     feature 2: SAVR = 0 / (3 * a^3) = 0,  Psi = (positive)/0 = +inf
+    //     feature 3: SAVR = 0 / (5 * a^3) = 0,  Psi = +inf
+    // DREAM3D 6.5.171 REJECTS this input outright (error -5555: it requires
+    // max(FeatureIds) == numFeatures - 1 exactly), so this section is SIMPLNX-only and is
+    // recorded as a deviation. See vv/deviations/ComputeSurfaceAreaToVolumeFilter.md.
+    std::vector<int32> ids(27, 0);
+    ids[1 * 9 + 1 * 3 + 1] = 1;
+    auto s = SavToy::Build({3, 3, 3}, {0.5F, 0.5F, 0.5F}, ids, {0, 1, 3, 5});
+    auto out = SavToy::Run(s);
+
+    REQUIRE(out.savr.size() == 4);
+    REQUIRE(out.savr[1] == 12.0F);
+    SavToy::RequireSphericity(out.sphericity, 1, SavToy::k_CubeSphericity);
+    for(usize i = 2; i < 4; ++i)
+    {
+      CAPTURE(i);
+      REQUIRE(out.savr[i] == 0.0F);
+      REQUIRE(std::isinf(out.sphericity[i]));
+    }
+
+    UnitTest::CheckArraysInheritTupleDims(s.ds);
+  }
+
+  SECTION("F2 2x2x2 interior cube - scale invariance")
+  {
+    // 4x4x4, spacing a = 0.5. Feature 1 fills the interior 2x2x2 block.
+    // Each of the 8 cells has 3 same-feature neighbours and 3 differing ones
+    //   -> 24 counted faces, A = 24a^2 = 6.0
+    // V = 8a^3 = 1.0, SAVR = 3/a = 6.0.
+    // Psi is (pi/6)^(1/3) again — identical to F1's single voxel, which is the
+    // scale-invariance invariant (Class 4) riding along on this fixture.
+    std::vector<int32> ids(64, 0);
+    for(usize z = 1; z <= 2; ++z)
+    {
+      for(usize y = 1; y <= 2; ++y)
+      {
+        for(usize x = 1; x <= 2; ++x)
+        {
+          ids[z * 16 + y * 4 + x] = 1;
+        }
+      }
+    }
+    auto s = SavToy::Build({4, 4, 4}, {0.5F, 0.5F, 0.5F}, ids, {0, 8});
+    auto out = SavToy::Run(s);
+
+    REQUIRE(out.savr[1] == 6.0F);
+    SavToy::RequireSphericity(out.sphericity, 1, SavToy::k_CubeSphericity);
+
+    UnitTest::CheckArraysInheritTupleDims(s.ds);
+  }
+
+  SECTION("F2b NumCells is user-supplied, never recounted")
+  {
+    // The volume is NumCells[f] * dx*dy*dz, where NumCells is whatever the user selected --
+    // the filter must NOT recount the cells of each feature from the FeatureIds array.
+    // Here exactly ONE cell carries id 1 but NumCells[1] is 8, so:
+    //   A = 6a^2 = 1.5  (from the FeatureIds geometry)
+    //   V = 8 * a^3 = 1.0  (from NumCells, NOT from the one cell present)
+    //   SAVR = 1.5,  Psi = pi^(1/3) * 6^(2/3) / 1.5 = 3.22398...
+    // A recount would give V = 0.125, SAVR = 12 and Psi = 0.806 instead.
+    std::vector<int32> ids(27, 0);
+    ids[1 * 9 + 1 * 3 + 1] = 1;
+    auto s = SavToy::Build({3, 3, 3}, {0.5F, 0.5F, 0.5F}, ids, {0, 8});
+    auto out = SavToy::Run(s);
+
+    REQUIRE(out.savr[1] == 1.5F);
+    SavToy::RequireSphericity(out.sphericity, 1, 3.2239839080329387);
+
+    UnitTest::CheckArraysInheritTupleDims(s.ds);
+  }
+
+  SECTION("F3 anisotropic rods - per-axis face areas")
+  {
+    // THE discriminating fixture for the +/-X <-> +/-Y face-area assignment.
+    //
+    // 6x8x3, spacing (dx, dy, dz) = (1, 2, 4)  ->  voxelVol = 8, and the three
+    // distinct face areas are all different:  dx*dy = 2, dx*dz = 4, dy*dz = 8.
+    //
+    // Feature 1 - a 4-cell rod along X at (x=1..4, y=1, z=1), fully interior:
+    //   2 end faces normal to X  -> 2 * (dy*dz = 8) = 16
+    //   8 side faces normal to Y -> 8 * (dx*dz = 4) = 32
+    //   8 side faces normal to Z -> 8 * (dx*dy = 2) = 16
+    //   A1 = 64,  V1 = 4 * 8 = 32,  SAVR1 = 2.0
+    //
+    // Feature 2 - the mirror, a 4-cell rod along Y at (x=1, y=3..6, z=1):
+    //   2 end faces normal to Y  -> 2 * (dx*dz = 4) = 8
+    //   8 side faces normal to X -> 8 * (dy*dz = 8) = 64
+    //   8 side faces normal to Z -> 8 * (dx*dy = 2) = 16
+    //   A2 = 88,  V2 = 32,  SAVR2 = 2.75
+    //
+    // Swapping the +/-X and +/-Y face areas exchanges A1 and A2 exactly (A1 -> 88,
+    // A2 -> 64, i.e. SAVR1 -> 2.75 and SAVR2 -> 2.0), which is what this section
+    // caught on the pre-fix code.
+    std::vector<int32> ids(6 * 8 * 3, 0);
+    const auto idx = [](usize x, usize y, usize z) { return z * 6 * 8 + y * 6 + x; };
+    for(usize x = 1; x <= 4; ++x)
+    {
+      ids[idx(x, 1, 1)] = 1;
+    }
+    for(usize y = 3; y <= 6; ++y)
+    {
+      ids[idx(1, y, 1)] = 2;
+    }
+    auto s = SavToy::Build({6, 8, 3}, {1.0F, 2.0F, 4.0F}, ids, {0, 4, 4});
+    auto out = SavToy::Run(s);
+
+    REQUIRE(out.savr[1] == 2.0F);  // A1 = 64 / V = 32
+    REQUIRE(out.savr[2] == 2.75F); // A2 = 88 / V = 32
+    SavToy::RequireSphericity(out.sphericity, 1, 0.7616184727713847);
+    SavToy::RequireSphericity(out.sphericity, 2, 0.5539043438337707);
+
+    // Class 4 invariant: the two rods are geometric mirrors of one another under the
+    // relabelling (x<->y, dx<->dy), so the multiset of their areas must be {64, 88}
+    // whichever way round the implementation assigns them. Asserting the SUM as well
+    // as the individual values documents that the pre-fix failure was an exchange and
+    // not a scale error: the sum was right, the assignment was not.
+    REQUIRE((out.savr[1] + out.savr[2]) == 4.75F);
+
+    UnitTest::CheckArraysInheritTupleDims(s.ds);
+  }
+
+  SECTION("F4 corner voxel - outer boundary faces are NOT counted")
+  {
+    // !!! READ THIS BEFORE "FIXING" THE EXPECTED VALUE BELOW !!!
+    //
+    // 3x3x3, spacing a = 0.5, one voxel of feature 1 at the (0,0,0) CORNER.
+    // Its -X, -Y and -Z neighbours are outside the grid, so those three faces are
+    // skipped entirely -- they are NOT treated as exposed surface. Only the three
+    // faces toward +X, +Y, +Z are counted:
+    //     A = 3a^2 = 0.75   (not 6a^2)
+    //     V = a^3 = 0.125,  SAVR = 3/a = 6.0
+    //     Psi = pi^(1/3)(6a^3)^(2/3)/(3a^2) = 2*(pi/6)^(1/3) = 1.61199...
+    //
+    // Psi > 1 IS THE EXPECTED, CORRECT OUTPUT of this filter for a feature that
+    // touches the sample boundary. A sphericity above 1 is geometrically impossible
+    // for a real solid; it appears here because the denominator A is a systematic
+    // UNDER-estimate of the true surface area whenever the boundary-face rule kicks
+    // in. This is a documented property of the algorithm (it matches DREAM3D 6.5.171),
+    // not a defect, and it is exactly why the user documentation now warns that
+    // boundary-touching features have skewed values. Do not "correct" 1.612 to
+    // something <= 1.
+    std::vector<int32> ids(27, 0);
+    ids[0] = 1;
+    auto s = SavToy::Build({3, 3, 3}, {0.5F, 0.5F, 0.5F}, ids, {0, 1});
+    auto out = SavToy::Run(s);
+
+    REQUIRE(out.savr[1] == 6.0F);
+    SavToy::RequireSphericity(out.sphericity, 1, 2.0 * SavToy::k_CubeSphericity);
+    REQUIRE(out.sphericity[1] > 1.0F); // stated explicitly so the intent survives a refactor
+
+    UnitTest::CheckArraysInheritTupleDims(s.ds);
+  }
+
+  SECTION("F5 feature fills the whole volume - degenerate divide")
+  {
+    // 3x3x3, spacing a = 0.5, every cell is feature 1. No neighbour differs and every
+    // face that would be exposed lies on the outer boundary, so A = 0 exactly.
+    //   SAVR = 0/V = 0
+    //   Psi  = (positive numerator)/0 = +inf   <- documented degenerate case
+    std::vector<int32> ids(27, 1);
+    auto s = SavToy::Build({3, 3, 3}, {0.5F, 0.5F, 0.5F}, ids, {0, 27});
+    auto out = SavToy::Run(s);
+
+    REQUIRE(out.savr[1] == 0.0F);
+    REQUIRE(std::isinf(out.sphericity[1]));
+    REQUIRE(out.sphericity[1] > 0.0F);
+
+    UnitTest::CheckArraysInheritTupleDims(s.ds);
+  }
+
+  SECTION("F6 id 0 counts as surface")
+  {
+    // Falsifies the old documentation claim that a face is only counted "as long as that
+    // neighboring featureId is > 0". A single voxel of feature 1 sits at the centre of a
+    // 3x3x3 grid; every other cell is given the SAME id, once 0 and once a positive 2.
+    // Feature 1's area is 6a^2 = 1.5 in BOTH cases: id 0 is an ordinary differing id.
+    // If id-0 neighbours were skipped, the shellId == 0 run would report A = 0 (SAVR = 0,
+    // Psi = +inf) instead.
+    const int32 shellId = GENERATE(0, 2);
+    DYNAMIC_SECTION("shell id = " << shellId)
+    {
+      std::vector<int32> ids(27, shellId);
+      ids[1 * 9 + 1 * 3 + 1] = 1;
+      // max(FeatureIds) == numFeatures - 1 in both cases, so both fixtures are also legal
+      // input to the legacy DREAM3D filter (which errors -5555 otherwise).
+      std::vector<int32> numCells = (shellId == 0) ? std::vector<int32>{0, 1} : std::vector<int32>{0, 1, 26};
+      auto s = SavToy::Build({3, 3, 3}, {0.5F, 0.5F, 0.5F}, ids, numCells);
+      auto out = SavToy::Run(s);
+
+      REQUIRE(out.savr[1] == 12.0F); // A = 1.5 either way
+      SavToy::RequireSphericity(out.sphericity, 1, SavToy::k_CubeSphericity);
+
+      if(shellId == 2)
+      {
+        // The shell itself: A = 1.5 (only the six faces it shares with feature 1; every
+        // other exposed face of the shell lies on the outer boundary), V = 26 * 0.125 = 3.25.
+        REQUIRE(out.savr[2] == Approx(1.5F / 3.25F).epsilon(1.0e-6));
+        SavToy::RequireSphericity(out.sphericity, 2, 7.073729355035006);
+      }
+
+      UnitTest::CheckArraysInheritTupleDims(s.ds);
+    }
+  }
+
+  SECTION("F7 2D slab - no +/-Z faces")
+  {
+    // 7x3x1, spacing (1, 2, 4). zPoints == 1, so for every cell BOTH z-neighbours are
+    // outside the grid and no dx*dy face is ever counted.
+    //
+    // Feature 1 - a single cell at (1,1,0):
+    //   2 faces normal to X -> 2 * (dy*dz = 8) = 16
+    //   2 faces normal to Y -> 2 * (dx*dz = 4) = 8
+    //   A1 = 24  (a 3D slab would have added 2 * (dx*dy = 2) = 4 on top)
+    //   V1 = 1 * 8 = 8,  SAVR1 = 3.0
+    //
+    // Feature 2 - a 2-cell rod along X at (x=3..4, y=1, z=0):
+    //   2 end faces normal to X  -> 2 * 8 = 16
+    //   4 side faces normal to Y -> 4 * 4 = 16
+    //   A2 = 32,  V2 = 2 * 8 = 16,  SAVR2 = 2.0
+    // Feature 2 also discriminates the face-area assignment in the 2D path: swapping the
+    // X and Y face areas would give A2 = 2*4 + 4*8 = 40 and SAVR2 = 2.5.
+    std::vector<int32> ids(7 * 3 * 1, 0);
+    ids[1 * 7 + 1] = 1;
+    ids[1 * 7 + 3] = 2;
+    ids[1 * 7 + 4] = 2;
+    auto s = SavToy::Build({7, 3, 1}, {1.0F, 2.0F, 4.0F}, ids, {0, 1, 2});
+    auto out = SavToy::Run(s);
+
+    REQUIRE(out.savr[1] == 3.0F);
+    REQUIRE(out.savr[2] == 2.0F);
+    SavToy::RequireSphericity(out.sphericity, 1, SavToy::k_CubeSphericity);
+    SavToy::RequireSphericity(out.sphericity, 2, 0.9595791455066552);
+
+    UnitTest::CheckArraysInheritTupleDims(s.ds);
+  }
+}
+
+TEST_CASE("SimplnxCore::ComputeSurfaceAreaToVolumeFilter: Sphericity Toggle Off", "[SimplnxCore][ComputeSurfaceAreaToVolumeFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  // F8. Same fixture as F1, but CalculateSphericity = false: the Sphericity array must not
+  // be created at all, and the ratio must still be computed.
+  //
+  // This path is SIMPLNX-only and cannot be compared against DREAM3D 6.5.171: legacy's
+  // readFilterParameters() never reads the CalculateSphericity key, so a legacy pipeline
+  // run always takes the sphericity-on path regardless of what the pipeline file says.
+  std::vector<int32> ids(27, 0);
+  ids[1 * 9 + 1 * 3 + 1] = 1;
+  auto s = SavToy::Build({3, 3, 3}, {0.5F, 0.5F, 0.5F}, ids, {0, 1});
+  auto out = SavToy::Run(s, false);
+
+  REQUIRE(out.savr[1] == 12.0F);
+  REQUIRE(s.ds.getDataAs<Float32Array>(s.sphericityPath) == nullptr);
+
+  UnitTest::CheckArraysInheritTupleDims(s.ds);
+}
+
+TEST_CASE("SimplnxCore::ComputeSurfaceAreaToVolumeFilter: Error Paths", "[SimplnxCore][ComputeSurfaceAreaToVolumeFilter]")
+{
+  UnitTest::LoadPlugins();
+
+  // The F1 geometry is reused throughout: 3x3x3, spacing 0.5, feature 1 at the centre.
+  const auto makeIds = []() {
+    std::vector<int32> ids(27, 0);
+    ids[1 * 9 + 1 * 3 + 1] = 1;
+    return ids;
+  };
+
+  SECTION("Execute error - negative FeatureIds (-5355)")
+  {
+    auto ids = makeIds();
+    ids[0] = -1;
+    auto s = SavToy::Build({3, 3, 3}, {0.5F, 0.5F, 0.5F}, ids, {0, 1});
+
     ComputeSurfaceAreaToVolumeFilter filter;
-    Arguments args;
-
-    const DataPath k_FeatureIdsArrayPath2({k_DataContainer, k_CellData, k_FeatureIds});
-    const DataPath k_CellFeatureAttributeMatrixPath({k_DataContainer, k_CellFeatureData});
-    const DataPath k_NumElementsArrayPath({k_DataContainer, k_CellFeatureData, k_NumElements});
-    const DataPath k_SelectedGeometryPath({k_DataContainer});
-
-    // Create default Parameters for the filter.
-    args.insertOrAssign(ComputeSurfaceAreaToVolumeFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(k_FeatureIdsArrayPath2));
-    args.insertOrAssign(ComputeSurfaceAreaToVolumeFilter::k_NumCellsArrayPath_Key, std::make_any<DataPath>(k_NumElementsArrayPath));
-    args.insertOrAssign(ComputeSurfaceAreaToVolumeFilter::k_SelectedImageGeometryPath_Key, std::make_any<DataPath>(k_SelectedGeometryPath));
-    args.insertOrAssign(ComputeSurfaceAreaToVolumeFilter::k_CalculateSphericity_Key, std::make_any<bool>(true));
-    args.insertOrAssign(ComputeSurfaceAreaToVolumeFilter::k_SurfaceAreaVolumeRatioArrayName_Key, std::make_any<std::string>(k_SurfaceAreaVolumeRationArrayNameNX));
-    args.insertOrAssign(ComputeSurfaceAreaToVolumeFilter::k_SphericityArrayName_Key, std::make_any<std::string>(k_SphericityArrayNameNX));
-
-    // Preflight the filter and check result
-    auto preflightResult = filter.preflight(dataStructure, args);
+    const Arguments args = SavToy::MakeArgs(s, true);
+    auto preflightResult = filter.preflight(s.ds, args);
     SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
 
-    // Execute the filter and check the result
-    auto executeResult = filter.execute(dataStructure, args);
-    SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result)
+    auto executeResult = filter.execute(s.ds, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result)
+    REQUIRE(executeResult.result.errors()[0].code == -5355);
   }
 
-  // Compare the output arrays with those precalculated from the file
+  SECTION("Execute error - FeatureId exceeds the Feature AM (-5351)")
   {
-    DataPath exemplarPath({k_DataContainer, k_CellFeatureData, k_SurfaceAreaVolumeRationArrayName});
-    DataPath calculatedPath({k_DataContainer, k_CellFeatureData, k_SurfaceAreaVolumeRationArrayNameNX});
-    CompareDataArrays<float32>(dataStructure.getDataRefAs<IDataArray>(exemplarPath), dataStructure.getDataRefAs<IDataArray>(calculatedPath));
-    exemplarPath = DataPath({k_DataContainer, k_CellFeatureData, k_SphericityArrayName});
-    calculatedPath = DataPath({k_DataContainer, k_CellFeatureData, k_SphericityArrayNameNX});
-    CompareDataArrays<float32>(dataStructure.getDataRefAs<IDataArray>(exemplarPath), dataStructure.getDataRefAs<IDataArray>(calculatedPath));
+    auto ids = makeIds();
+    ids[2] = 5; // NumElements has only 2 tuples
+    auto s = SavToy::Build({3, 3, 3}, {0.5F, 0.5F, 0.5F}, ids, {0, 1});
+
+    ComputeSurfaceAreaToVolumeFilter filter;
+    const Arguments args = SavToy::MakeArgs(s, true);
+    auto preflightResult = filter.preflight(s.ds, args);
+    SIMPLNX_RESULT_REQUIRE_VALID(preflightResult.outputActions)
+
+    auto executeResult = filter.execute(s.ds, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(executeResult.result)
+    REQUIRE(executeResult.result.errors()[0].code == -5351);
   }
 
-// Write the DataStructure out to the file system
-#ifdef SIMPLNX_WRITE_TEST_OUTPUT
-  WriteTestDataStructure(dataStructure, fs::path(fmt::format("{}/find_surface_area_volume_ratio.dream3d", unit_test::k_BinaryTestOutputDir)));
-#endif
+  SECTION("Preflight error - NumCells not in an AttributeMatrix (-12802)")
+  {
+    auto s = SavToy::Build({3, 3, 3}, {0.5F, 0.5F, 0.5F}, makeIds(), {0, 1});
 
-  UnitTest::CheckArraysInheritTupleDims(dataStructure);
+    // A NumElements array parented to a plain DataGroup rather than an AttributeMatrix.
+    auto* groupPtr = DataGroup::Create(s.ds, "Loose Group");
+    CreateTestDataArray<int32>(s.ds, SavToy::k_NumCellsName, ShapeType{2}, {1}, groupPtr->getId());
+
+    Arguments args = SavToy::MakeArgs(s, true);
+    args.insertOrAssign(ComputeSurfaceAreaToVolumeFilter::k_NumCellsArrayPath_Key, std::make_any<DataPath>(DataPath({"Loose Group", SavToy::k_NumCellsName})));
+
+    ComputeSurfaceAreaToVolumeFilter filter;
+    auto preflightResult = filter.preflight(s.ds, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions)
+    REQUIRE(preflightResult.outputActions.errors()[0].code == -12802);
+  }
+
+  SECTION("Preflight error - FeatureIds tuple count does not match the geometry (-12803)")
+  {
+    // The algorithm walks the ImageGeom's cell extents and indexes FeatureIds with the
+    // resulting flat index. If the selected FeatureIds array has fewer tuples than the
+    // geometry has cells -- easy to do, since nothing forces the selection to come from
+    // the geometry's own cell AttributeMatrix -- every read past the end is out of bounds.
+    // Preflight must reject that before execute() can run off the end of the store.
+    auto s = SavToy::Build({3, 3, 3}, {0.5F, 0.5F, 0.5F}, makeIds(), {0, 1});
+
+    auto* groupPtr = DataGroup::Create(s.ds, "Other Data");
+    CreateTestDataArray<int32>(s.ds, SavToy::k_FeatureIdsName, ShapeType{26}, {1}, groupPtr->getId());
+
+    Arguments args = SavToy::MakeArgs(s, true);
+    args.insertOrAssign(ComputeSurfaceAreaToVolumeFilter::k_CellFeatureIdsArrayPath_Key, std::make_any<DataPath>(DataPath({"Other Data", SavToy::k_FeatureIdsName})));
+
+    ComputeSurfaceAreaToVolumeFilter filter;
+    auto preflightResult = filter.preflight(s.ds, args);
+    SIMPLNX_RESULT_REQUIRE_INVALID(preflightResult.outputActions)
+    REQUIRE(preflightResult.outputActions.errors()[0].code == -12803);
+  }
 }
 
 TEST_CASE("SimplnxCore::ComputeSurfaceAreaToVolumeFilter: SIMPL Backwards Compatibility", "[SimplnxCore][ComputeSurfaceAreaToVolumeFilter][BackwardsCompatibility]")

--- a/src/Plugins/SimplnxCore/vv/ComputeSurfaceAreaToVolumeFilter.md
+++ b/src/Plugins/SimplnxCore/vv/ComputeSurfaceAreaToVolumeFilter.md
@@ -1,0 +1,187 @@
+# V&V Report: ComputeSurfaceAreaToVolumeFilter
+
+|                            |                                                                                     |
+|----------------------------|-------------------------------------------------------------------------------------|
+| Plugin                     | SimplnxCore                                                                         |
+| SIMPLNX UUID               | `94e83e4f-797d-4594-b130-3819b7676f01`                                              |
+| SIMPLNX Human Name         | Compute Surface Area to Volume & Sphericity                                         |
+| DREAM3D 6.5.171 equivalent | `FindSurfaceAreaToVolume` — SIMPL UUID `5d586366-6b59-566e-8de1-57aa9ae8a91c`       |
+| Verified commit            | *<filled at SBIR deliverable assembly>*                                             |
+| Status                     | READY FOR REVIEW                                                                    |
+| Sign-off                   | Authored by Michael Jackson <mike.jackson@bluequartz.net>, 2026-08-20. Second-engineer sign-off **delegated to the PR reviewer** (requester decision, 2026-08-19). |
+
+## At a glance
+
+| Aspect                 | Current state |
+|------------------------|----------------|
+| Algorithm Relationship | **Port.** `SimplnxCoreLegacyUUIDMapping.hpp:186` maps the legacy SIMPL UUID straight onto this filter. Legacy `FindSurfaceAreaToVolume.cpp` was diffed line-by-line against `Algorithms/ComputeSurfaceAreaToVolume.cpp` this pass: neighbor offsets, boundary guards, the differing-id face test, the face-area assignments and both finalize loops are structurally identical, including two shared arithmetic bugs. Four SIMPLNX-side additions (validation guard, cancel check, progress messages, honoring the sphericity toggle) — see *Port-time deltas*. |
+| Oracle (confirmed)     | **Class 1 (Analytical)** primary, **Class 4 (Invariant)** companion. Surface area is a hand-countable sum of face areas and sphericity is a closed form, so every expected value is derivable without reference to any implementation. Confirmed — 10 fixtures as `SECTION`s/TEST_CASEs in `test/ComputeSurfaceAreaToVolumeTest.cpp`, all pass. Invariants riding along: sphericity scale-invariance (F1 vs F2), the X-rod/Y-rod mirror pair (F3), and id-0 / positive-shell area equality (F6). |
+| Code paths enumerated  | **20 of 22 exercised.** Gaps: the per-Z-slice `m_ShouldCancel` early return (needs cancel-signal injection) and the per-Z-slice progress message (emitted on every run, never asserted). |
+| Tests today            | **4 TEST_CASEs / 4 ctest entries, 211 assertions, all pass** — 1 Class 1 analytical TEST_CASE carrying 9 fixtures (158 assertions) + 1 sphericity-toggle-off test (13) + 1 four-section error-path test (15) + 1 SIMPL backwards-compatibility test (25). Full `SimplnxCore::` suite green at 981/981 and `PIPELINE::OrientationAnalysis` green at 21/21 after the new preflight guard. |
+| Exemplar archive       | **None consumed.** The prior test's `6_6_stats_test_v2.tar.gz` dependency is retired (circular oracle that additionally carried both bugs — proof below). The `download_test_data()` entry in `test/CMakeLists.txt` is left untouched because other tests still consume the archive. |
+| Legacy comparison      | **Run.** Ten fixtures through the 6.5.171 `PipelineRunner`, plus one extra negative-id probe. **10/10 SIMPLNX matches the oracle; 10/10 legacy matches the prediction made from the legacy source before the run.** Legacy differs from fixed SIMPLNX on surface area for the two anisotropic fixtures and on sphericity for eight — both differences are the pre-identified shared bugs. Root cause proven by surgically patching a local build of the legacy source: patched-legacy == fixed-SIMPLNX == oracle on **9 of 9** legacy-admissible fixtures. |
+| Bug flags              | `-D1` (±X/±Y face areas swapped) and `-D2` (truncated sphericity exponents) — both **confirmed shared bugs, fixed in SIMPLNX this pass**. `-D3`/`-D4`/`-D5` are behavior differences where SIMPLNX is already correct. One SIMPLNX-only gap closed: no preflight cross-check of FeatureIds tuple count against the geometry cell count (out-of-bounds read), now error `-12803`. |
+| V&V phase              | Oracle designed and confirmed before any legacy run; two shared bugs found, fixed and alignment-validated; preflight guard added RED-first; six-mutation verification sweep passed; user documentation rewritten; deviations written. Outstanding before promotion to COMPLETE: PR-reviewer sign-off (see header), the uncovered cancel path, and **out-of-core build runs, waived by requester decision 2026-08-19**. |
+
+## Summary
+
+`ComputeSurfaceAreaToVolumeFilter` computes, for each Feature in an Image Geometry, the ratio of its voxelized surface area to its volume, and optionally its sphericity. Verification is **Class 1 (Analytical)**: surface area is a hand-countable sum of shared-face areas and sphericity is a closed form, so every expected value is derivable without reference to any implementation. Fixtures F1–F7 (eight TEST_CASE sections, counting F6's two shell variants) were hand-derived, frozen in `derive.py`, and RED-run before any binary was invoked; F1b and F2b were added afterward — F1b for deviation D3's over-provisioned Feature AM case, F2b to close the volume-recount blind spot — with their expected values likewise hand-derived from the same rules (F2b's checked post-hoc against `derive.py` as well) rather than read off any observed run. Two bugs shared with DREAM3D 6.5.171 were found and fixed — the ±X and ±Y face areas were swapped (invisible on isotropic spacing, wrong on every anisotropic dataset) and the sphericity exponents were truncated decimals — a missing FeatureIds/geometry preflight cross-check was closed, the user documentation's two false claims were corrected, and a surgical patch to a local legacy build proves the two fixes bring SIMPLNX and SIMPL back into output alignment on all nine legacy-admissible fixtures.
+
+## Algorithm Relationship
+
+*Classification:* **Port** ~~| Minor changes | Rewrite | New filter~~
+
+*Evidence:* `src/Plugins/SimplnxCore/src/SimplnxCore/SimplnxCoreLegacyUUIDMapping.hpp:186` maps legacy SIMPL UUID `5d586366-6b59-566e-8de1-57aa9ae8a91c` directly to `FilterTraits<ComputeSurfaceAreaToVolumeFilter>`, and `test/simpl_conversion/{6_4,6_5}/ComputeSurfaceAreaToVolumeFilter.json` carry the legacy `FeatureIdsArrayPath` / `NumCellsArrayPath` / `SurfaceAreaVolumeRatioArrayName` / `CalculateSphericity` / `SphericityArrayName` parameter set unchanged. The legacy source (`Source/Plugins/Statistics/StatisticsFilters/FindSurfaceAreaToVolume.cpp`, from a sibling `DREAM3D` checkout on the authoring engineer's machine, not committed to this repository) was diffed line-by-line against `Algorithms/ComputeSurfaceAreaToVolume.cpp` this pass rather than inferred from documentation. The correspondence is close enough that both files carried the same two arithmetic defects and the same three mislabeled comments.
+
+*Port-time deltas:*
+
+1. **Feature-count validation.** Legacy scans FeatureIds itself and errors `-5555` unless `max(FeatureIds) == numFeatures - 1` exactly. SIMPLNX calls `ValidateFeatureIdsToFeatureAttributeMatrixIndexing`, which errors `-5355` on negative ids and `-5351` when an id would index past the feature arrays, and accepts an over-provisioned Feature AttributeMatrix. Changes which inputs are *accepted*, not the values computed for accepted inputs — deviations D3 and D5.
+2. **Sphericity toggle honored.** Legacy never reads `CalculateSphericity` from a pipeline file and writes `m_Sphericity[i]` unconditionally; SIMPLNX creates the array and runs the loop only when the flag is set. Fixes a latent legacy null dereference — deviation D4.
+3. **Cancel check.** SIMPLNX reads `m_ShouldCancel` once per Z slice and returns early (added by PR #1582); legacy has none. Additive; no output change on a run to completion.
+4. **Progress reporting.** SIMPLNX emits a per-Z-slice `Computing Z Slice: 'n'` info message and a `Computing Sphericity` message (PR #1267); legacy is silent. No output change.
+5. **Preflight output creation.** SIMPLNX creates both outputs through `CreateArrayAction` sized from the Feature AttributeMatrix shape; legacy used `createNonPrereqArrayFromPath` with an initial value of 0. Both zero-initialize, which is what makes the untouched index-0 tuple deterministically `0.0f` in each.
+6. **This branch.** Added preflight error `-12803` (FeatureIds tuple count vs geometry cell count), fixed D1 and D2, and rebuilt the test suite.
+
+*Material PRs since baseline:* six PRs have touched these two files; none is behavioral except as noted. #1278 (`BUG: Ensure FeatureId arrays are range checked against the Feature Attribute Matrix`) and #1308 (validation API update) introduced delta 1; #1267 and #1582 introduced deltas 3–4; #1439 and #1238 are store-API and pipeline-path churn.
+
+## Bug Fixes (this pass)
+
+### D1: ±X and ±Y face areas were swapped — fixed
+
+The face shared with a ±Y neighbor lies in the XZ plane (`dx·dz`); the face shared with a ±X neighbor lies in the YZ plane (`dy·dz`). Both were assigned the other's product. Fixed in `Algorithms/ComputeSurfaceAreaToVolume.cpp`, along with the three comments that had recorded the same misconception. RED evidence: fixture F3 reported `SAVR = [_, 2.75, 2.0]` against the derived `[_, 2.0, 2.75]` — the two rods' values exchanged — and fixture F7's 2-cell rod reported `2.5` against `2.0`. Shared with 6.5.171; see deviations doc and the alignment patch.
+
+### D2: sphericity exponents were truncated decimals — fixed
+
+`0.333333f` / `0.66666f` replaced with `1.0f / 3.0f` / `2.0f / 3.0f`. RED evidence: every one of the nine sphericity-bearing fixtures whose value is exponent-sensitive failed pre-fix at a 1e-6 relative tolerance — F5's degenerate `+inf` is the tenth fixture and is immune to either exponent — by 1.405e-6 to 2.009e-5 relative on the isotropic fixtures, larger still where compounded with D1 on the anisotropic ones. Shared with 6.5.171.
+
+### SIMPLNX-only gap closed: FeatureIds/geometry cross-check (`-12803`)
+
+The algorithm walks the ImageGeom's cell extents and indexes FeatureIds with the resulting flat index, but nothing forced the FeatureIds selection to come from the geometry's own cell AttributeMatrix — a smaller selection was read out of bounds with no diagnostic. `preflightImpl` now errors `-12803` when the tuple counts disagree, naming both actual values. Written RED-first: the new Error Paths section failed (`preflight` returned valid) before the guard existed. Legacy has no equivalent check either, but this is a new guard rather than a behavior difference on any valid input, so it is recorded here and not as a deviation.
+
+## Oracle
+
+*Class:* **1 (Analytical)**, with **4 (Invariant)** companions.
+
+*Applied:* The two outputs have closed forms that need no implementation to evaluate:
+
+- `A(f)` = the sum, over every cell of feature `f` and every one of its six face neighbors, of the shared face area — counted iff the neighbor is **inside** the grid and carries a **different** id (id 0 included as "different"). The ±Z face is `dx·dy`, the ±Y face is `dx·dz`, the ±X face is `dy·dz`.
+- `V(f) = NumCells[f] · dx·dy·dz`, from the user-supplied array, never recounted.
+- `SAVR(f) = A/V`; `Sphericity(f) = π^(1/3)(6V)^(2/3)/A` (Wadell 1935).
+
+Expected values for F1–F7 (eight TEST_CASE sections) were produced by an independent brute-force face enumeration (`derive.py` in the V&V working folder) written from those rules and RED-run before either binary was invoked on any fixture. F1b and F2b were added afterward — F1b for deviation D3's over-provisioned Feature AM case, F2b to close the volume-recount blind spot the blind-suite proof exposed — and their expected values were likewise hand-derived from the same rules (F2b's also checked post-hoc against `derive.py`) rather than taken from an observed run. Spacings are dyadic (0.5) or small integers (1, 2, 4), so every expected area, volume and ratio is exactly representable in float32 and the ratio assertions are **exact equalities**, not tolerances. Sphericity involves cube roots; the tolerance is 1e-6 relative, chosen after confirming with a float32 simulation that the fixed expression reproduces the double-precision oracle to within 1.3e-7 on every fixture — so 1e-6 is a real constraint, and indeed the pre-fix truncated exponents miss it on all nine sphericity-bearing fixtures whose value is exponent-sensitive (F5's degenerate `+inf` is immune to either exponent).
+
+*Ordering evidence (the one ordering rule):* the derivation predicted, before any run, both the correct values **and** what the pre-fix code must produce under the swapped-area and truncated-exponent hypotheses. The observed pre-fix output matched those predictions to nine decimal places (F1 `0.805997133` predicted vs `0.8059971333` observed; F2 `0.805986106` vs `0.8059861064`; F4 `1.611994267` vs `1.6119942665`; F3 `SAVR[1] = 2.75` vs `2.75`). That agreement is what establishes the oracle and the bug model together rather than one being fitted to the other.
+
+*Fixtures (all in `test/ComputeSurfaceAreaToVolumeTest.cpp`):*
+
+| # | Fixture | Geometry / spacing | What it pins | Pre-fix value |
+|---|---|---|---|---|
+| F1 | single interior voxel | 3³, spacing 0.5 | `A = 6a²`, `SAVR = 6/a = 12`, `Ψ = (π/6)^⅓ = 0.805996`; `NumCells[0] = 5` sentinel proves index 0 of both outputs is never written | `Ψ = 0.805997133` |
+| F1b | over-provisioned Feature AM | 3³, 4 feature tuples, `max(id) = 1` | SIMPLNX accepts; unused tuples get `SAVR = 0`, `Ψ = +inf`. Legacy rejects (`-5555`) — deviation D3 | (same) |
+| F2 | 2×2×2 interior cube | 4³, spacing 0.5 | `A = 24a²`, `SAVR = 3/a = 6`; `Ψ` identical to F1 → **sphericity scale invariance** (Class 4) | `Ψ = 0.805986106` |
+| F2b | NumCells ≠ cell count | 3³, one cell of id 1, `NumCells[1] = 8` | volume comes from `NumCells`: `SAVR = 1.5`, not the `12` a recount gives | `Ψ = 3.223944` |
+| F3 | anisotropic X-rod + Y-rod | 6×8×3, spacing (1, 2, 4) | **the D1 discriminator.** `A₁ = 2·8 + 8·4 + 8·2 = 64` (`SAVR = 2.0`); the mirror `A₂ = 2·4 + 8·8 + 8·2 = 88` (`SAVR = 2.75`). The swap exchanges them exactly — `SAVR[1]` and `SAVR[2]` individually are what catch D1. The fixture also asserts `SAVR[1] + SAVR[2] == 4.75`, a **conservation check** (Class 4), not a discriminator: the sum is exchange-invariant and passes identically whether or not the swap is present, so it only documents that the pre-fix failure was an exchange rather than a scale error | `SAVR = [2.75, 2.0]` |
+| F4 | corner voxel | 3³, spacing 0.5, cell at (0,0,0) | **outer-boundary faces are not counted**: `A = 3a²` not `6a²`, and `Ψ = 2(π/6)^⅓ = 1.612 > 1` — the signature of the boundary rule, commented at length in the test so it is not "corrected" | `Ψ = 1.611994` |
+| F5 | feature fills the volume | 3³, all cells id 1 | degenerate divide: `A = 0`, `SAVR = 0`, `Ψ = +inf` | (same) |
+| F6 | id-0 vs positive shell | 3³, `GENERATE(0, 2)` shell id | **falsifies the old doc claim** that only ids > 0 count: feature 1's `A = 6a²` for both shells. Had id 0 been skipped, the shell-0 run would give `A = 0` | `Ψ = 0.805997` |
+| F7 | 2D slab | 7×3×1, spacing (1, 2, 4) | `zPoints == 1` → no `dx·dy` face ever counted; feature 1 has exactly 4 counted faces. Feature 2's 2-cell rod also discriminates D1 in the 2D path (`SAVR = 2.0` vs the swap's `2.5`) | `SAVR[2] = 2.5` |
+| F8 | sphericity off | 3³ | `Sphericity` array is **not created**; `SAVR` still computed. **No legacy counterpart** (deviation D4) | n/a |
+
+Error paths are a separate TEST_CASE with four sections: `-5355` (negative ids), `-5351` (id exceeds the Feature AM), `-12802` (NumCells not in an AttributeMatrix) and `-12803` (FeatureIds/geometry tuple mismatch — new).
+
+*Retired oracle, and proof it was circular AND bug-carrying:* the prior test compared freshly computed `SurfaceAreaVolumeRatioNX` / `SphericityNX` against sibling arrays of the same base name inside `6_6_stats_test_v2.dream3d` — output of the code under test, i.e. a consistency-with-self oracle (`docs/vv_templates/oracle_classes.md`, "What is NOT an oracle"). Two **executed** facts settle its value (script `blind_suite.py`, output `results_blind_suite.txt`, in the V&V working folder):
+
+1. That archive's spacing is `(0.25, 0.25, 0.25)`. D1 swaps `dy·dz` with `dx·dz`, which are **equal** at that spacing, so the test was *structurally* incapable of detecting D1 — no amount of extra assertions against that file would have found it.
+2. Reconstructing `A` from the archive's own `SurfaceAreaVolumeRatio` and `NumElements` and recomputing sphericity both ways over its 619 features: the archived `Sphericity` agrees with the **truncated**-exponent formula to 1.6e-7 relative and disagrees with the exact-exponent formula by up to 4.9e-5. The archive carries D2. After the D2 fix the old test would have started failing against its own reference data.
+
+*Mutation verification:* six mutations were applied to the fixed source, each rebuilt and run against the gate, then reverted; the MD5 of both touched files is identical before and after the sweep. Full transcript in `mutation_transcript.md` (V&V working folder). All six were killed. Kill sets matched the pre-run prediction exactly for M1, M2, M4 and M6. M3 killed a strict superset of its prediction — F1, F2, F4, F6 (shell 0) and F7 were predicted, but F1b, F2b, F3 and the sphericity-toggle test were also killed and were not called out beforehand. M5's pre-run prediction misnamed F1 as a killer (F1 in fact survived); the actual killers were F1b and F2b, with F1b unpredicted. Both misses are benign for discriminating power — a mutation killing more than predicted, never fewer, and M5 was still killed twice over — but they are prediction misses, recorded as such rather than retrofitted:
+
+| Mutation | Killed by | Surviving fixtures, and why that is correct |
+|---|---|---|
+| M1 — D1 revert (face areas swapped back) | F3, F7 | every isotropic fixture — `dy·dz == dx·dz` there, so the swap is genuinely a no-op |
+| M2 — outer-boundary faces counted as surface | F4, F5, F6 (shell 2), F7 | F1, F1b, F2, F2b, F3, F6 (shell 0) — their asserted features are fully interior, so no boundary face is involved |
+| M3 — skip id-0 neighbors (the false doc claim) | F1, F1b, F2, F2b, F3, F4, F6 (shell 0), F7, and the sphericity-toggle test | F5 (no id-0 cell exists) and F6 (shell 2) (the shell is a positive id) |
+| M4 — D2 revert (exponents re-truncated) | all nine sphericity-bearing fixtures | F5 only, whose sphericity is `+inf` under either exponent |
+| M5 — volume recounted from FeatureIds instead of NumCells | F1b, F2b | every fixture whose `NumCells` happens to equal the true cell count — which is all the others |
+| M6 — drop the new `-12803` preflight guard | the `-12803` error-path section | everything else; the guard rejects only invalid input |
+
+M5 is the load-bearing case for the blind-suite question. Every fixture except F1b and F2b sets `NumCells` to the true cell count, so the suite as it stood after F1–F7 could not tell "volume from `NumCells`" from "volume from a recount". **F2b was added specifically to close that hole** — the mutation was predicted by inspection to survive the F1–F7 set (every one of those fixtures sets `NumCells` to the true cell count), and F2b was written before the sweep was ever run; F1b, added later for deviation D3, turns out to catch it too, because a recount gives its unused features a zero volume and hence `NaN` rather than `0`. The retired archive test could not have caught M5 either: **executed** check on `6_6_stats_test_v2.dream3d` — its `NumElements` array equals `bincount(FeatureIds)` exactly, for all 620 features, so a recount and the array are indistinguishable there.
+
+*Second-engineer review:* **delegated to the PR reviewer** (requester decision, 2026-08-19). The two items most worth a reviewer's attention are the F3 area derivation (`A₁ = 64`, `A₂ = 88` — the numbers the whole D1 argument rests on) and the deliberate `Ψ > 1` expectation in F4, which looks like a bug and is not.
+
+## Code path coverage
+
+20 of 22 paths exercised. The filter has four logical phases: (a) preflight validation and output creation, (b) execute-time FeatureId validation, (c) the per-cell face accumulation sweep, (d) the per-feature finalize loops.
+
+Source: `src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/ComputeSurfaceAreaToVolume.cpp` (177 lines) and `Filters/ComputeSurfaceAreaToVolumeFilter.cpp` (201 lines).
+
+| #  | Phase | Path | Test case |
+|----|-------|------|-----------|
+| 1  | (a) Preflight | NumCells path is not an `Int32Array` → `-12801` | *Not directly tested. The `ArraySelectionParameter` restricts the selection to `DataType::int32`, so parameter validation rejects a wrong-typed selection before `preflightImpl` runs; the branch is a defensive guard only reachable by calling `preflightImpl` directly.* |
+| 2  | (a) Preflight | NumCells parent is not an `AttributeMatrix` → `-12802` | `Error Paths` — *NumCells not in an AttributeMatrix* |
+| 3  | (a) Preflight | FeatureIds tuple count ≠ geometry cell count → `-12803` | `Error Paths` — *FeatureIds tuple count does not match the geometry*. Added this pass, RED-first |
+| 4  | (a) Preflight | create `SurfaceAreaVolumeRatio` sized from the Feature AM shape | all tests |
+| 5  | (a) Preflight | `CalculateSphericity` true → also create `Sphericity` | all except `Sphericity Toggle Off` |
+| 6  | (a) Preflight | `CalculateSphericity` false → `Sphericity` not created | `Sphericity Toggle Off` (asserts the array is absent) |
+| 7  | (b) Validate | negative FeatureId → `-5355`, no output written | `Error Paths` — *negative FeatureIds* |
+| 8  | (b) Validate | `max(FeatureId) >= numFeatures` → `-5351` | `Error Paths` — *FeatureId exceeds the Feature AM* |
+| 9  | (b) Validate | valid, including an over-provisioned Feature AM → proceed | F1b (over-provisioned), all others (exactly sized) |
+| 10 | (c) Per-cell | `currentFeatureId < 1` → skip the cell entirely | F1, F6 (shell 0), F7 — most cells in these fixtures are id 0 |
+| 11 | (c) Per-cell | `zIdx == 0` → skip the −Z face | F4 (corner cell at z=0), F5, F7 |
+| 12 | (c) Per-cell | `zIdx == zPoints-1` → skip the +Z face | F5 (top layer), F7 (`zPoints-1 == 0`) |
+| 13 | (c) Per-cell | `yIdx == 0` → skip the −Y face | F4, F5 |
+| 14 | (c) Per-cell | `yIdx == yPoints-1` → skip the +Y face | F5 |
+| 15 | (c) Per-cell | `xIdx == 0` → skip the −X face | F4, F5, F6 (shell 2) |
+| 16 | (c) Per-cell | `xIdx == xPoints-1` → skip the +X face | F5, F6 (shell 2) |
+| 17 | (c) Per-cell | in-bounds neighbor with the **same** id → no contribution | F2 (cube interior), F3 (rod interior), F5 (every neighbor) |
+| 18 | (c) Per-cell | ±Z neighbor differs → add `dx·dy` | F1, F3 (8 such faces per rod) |
+| 19 | (c) Per-cell | ±Y neighbor differs → add `dx·dz` | F1, F3, F7 |
+| 20 | (c) Per-cell | ±X neighbor differs → add `dy·dz` | F1, F3, F7 |
+| 21 | (d) Finalize | `SAVR` loop from feature 1; `Sphericity` loop from feature 1 when enabled | every fixture; F1's `NumCells[0] = 5` sentinel is what makes the "starts at 1" claim falsifiable |
+| 22 | (c) Cancel / progress | `m_ShouldCancel` read once per Z slice → early `return {}`; per-Z-slice info message | *Not directly tested. The cancel path requires cancel-signal injection, which no test performs; the progress messages are emitted on every run but no test asserts them. Legacy has neither, so SIMPLNX is ahead here — not a deviation.* |
+
+## Test inventory
+
+| Test case | Status | Notes |
+|-----------|--------|-------|
+| `SimplnxCore::ComputeSurfaceAreaToVolume` | **retired** | The prior sole correctness test. It compared freshly computed `SurfaceAreaVolumeRatioNX` / `SphericityNX` against sibling arrays inside `6_6_stats_test_v2.dream3d` produced by the code under test — a circular oracle. Executed proof that it was also incapable of doing its job: the archive's spacing is isotropic, so D1 is invisible to it, and its `Sphericity` array itself carries D2 (see *Oracle*). It also called `getDataRefAs<IDataArray>()` four times with no `REQUIRE_NOTHROW`, so a missing array surfaced as an uncaught exception rather than a test failure. Replaced wholesale. |
+| `SimplnxCore::ComputeSurfaceAreaToVolumeFilter: Class 1 - Analytical Surface Area & Sphericity` | new-for-V&V | Nine `SECTION` fixtures (F1, F1b, F2, F2b, F3, F4, F5, F6 × 2 shell ids, F7); 158 assertions. Ratio assertions are exact float32 equalities; sphericity to 1e-6 relative via `Approx().epsilon()`. Each section carries its hand derivation as a comment, and F4's `Ψ > 1` expectation carries an explicit "do not correct this" note. |
+| `SimplnxCore::ComputeSurfaceAreaToVolumeFilter: Sphericity Toggle Off` | new-for-V&V | F8. Asserts `SAVR` is still computed and `dataStructure.getDataAs<Float32Array>(sphericityPath) == nullptr`; 13 assertions. The one code path with no legacy counterpart (deviation D4). |
+| `SimplnxCore::ComputeSurfaceAreaToVolumeFilter: Error Paths` | new-for-V&V | Four sections: `-5355`, `-5351`, `-12802`, `-12803`; 15 assertions. Each asserts `invalid()` **and** the exact error code. The `-12803` section was written before the guard existed and observed to fail. |
+| `SimplnxCore::ComputeSurfaceAreaToVolumeFilter: SIMPL Backwards Compatibility` | kept | Untouched. `DYNAMIC_SECTION` over `simpl_conversion/{6_5,6_4}/ComputeSurfaceAreaToVolumeFilter.json`, checking the converted geometry / FeatureIds / NumCells paths and the three name/flag arguments; 25 assertions. Not an oracle test. |
+
+All four tests pass at 211 assertions total. **Out-of-core build runs are waived** for this cycle by requester decision 2026-08-19; the assertions that depend on storage behavior are the two index-0 zero-initialization checks in F1, which rely on `CoreDataIOManager`'s data-store factory zero-filling `float32` stores — verified by source inspection (`CoreDataIOManager.cpp`, `Float32DataStore(..., 0.0f)`) and executed only in the in-core build.
+
+Regression scope checked after the new preflight guard: full `SimplnxCore::` suite 981/981 pass, and `PIPELINE::OrientationAnalysis` 21/21 pass (the `(03) Small IN100 Morphological Statistics` and GBCD/GBPD pipelines use this filter).
+
+## Exemplar archive
+
+**None.** As of this V&V cycle the filter's correctness tests are inline Class 1 / Class 4 fixtures in `test/ComputeSurfaceAreaToVolumeTest.cpp` (`namespace SavToy`); there is no `.dream3d` gold master to hash. Provenance sidecar: `src/Plugins/SimplnxCore/vv/provenance/ComputeSurfaceAreaToVolumeFilter.md`.
+
+`6_6_stats_test_v2.tar.gz` is no longer consumed by this filter's tests. Its `download_test_data()` entry in `src/Plugins/SimplnxCore/test/CMakeLists.txt` is **deliberately left untouched** — `ComputeEuclideanDistMapTest` and `ComputeFeatureNeighborsTest` still consume it in this plugin, as do `ComputeShapesFilterTest`, `ComputeSchmidsTest` and `AlignSectionsMutualInformationTest` in OrientationAnalysis.
+
+## Deviations from DREAM3D 6.5.171
+
+Comparison run on the ten A/B fixtures listed in *Oracle* (the unit-test fixtures themselves, written as legacy-format `.dream3d` with matching SIMPL and NX pipelines), plus a one-off negative-id probe. Results: **10/10 SIMPLNX matches the oracle**, and **10/10 legacy matches the prediction derived from the legacy source before the run** — no unpredicted differences, so nothing entered the bug-adjudication protocol beyond the two pre-identified findings.
+
+Where legacy and fixed SIMPLNX differ, and why:
+
+| Fixture | `SurfaceAreaVolumeRatio` | `Sphericity` |
+|---|---|---|
+| F1, F2, F2b, F4, F6a, F6b | identical (D1 is a no-op at isotropic spacing) | differs, 1.405e-6 – 2.009e-5 relative (D2) |
+| F5 | identical (`A = 0`) | identical (`+inf` both) |
+| F3 | **differs**: legacy `[_, 2.75, 2.0]` vs `[_, 2.0, 2.75]` (D1) | differs (D1 + D2) |
+| F7 | **differs** at feature 2: legacy `2.5` vs `2.0` (D1) | differs (D1 + D2) |
+| F1b | legacy produces no output (`-5555`) — D3 | — |
+
+*Alignment validation.* To prove the two fixes are exactly what separated the codebases, the same two changes were applied to a local build of the legacy source (commit `304706bae`, `BUG: FindSurfaceAreaToVolume — correct the per-face areas and the sphericity exponents`; diff preserved as `patch_6_5_172.diff` in the V&V working folder — a two-hunk change touching seven lines). Result: **9 of 9 legacy-admissible fixtures give patched-legacy == fixed-SIMPLNX == oracle**, and the patch changed the legacy output on 8 of those 9 (F5's `A = 0` / `Ψ = +inf` is invariant under both bugs). F1b is excluded because the patch deliberately leaves the `-5555` feature-count guard alone, which is deviation D3 in its own right. The patched build is internal proof tooling, not a shipping comparison target.
+
+Deviation entries — full text in [`deviations/ComputeSurfaceAreaToVolumeFilter.md`](deviations/ComputeSurfaceAreaToVolumeFilter.md):
+
+- `ComputeSurfaceAreaToVolumeFilter-D1` — ±X/±Y face areas swapped; anisotropic surface areas exchanged between differently oriented features. **Shared bug, fixed in SIMPLNX, alignment-patch validated.**
+- `ComputeSurfaceAreaToVolumeFilter-D2` — sphericity exponents truncated to `0.333333` / `0.66666`; systematic bias up to 4.9e-5 relative on real data. **Shared bug, fixed in SIMPLNX, alignment-patch validated.**
+- `ComputeSurfaceAreaToVolumeFilter-D3` — an over-provisioned Feature AttributeMatrix is accepted by SIMPLNX and rejected by legacy (`-5555`). Algorithmic choice; trust SIMPLNX.
+- `ComputeSurfaceAreaToVolumeFilter-D4` — legacy never reads `CalculateSphericity` or `SphericityArrayName` from a pipeline file (and would null-dereference if the flag were honored false); SIMPLNX honors both. Legacy bug, fixed at port time; trust SIMPLNX. This is why the sphericity-off path has no A/B counterpart.
+- `ComputeSurfaceAreaToVolumeFilter-D5` — negative FeatureIds: SIMPLNX errors `-5355`, legacy silently succeeds via an out-of-bounds (but, as measured, output-neutral) write. Latent legacy UB; trust SIMPLNX.
+
+Five confirmed **non**-deviations are recorded in the same file so they are not relitigated: the outer-boundary face skip, id 0 counting as surface, volume coming from `NumCells`, index 0 never being written, and the additive progress/cancel behavior.

--- a/src/Plugins/SimplnxCore/vv/deviations/ComputeSurfaceAreaToVolumeFilter.md
+++ b/src/Plugins/SimplnxCore/vv/deviations/ComputeSurfaceAreaToVolumeFilter.md
@@ -1,0 +1,109 @@
+# Deviations from DREAM3D 6.5.171: ComputeSurfaceAreaToVolumeFilter
+
+This file lists every documented behavioral difference between this SIMPLNX filter and its DREAM3D 6.5.171 equivalent, `FindSurfaceAreaToVolume` (SIMPL UUID `5d586366-6b59-566e-8de1-57aa9ae8a91c`).
+
+Entries are referenced by stable ID (`ComputeSurfaceAreaToVolumeFilter-D<N>`) from the V&V report and from public migration guidance. The ID is stable across renames; the Filter UUID field is the permanent cross-reference anchor.
+
+All five entries were produced by the 2026-08-20 V&V cycle. The A/B binary of record is the 6.5.171 `PipelineRunner` shipped in `~/Applications/DREAM3D.app`; the fixtures are the ten A/B fixtures described in the report's *Deviations* section.
+
+---
+
+## ComputeSurfaceAreaToVolumeFilter-D1
+
+| Field | Value |
+|---|---|
+| **Deviation ID** | `ComputeSurfaceAreaToVolumeFilter-D1` |
+| **Filter UUID** | `94e83e4f-797d-4594-b130-3819b7676f01` |
+| **Status** | active |
+
+**Symptom:** On an **anisotropic** Image Geometry, `SurfaceAreaVolumeRatio` (and, through it, `Sphericity`) differs between SIMPLNX and 6.5.171. On the V&V fixture F3 — a 6×8×3 grid with spacing (1, 2, 4) holding one 4-cell rod along X (feature 1) and one 4-cell rod along Y (feature 2) — 6.5.171 reports `SAVR = [_, 2.75, 2.0]` where the correct values are `[_, 2.0, 2.75]`. The two features' values are *exchanged*. On isotropic spacing there is no difference at all.
+
+**Root cause:** Bug, shared. Both codebases assigned the wrong spacing product to two of the three face orientations. The face shared with a ±Y neighbor lies in the XZ plane and has area `dx·dz`; the face shared with a ±X neighbor lies in the YZ plane and has area `dy·dz`. Both implementations had those two swapped — 6.5.171 at `Source/Plugins/Statistics/StatisticsFilters/FindSurfaceAreaToVolume.cpp:299-306` (`l == 1 || l == 4` → `yRes * zRes`, `l == 2 || l == 3` → `zRes * xRes`) and SIMPLNX at the corresponding lines of `Algorithms/ComputeSurfaceAreaToVolume.cpp`. The misleading `// YZ face shared` / `// XZ face shared` comments in both files record the same misconception. With `dx == dy == dz` the two products are equal, which is why the defect survived: every dataset in the shipping test suite is isotropic, and the retired exemplar archive is a Small IN100 slice at spacing (0.25, 0.25, 0.25) — structurally incapable of showing it (see the report's *Oracle* section for the executed proof).
+
+**Affected users:** Anyone who ran the filter on an Image Geometry with non-cubic voxels — which includes most serial-sectioning EBSD data, where the Z spacing is the section thickness and rarely equals the in-plane step. The error is not a uniform scale factor: it redistributes area between features according to their elongation direction, so relative comparisons between features are affected as well as absolute values. Isotropic-spacing users are unaffected and their prior results stand.
+
+**Recommendation:** Trust SIMPLNX. The 6.5.171 result was geometrically wrong. Fixed in SIMPLNX on this branch. To prove that this single change is what separated the two codebases, the same two lines were patched in a local build of the legacy source (`BUG: FindSurfaceAreaToVolume — correct the per-face areas and the sphericity exponents`, commit `304706bae` on the local 6.5.172 staging branch; diff preserved as `patch_6_5_172.diff` in the V&V working folder): with it, the legacy binary reproduces the fixed SIMPLNX output and the independent oracle on all nine legacy-admissible fixtures. The patched build is internal proof tooling and is not a shipping comparison target.
+
+---
+
+## ComputeSurfaceAreaToVolumeFilter-D2
+
+| Field | Value |
+|---|---|
+| **Deviation ID** | `ComputeSurfaceAreaToVolumeFilter-D2` |
+| **Filter UUID** | `94e83e4f-797d-4594-b130-3819b7676f01` |
+| **Status** | active |
+
+**Symptom:** `Sphericity` differs between SIMPLNX and 6.5.171 by a small relative amount on **every** feature of **every** dataset, isotropic spacing included. Measured across the six isotropic V&V fixtures (F1, F2, F2b, F4, F6a, F6b) the difference runs from 1.405e-6 to 2.009e-5 relative; on the anisotropic fixtures (F3, F7) it is compounded by D1 and much larger; on the 619 features of the retired Small IN100 exemplar archive it reaches 4.9e-5. `SurfaceAreaVolumeRatio` is unaffected.
+
+**Root cause:** Bug (precision, but a deterministic bias rather than round-off), shared. Sphericity is `π^(1/3) · (6V)^(2/3) / A`. Both codebases wrote the exponents as truncated decimal literals — `0.333333f` and `0.66666f` — instead of the exact rationals (6.5.171 at `FindSurfaceAreaToVolume.cpp:316,322`; SIMPLNX at the corresponding lines of `Algorithms/ComputeSurfaceAreaToVolume.cpp`). The `2/3` truncation is the dominant term: `2/3 - 0.66666 = 6.67e-6`, and the resulting relative error in `(6V)^(2/3)` is that residual times `ln(6V)`, so the bias grows with feature volume and is not bounded by float32 round-off. It is a systematic bias in a dimensionless shape descriptor that users compare across datasets, and it costs nothing to remove.
+
+**Affected users:** Every user of the sphericity output, on every dataset. The magnitude is below the level at which the aliasing warning in the user documentation matters — a digital cube's sphericity is under-estimated by ~19% by voxelization alone — so no published conclusion is likely to change. The value is that sphericity is now the quantity the documented equation says it is.
+
+**Recommendation:** Trust SIMPLNX. Fixed in SIMPLNX on this branch. Covered by the same alignment patch cited in D1 (`304706bae`): with the exponents corrected, the legacy binary reproduces the fixed SIMPLNX sphericity to within 1e-6 relative on all nine legacy-admissible fixtures. Users migrating a stored sphericity column should expect a change in the fifth significant figure; the pre-fix values for the V&V fixtures are tabulated in the report's *Oracle* section for anyone reconciling old output.
+
+---
+
+## ComputeSurfaceAreaToVolumeFilter-D3
+
+| Field | Value |
+|---|---|
+| **Deviation ID** | `ComputeSurfaceAreaToVolumeFilter-D3` |
+| **Filter UUID** | `94e83e4f-797d-4594-b130-3819b7676f01` |
+| **Status** | active |
+
+**Symptom:** An input whose Feature AttributeMatrix is *over-provisioned* — more feature tuples than `max(FeatureIds) + 1` — is accepted by SIMPLNX and rejected by 6.5.171 with error `-5555` ("The number of Features in the NumCells array (4) does not match the largest Feature Id in the FeatureIds array"). Observed on V&V fixture F1b: a 3×3×3 grid with a single cell of feature 1 and a 4-tuple Feature AttributeMatrix. SIMPLNX writes feature 1's correct values and leaves the two unused tuples at `SAVR = 0`, `Sphericity = +inf`; 6.5.171 produces no output at all.
+
+**Root cause:** Algorithmic choice. 6.5.171's `execute()` scans the FeatureIds array and errors when `largestFeature != numFeatures - 1` (`FindSurfaceAreaToVolume.cpp:216-222`), i.e. it demands an exactly-sized Feature AttributeMatrix. SIMPLNX calls `ValidateFeatureIdsToFeatureAttributeMatrixIndexing` (`DataArrayUtilities.cpp`), which rejects only ids that would index *past* the feature arrays (`maxFeatureId >= numFeatures`, error `-5351`) and negative ids (`-5355`). Extra unused feature tuples are legal in SIMPLNX — they are simply never written. This is the same relaxation already documented for `CopyFeatureArrayToElementArrayFilter-D2`.
+
+**Affected users:** Anyone whose pipeline produces a Feature AttributeMatrix sized independently of the FeatureIds actually present — for example after removing features without renumbering. Such pipelines failed outright in 6.5.171 and now run. The unused tuples' `Sphericity = +inf` is the ordinary zero-area degenerate case (see D5) and is not new behavior.
+
+**Recommendation:** Trust SIMPLNX. Rejecting an input the filter can process correctly is not a safety property; the case that *is* dangerous (an id larger than the feature arrays) is still an error. Users who relied on `-5555` as a renumbering canary should add an explicit check, and should note that SIMPLNX's leniency means unused tuples carry `0` / `+inf` rather than being absent.
+
+---
+
+## ComputeSurfaceAreaToVolumeFilter-D4
+
+| Field | Value |
+|---|---|
+| **Deviation ID** | `ComputeSurfaceAreaToVolumeFilter-D4` |
+| **Filter UUID** | `94e83e4f-797d-4594-b130-3819b7676f01` |
+| **Status** | active |
+
+**Symptom:** The *Calculate Sphericity* switch has no effect in a 6.5.171 pipeline: a saved pipeline that sets it to false still produces a sphericity array, and that array is always named literally `Sphericity` regardless of the *Sphericity Array Name* in the pipeline file. In SIMPLNX both parameters are honored. Additionally, 6.5.171 will **crash** (null pointer dereference) if the flag is somehow false at execute time — reachable from the GUI or the C++ API, though not from a pipeline file.
+
+**Root cause:** Bug in 6.5.171, corrected at port time. `FindSurfaceAreaToVolume::readFilterParameters()` reads only `FeatureIdsArrayPath`, `NumCellsArrayPath` and `SurfaceAreaVolumeRatioArrayName` (`FindSurfaceAreaToVolume.cpp:99-106`); `CalculateSphericity` and `SphericityArrayName` are never read, so both keep their constructor defaults of `true` and `"Sphericity"` (`:57-58`). Separately, `execute()` writes `m_Sphericity[i]` unconditionally (`:322`) while `dataCheck()` only allocates that array when `getCalculateSphericity()` is true (`:150-158`) — so honoring a false flag would dereference a null pointer. SIMPLNX guards the write with `if(m_InputValues->CalculateSphericity)` and creates the array only under the same condition, so both halves are correct.
+
+**Affected users:** Every 6.5.171 pipeline user who turned sphericity off expecting it not to be computed (it was, and was written under a fixed name), or who renamed the sphericity output (the rename was ignored). Nobody hit the crash from a pipeline file, because the flag could never become false there.
+
+**Recommendation:** Trust SIMPLNX. Migration consequence: this is the one code path in the filter that **cannot** be A/B'd against 6.5.171 at all — the legacy binary has no way to take it. The SIMPLNX behavior is verified by the `Sphericity Toggle Off` TEST_CASE, which asserts the array is not created, and that test is an oracle test with no legacy counterpart.
+
+---
+
+## ComputeSurfaceAreaToVolumeFilter-D5
+
+| Field | Value |
+|---|---|
+| **Deviation ID** | `ComputeSurfaceAreaToVolumeFilter-D5` |
+| **Filter UUID** | `94e83e4f-797d-4594-b130-3819b7676f01` |
+| **Status** | active |
+
+**Symptom:** A negative *Feature Id* is a hard error in SIMPLNX (`-5355`, no output). 6.5.171 accepts the same input silently and produces output. **Executed** on the F1 geometry with `FeatureIds[0]` set to `-1`: `PipelineRunner` exits 0 with no error or warning about the negative value and writes `SurfaceAreaVolumeRatio = [0, 12]`, `Sphericity = [0, 0.80599713]` — bit-for-bit what it produces when that cell carries id 0.
+
+**Root cause:** Bug in 6.5.171 (latent undefined behavior), corrected at port time. 6.5.171's feature-count scan tracks only the *largest* id (`FindSurfaceAreaToVolume.cpp:195-206`), so a negative never trips a guard. Execution then reaches the unconditional accumulator `featureSurfaceArea[m_FeatureIds[...]] = featureSurfaceArea[m_FeatureIds[...]] + onsurf` (`:311`), which for id `-1` reads and writes one `float` *before* the start of a `std::vector<float>`. Scope of the risk, stated precisely: because the `feature > 0` guard at `:263` skips the face loop for negative ids, `onsurf` is always `0.0f` at that point, so the out-of-bounds write stores back the value it just read. The access is real undefined behavior — a hardened allocator or a sanitizer build will trap it — but it is not observed data corruption, and the run's own output is unaffected. SIMPLNX's `ValidateFeatureIdsToFeatureAttributeMatrixIndexing` call rejects the input with `-5355` before any accumulation, and its per-cell loop additionally `continue`s on ids below 1.
+
+**Affected users:** Anyone whose upstream pipeline can emit a negative feature id (a masked or sentinel-marked segmentation, for instance). Under 6.5.171 the run succeeded and those cells were effectively treated as background; under SIMPLNX the pipeline now stops.
+
+**Recommendation:** Trust SIMPLNX — an out-of-bounds index should not be accepted, and silently reinterpreting a negative id as background hides an upstream defect. Migration note: a pipeline that used to run under 6.5.171 with negative ids will now fail with `-5355`. To reproduce the old numbers deliberately, replace negative ids with 0 upstream; the legacy output above is exactly what SIMPLNX produces for the id-0 equivalent. Covered by the `Execute error - negative FeatureIds (-5355)` section of the Error Paths TEST_CASE. Deliberately **not** included in the alignment patch: the patch's charter is output alignment for the two shared arithmetic bugs, and 6.5.171's output for this input already matches SIMPLNX's id-0 interpretation, so there is nothing to align.
+
+---
+
+## Confirmed non-deviations
+
+Recorded so they are not relitigated. Each was checked against both sources and, where an observable follows, against both binaries.
+
+- **Outer-boundary faces are skipped in both codebases.** The six boundary guards are line-for-line equivalent (6.5.171 `:269-292` sets a `good` flag; SIMPLNX `continue`s). Fixtures F4 (corner voxel, sphericity 1.612) and F5 (feature fills the volume, area 0, sphericity `+inf`) produce identical output from both binaries. The behavior is a real limitation and is now documented in the user doc rather than changed — changing it would alter every existing result.
+- **Feature Id 0 counts as a differing neighbor in both codebases.** Neither implementation gates the face test on the neighbor's id being positive. Fixtures F6a (id-0 shell) and F6b (positive-id shell) give feature 1 the same area in both binaries. The old SIMPLNX user documentation claimed the opposite; the documentation was wrong, not the code.
+- **Volume comes from the user-supplied *Number of Cells* array in both codebases**, never from a recount of FeatureIds. Fixture F2b (one cell of feature 1, `NumCells[1] = 8`) yields `SAVR = 1.5` from both binaries, not the `12.0` a recount would give.
+- **Index 0 of both outputs is never written by either codebase** (both finalize loops start at feature 1). Fixture F1 sets `NumCells[0] = 5` so that a loop starting at 0 would write `Sphericity[0] = +inf`; both binaries leave it at 0.
+- **Progress and cancel behavior.** SIMPLNX emits a per-Z-slice info message and reads `m_ShouldCancel` once per Z slice; 6.5.171 has neither. Additive, no output change on a run to completion.

--- a/src/Plugins/SimplnxCore/vv/provenance/ComputeFeatureCentroidsFilter.md
+++ b/src/Plugins/SimplnxCore/vv/provenance/ComputeFeatureCentroidsFilter.md
@@ -6,7 +6,7 @@
 
 The prior test `SimplnxCore::ComputeFeatureCentroidsFilter` compared a freshly computed `Centroids NX` array against a **sibling `Centroids` array in the same `6_6_stats_test_v2.dream3d` file**. That reference array was itself produced by an earlier DREAM3D run, making the check a **consistency-with-self / circular oracle** (see `docs/vv_templates/oracle_classes.md` "What is NOT an oracle"). It was **retired** and replaced by the analytical fixtures below.
 
-- `6_6_stats_test_v2.tar.gz` — the centroids test no longer consumes it. The `download_test_data()` entry stays in `test/CMakeLists.txt` because five other tests still use it (`ComputeEuclideanDistMap`, `ComputeSurfaceAreaToVolume`, `ComputeFeatureNeighbors`, `ComputeFeatureSizes`, `ComputeFeaturePhases`).
+- `6_6_stats_test_v2.tar.gz` — the centroids test no longer consumes it. The `download_test_data()` entry stays in `test/CMakeLists.txt` because other tests still use it (`ComputeEuclideanDistMap` and `ComputeFeatureNeighbors` in SimplnxCore; `ComputeShapes`, `ComputeSchmids` and `AlignSectionsMutualInformation` in OrientationAnalysis). `ComputeSurfaceAreaToVolume` was on this list until its own V&V cycle (2026-08-20) retired its use of the archive.
 - `6_6_find_feature_centroids.tar.gz` — **kept**; used by `ExtractComponentAsArray` and `WriteAbaqusHexahedron` tests (the retroactive report's "orphan" claim was incorrect).
 
 ## Canonical oracle output (Class 1 — hand derivation)

--- a/src/Plugins/SimplnxCore/vv/provenance/ComputeSurfaceAreaToVolumeFilter.md
+++ b/src/Plugins/SimplnxCore/vv/provenance/ComputeSurfaceAreaToVolumeFilter.md
@@ -1,0 +1,56 @@
+# Exemplar Provenance: ComputeSurfaceAreaToVolumeFilter
+
+**No exemplar archive.** As of this V&V cycle (2026-08-20) the filter's correctness tests are **inline Class 1 (Analytical) + Class 4 (Invariant) fixtures** built directly in `test/ComputeSurfaceAreaToVolumeTest.cpp` (`namespace SavToy`). There is no `.dream3d` gold master to hash — the oracle lives in the test code as hand-derived `REQUIRE` values, each accompanied by its derivation as a comment.
+
+## Retired test / circular-oracle removal
+
+The prior test `SimplnxCore::ComputeSurfaceAreaToVolume` compared freshly computed `SurfaceAreaVolumeRatioNX` / `SphericityNX` arrays against **sibling `SurfaceAreaVolumeRatio` / `Sphericity` arrays in the same `6_6_stats_test_v2.dream3d` file**. Those reference arrays were produced by an earlier DREAM3D run of the same algorithm, making the check a **consistency-with-self / circular oracle** (see `docs/vv_templates/oracle_classes.md`, "What is NOT an oracle"). It was **retired** and replaced by the analytical fixtures below.
+
+Two **executed** facts establish that the retired test was not merely circular but incapable of doing its job (script `blind_suite.py` and output `results_blind_suite.txt` in the V&V working folder; re-runnable against any extraction of the archive):
+
+1. **It could not see the face-area bug.** The archive's `_SIMPL_GEOMETRY/SPACING` is `(0.25, 0.25, 0.25)`. Deviation D1 swaps the ±X face area (`dy·dz`) with the ±Y face area (`dx·dz`); at isotropic spacing those products are equal, so the swap is a no-op on this dataset. No number of additional assertions against this file could have detected D1.
+2. **Its reference data carried the sphericity bug.** Reconstructing `A` from the archive's own `SurfaceAreaVolumeRatio` and `NumElements` and recomputing sphericity over its 619 non-background features: the archived `Sphericity` matches the **truncated**-exponent expression (`π^0.333333 (6V)^0.66666 / A`) to 1.6e-7 relative, and differs from the exact-exponent expression by up to **4.9e-5** relative. After the D2 fix the retired test would have begun failing against its own reference arrays.
+
+A third limitation, relevant to the mutation sweep: the archive's `NumElements` array equals `bincount(FeatureIds)` exactly for all 620 features (executed check), so it cannot distinguish "volume from the user-supplied `NumCells`" from "volume recounted from `FeatureIds`". Inline fixture F2b exists to close that gap.
+
+### Archive disposition
+
+- `6_6_stats_test_v2.tar.gz` — this filter's tests no longer consume it. The `download_test_data()` entry in `src/Plugins/SimplnxCore/test/CMakeLists.txt` (SHA512 `e84999de…089723`) is **left untouched**: `ComputeEuclideanDistMapTest` and `ComputeFeatureNeighborsTest` still consume it in SimplnxCore, and `ComputeShapesFilterTest`, `ComputeSchmidsTest` and `AlignSectionsMutualInformationTest` consume it in OrientationAnalysis. Any future regeneration must account for all five consumers.
+
+## Canonical oracle output (Class 1 — hand derivation)
+
+`A(f)` = Σ over each cell of feature `f` and each of its six face neighbors of the shared face area, counted iff the neighbor is inside the grid **and** carries a different id (id 0 included as "different"). ±Z face = `dx·dy`; ±Y face = `dx·dz`; ±X face = `dy·dz`. `V(f) = NumCells[f]·dx·dy·dz`. `SAVR = A/V`. `Sphericity = π^(1/3)(6V)^(2/3)/A`.
+
+F1–F7 (eight TEST_CASE sections) were derived by an independent brute-force face enumeration (`derive.py`) written from those rules and RED-run before either the SIMPLNX or the DREAM3D binary was invoked on any fixture. F1b and F2b were added afterward — F1b for deviation D3's over-provisioned Feature AM case, F2b to close the volume-recount blind spot — with expected values likewise hand-derived from the same rules rather than read off any observed run (F2b's was also checked post-hoc against `derive.py`, but that check confirms a hand-derived value, not a recount: the expected value is specifically not what a recount would produce). Ratio values are exactly representable in float32 and are asserted as exact equalities; sphericity is asserted to 1e-6 relative, a bound justified by a float32 simulation of the fixed expression (`f32check.py`, worst case 1.3e-7).
+
+| Fixture | Grid / spacing | Purpose | Key expected value |
+|---|---|---|---|
+| F1 | 3³, spacing 0.5 | single interior voxel; index-0 sentinel | `SAVR[1] = 12.0`; `Ψ[1] = 0.8059959770`; `SAVR[0] = Ψ[0] = 0` |
+| F1b | 3³, 4 feature tuples | over-provisioned Feature AM (deviation D3) | `SAVR = [0, 12, 0, 0]`; `Ψ[2] = Ψ[3] = +inf` |
+| F2 | 4³, spacing 0.5 | 2×2×2 cube; sphericity scale invariance | `SAVR[1] = 6.0`; `Ψ[1] = 0.8059959770` (same as F1) |
+| F2b | 3³, spacing 0.5, `NumCells[1] = 8` | volume from `NumCells`, not a recount | `SAVR[1] = 1.5`; `Ψ[1] = 3.2239839080` |
+| F3 | 6×8×3, spacing (1, 2, 4) | anisotropic X-rod + Y-rod; the D1 discriminator | `A = [_, 64, 88]` → `SAVR = [_, 2.0, 2.75]`; `Ψ = [_, 0.7616184728, 0.5539043438]` |
+| F4 | 3³, spacing 0.5, corner cell | outer-boundary faces not counted | `A = 3a² = 0.75`; `SAVR[1] = 6.0`; `Ψ[1] = 1.6119919540` (> 1, expected) |
+| F5 | 3³, all cells id 1 | degenerate divide | `SAVR[1] = 0`; `Ψ[1] = +inf` |
+| F6 | 3³, shell id ∈ {0, 2} | id 0 counts as surface | `SAVR[1] = 12.0` for both shells; shell 2: `SAVR[2] = 1.5/3.25`, `Ψ[2] = 7.0737293550` |
+| F7 | 7×3×1, spacing (1, 2, 4) | 2D slab, no ±Z faces; D1 in the 2D path | `SAVR = [_, 3.0, 2.0]`; `Ψ = [_, 0.8059959770, 0.9595791455]` |
+| F8 | 3³, sphericity off | array not created (no legacy counterpart) | `getDataAs<Float32Array>(sphericityPath) == nullptr` |
+| errors | 3³ variants | `-5355`, `-5351`, `-12802`, `-12803` | `preflight`/`execute` invalid with the exact code |
+
+**Pre-fix values, for anyone reconciling stored output.** The same derivation, evaluated with the two shipped defects (swapped ±X/±Y areas, exponents `0.333333`/`0.66666`), predicted the pre-fix output before it was observed; the observed pre-fix values matched to nine decimal places. `Ψ`: F1 `0.805997133`, F2 `0.805986106`, F2b `3.223944167`, F3 `[0.553884745, 0.761591554]` (also exchanged), F4 `1.611994267`, F6 shell 2 `7.073586941`, F7 `[0.805974901, 0.767639]`. `SAVR`: F3 `[2.75, 2.0]` (exchanged), F7 feature 2 `2.5`.
+
+## Second-engineer oracle review
+
+- **Delegated to the PR reviewer** (requester decision, 2026-08-19).
+- Suggested review focus: the F3 area arithmetic (`A₁ = 2·(dy·dz) + 8·(dx·dz) + 8·(dx·dy) = 16 + 32 + 16 = 64`, and its mirror `A₂ = 2·4 + 8·8 + 8·2 = 88`), on which the entire D1 argument rests; and the deliberate `Ψ > 1` expectation in F4, which reads like a defect and is the documented consequence of the boundary-face rule.
+
+## Reproduction
+
+The fixtures require no external data:
+
+```
+cmake --build <build-dir> --target SimplnxCoreUnitTest
+ctest -R "SimplnxCore::ComputeSurfaceAreaToVolume" --verbose
+```
+
+The A/B and alignment evidence (fixture writer, both pipeline sets, comparison and alignment scripts, the mutation transcript, and the legacy patch diff) lives in the V&V working folder `ww_work/ComputeSurfaceAreaToVolume/`, which is intentionally not committed to this repository. All hand derivations are also in the code comments beside each fixture and in `src/Plugins/SimplnxCore/vv/ComputeSurfaceAreaToVolumeFilter.md`.


### PR DESCRIPTION
## Summary
Full V&V of `ComputeSurfaceAreaToVolumeFilter`: ten hand-derived Class 1 + Class 4 fixtures replace the circular exemplar comparison against `6_6_stats_test_v2` (archive lines untouched — other consumers remain).

* Fixes two legacy-shared bugs, both invisible to the old isotropic-spacing test: the ±X/±Y face areas were swapped in the surface accumulation (`ComputeSurfaceAreaToVolumeFilter-D1`), and the sphericity exponents were truncated literals (`-D2`). Both documented against 6.5.171 and validated by one surgical 6.5.172 alignment patch — patched-legacy ≡ fixed-NX ≡ oracle on 9/9 legacy-admissible fixtures.
* Documents three legacy-side deviations: the exact-feature-count `-5555` strictness (D3), the sphericity toggle never being read from pipeline files plus a latent null-deref legacy crash NX never had (D4), and negative-FeatureId UB whose legacy OOB write silently stores back what it read (D5).
* Adds a FeatureIds-tuple-count vs geometry-cell-count preflight guard (`-12803`). Rewrites the user doc: the outer-boundary face-skip rule is now stated (a boundary-touching feature can legitimately report sphericity > 1 — pinned by a fixture), and the false id-0 claim is corrected.
* A/B vs 6.5.171: 10/10 fixtures matched source-derived predictions; NX matched the analytical oracle 10/10. Six mutations killed with blind-suite proof.

## Test Plan
- [x] `ctest -R "SimplnxCore::ComputeSurfaceAreaToVolume"` — 4/4 pass (211 assertions)
- [x] Full `ctest -R "SimplnxCore::"` — 981/981